### PR TITLE
Fix sprite rotation, keep same with spx1

### DIFF
--- a/gdspx.go
+++ b/gdspx.go
@@ -100,7 +100,8 @@ func (p *Game) updateProxy() {
 			if sprite.isVisible {
 				x, y := sprite.getXY()
 				applyRenderOffset(sprite, &x, &y)
-				proxy.UpdatePosRot(x, y, sprite.Heading()-sprite.initDirection)
+				rot := calcRenderRotation(sprite)
+				proxy.UpdatePosRot(x, y, rot)
 				if sprite.isCostumeAltas() {
 					proxy.UpdateTextureAltas(sprite.getCostumePath(), sprite.getCostumeAltasRegion().ToRect2(), sprite.getCostumeRenderScale())
 				} else {
@@ -188,6 +189,22 @@ func initSpritePhysicInfo(sprite *SpriteImpl, proxy *engine.ProxySprite) {
 	}
 
 }
+
+func calcRenderRotation(p *SpriteImpl) float64 {
+	cs := p.costumes[p.costumeIndex_]
+	degree := p.Heading() + cs.faceRight
+	degree -= 90
+	if p.rotationStyle == LeftRight {
+		if math.Abs(p.direction) > 155 && math.Abs(p.direction) < 205 {
+			degree = 180
+		}
+		if math.Abs(p.direction) > 0 && math.Abs(p.direction) < 25 {
+			degree = 180
+		}
+	}
+	return degree
+}
+
 func applyRenderOffset(p *SpriteImpl, cx, cy *float64) {
 	cs := p.costumes[p.costumeIndex_]
 	x, y := -(cs.center.X+p.pivot.X)/float64(cs.bitmapResolution)*p.scale,

--- a/sprite.go
+++ b/sprite.go
@@ -161,7 +161,6 @@ type SpriteImpl struct {
 	x, y          float64
 	scale         float64
 	direction     float64
-	initDirection float64
 	rotationStyle RotationStyle
 	rRect         *math32.RotatedRect
 	pivot         math32.Vector2
@@ -237,7 +236,6 @@ func (p *SpriteImpl) init(
 	p.x, p.y = spriteCfg.X, spriteCfg.Y
 	p.scale = spriteCfg.Size
 	p.direction = spriteCfg.Heading
-	p.initDirection = spriteCfg.Heading
 	p.rotationStyle = toRotationStyle(spriteCfg.RotationStyle)
 	p.isVisible = spriteCfg.Visible
 	p.pivot = spriteCfg.Pivot
@@ -388,7 +386,6 @@ func (p *SpriteImpl) InitFrom(src *SpriteImpl) {
 	p.hasOnTouching = false
 	p.hasOnTouchEnd = false
 
-	p.initDirection = src.initDirection
 	p.collisionMask = src.collisionMask
 	p.collisionLayer = src.collisionLayer
 	p.triggerMask = src.triggerMask


### PR DESCRIPTION
test project: ./test/Measure
fix: 
- https://github.com/goplus/spx/issues/430
- https://github.com/goplus/spx/issues/428
- https://github.com/goplus/spx/issues/432

![fix_rotation](https://github.com/user-attachments/assets/9789cdbc-30dc-4a74-90f4-21a7e272bca9)
