### PR TITLE
fix issue: Die behavior with animation #315

### DIFF
--- a/sprite.go
+++ b/sprite.go
@@ -488,6 +488,8 @@ func (p *Sprite) OnTurning__1(onTurning func()) {
 func (p *Sprite) Die() {
 	aniName := p.getStateAnimName(StateDie)
 	p.SetDying()
+
+	p.Stop(OtherScriptsInSprite)
 	if ani, ok := p.animations[aniName]; ok {
 		p.goAnimate(aniName, ani)
 	}

--- a/sprite.go
+++ b/sprite.go
@@ -485,30 +485,22 @@ func (p *Sprite) OnTurning__1(onTurning func()) {
 	})
 }
 
-func (p *Sprite) Die() { // prototype sprite can't be destroyed, but can die
+func (p *Sprite) Die() {
 	aniName := p.getStateAnimName(StateDie)
 	p.SetDying()
 	if ani, ok := p.animations[aniName]; ok {
 		p.goAnimate(aniName, ani)
 	}
-	if p.isCloned_ {
-		p.doDestroy()
-	} else {
-		p.Hide()
-	}
+
+	p.Destroy()
 }
 
-func (p *Sprite) Destroy() { // delete this clone
-	if p.isCloned_ {
-		p.doDestroy()
-	}
-}
-
-func (p *Sprite) doDestroy() {
+func (p *Sprite) Destroy() {
 	if debugInstr {
 		log.Println("Destroy", p.name)
 	}
-	p.doStopSay()
+
+	p.Hide()
 	p.doDeleteClone()
 	p.g.removeShape(p)
 	p.Stop(ThisSprite)


### PR DESCRIPTION
While Die() called, first stop other behevior of the sprite, then play die animation.