### PR TITLE
fix: Initial costumeIndex for sprite not working #317

### DIFF
--- a/sprite.go
+++ b/sprite.go
@@ -118,7 +118,7 @@ func (p *Sprite) init(
 	} else {
 		p.baseObj.initWith(base, sprite, shared)
 	}
-    p.defaultCostumeIndex = p.baseObj.costumeIndex_
+	p.defaultCostumeIndex = p.baseObj.costumeIndex_
 	p.eventSinks.init(&g.sinkMgr, p)
 
 	p.gamer = gamer

--- a/sprite.go
+++ b/sprite.go
@@ -118,6 +118,7 @@ func (p *Sprite) init(
 	} else {
 		p.baseObj.initWith(base, sprite, shared)
 	}
+    p.defaultCostumeIndex = p.baseObj.costumeIndex_
 	p.eventSinks.init(&g.sinkMgr, p)
 
 	p.gamer = gamer


### PR DESCRIPTION
reset default costume index after the sprite initialized.
no need to switch behaviour of playDefaultAnimation in sprite.go.