### PR TITLE
Builder#648  Convert the "GetWidget" function to a generic function

### DIFF
--- a/game.go
+++ b/game.go
@@ -1351,8 +1351,17 @@ func (p *Game) ShowVar(name string) {
 // Widget
 
 // GetWidget returns the widget instance with given name. It panics if not found.
-func Gopt_Game_Gopx_GetWidget[T any](game interface{ Parent() *Game }, name string) *T {
-	items := game.Parent().items
+func Gopt_Game_Gopx_GetWidget[T any](game interface{}, name string) *T {
+	var gamePtr *Game
+	switch ptr := game.(type) {
+	case *Game:
+		gamePtr = ptr
+	case interface{ Parent() *Game }:
+		gamePtr = ptr.Parent()
+	default:
+		panic("GetWidget: unexpected game type" + reflect.TypeOf(game).String())
+	}
+	items := gamePtr.items
 	for _, item := range items {
 		widget, ok := item.(Widget)
 		if ok && widget.GetName() == name {

--- a/game.go
+++ b/game.go
@@ -110,9 +110,9 @@ type Spriter interface {
 	Shape
 	Main()
 }
-
 type Gamer interface {
 	initGame(sprites []Spriter) *Game
+	getGame() *Game
 }
 
 func (p *Game) IsRunned() bool {
@@ -163,6 +163,10 @@ func (p *Game) reset() {
 	p.items = nil
 	p.isLoaded = false
 	p.sprs = make(map[string]Spriter)
+}
+
+func (p *Game) getGame() *Game {
+	return p
 }
 
 func (p *Game) initGame(sprites []Spriter) *Game {
@@ -1358,6 +1362,8 @@ func Gopt_Game_Gopx_GetWidget[T any](game interface{}, name string) *T {
 		gamePtr = ptr
 	case interface{ Parent() *Game }:
 		gamePtr = ptr.Parent()
+	case Gamer:
+		gamePtr = ptr.getGame()
 	default:
 		panic("GetWidget: unexpected game type" + reflect.TypeOf(game).String())
 	}

--- a/game.go
+++ b/game.go
@@ -114,9 +114,11 @@ type Spriter interface {
 type Gamer interface {
 	initGame(sprites []Spriter) *Game
 }
+
 var (
 	gameInstance *Game
 )
+
 func (p *Game) IsRunned() bool {
 	return p.isRunned
 }
@@ -1342,14 +1344,14 @@ func (p *Game) ShowVar(name string) {
 
 // GetWidget returns the widget instance with given name. It panics if not found.
 
-func Gopx_GetWidget[T any](name string) *T{
+func Gopx_GetWidget[T any](name string) *T {
 	items := gameInstance.items
 	for _, item := range items {
 		widget, ok := item.(Widget)
 		if ok && widget.GetName() == name {
 			if result, ok := widget.(interface{}).(*T); ok {
 				return result
-			}else{
+			} else {
 				panic("GetWidget: type mismatch - expected " + reflect.TypeOf((*T)(nil)).Elem().String() + ", got " + reflect.TypeOf(widget).String())
 			}
 		}

--- a/game.go
+++ b/game.go
@@ -736,6 +736,18 @@ func (p *Game) getWidth() int {
 	return p.windowWidth_
 }
 
+// convert pos from win space(0,0 is top left) to game space(0,0 is center)
+func convertWinSpace2GameSpace(x, y float64) (float64, float64) {
+	winW, winH := gameInstance.getWindowSize()
+	x += float64(winW) / 2
+	y = float64(winH)/2 - y
+	return x, y
+}
+
+func (p *Game) getWindowSize() (int, int) {
+	return p.windowSize_()
+}
+
 func (p *Game) windowSize_() (int, int) {
 	if p.windowWidth_ == 0 {
 		p.doWindowSize()

--- a/monitor.go
+++ b/monitor.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/goplus/spx/internal/gdi"
 	xfont "github.com/goplus/spx/internal/gdi/font"
+	"github.com/goplus/spx/internal/tools"
 	"github.com/hajimehoshi/ebiten/v2"
 	"golang.org/x/image/font"
 )
@@ -65,9 +66,9 @@ func newMonitor(g reflect.Value, v specsp) (*Monitor, error) {
 	target := v["target"].(string)
 	val := v["val"].(string)
 	name := v["name"].(string)
-	size := v["size"].(float64)
-	if size == 0 {
-		size = 1
+	size := 1.0
+	if v["size"] != nil {
+		size, _ = tools.GetFloat(v["size"])
 	}
 	eval := buildMonitorEval(g, target, val)
 	if eval == nil {
@@ -76,7 +77,7 @@ func newMonitor(g reflect.Value, v specsp) (*Monitor, error) {
 	mode := int(v["mode"].(float64))
 	color, err := parseColor(getSpcspVal(v, "color"))
 	if err != nil {
-		panic(err)
+		color = Color{R: 0xff, G: 0xff, B: 0xff, A: 0xff}
 	}
 	label := v["label"].(string)
 	x := v["x"].(float64)

--- a/monitor.go
+++ b/monitor.go
@@ -177,9 +177,10 @@ func (p *Monitor) draw(dc drawContext) {
 		return
 	}
 	val := p.eval()
+	x, y := p.x, p.y
+	x, y = convertWinSpace2GameSpace(x, y)
 	switch p.mode {
 	case 2:
-		x, y := p.x, p.y
 		render := gdi.NewTextRender(defaultFont, 0x80000, 0)
 		render.AddText(val)
 		intw, inth := render.Size()
@@ -192,7 +193,6 @@ func (p *Monitor) draw(dc drawContext) {
 		render.Draw(dc.Image, int(x+((w-textW)/2)), int(y), color.White, 0)
 	default:
 		font := getOrCreateFont(int(p.size * 12))
-		x, y := p.x, p.y
 		labelRender := gdi.NewTextRender(font, 0x80000, 0)
 		labelRender.AddText(p.label)
 		intw, inth := labelRender.Size()

--- a/monitor.go
+++ b/monitor.go
@@ -36,6 +36,7 @@ import (
 
 // Monitor class.
 type Monitor struct {
+	game    *Game
 	name    string
 	size    float64
 	target  string
@@ -178,7 +179,7 @@ func (p *Monitor) draw(dc drawContext) {
 	}
 	val := p.eval()
 	x, y := p.x, p.y
-	x, y = convertWinSpace2GameSpace(x, y)
+	x, y = p.game.convertWinSpace2GameSpace(x, y)
 	switch p.mode {
 	case 2:
 		render := gdi.NewTextRender(defaultFont, 0x80000, 0)


### PR DESCRIPTION
1. convert the "GetWidget" function to a generic function  https://github.com/goplus/spx/pull/306#discussion_r1713095270
```
monitor := getWidget(Monitor,"life")
```
2. add default values for the 'size' and 'color' attributes of the Monitor https://github.com/goplus/spx/pull/306#discussion_r1705019171
3. make the coordinate concept of Widget consistent with sprite, where 0,0 represents the center of the screen, and the y-axis points upwards https://github.com/goplus/spx/pull/306#discussion_r1706601813 https://github.com/goplus/spx/pull/306#discussion_r1706616273

[Project : 648_generic.zip](https://github.com/user-attachments/files/16622490/648_generic.zip)

