### PR TITLE
fix: 1. when the window is larger than the map size, it is resized, just equal to the scale. the coordinate system has not changed  2. background default white

### DIFF
--- a/game.go
+++ b/game.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"image"
+	"image/color"
 	"io"
 	"log"
 	"math/rand"
@@ -1163,7 +1164,8 @@ func (p *Game) drawBackground(dc drawContext) {
 }
 
 func (p *Game) onDraw(dc drawContext) {
-	dc.Clear()
+	//dc.Clear()
+	dc.Fill(color.White)
 	p.drawBackground(dc)
 	p.getTurtle().draw(dc, p.fs)
 

--- a/game.go
+++ b/game.go
@@ -527,6 +527,7 @@ func (p *Game) loadIndex(g reflect.Value, index interface{}) (err error) {
 	if debugLoad {
 		log.Println("==> SetWindowSize", p.windowWidth_, p.windowHeight_)
 	}
+	ebiten.SetWindowSize(p.windowWidth_, p.windowHeight_)
 	if p.windowWidth_ > p.worldWidth_ {
 		p.windowWidth_ = p.worldWidth_
 	}
@@ -535,7 +536,6 @@ func (p *Game) loadIndex(g reflect.Value, index interface{}) (err error) {
 	}
 	p.Camera.init(p, float64(p.windowWidth_), float64(p.windowHeight_), float64(p.worldWidth_), float64(p.worldHeight_))
 
-	ebiten.SetWindowSize(p.windowWidth_, p.windowHeight_)
 	ebiten.SetWindowResizable(true)
 	if proj.Camera != nil && proj.Camera.On != "" {
 		p.Camera.On(proj.Camera.On)


### PR DESCRIPTION
fix: when the window is larger than the map size, it is resized, just equal to the scale. the coordinate system has not changed