### PR TITLE
Fix the offset of the sprite's center coordinates in the costume set.

### DIFF
--- a/spbase.go
+++ b/spbase.go
@@ -82,6 +82,8 @@ func newCostumeWithSize(width, height int) *costume {
 	}
 	value.posX = 0
 	value.posY = 0
+	value.center.X = float64(value.width) / 2
+	value.center.Y = float64(value.height) / 2
 	return value
 }
 
@@ -102,6 +104,8 @@ func newCostumeWith(name string, img *costumeSetImage, faceRight float64, i, bit
 		value.posX = int(img.rc.X) + i*value.width
 		value.posY = int(img.rc.Y)
 	}
+	value.center.X = float64(value.width) / 2
+	value.center.Y = float64(value.height) / 2
 	return value
 }
 

--- a/sprite.go
+++ b/sprite.go
@@ -1037,7 +1037,6 @@ func (p *SpriteImpl) doMoveTo(x, y float64) {
 }
 
 func (p *SpriteImpl) doMoveToForAnim(x, y float64, ani *anim.Anim) {
-	x, y = p.fixWorldRange(x, y)
 	if p.hasOnMoving {
 		mi := &MovingInfo{OldX: p.x, OldY: p.y, NewX: x, NewY: y, Obj: p, ani: ani}
 		p.doWhenMoving(p, mi)


### PR DESCRIPTION
test project: test\Measure
https://github.com/goplus/spx/issues/433
Fix the offset of the sprite's center coordinates in the costume set.

before:
![image](https://github.com/user-attachments/assets/0b1b30bf-23d4-4860-82f9-f1df25dcf5a0)

after:
![image](https://github.com/user-attachments/assets/43761236-7a5b-47b4-8524-e68dfb624b42)
