### PR TITLE
Fix sprite render offset  issue#387

### DIFF
--- a/gdspx.go
+++ b/gdspx.go
@@ -109,6 +109,7 @@ func (p *Game) updateProxy() {
 			// sync position
 			if sprite.isVisible {
 				x, y := sprite.getXY()
+				applyRenderOffset(sprite, &x, &y)
 				proxy.UpdatePosRot(x, y, sprite.Heading()-sprite.initDirection)
 				if sprite.isCostumeAltas() {
 					proxy.UpdateTextureAltas(sprite.getCostumePath(), sprite.getCostumeAltasRegion().ToRect2(), sprite.getCostumeRenderScale())
@@ -181,4 +182,18 @@ func initSpritePhysicInfo(sprite *SpriteImpl, proxy *engine.ProxySprite) {
 		proxy.SetTriggerRect(engine.NewVec2(0, 0), engine.NewVec2(w, h))
 	}
 
+}
+func applyRenderOffset(p *SpriteImpl, cx, cy *float64) {
+	cs := p.costumes[p.costumeIndex_]
+	x, y := cs.center.X, cs.center.Y
+	x, y = p.applyPivot(cs, x, y)
+
+	// spx's start point is top left, gdspx's start point is center
+	// so we should remove the offset to make the pivot point is the same
+	w, h := p.getCostumeSize()
+	x = x + float64(w)/2*p.scale
+	y = y - float64(h)/2*p.scale
+
+	*cx = *cx + x
+	*cy = *cy + y
 }


### PR DESCRIPTION
fix issue: https://github.com/goplus/spx/issues/387
Align the SPX1 position calculation algorithm: the starting point for… the `spx` image is the top left corner, while the starting point for the `gdspx` image is the center.

test project: 
[10-WebTestProj.zip](https://github.com/user-attachments/files/17712216/10-WebTestProj.zip)


before :
![image](https://github.com/user-attachments/assets/a2ffecda-69d7-41e4-bbce-2a8926661eca)

after this pr:
![image](https://github.com/user-attachments/assets/743b3433-88cb-4844-9016-28b1aa246279)
