### PR TITLE
add gopherjs build support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/qiniu/x v1.11.9
 	github.com/srwiley/oksvg v0.0.0-20210519022825-9fc0c575d5fe
 	github.com/srwiley/rasterx v0.0.0-20210519020934-456a8d69b780
+	github.com/visualfc/gopherjs-fixed v0.1.1
 	golang.org/x/image v0.0.0-20220321031419-a8550c1d254a
 	golang.org/x/mobile v0.0.0-20220518205345-8578da9835fd
 )

--- a/go.sum
+++ b/go.sum
@@ -65,6 +65,8 @@ github.com/srwiley/rasterx v0.0.0-20210519020934-456a8d69b780 h1:oDMiXaTMyBEuZMU
 github.com/srwiley/rasterx v0.0.0-20210519020934-456a8d69b780/go.mod h1:mvWM0+15UqyrFKqdRjY6LuAVJR0HOVhJlEgZ5JWtSWU=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/visualfc/gopherjs-fixed v0.1.1 h1:IwYhv8J831jwgFGBq/LjxDQhJdqryg+mPP3j/YE2O44=
+github.com/visualfc/gopherjs-fixed v0.1.1/go.mod h1:Y46lAao4mp9Kz8DsQErCzNv716suKlkTTfzFaFl+CZI=
 github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=

--- a/gopherjs.go
+++ b/gopherjs.go
@@ -1,0 +1,10 @@
+//go:build js && !wasm
+// +build js,!wasm
+
+package spx
+
+import (
+	_ "github.com/visualfc/gopherjs-fixed/audio"
+	_ "github.com/visualfc/gopherjs-fixed/ebiten"
+	_ "github.com/visualfc/gopherjs-fixed/oto"
+)


### PR DESCRIPTION
support build for gopherjs
```
GOOS=js GOARCH=ecmascript gopherjs serve -v --tags canvas .
```

**replace function for gopehrjs runtime.**

[github.com/visualfc/gopherjs-fixed](https://github.com/visualfc/gopherjs-fixed)

- github.com/hajimehoshi/ebiten/v2/internal/jsutil
```
jsutil.TemporaryUint8ArrayFromUint8Slice
jsutil.TemporaryUint8ArrayFromUint16Slice
jsutil.TemporaryUint8ArrayFromFloat32Slice
jsutil.TemporaryFloat32Array
```
- github.com/hajimehoshi/oto/v2
```
oto.NewContext
```
- github.com/hajimehoshi/ebiten/v2/audio 
```
audio.NewContext  // sample 11025
```
