### PR TITLE
fix: Die behavior with animation #315

### DIFF
--- a/sprite.go
+++ b/sprite.go
@@ -492,6 +492,7 @@ func (p *Sprite) Die() {
 		p.goAnimate(aniName, ani)
 	}
 
+	p.Stop(OtherScriptsInSprite)
 	p.Destroy()
 }
 


### PR DESCRIPTION
While Die() called, first stop other behevior of the sprite, then play die animation.