### PR TITLE
Simplify web editor api

### DIFF
--- a/cmd/spx/template/project/.builds/web/game.js
+++ b/cmd/spx/template/project/.builds/web/game.js
@@ -139,13 +139,11 @@ class GameApp {
         await this.stopGame(() => {
             this.isEditor = true
             this.onProgress(1.0);
-            this.exitFunc = () => {
-                this.logVerbose("on editor quit")
-                this.editor = null
-                this.exitFunc = null
-                resolve();
-            }
             this.editor.requestQuit()
+            this.logVerbose("on editor quit")
+            this.editor = null
+            this.exitFunc = null
+            resolve();
         }, null)
     }
 
@@ -204,7 +202,7 @@ class GameApp {
         curGame.init().then(async () => {
             this.onProgress(0.7);
             await this.unpackGameData(curGame)
-            
+
             curGame.start({ 'args': args, 'canvas': this.gameCanvas }).then(async () => {
                 this.gameCanvas.focus();
                 await this.waitFsSyncDone(this.gameCanvas)
@@ -324,7 +322,7 @@ class GameApp {
             request.onerror = function (event) {
                 reject('Error opening database: ' + dbName + " " + storeName + " " + event.target.error);
             };
-            
+
             request.onblocked = function (event) {
                 reject('Database is blocked. Please close other tabs or windows using this database. ', dbName + " " + storeName + " " + event.target.error);
             }

--- a/cmd/spx/template/project/.builds/web/index.html
+++ b/cmd/spx/template/project/.builds/web/index.html
@@ -21,15 +21,10 @@
 	</style>
 </head>
 
-<body>	
-	<label for="editorToggle">ShowEditor</label>
-	<input type="checkbox" id="editorToggle" checked>
-	<button id="startProjectNewBtn">StartNew</button>
-	<button id="startProjectBtn">Start</button>
-	<button id="updateProjectBtn">Update</button>
-	<button id="stopProjectBtn">Stop</button>
-	<button id="runGameBtn">RunGame</button>
-	<button id="stopGameBtn">StopGame</button>
+<body>
+	<button id="startGameBtn">Start</button>
+	<button id="stopGameBtn">Stop</button>
+	<button id="startNewGameBtn">StartNew</button>
 	<progress id="progress-bar" value="0" max="1" style="display: none;"></progress>
 	<div id="tabs">
 		<div id="tab-loader">
@@ -41,17 +36,9 @@
 
 	<script src="jszip-3.10.1.min.js"></script>
 	<script>
-		let runnerWindow = {}		
-		let showEditor = true
-		document.getElementById('editorToggle').addEventListener('change', function () {
-			showEditor = this.checked
-		});
-		document.getElementById('startProjectNewBtn').addEventListener('click', startProjectNew);
-		document.getElementById('startProjectBtn').addEventListener('click', startProject);
-		document.getElementById('updateProjectBtn').addEventListener('click', updateProject);
-		document.getElementById('stopProjectBtn').addEventListener('click', stopProject);
-		
-		document.getElementById('runGameBtn').addEventListener('click', runGame);
+		let runnerWindow = {}
+		document.getElementById('startNewGameBtn').addEventListener('click', startNewGame);
+		document.getElementById('startGameBtn').addEventListener('click', startGame);
 		document.getElementById('stopGameBtn').addEventListener('click', stopGame);
 
 		function onProgress(value) {
@@ -60,122 +47,30 @@
 				document.getElementById('tab-game').style.display = 'block';
 				document.getElementById('tab-loader').style.display = 'none';
 			}
-			document.getElementById('progress-bar').style.display = value >= 1 ? 'none': 'block';
+			document.getElementById('progress-bar').style.display = value >= 1 ? 'none' : 'block';
 		}
 
-		async function startProjectNew() {
-			runnerWindow = document.getElementById('runnerFrame').contentWindow;
-			runnerWindow.addEventListener('onProgress', (event) => {
-				onProgress(event.detail.progress)
-			})
-
-			let buffer = await (await (fetch('/diff.zip'))).arrayBuffer();
-			runnerWindow.startProject(buffer, "Game", showEditor);
-		}
-		async function startProject() {
-			runnerWindow = document.getElementById('runnerFrame').contentWindow;
-			runnerWindow.addEventListener('onProgress', (event) => {
-				onProgress(event.detail.progress)
-			})
-
-			let buffer = await (await (fetch('/game.zip'))).arrayBuffer();
-			runnerWindow.startProject(buffer, "Game", showEditor);
+		async function startNewGame() {
+			await startProject('/diff.zip')
 		}
 
-		async function updateProject() {
-			oldData = await (await fetch('/game.zip')).arrayBuffer();
-			newData = await (await fetch('/diff.zip')).arrayBuffer();
-			const diffInfos = await getZipDiffInfos(oldData, newData);
-			runnerWindow.updateProject(newData, diffInfos.addInfos, diffInfos.deleteInfos, diffInfos.updateInfos);
-		}
-
-		async function stopProject() {
-			runnerWindow.stopProject()		
-		}
-
-		async function runGame() {
-			runnerWindow.runGame()
+		async function startGame() {
+			await startProject('/game.zip')
 		}
 
 		async function stopGame() {
 			runnerWindow.stopGame()
 		}
 
-		async function getZipDiffInfos(srcZip, dstZip) {
-			function areBuffersEqual(buffer1, buffer2) {
-				if (buffer1.byteLength !== buffer2.byteLength) return false;
-				const view1 = new Uint8Array(buffer1);
-				const view2 = new Uint8Array(buffer2);
-				for (let i = 0; i < view1.length; i++) {
-					if (view1[i] !== view2[i]) return false;
-				}
-				return true;
-			}
-			function mergeDeleteInfos(deleteInfos) {
-				deleteInfos.sort();
-				const merged = [];
+		async function startProject(zipUrl) {
+			runnerWindow = document.getElementById('runnerFrame').contentWindow;
+			runnerWindow.addEventListener('onProgress', (event) => {
+				onProgress(event.detail.progress)
+			})
 
-				for (let i = 0; i < deleteInfos.length; i++) {
-					const currentPath = deleteInfos[i];
-					if (
-						merged.length === 0 ||
-						!currentPath.startsWith(merged[merged.length - 1])
-					) {
-						merged.push(currentPath);
-					}
-				}
-
-				return merged;
-			}
-			let addInfos = [];
-			let deleteInfos = [];
-			let updateInfos = [];
-
-			const zip1 = new JSZip();
-			const zip2 = new JSZip();
-
-			const srcZipContent = await zip1.loadAsync(srcZip);
-			const dstZipContent = await zip2.loadAsync(dstZip);
-
-			const srcFiles = new Set(Object.keys(srcZipContent.files));
-			const dstFiles = new Set(Object.keys(dstZipContent.files));
-
-			for (const filePath of dstFiles) {
-				if (!srcFiles.has(filePath)) {
-					addInfos.push(filePath);
-				}
-			}
-
-			for (const filePath of srcFiles) {
-				if (!dstFiles.has(filePath)) {
-					deleteInfos.push(filePath);
-				}
-			}
-
-			for (const filePath of dstFiles) {
-				if (srcFiles.has(filePath)) {
-					const srcFile = srcZipContent.files[filePath];
-					const dstFile = dstZipContent.files[filePath];
-
-					if (!srcFile.dir && !dstFile.dir) {
-						const srcContent = await srcFile.async('arraybuffer');
-						const dstContent = await dstFile.async('arraybuffer');
-
-						if (!areBuffersEqual(srcContent, dstContent)) {
-							updateInfos.push(filePath);
-						}
-					}
-				}
-			}
-			addInfos.sort();
-			deleteInfos.sort();
-			updateInfos.sort();
-
-			deleteInfos = mergeDeleteInfos(deleteInfos);
-
-			return { addInfos, deleteInfos, updateInfos }
+			let buffer = await (await (fetch(zipUrl))).arrayBuffer();
+			runnerWindow.startGame(buffer);
 		}
-
 	</script>
 </body>
 

--- a/cmd/spx/template/project/.builds/web/runner.html
+++ b/cmd/spx/template/project/.builds/web/runner.html
@@ -7,17 +7,18 @@
 		content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1, user-scalable=no">
 	<title>Go+ Builder</title>
 	<style>
-    	body, html {
-            margin: 0;
-            padding: 0;
-            width: 100%;
-            height: 100%;
-            display: flex;
-            justify-content: center;
-            align-items: center;
-            background-color: #333;
-            overflow: hidden;
-        }
+		body,
+		html {
+			margin: 0;
+			padding: 0;
+			width: 100%;
+			height: 100%;
+			display: flex;
+			justify-content: center;
+			align-items: center;
+			background-color: #333;
+			overflow: hidden;
+		}
 
 		canvas {
 			display: block;
@@ -74,10 +75,11 @@
 		}
 
 
-		window.startProject = async (buffer, projectName = "Game", showEditor = false, assetURLs = null) => {
-			isShowEditor = showEditor
+
+		window.startGame = async (buffer, assetURLs = null) => {
+			isShowEditor = false
 			const config = {
-				'projectName': projectName,
+				'projectName': "spx_game",
 				'onProgress': onProgress,
 				"gameCanvas": document.getElementById('game-canvas'),
 				"editorCanvas": document.getElementById('editor-canvas'),
@@ -90,46 +92,25 @@
 					"godot.editor.wasm": "/godot.editor.wasm",
 				},
 			};
-			if(assetURLs != null){
+			if (assetURLs != null) {
 				config.assetURLs = assetURLs
 			}
-			if(gameApp != null){
+			if (gameApp != null) {
 				await gameApp.StopProject();
 			}
 			gameApp = new GameApp(config);
 			await gameApp.StartProject();
+			await gameApp.RunGame();
 		}
 
-		window.updateProject = async (buffer, addInfos, deleteInfos, updateInfos) => {
-			if (gameApp == null) {
-				console.error("gameApp is null, should call startProject first")
-				return
-			}
-			await gameApp.UpdateProject(new Uint8Array(buffer), addInfos, deleteInfos, updateInfos)
-		}
 
-		window.stopProject = async () => {
+		window.stopGame = async () => {
 			if (gameApp == null) {
-				console.error("gameApp is null, should call startProject first")
+				console.error("gameApp is null, should call startGame first")
 				return
 			}
 			await gameApp.StopProject()
-			gameApp = null;
-		}
-
-		window.runGame = async () => {
-			if (gameApp == null) {
-				console.error("gameApp is null, should call startProject first")
-				return
-			}
-			await gameApp.RunGame()
-		}
-		window.stopGame = async () => {
-			if (gameApp == null) {
-				console.error("gameApp is null, should call startProject first")
-				return
-			}
-			await gameApp.StopGame()
+			gameApp = null
 		}
 
 		// Inform the parent window that the runner is ready (methods on the window object are callable)


### PR DESCRIPTION
Simplify web editor api: only keep `start & stop`
Fix: https://github.com/goplus/spx/issues/452

```js
window.startGame = async (buffer, assetURLs = null) => {}
window.stopGame = async () => {}
```

![image](https://github.com/user-attachments/assets/a40bb36d-e935-4f90-8d56-7de8c8ce5328)
