### PR TITLE
Issue330

### DIFF
--- a/sprite.go
+++ b/sprite.go
@@ -492,6 +492,7 @@ func (p *Sprite) Die() {
 		p.goAnimate(aniName, ani)
 	}
 
+	p.Stop(OtherScriptsInSprite)
 	p.Destroy()
 }
 


### PR DESCRIPTION
When the game starts and analyses the var definition in main.spx, 
the sprite is automatically bound if assets/sprites/{name}/index.json exists,
and the sound is automatically bound if assets/sounds/{name}/index.json exists.
No effect on the sprites and sounds in ZOrder of stage config.
[Archive.zip](https://github.com/user-attachments/files/17069361/Archive.zip)
