### PR TITLE
Apply sprite's  scale to collider

### DIFF
--- a/gdspx.go
+++ b/gdspx.go
@@ -169,6 +169,7 @@ func initSpritePhysicInfo(sprite *SpriteImpl, proxy *engine.ProxySprite) {
 		proxy.SetColliderRect(sprite.colliderCenter.ToVec2(), sprite.colliderSize.ToVec2())
 	case physicColliderNone:
 		w, h := sprite.getCostumeSize()
+		w, h = w*sprite.scale, h*sprite.scale
 		proxy.SetColliderRect(engine.NewVec2(0, 0), engine.NewVec2(w, h))
 	}
 
@@ -179,6 +180,7 @@ func initSpritePhysicInfo(sprite *SpriteImpl, proxy *engine.ProxySprite) {
 		proxy.SetTriggerRect(sprite.triggerCenter.ToVec2(), sprite.triggerSize.ToVec2())
 	case physicColliderNone:
 		w, h := sprite.getCostumeSize()
+		w, h = w*sprite.scale, h*sprite.scale
 		proxy.SetTriggerRect(engine.NewVec2(0, 0), engine.NewVec2(w, h))
 	}
 


### PR DESCRIPTION
fix: https://github.com/goplus/spx/issues/397
Apply sprite's  scale to collider

test project :[10-WebTestProj.zip](https://github.com/user-attachments/files/17712325/10-WebTestProj.zip)

before:

![image](https://github.com/user-attachments/assets/963abd3c-f280-4dc2-9780-345fa98134db)

current:
![image](https://github.com/user-attachments/assets/b7e9512a-e1b5-408e-907e-b924b9248c10)
