### PR TITLE
Fix the mouse position error when camera move

### DIFF
--- a/gdspx.go
+++ b/gdspx.go
@@ -74,8 +74,9 @@ func (p *Game) updateCamera() {
 
 func (p *Game) updateInput() {
 	pos := gdspx.InputMgr.GetMousePos()
-	atomic.StoreInt64(&p.gMouseX, int64(pos.X))
-	atomic.StoreInt64(&p.gMouseY, int64(pos.Y))
+	posX, posY := engine.ScreenToWorld(float64(pos.X), float64(pos.Y))
+	atomic.StoreInt64(&p.gMouseX, int64(posX))
+	atomic.StoreInt64(&p.gMouseY, int64(posY))
 }
 
 func (p *Game) updateProxy() {

--- a/internal/engine/sync.go
+++ b/internal/engine/sync.go
@@ -101,6 +101,45 @@ func SyncSetDebugMode(isDebug bool) {
 }
 
 // =============== setting ===================
+func ScreenToWorld(x, y float64) (float64, float64) {
+	camPos := CameraMgr.GetCameraPosition()
+	posX, posY := float64(camPos.X), -float64(camPos.Y)
+	x += posX
+	y += posY
+	return x, y
+}
+
+func WorldToScreen(x, y float64) (float64, float64) {
+	camPos := CameraMgr.GetCameraPosition()
+	posX, posY := float64(camPos.X), -float64(camPos.Y)
+	x -= posX
+	y -= posY
+	return x, y
+}
+
+func SyncScreenToWorld(x, y float64) (float64, float64) {
+	var _x, _y float64
+	done := make(chan struct{})
+	job := func() {
+		_x, _y = ScreenToWorld(x, y)
+		done <- struct{}{}
+	}
+	updateJobQueue <- job
+	<-done
+	return _x, _y
+}
+func SyncWorldToScreen(x, y float64) (float64, float64) {
+	var _x, _y float64
+	done := make(chan struct{})
+	job := func() {
+		_x, _y = WorldToScreen(x, y)
+		done <- struct{}{}
+	}
+	updateJobQueue <- job
+	<-done
+	return _x, _y
+}
+
 func SyncGetCameraLocalPosition(x, y float64) (float64, float64) {
 	posX, posY := SyncGetCameraPosition()
 	x -= posX


### PR DESCRIPTION
fix: 
- https://github.com/goplus/spx/issues/429


- Add coord system convert function: World <=>Screen
- Apply camera's offset to gMouseX,gMouseY



![fix_camera_input2](https://github.com/user-attachments/assets/09a8e34a-b23a-420a-afc2-daeadcdd8c97)


