### PR TITLE
Add WASM cache to speed up game loading

### DIFF
--- a/cmd/spx/template/game.js
+++ b/cmd/spx/template/game.js
@@ -462,7 +462,6 @@ class GameApp {
         try {
             let url = this.assetURLs[assetName]
             if (!this.useAssetCache) {
-                this.logVerbose("Direct download engine asset:", assetName, url);
                 return await (await fetch(url)).arrayBuffer();
             }
 

--- a/cmd/spx/template/runner.html
+++ b/cmd/spx/template/runner.html
@@ -68,7 +68,7 @@
 		}
 
 
-		window.startProject = async (buffer, projectName = "Game", showEditor = false) => {
+		window.startProject = async (buffer, projectName = "Game", showEditor = false, assetURLs = null) => {
 			isShowEditor = showEditor
 			const config = {
 				'projectName': projectName,
@@ -77,7 +77,14 @@
 				"editorCanvas": document.getElementById('editor-canvas'),
 				"projectData": new Uint8Array(buffer),
 				"logVerbose": true,
+				"assetURLs": {
+					"gdspx.wasm": "/gdspx.wasm",
+					"godot.editor.wasm": "/godot.editor.wasm",
+				},
 			};
+			if(assetURLs != null){
+				config.assetURLs = assetURLs
+			}
 			gameApp = new GameApp(config);
 			await gameApp.StartProject();
 		}


### PR DESCRIPTION
Add WASM cache to speed up game loading, especially in poor network conditions. 
If the engine code hasn't changed, there's no need to redownload the WASM (across projects)