### PR TITLE
Add music api

### DIFF
--- a/audio.go
+++ b/audio.go
@@ -34,6 +34,7 @@ type PlayOptions struct {
 	Action PlayAction
 	Wait   bool
 	Loop   bool
+	Music  bool
 }
 
 type soundMgr struct {
@@ -47,7 +48,11 @@ func (p *soundMgr) init(g *Game) {
 }
 
 func (p *soundMgr) play(media Sound, opts *PlayOptions) (err error) {
-	err = p.playSfx(media, opts.Wait, false)
+	if opts.Music {
+		err = p.playBgm(media, opts.Action)
+	} else {
+		err = p.playSfx(media)
+	}
 	return
 }
 
@@ -55,8 +60,29 @@ func (p *soundMgr) stopAll() {
 	engine.SyncAudioStopAll()
 }
 
-func (p *soundMgr) playSfx(media Sound, wait, loop bool) (err error) {
+func (p *soundMgr) playBgm(media Sound, action PlayAction) (err error) {
+	switch action {
+	case PlayRewind:
+		p.playMusic(media)
+	case PlayContinue:
+		p.resumeMusic(media)
+	case PlayPause:
+		p.pauseMusic(media)
+	case PlayResume:
+		p.resumeMusic(media)
+	case PlayStop:
+		p.stopMusic(media)
+	}
+	return
+}
+
+func (p *soundMgr) playSfx(media Sound) (err error) {
 	engine.SyncAudioPlaySfx(engine.ToAssetPath(media.Path))
+	return
+}
+
+func (p *soundMgr) playMusic(media Sound) (err error) {
+	engine.SyncAudioPlayMusic(engine.ToAssetPath(media.Path))
 	return
 }
 

--- a/config.go
+++ b/config.go
@@ -114,6 +114,7 @@ type projConfig struct {
 	Camera        *cameraConfig     `json:"camera"`
 	Run           *Config           `json:"run"`
 	Debug         bool              `json:"debug"`
+	Bgm           string            `json:"bgm"`
 
 	// deprecated properties
 	Scenes              []*backdropConfig `json:"scenes"`              //this property is deprecated, use Backdrops instead

--- a/game.go
+++ b/game.go
@@ -471,6 +471,10 @@ func (p *Game) loadIndex(g reflect.Value, proj *projConfig) (err error) {
 	if loader, ok := g.Addr().Interface().(interface{ OnLoaded() }); ok {
 		loader.OnLoaded()
 	}
+
+	if proj.Bgm != "" {
+		p.Play__5(proj.Bgm, &PlayOptions{Music: true})
+	}
 	// game load success
 	p.isLoaded = true
 	return


### PR DESCRIPTION
## 1. implement:
- https://github.com/goplus/spx/issues/343

## 2. test project: (please build your engine from source before run it)
[16-BGM.zip](https://github.com/user-attachments/files/17829120/16-BGM.zip)

## 3. scene config:
```
{
  "bgm":"bgm",
  "zorder": [
    "Bullet"
  ]
}
```
## 4. demo script: 
```go
onStart => {
	println "onStart"
	wait 1
	play "bgm", {Music:true, Action: PlayPause}
	println "PlayPause"
	wait 1
	play "bgm", {Music:true, Action: PlayResume}
	println "PlayResume"
	wait 1
	play "bgm", {Music:true, Action: PlayStop}
	println "PlayStop"
	wait 3
	play "bgm", {Music:true, Action: PlayRewind}
	println "PlayRewind"
}
```


## 5. demo video: please download this video and play it (github can not play audio)
https://github.com/user-attachments/assets/db45ef39-3a4b-4735-9d5f-c0fc48e6611c
