### PR TITLE
Set trigger's layer and mask to 1 by default issue#349

### DIFF
--- a/config.go
+++ b/config.go
@@ -254,10 +254,10 @@ type spriteConfig struct {
 	Pivot               math32.Vector2        `json:"pivot"`
 	DefaultAnimation    string                `json:"defaultAnimation"`
 	AnimBindings        map[string]string     `json:"animBindings"`
-	CollisionMask       int64                 `json:"collisionMask"`
-	CollisionLayer      int64                 `json:"collisionLayer"`
-	TriggerMask         int64                 `json:"triggerMask"`
-	TriggerLayer        int64                 `json:"triggerLayer"`
+	CollisionMask       *int64                `json:"collisionMask"`
+	CollisionLayer      *int64                `json:"collisionLayer"`
+	TriggerMask         *int64                `json:"triggerMask"`
+	TriggerLayer        *int64                `json:"triggerLayer"`
 	ColliderType        string                `json:"colliderType"`
 	ColliderCenter      math32.Vector2        `json:"colliderCenter"`
 	ColliderSize        math32.Vector2        `json:"colliderSize"`

--- a/physic.go
+++ b/physic.go
@@ -22,6 +22,15 @@ const (
 	physicColliderRect   = 0x02
 )
 
+func parseDefaultValue(pval *int64, defaultValue int64) int64 {
+	if pval == nil {
+		return defaultValue
+	}
+	return *pval
+}
+func parseLayerMaskValue(pval *int64) int64 {
+	return parseDefaultValue(pval, 1)
+}
 func paserColliderType(typeName string) int64 {
 	switch typeName {
 	case "circle":

--- a/sprite.go
+++ b/sprite.go
@@ -249,10 +249,10 @@ func (p *SpriteImpl) init(
 	}
 
 	// bind physic config
-	p.collisionMask = spriteCfg.CollisionMask
-	p.collisionLayer = spriteCfg.CollisionLayer
-	p.triggerMask = spriteCfg.TriggerMask
-	p.triggerLayer = spriteCfg.TriggerLayer
+	p.collisionMask = parseLayerMaskValue(spriteCfg.CollisionMask)
+	p.collisionLayer = parseLayerMaskValue(spriteCfg.CollisionLayer)
+	p.triggerMask = parseLayerMaskValue(spriteCfg.TriggerMask)
+	p.triggerLayer = parseLayerMaskValue(spriteCfg.TriggerLayer)
 
 	p.colliderType = paserColliderType(spriteCfg.ColliderType)
 	p.colliderCenter = spriteCfg.ColliderCenter

--- a/tutorial/05-Animation/assets/sprites/Bullet/index.json
+++ b/tutorial/05-Animation/assets/sprites/Bullet/index.json
@@ -9,8 +9,6 @@
       "y": 20
     }
   ],
-  "triggerMask":1,
-  "triggerLayer":1,
   "costumeIndex": 0,
   "heading": 0,
   "isDraggable": false,

--- a/tutorial/05-Animation/assets/sprites/SmallEnemy/index.json
+++ b/tutorial/05-Animation/assets/sprites/SmallEnemy/index.json
@@ -47,8 +47,6 @@
       "frameTo": "die-3"
     }
   },
-  "triggerMask":1,
-  "triggerLayer":1,
   "heading": 90,
   "isDraggable": false,
   "rotationStyle": "normal",


### PR DESCRIPTION
https://github.com/goplus/spx/issues/349
Set trigger's layer and mask to 1 by default  to maintain the same behavior as in spx1.0.

test:

```
cd tutorial/05-Animation
spx run .
```