### PR TITLE
fix: Unify Die behavior of initial / cloned sprite #314

### DIFF
--- a/sprite.go
+++ b/sprite.go
@@ -492,10 +492,10 @@ func (p *Sprite) Die() {
 		p.goAnimate(aniName, ani)
 	}
 
-	p.Destroy()
+	p.doDestroy()
 }
 
-func (p *Sprite) Destroy() {
+func (p *Sprite) doDestroy() {
 	if debugInstr {
 		log.Println("Destroy", p.name)
 	}
@@ -507,6 +507,14 @@ func (p *Sprite) Destroy() {
 	if p == gco.Current().Obj {
 		gco.Abort()
 	}
+}
+
+func (p *Sprite) DeleteThisClone() {
+	if !p.isCloned_ {
+		return
+	}
+
+	p.doDestroy()
 }
 
 func (p *Sprite) Hide() {

--- a/sprite.go
+++ b/sprite.go
@@ -485,30 +485,22 @@ func (p *Sprite) OnTurning__1(onTurning func()) {
 	})
 }
 
-func (p *Sprite) Die() { // prototype sprite can't be destroyed, but can die
+func (p *Sprite) Die() {
 	aniName := p.getStateAnimName(StateDie)
 	p.SetDying()
 	if ani, ok := p.animations[aniName]; ok {
 		p.goAnimate(aniName, ani)
 	}
-	if p.isCloned_ {
-		p.doDestroy()
-	} else {
-		p.Hide()
-	}
+
+	p.Destroy()
 }
 
-func (p *Sprite) Destroy() { // delete this clone
-	if p.isCloned_ {
-		p.doDestroy()
-	}
-}
-
-func (p *Sprite) doDestroy() {
+func (p *Sprite) Destroy() {
 	if debugInstr {
 		log.Println("Destroy", p.name)
 	}
-	p.doStopSay()
+
+	p.Hide()
 	p.doDeleteClone()
 	p.g.removeShape(p)
 	p.Stop(ThisSprite)

--- a/sprite.go
+++ b/sprite.go
@@ -509,7 +509,9 @@ func (p *Sprite) Destroy() { // destroy sprite, whether prototype or cloned
 	}
 }
 
-func (p *Sprite) DeleteThisClone() { // delete only cloned sprite, no effect on prototype sprite
+// delete only cloned sprite, no effect on prototype sprite.
+// Add this interface, to match Scratch.
+func (p *Sprite) DeleteThisClone() {
 	if !p.isCloned_ {
 		return
 	}

--- a/sprite.go
+++ b/sprite.go
@@ -492,10 +492,10 @@ func (p *Sprite) Die() {
 		p.goAnimate(aniName, ani)
 	}
 
-	p.doDestroy()
+	p.Destroy()
 }
 
-func (p *Sprite) doDestroy() {
+func (p *Sprite) Destroy() { // destroy sprite, whether prototype or cloned
 	if debugInstr {
 		log.Println("Destroy", p.name)
 	}
@@ -509,12 +509,12 @@ func (p *Sprite) doDestroy() {
 	}
 }
 
-func (p *Sprite) DeleteThisClone() {
+func (p *Sprite) DeleteThisClone() { // delete only cloned sprite, no effect on prototype sprite
 	if !p.isCloned_ {
 		return
 	}
 
-	p.doDestroy()
+	p.Destroy()
 }
 
 func (p *Sprite) Hide() {


### PR DESCRIPTION
Unify Die behavior of initial / cloned sprite https://github.com/goplus/spx/issues/314
This fix is temporary. It's better to switch to the prefab/instance workflow like unity.