### PR TITLE
Make sure the window is initialized before game objects, as some objects rely on the window's size (eg: Measure)

### DIFF
--- a/game.go
+++ b/game.go
@@ -431,6 +431,19 @@ func (p *Game) loadIndex(g reflect.Value, proj *projConfig) (err error) {
 
 	p.doWindowSize() // set window size
 
+	if debugLoad {
+		log.Println("==> SetWindowSize", p.windowWidth_, p.windowHeight_)
+	}
+	if p.windowWidth_ > p.worldWidth_ {
+		p.windowWidth_ = p.worldWidth_
+	}
+	if p.windowHeight_ > p.worldHeight_ {
+		p.windowHeight_ = p.worldHeight_
+	}
+	engine.SyncPlatformSetWindowSize(int64(p.windowWidth_), int64(p.windowHeight_))
+
+	p.Camera.init(p, float64(p.windowWidth_), float64(p.windowHeight_), float64(p.worldWidth_), float64(p.worldHeight_))
+
 	inits := make([]Sprite, 0, len(proj.Zorder))
 	for _, v := range proj.Zorder {
 		if name, ok := v.(string); ok {
@@ -452,19 +465,6 @@ func (p *Game) loadIndex(g reflect.Value, proj *projConfig) (err error) {
 		ini.Main()
 	}
 
-	if debugLoad {
-		log.Println("==> SetWindowSize", p.windowWidth_, p.windowHeight_)
-	}
-	if p.windowWidth_ > p.worldWidth_ {
-		p.windowWidth_ = p.worldWidth_
-	}
-	if p.windowHeight_ > p.worldHeight_ {
-		p.windowHeight_ = p.worldHeight_
-	}
-
-	engine.SyncPlatformSetWindowSize(int64(p.windowWidth_), int64(p.windowHeight_))
-
-	p.Camera.init(p, float64(p.windowWidth_), float64(p.windowHeight_), float64(p.worldWidth_), float64(p.worldHeight_))
 	if proj.Camera != nil && proj.Camera.On != "" {
 		p.Camera.On(proj.Camera.On)
 	}


### PR DESCRIPTION
fix: 
- https://github.com/goplus/spx/issues/433


Make sure the window is initialized before game objects, as some objects rely on the window's size (eg: Measure)