### PR TITLE
fix: Strange behavior of OnTouched #298

### DIFF
--- a/event.go
+++ b/event.go
@@ -95,7 +95,7 @@ type eventSinkMgr struct {
 	allWhenBackdropChanged *eventSink
 	allWhenCloned          *eventSink
 	allWhenTouchStart      *eventSink
-	allWhenTouched         *eventSink
+	allWhenTouching        *eventSink
 	allWhenTouchEnd        *eventSink
 	allWhenClick           *eventSink
 	allWhenMoving          *eventSink
@@ -110,7 +110,7 @@ func (p *eventSinkMgr) reset() {
 	p.allWhenBackdropChanged = nil
 	p.allWhenCloned = nil
 	p.allWhenTouchStart = nil
-	p.allWhenTouched = nil
+	p.allWhenTouching = nil
 	p.allWhenTouchEnd = nil
 	p.allWhenClick = nil
 	p.allWhenMoving = nil
@@ -125,7 +125,7 @@ func (p *eventSinkMgr) doDeleteClone(this interface{}) {
 	p.allWhenBackdropChanged = p.allWhenBackdropChanged.doDeleteClone(this)
 	p.allWhenCloned = p.allWhenCloned.doDeleteClone(this)
 	p.allWhenTouchStart = p.allWhenTouchStart.doDeleteClone(this)
-	p.allWhenTouched = p.allWhenTouched.doDeleteClone(this)
+	p.allWhenTouching = p.allWhenTouching.doDeleteClone(this)
 	p.allWhenTouchEnd = p.allWhenTouchEnd.doDeleteClone(this)
 	p.allWhenClick = p.allWhenClick.doDeleteClone(this)
 	p.allWhenMoving = p.allWhenMoving.doDeleteClone(this)
@@ -168,10 +168,10 @@ func (p *eventSinkMgr) doWhenTouchStart(this threadObj, obj *Sprite) {
 	})
 }
 
-func (p *eventSinkMgr) doWhenTouched(this threadObj, obj *Sprite) {
-	p.allWhenTouched.asyncCall(false, this, func(ev *eventSink) {
+func (p *eventSinkMgr) doWhenTouching(this threadObj, obj *Sprite) {
+	p.allWhenTouching.asyncCall(false, this, func(ev *eventSink) {
 		if debugEvent {
-			log.Println("==> onTouched", nameOf(this), obj.name)
+			log.Println("==> onTouching", nameOf(this), obj.name)
 		}
 		ev.sink.(func(*Sprite))(obj)
 	})

--- a/event.go
+++ b/event.go
@@ -94,7 +94,9 @@ type eventSinkMgr struct {
 	allWhenIReceive        *eventSink
 	allWhenBackdropChanged *eventSink
 	allWhenCloned          *eventSink
+	allWhenTouchBegin      *eventSink
 	allWhenTouched         *eventSink
+	allWhenTouchEnd        *eventSink
 	allWhenClick           *eventSink
 	allWhenMoving          *eventSink
 	allWhenTurning         *eventSink
@@ -107,7 +109,9 @@ func (p *eventSinkMgr) reset() {
 	p.allWhenIReceive = nil
 	p.allWhenBackdropChanged = nil
 	p.allWhenCloned = nil
+	p.allWhenTouchBegin = nil
 	p.allWhenTouched = nil
+	p.allWhenTouchEnd = nil
 	p.allWhenClick = nil
 	p.allWhenMoving = nil
 	p.allWhenTurning = nil
@@ -120,7 +124,9 @@ func (p *eventSinkMgr) doDeleteClone(this interface{}) {
 	p.allWhenIReceive = p.allWhenIReceive.doDeleteClone(this)
 	p.allWhenBackdropChanged = p.allWhenBackdropChanged.doDeleteClone(this)
 	p.allWhenCloned = p.allWhenCloned.doDeleteClone(this)
+	p.allWhenTouchBegin = p.allWhenTouchBegin.doDeleteClone(this)
 	p.allWhenTouched = p.allWhenTouched.doDeleteClone(this)
+	p.allWhenTouchEnd = p.allWhenTouchEnd.doDeleteClone(this)
 	p.allWhenClick = p.allWhenClick.doDeleteClone(this)
 	p.allWhenMoving = p.allWhenMoving.doDeleteClone(this)
 	p.allWhenTurning = p.allWhenTurning.doDeleteClone(this)
@@ -153,10 +159,28 @@ func (p *eventSinkMgr) doWhenClick(this threadObj) {
 	})
 }
 
+func (p *eventSinkMgr) doWhenTouchBegin(this threadObj, obj *Sprite) {
+	p.allWhenTouchBegin.asyncCall(false, this, func(ev *eventSink) {
+		if debugEvent {
+			log.Println("===> onTouchBegin", nameOf(this), obj.name)
+		}
+		ev.sink.(func(*Sprite))(obj)
+	})
+}
+
 func (p *eventSinkMgr) doWhenTouched(this threadObj, obj *Sprite) {
 	p.allWhenTouched.asyncCall(false, this, func(ev *eventSink) {
 		if debugEvent {
 			log.Println("==> onTouched", nameOf(this), obj.name)
+		}
+		ev.sink.(func(*Sprite))(obj)
+	})
+}
+
+func (p *eventSinkMgr) doWhenTouchEnd(this threadObj, obj *Sprite) {
+	p.allWhenTouchEnd.asyncCall(false, this, func(ev *eventSink) {
+		if debugEvent {
+			log.Println("===> onTouchEnd", nameOf(this), obj.name)
 		}
 		ev.sink.(func(*Sprite))(obj)
 	})

--- a/event.go
+++ b/event.go
@@ -94,7 +94,7 @@ type eventSinkMgr struct {
 	allWhenIReceive        *eventSink
 	allWhenBackdropChanged *eventSink
 	allWhenCloned          *eventSink
-	allWhenTouchBegin      *eventSink
+	allWhenTouchStart      *eventSink
 	allWhenTouched         *eventSink
 	allWhenTouchEnd        *eventSink
 	allWhenClick           *eventSink
@@ -109,7 +109,7 @@ func (p *eventSinkMgr) reset() {
 	p.allWhenIReceive = nil
 	p.allWhenBackdropChanged = nil
 	p.allWhenCloned = nil
-	p.allWhenTouchBegin = nil
+	p.allWhenTouchStart = nil
 	p.allWhenTouched = nil
 	p.allWhenTouchEnd = nil
 	p.allWhenClick = nil
@@ -124,7 +124,7 @@ func (p *eventSinkMgr) doDeleteClone(this interface{}) {
 	p.allWhenIReceive = p.allWhenIReceive.doDeleteClone(this)
 	p.allWhenBackdropChanged = p.allWhenBackdropChanged.doDeleteClone(this)
 	p.allWhenCloned = p.allWhenCloned.doDeleteClone(this)
-	p.allWhenTouchBegin = p.allWhenTouchBegin.doDeleteClone(this)
+	p.allWhenTouchStart = p.allWhenTouchStart.doDeleteClone(this)
 	p.allWhenTouched = p.allWhenTouched.doDeleteClone(this)
 	p.allWhenTouchEnd = p.allWhenTouchEnd.doDeleteClone(this)
 	p.allWhenClick = p.allWhenClick.doDeleteClone(this)
@@ -159,10 +159,10 @@ func (p *eventSinkMgr) doWhenClick(this threadObj) {
 	})
 }
 
-func (p *eventSinkMgr) doWhenTouchBegin(this threadObj, obj *Sprite) {
-	p.allWhenTouchBegin.asyncCall(false, this, func(ev *eventSink) {
+func (p *eventSinkMgr) doWhenTouchStart(this threadObj, obj *Sprite) {
+	p.allWhenTouchStart.asyncCall(false, this, func(ev *eventSink) {
 		if debugEvent {
-			log.Println("===> onTouchBegin", nameOf(this), obj.name)
+			log.Println("===> onTouchStart", nameOf(this), obj.name)
 		}
 		ev.sink.(func(*Sprite))(obj)
 	})

--- a/sprite.go
+++ b/sprite.go
@@ -85,7 +85,7 @@ func (c *Collider) SetTouching(other *Sprite, on bool) {
 			c.others[other] = true
 			c.sprite.fireTouchStart(other)
 		} else {
-			c.sprite.fireTouched(other)
+			c.sprite.fireTouching(other)
 		}
 	} else {
 		if exist {
@@ -141,7 +141,7 @@ type Sprite struct {
 	hasOnMoving     bool
 	hasOnCloned     bool
 	hasOnTouchStart bool
-	hasOnTouched    bool
+	hasOnTouching   bool
 	hasOnTouchEnd   bool
 
 	gamer               reflect.Value
@@ -309,7 +309,7 @@ func (p *Sprite) InitFrom(src *Sprite) {
 	p.hasOnMoving = false
 	p.hasOnCloned = false
 	p.hasOnTouchStart = false
-	p.hasOnTouched = false
+	p.hasOnTouching = false
 	p.hasOnTouchEnd = false
 
 	p.collider.others = make(map[*Sprite]bool)
@@ -426,9 +426,9 @@ func (p *Sprite) fireTouchStart(obj *Sprite) {
 	}
 }
 
-func (p *Sprite) fireTouched(obj *Sprite) {
-	if p.hasOnTouched {
-		p.doWhenTouched(p, obj)
+func (p *Sprite) fireTouching(obj *Sprite) {
+	if p.hasOnTouching {
+		p.doWhenTouching(p, obj)
 	}
 }
 

--- a/sprite.go
+++ b/sprite.go
@@ -85,7 +85,7 @@ func (c *Collider) SetTouching(other *Sprite, on bool) {
 		}
 	} else {
 		if exist {
-			delete(c.others, other) // shared container in multiple goroutines, any problem?
+			delete(c.others, other)
 			c.sprite.fireTouchEnd(other)
 		}
 	}

--- a/sprite.go
+++ b/sprite.go
@@ -79,7 +79,7 @@ func (c *Collider) SetTouching(other *Sprite, on bool) {
 	if on {
 		if !exist {
 			c.others[other] = true
-			c.sprite.fireTouchBegin(other)
+			c.sprite.fireTouchStart(other)
 		} else {
 			c.sprite.fireTouched(other)
 		}
@@ -136,7 +136,7 @@ type Sprite struct {
 	hasOnTurning    bool
 	hasOnMoving     bool
 	hasOnCloned     bool
-	hasOnTouchBegin bool
+	hasOnTouchStart bool
 	hasOnTouched    bool
 	hasOnTouchEnd   bool
 
@@ -304,7 +304,7 @@ func (p *Sprite) InitFrom(src *Sprite) {
 	p.hasOnTurning = false
 	p.hasOnMoving = false
 	p.hasOnCloned = false
-	p.hasOnTouchBegin = false
+	p.hasOnTouchStart = false
 	p.hasOnTouched = false
 	p.hasOnTouchEnd = false
 
@@ -416,9 +416,9 @@ func (p *Sprite) OnCloned__1(onCloned func()) {
 	})
 }
 
-func (p *Sprite) fireTouchBegin(obj *Sprite) {
-	if p.hasOnTouchBegin {
-		p.doWhenTouchBegin(p, obj)
+func (p *Sprite) fireTouchStart(obj *Sprite) {
+	if p.hasOnTouchStart {
+		p.doWhenTouchStart(p, obj)
 	}
 }
 
@@ -434,12 +434,12 @@ func (p *Sprite) fireTouchEnd(obj *Sprite) {
 	}
 }
 
-func (p *Sprite) OnTouchBegin(onTouchBegin func(obj *Sprite)) {
-	p.hasOnTouchBegin = true
-	p.allWhenTouchBegin = &eventSink{
-		prev:  p.allWhenTouchBegin,
+func (p *Sprite) OnTouchStart(onTouchStart func(obj *Sprite)) {
+	p.hasOnTouchStart = true
+	p.allWhenTouchStart = &eventSink{
+		prev:  p.allWhenTouchStart,
 		pthis: p,
-		sink:  onTouchBegin,
+		sink:  onTouchStart,
 		cond: func(data interface{}) bool {
 			return data == p
 		},

--- a/sprite.go
+++ b/sprite.go
@@ -17,12 +17,10 @@
 package spx
 
 import (
-	"fmt"
 	"image/color"
 	"log"
 	"math"
 	"reflect"
-	"runtime"
 	"sync"
 
 	"github.com/goplus/spx/internal/anim"

--- a/sprite.go
+++ b/sprite.go
@@ -478,24 +478,6 @@ func (p *Sprite) OnTouched__3(name string, onTouched func()) {
 	})
 }
 
-func (p *Sprite) OnTouched__4(names []string, onTouched func(obj *Sprite)) {
-	p.OnTouched__0(func(obj *Sprite) {
-		name := obj.name
-		for _, v := range names {
-			if v == name {
-				onTouched(obj)
-				return
-			}
-		}
-	})
-}
-
-func (p *Sprite) OnTouched__5(names []string, onTouched func()) {
-	p.OnTouched__4(names, func(*Sprite) {
-		onTouched()
-	})
-}
-
 func (p *Sprite) OnTouchEnd(onTouchEnd func(obj *Sprite)) {
 	p.hasOnTouchEnd = true
 	p.allWhenTouchEnd = &eventSink{

--- a/sprite.go
+++ b/sprite.go
@@ -434,7 +434,7 @@ func (p *Sprite) fireTouchEnd(obj *Sprite) {
 	}
 }
 
-func (p *Sprite) OnTouchStart(onTouchStart func(obj *Sprite)) {
+func (p *Sprite) OnTouchStart__0(onTouchStart func(obj *Sprite)) {
 	p.hasOnTouchStart = true
 	p.allWhenTouchStart = &eventSink{
 		prev:  p.allWhenTouchStart,
@@ -446,48 +446,24 @@ func (p *Sprite) OnTouchStart(onTouchStart func(obj *Sprite)) {
 	}
 }
 
-func (p *Sprite) OnTouched__0(onTouched func(obj *Sprite)) {
-	p.hasOnTouched = true
-	p.allWhenTouched = &eventSink{
-		prev:  p.allWhenTouched,
-		pthis: p,
-		sink:  onTouched,
-		cond: func(data interface{}) bool {
-			return data == p
-		},
-	}
-}
-
-func (p *Sprite) OnTouched__1(onTouched func()) {
-	p.OnTouched__0(func(*Sprite) {
-		onTouched()
+func (p *Sprite) OnTouchStart__1(onTouchStart func()) {
+	p.OnTouchStart__0(func(*Sprite) {
+		onTouchStart()
 	})
 }
 
-func (p *Sprite) OnTouched__2(name string, onTouched func(obj *Sprite)) {
-	p.OnTouched__0(func(obj *Sprite) {
+func (p *Sprite) OnTouchStart__2(name string, onTouchStart func(*Sprite)) {
+	p.OnTouchStart__0(func(obj *Sprite) {
 		if obj.name == name {
-			onTouched(obj)
+			onTouchStart(obj)
 		}
 	})
 }
 
-func (p *Sprite) OnTouched__3(name string, onTouched func()) {
-	p.OnTouched__2(name, func(*Sprite) {
-		onTouched()
+func (p *Sprite) OnTouchStart__3(name string, onTouchStart func()) {
+	p.OnTouchStart__2(name, func(*Sprite) {
+		onTouchStart()
 	})
-}
-
-func (p *Sprite) OnTouchEnd(onTouchEnd func(obj *Sprite)) {
-	p.hasOnTouchEnd = true
-	p.allWhenTouchEnd = &eventSink{
-		prev:  p.allWhenTouchEnd,
-		pthis: p,
-		sink:  onTouchEnd,
-		cond: func(data interface{}) bool {
-			return data == p
-		},
-	}
 }
 
 type MovingInfo struct {

--- a/sprite.go
+++ b/sprite.go
@@ -62,11 +62,15 @@ const (
 )
 
 type Collider struct {
-	sprite *Sprite
-	others map[*Sprite]bool
+	sprite  *Sprite
+	others  map[*Sprite]bool
+	othersM sync.Mutex
 }
 
 func (c *Collider) SetTouching(other *Sprite, on bool) {
+	c.othersM.Lock()
+	defer c.othersM.Unlock()
+
 	if other == nil || c.sprite == nil {
 		return
 	}

--- a/tutorial/05-Animation/Bullet.spx
+++ b/tutorial/05-Animation/Bullet.spx
@@ -1,4 +1,4 @@
-onTouched => {
+onTouchStart => {
 	destroy
 }
 

--- a/tutorial/05-Animation/SmallEnemy.spx
+++ b/tutorial/05-Animation/SmallEnemy.spx
@@ -1,3 +1,4 @@
+var life int
 onStart => {
 	for {
 		wait 0.3
@@ -6,6 +7,7 @@ onStart => {
 }
 
 onCloned => {
+	life = 3
 	setXYpos rand(-131, 131), 237
 	show
 	for {
@@ -17,15 +19,11 @@ onCloned => {
 	}
 }
 
-onCloned => {
-	life := 3
-	for {
-		wait 0.05
-		if touching("Bullet") {
-			life--
-			if life == 0 {
-				die
-			}
-		}
-	}
+onTouchStart "Bullet", => {
+	if life > 0 {
+        life --
+        if life <= 0 {
+            die
+        }
+    }
 }


### PR DESCRIPTION
Add lifecycle of touch behaviour, like touchBegin, touched, touchEnd;
Add DbgFlagPerf flag of game, monitoring performance like collision detection in each frame;
Changed the old usage of Touching(something),
(1) if the parameter is a name of a sprite, no life cycle of touching is triggered.
(2) for the other cases, such as edge or mouse parameters, the usage remains.

The folders issue298/  and res/ in test case .zip should be in the same folder.
[issue298.zip](https://github.com/user-attachments/files/17186333/issue298.zip)


