### PR TITLE
Add feature:`wait for next frame`

### DIFF
--- a/event.go
+++ b/event.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 
 	"github.com/goplus/spx/internal/coroutine"
+	"github.com/goplus/spx/internal/engine"
 )
 
 // -------------------------------------------------------------------------------------
@@ -75,7 +76,7 @@ func (p *eventSink) syncCall(data interface{}, doSth func(*eventSink)) {
 		}
 		p = p.prev
 	}
-	waitToDo(wg.Wait)
+	engine.WaitToDo(wg.Wait)
 }
 
 func (p *eventSink) call(wait bool, data interface{}, doSth func(*eventSink)) {

--- a/game.go
+++ b/game.go
@@ -26,12 +26,12 @@ import (
 	"reflect"
 	"sync"
 	"sync/atomic"
-	"time"
 	"unsafe"
 
 	"github.com/goplus/spx/internal/audiorecord"
 	"github.com/goplus/spx/internal/coroutine"
 	"github.com/goplus/spx/internal/engine"
+	gtime "github.com/goplus/spx/internal/time"
 
 	spxfs "github.com/goplus/spx/fs"
 	_ "github.com/goplus/spx/fs/asset"
@@ -215,7 +215,6 @@ func Gopt_Game_Run(game Gamer, resource interface{}, gameConf ...*Config) {
 	if err != nil {
 		panic(err)
 	}
-
 	if !conf.DontParseFlags {
 		f := flag.CommandLine
 		verbose := f.Bool("v", false, "print verbose information")
@@ -721,33 +720,26 @@ func (p *Game) fireEvent(ev event) {
 func (p *Game) eventLoop(me coroutine.Thread) int {
 	for {
 		var ev event
-		go func() {
-			ev = <-p.events
-			gco.Resume(me)
-		}()
-		gco.Yield(me)
+		engine.WaitForChan(p.events, &ev)
 		p.handleEvent(ev)
 	}
 }
 func (p *Game) logicLoop(me coroutine.Thread) int {
-	deltaTime := 0.03
 	for {
-		p.Wait(deltaTime)
 		tempItems := p.getTempShapes()
 		for _, item := range tempItems {
 			if result, ok := item.(interface{ onUpdate(float64) }); ok {
-				result.onUpdate(deltaTime)
+				result.onUpdate(gtime.DeltaTime())
 			}
 		}
+		engine.WaitNextFrame()
 	}
 }
 
 func (p *Game) inputEventLoop(me coroutine.Thread) int {
-
 	lastLbtnPressed := false
 	keyEvents := make([]engine.KeyEvent, 0)
 	for {
-		p.Wait(0.01)
 		curLbtnPressed := engine.SyncInputGetMouseState(MOUSE_BUTTON_LEFT)
 		if curLbtnPressed != lastLbtnPressed {
 			if lastLbtnPressed {
@@ -767,6 +759,7 @@ func (p *Game) inputEventLoop(me coroutine.Thread) int {
 			}
 		}
 		keyEvents = keyEvents[:0]
+		engine.WaitNextFrame()
 	}
 }
 
@@ -787,43 +780,13 @@ var (
 
 type threadObj = coroutine.ThreadObj
 
-func waitToDo(fn func()) {
-	me := gco.Current()
-	go func() {
-		fn()
-		gco.Resume(me)
-	}()
-	gco.Yield(me)
-}
-
-func waitForChan(done chan bool) {
-	me := gco.Current()
-	go func() {
-		<-done
-		gco.Resume(me)
-	}()
-	gco.Yield(me)
-}
-
 func SchedNow() int {
-	if me := gco.Current(); me != nil {
-		gco.Sched(me)
-	}
 	return 0
 }
 
 func Sched() int {
-	now := time.Now()
-	if now.Sub(lastSched) >= 3e7 {
-		if me := gco.Current(); me != nil {
-			gco.Sched(me)
-		}
-		lastSched = now
-	}
 	return 0
 }
-
-var lastSched time.Time
 
 // -----------------------------------------------------------------------------
 
@@ -1151,8 +1114,12 @@ func (p *Game) Username() string {
 
 // -----------------------------------------------------------------------------
 
-func (p *Game) Wait(secs float64) {
-	gco.Sleep(time.Duration(secs * 1e9))
+func (p *Game) Wait__0() float64 {
+	return engine.WaitNextFrame()
+}
+
+func (p *Game) Wait__1(secs float64) float64 {
+	return engine.Wait(secs)
 }
 
 func (p *Game) Timer() float64 {

--- a/game.go
+++ b/game.go
@@ -1113,13 +1113,12 @@ func (p *Game) Username() string {
 }
 
 // -----------------------------------------------------------------------------
-
-func (p *Game) Wait__0() float64 {
+func (p *Game) WaitNextFrame() float64 {
 	return engine.WaitNextFrame()
 }
 
-func (p *Game) Wait__1(secs float64) float64 {
-	return engine.Wait(secs)
+func (p *Game) Wait(secs float64) {
+	engine.Wait(secs)
 }
 
 func (p *Game) Timer() float64 {

--- a/gdspx.go
+++ b/gdspx.go
@@ -46,6 +46,11 @@ func (p *Game) OnEngineUpdate(delta float32) {
 	p.updateInput()
 	p.updateCamera()
 	p.updateLogic()
+}
+func (p *Game) OnEngineRender(delta float32) {
+	if !p.isRunned {
+		return
+	}
 	p.updateProxy()
 	p.updatePhysic()
 }
@@ -59,6 +64,7 @@ func (p *Game) onStartAsync() {
 	if !p.isRunned {
 		Gopt_Game_Run(gamer, "assets")
 	}
+	engine.OnGameStarted()
 }
 
 func (p *Game) updateLogic() error {

--- a/internal/audiorecord/audiorecord_nojs.go
+++ b/internal/audiorecord/audiorecord_nojs.go
@@ -6,9 +6,9 @@ package audiorecord
 import (
 	"encoding/binary"
 	"math"
-	"time"
 
 	"github.com/goplus/spx/internal/coroutine"
+	"github.com/goplus/spx/internal/engine"
 )
 
 const (
@@ -18,7 +18,7 @@ const (
 	audioFrameSize = 6 * audioSampleRate / 100
 
 	// audioDefaultInterval is the default interval that audio packets are sent
-	audioInterval = 6 * 10 * time.Millisecond
+	audioInterval = 0.06 //6 * 10 * time.Millisecond
 
 	VOLUMEMAX = 32767.0
 	VOLUMEMIN = -32768.0
@@ -50,13 +50,13 @@ func Open(gco *coroutine.Coroutines) *Recorder {
 				int16Buffer[i] = int16(binary.LittleEndian.Uint16(buff[i*2 : (i+1)*2]))
 			}
 			p.deviceVolume = p.doubleCalculateVolume(int16Buffer)
-			gco.Sleep(audioInterval)
+			engine.Wait(audioInterval)
 		}
 	})
 	return p
 }
 
-//loudness scaled 0 to 100
+// loudness scaled 0 to 100
 func (p *Recorder) doubleCalculateVolume(buffer []int16) float64 {
 
 	var sum float64 = 0

--- a/internal/coroutine/coro.go
+++ b/internal/coroutine/coro.go
@@ -2,11 +2,14 @@ package coroutine
 
 import (
 	"errors"
+	"fmt"
 	"runtime"
 	"sync"
 	"sync/atomic"
-	"time"
+	stime "time"
 	"unsafe"
+
+	"github.com/goplus/spx/internal/time"
 )
 
 var (
@@ -23,6 +26,7 @@ type ThreadObj interface {
 type threadImpl struct {
 	Obj      ThreadObj
 	stopped_ bool
+	frame    int
 }
 
 func (p *threadImpl) Stopped() bool {
@@ -30,31 +34,58 @@ func (p *threadImpl) Stopped() bool {
 }
 
 // Thread represents a coroutine id.
-//
 type Thread = *threadImpl
 
 // Coroutines represents a coroutine manager.
-//
 type Coroutines struct {
+	hasInited bool
 	suspended map[Thread]bool
 	current   Thread
 	mutex     sync.Mutex
 	cond      sync.Cond
 	sema      sync.Mutex
+	frame     int
+	curQueue  *Queue[*WaitJob]
+	nextQueue *Queue[*WaitJob]
+	curId     int64
+
+	waitingFrame map[Thread]bool
+	debug        bool
+}
+
+const (
+	waitTypeFrame = iota
+	waitTypeTime
+	waitTypeMainThread
+)
+
+type WaitJob struct {
+	Id    int64
+	Type  int
+	Call  func()
+	Time  float64
+	Frame int64
 }
 
 // New creates a coroutine manager.
-//
 func New() *Coroutines {
 	p := &Coroutines{
-		suspended: make(map[Thread]bool),
+		suspended:    make(map[Thread]bool),
+		waitingFrame: make(map[Thread]bool),
+		debug:        false,
 	}
 	p.cond.L = &p.mutex
+	p.curQueue = NewQueue[*WaitJob]()
+	p.nextQueue = NewQueue[*WaitJob]()
+	p.hasInited = false
 	return p
 }
 
+func (p *Coroutines) OnInited() {
+	p.hasInited = true
+}
+
 // Create creates a new coroutine.
-//
 func (p *Coroutines) Create(tobj ThreadObj, fn func(me Thread) int) Thread {
 	return p.CreateAndStart(false, tobj, fn)
 }
@@ -68,15 +99,16 @@ func (p *Coroutines) Current() Thread {
 }
 
 // CreateAndStart creates and executes the new coroutine.
-//
 func (p *Coroutines) CreateAndStart(start bool, tobj ThreadObj, fn func(me Thread) int) Thread {
-	id := &threadImpl{Obj: tobj}
+	id := &threadImpl{Obj: tobj, frame: p.frame}
 	go func() {
 		p.sema.Lock()
 		p.setCurrent(id)
 		defer func() {
 			p.mutex.Lock()
 			delete(p.suspended, id)
+			delete(p.waitingFrame, id)
+
 			p.mutex.Unlock()
 			p.sema.Unlock()
 			if e := recover(); e != nil {
@@ -85,6 +117,9 @@ func (p *Coroutines) CreateAndStart(start bool, tobj ThreadObj, fn func(me Threa
 				}
 			}
 		}()
+		p.mutex.Lock()
+		p.waitingFrame[id] = false
+		p.mutex.Unlock()
 		fn(id)
 	}()
 	if start {
@@ -106,9 +141,19 @@ func (p *Coroutines) StopIf(filter func(th Thread) bool) {
 		}
 	}
 }
+func (p *Coroutines) getActiveCount() int {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+	count := 0
+	for _, val := range p.waitingFrame {
+		if !val {
+			count++
+		}
+	}
+	return count
+}
 
 // Yield suspends a running coroutine.
-//
 func (p *Coroutines) Yield(me Thread) {
 	if p.Current() != me {
 		panic(ErrCannotYieldANonrunningThread)
@@ -129,13 +174,12 @@ func (p *Coroutines) Yield(me Thread) {
 }
 
 // Resume resumes a suspended coroutine.
-//
-func (p *Coroutines) Resume(th Thread) {
+func (p *Coroutines) Resume(me Thread) {
 	for {
 		done := false
 		p.mutex.Lock()
-		if p.suspended[th] {
-			p.suspended[th] = false
+		if p.suspended[me] {
+			p.suspended[me] = false
 			p.cond.Broadcast()
 			done = true
 		}
@@ -147,22 +191,153 @@ func (p *Coroutines) Resume(th Thread) {
 	}
 }
 
-// Sched func.
-//
-func (p *Coroutines) Sched(me Thread) {
+func (p *Coroutines) markWaiting(me *threadImpl, isWaiting bool) {
+	p.mutex.Lock()
+	p.waitingFrame[me] = isWaiting
+	p.mutex.Unlock()
+}
+
+func (p *Coroutines) Wait(t float64) {
+	id := atomic.AddInt64(&p.curId, 1)
+	me := p.Current()
+	dstTime := time.TimeSinceLevelLoad() + t
 	go func() {
+		done := make(chan int)
+		job := &WaitJob{
+			Id:   id,
+			Type: waitTypeTime,
+			Call: func() {
+				p.markWaiting(me, false)
+				done <- 1
+			},
+			Time: dstTime,
+		}
+		p.curQueue.Enqueue(job)
+		<-done
 		p.Resume(me)
 	}()
+	p.markWaiting(me, true)
 	p.Yield(me)
 }
 
-func (p *Coroutines) Sleep(t time.Duration) {
+func (p *Coroutines) WaitNextFrame() {
+	id := atomic.AddInt64(&p.curId, 1)
+	me := p.Current()
+	frame := time.Frame()
+	go func() {
+		done := make(chan int)
+		job := &WaitJob{
+			Id:   id,
+			Type: waitTypeFrame,
+			Call: func() {
+				p.markWaiting(me, false)
+				done <- 1
+			},
+			Frame: frame,
+		}
+		p.curQueue.Enqueue(job)
+		<-done
+		p.Resume(me)
+		if time.Frame()-frame > 1 {
+			println("Warning: Logic error! WaitNextFrame wait too many frames, count=", time.Frame()-frame, "id", id)
+		}
+	}()
+	p.markWaiting(me, true)
+	p.Yield(me)
+}
+
+func (p *Coroutines) WaitMainThread(call func()) {
+	id := atomic.AddInt64(&p.curId, 1)
+	me := p.Current()
+	coro := func(isResume bool) {
+		done := make(chan int)
+		job := &WaitJob{
+			Id:   id,
+			Type: waitTypeMainThread,
+			Call: func() {
+				call()
+				done <- 1
+			},
+		}
+		p.curQueue.Enqueue(job)
+		<-done
+		if isResume {
+			// main thread call does NOT count as blocking
+			p.Resume(me)
+		}
+	}
+	if p.hasInited {
+		go coro(true)
+		// main thread call does NOT count as blocking
+		p.Yield(me)
+	} else {
+		coro(false)
+	}
+}
+
+func (p *Coroutines) WaitToDo(fn func()) {
 	me := p.Current()
 	go func() {
-		time.Sleep(t)
+		fn()
+		p.markWaiting(me, false)
 		p.Resume(me)
 	}()
+	p.markWaiting(me, true)
 	p.Yield(me)
+}
+
+func WaitForChan[T any](p *Coroutines, done chan T, data *T) {
+	me := p.Current()
+	go func() {
+		*data = <-done
+		p.markWaiting(me, false)
+		p.Resume(me)
+	}()
+	p.markWaiting(me, true)
+	p.Yield(me)
+}
+
+func (p *Coroutines) UpdateJobs() {
+	timestamp := time.RealTimeSinceStart()
+	curQueue := p.curQueue
+	nextQueue := p.nextQueue
+	curFrame := time.Frame()
+	curTime := time.TimeSinceLevelLoad()
+	debugStartTime := time.RealTimeSinceStart()
+	taskCount := 0
+	for curQueue.Count() > 0 || !p.hasInited || p.getActiveCount() > 0 {
+		if curQueue.Count() == 0 {
+			stime.Sleep(stime.Microsecond * 100) // sleep 0.1 ms
+			continue
+		}
+		task := curQueue.Dequeue()
+		switch task.Type {
+		case waitTypeFrame:
+			if task.Frame >= curFrame {
+				nextQueue.Enqueue(task)
+			} else {
+				task.Call()
+				taskCount++
+			}
+		case waitTypeTime:
+			if task.Time >= curTime {
+				nextQueue.Enqueue(task)
+			} else {
+				task.Call()
+			}
+		case waitTypeMainThread:
+			task.Call()
+		}
+		if time.RealTimeSinceStart()-debugStartTime > 1 {
+			println("Warning: engine update > 1 seconds, please check your code !")
+		}
+	}
+	nextCount := nextQueue.Count()
+	curQueue.Move(nextQueue)
+	delta := (time.RealTimeSinceStart() - timestamp) * 1000
+	if p.debug {
+		fmt.Printf("curFrame %d,useTime %fms,fps %d, taskCount %d,curTime %f , moveCount %d \n", curFrame, delta, int(time.FPS()), taskCount, curTime, nextCount)
+	}
 }
 
 // -------------------------------------------------------------------------------------

--- a/internal/coroutine/queue.go
+++ b/internal/coroutine/queue.go
@@ -1,0 +1,47 @@
+package coroutine
+
+import "sync"
+
+type Queue[T any] struct {
+	mu sync.Mutex
+	// TODO Use a linked list to avoid moving a whole
+	// block of memory when dequeuing
+	tasks []T
+}
+
+func NewQueue[T any]() *Queue[T] {
+	return &Queue[T]{
+		tasks: make([]T, 0),
+	}
+}
+
+// Move all tasks from the src queue to the current queue.
+// Afterward, the src queue will be empty.
+func (s *Queue[T]) Move(src *Queue[T]) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	src.mu.Lock()
+	defer src.mu.Unlock()
+	s.tasks = append(s.tasks, src.tasks...)
+	src.tasks = src.tasks[:0]
+}
+
+func (s *Queue[T]) Count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.tasks)
+}
+
+func (s *Queue[T]) Enqueue(value T) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.tasks = append(s.tasks, value)
+}
+
+func (s *Queue[T]) Dequeue() T {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	value := s.tasks[0]
+	s.tasks = s.tasks[1:]
+	return value
+}

--- a/internal/engine/coro.go
+++ b/internal/engine/coro.go
@@ -1,9 +1,8 @@
 package engine
 
 import (
-	"time"
-
 	"github.com/goplus/spx/internal/coroutine"
+	"github.com/goplus/spx/internal/time"
 )
 
 var (
@@ -14,44 +13,25 @@ func SetCoroutines(co *coroutine.Coroutines) {
 	gco = co
 }
 
-func Wait(secs float64) {
-	gco.Sleep(time.Duration(secs * 1e9))
+func Wait(secs float64) float64 {
+	startTime := time.TimeSinceLevelLoad()
+	gco.Wait(secs)
+	return time.TimeSinceLevelLoad() - startTime
 }
 
-// ========== Engine Coroutines ==========
-const (
-	maxExecTime = 16 * time.Millisecond
-)
+func WaitNextFrame() float64 {
+	gco.WaitNextFrame()
+	return time.DeltaTime()
+}
 
-var (
-	updateJobQueue = make(chan Job, 1)
-)
+func WaitMainThread(call func()) {
+	gco.WaitMainThread(call)
+}
 
-type Job func()
+func WaitToDo(fn func()) {
+	gco.WaitToDo(fn)
+}
 
-func handleEngineCoroutines() {
-	startTime := time.Now()
-	timer := time.NewTimer(maxExecTime)
-	defer timer.Stop()
-
-	for {
-		isTimeout := false
-		select {
-		case job, ok := <-updateJobQueue:
-			if !ok {
-				return
-			}
-			job()
-		case <-timer.C:
-			isTimeout = true
-			break
-		}
-
-		if isTimeout {
-			break
-		}
-		if time.Since(startTime) > maxExecTime {
-			break
-		}
-	}
+func WaitForChan[T any](done chan T, data *T) {
+	coroutine.WaitForChan(gco, done, data)
 }

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -33,11 +33,19 @@ var (
 	startTimestamp     stime.Time
 	lastTimestamp      stime.Time
 	timeSinceLevelLoad float64
+
+	// statistic info
+	fps float64
+)
+var (
+	debugLastTime  float64 = 0
+	debugLastFrame int64   = 0
 )
 
 type Gamer interface {
 	OnEngineStart()
 	OnEngineUpdate(delta float32)
+	OnEngineRender(delta float32)
 	OnEngineDestroy()
 }
 
@@ -52,6 +60,10 @@ func GdspxMain(g Gamer) {
 	})
 }
 
+func OnGameStarted() {
+	gco.OnInited()
+}
+
 // callbacks
 func onStart() {
 	triggerEventsTemp = make([]TriggerEvent, 0)
@@ -59,9 +71,9 @@ func onStart() {
 	keyEventsTemp = make([]KeyEvent, 0)
 	keyEvents = make([]KeyEvent, 0)
 
+	time.Start(onSetTimeScale)
 	startTimestamp = stime.Now()
 	lastTimestamp = stime.Now()
-	time.Start(onSetTimeScale)
 	game.OnEngineStart()
 }
 
@@ -70,9 +82,20 @@ func onUpdate(delta float32) {
 	cacheTriggerEvents()
 	cacheKeyEvents()
 	game.OnEngineUpdate(delta)
-	handleEngineCoroutines()
+	gco.UpdateJobs()
+	game.OnEngineRender(delta)
 }
 
+func calcfps() {
+	curTime := time.RealTimeSinceStart()
+	timeDiff := curTime - debugLastTime
+	frameDiff := time.Frame() - debugLastFrame
+	if timeDiff > 0.25 {
+		fps = float64(frameDiff) / timeDiff
+		debugLastFrame = time.Frame()
+		debugLastTime = curTime
+	}
+}
 func onSetTimeScale(scale float64) {
 	SyncPlatformSetTimeScale(float32(scale))
 }
@@ -82,11 +105,12 @@ func updateTime(delta float64) {
 	timeSinceLevelLoad += deltaTime
 
 	curTime := stime.Now()
-	realTimeSinceStartup := curTime.Sub(startTimestamp).Seconds()
+	unscaledTimeSinceLevelLoad := curTime.Sub(startTimestamp).Seconds()
 	unscaledDeltaTime := curTime.Sub(lastTimestamp).Seconds()
 	lastTimestamp = curTime
 	timeScale := PlatformMgr.GetTimeScale()
-	time.Update(float64(timeScale), realTimeSinceStartup, timeSinceLevelLoad, deltaTime, unscaledDeltaTime)
+	calcfps()
+	time.Update(float64(timeScale), unscaledTimeSinceLevelLoad, timeSinceLevelLoad, deltaTime, unscaledDeltaTime, fps)
 }
 
 func onDestroy() {
@@ -129,4 +153,11 @@ func GetKeyEvents(lst []KeyEvent) []KeyEvent {
 	keyEvents = keyEvents[:0]
 	keyMutex.Unlock()
 	return lst
+}
+
+func GetFPS() float64 {
+	return fps
+}
+func GetTPS() float64 {
+	return 30
 }

--- a/internal/engine/sync.gen.go
+++ b/internal/engine/sync.gen.go
@@ -13,1951 +13,1139 @@ import (
 
 // IAudioMgr
 func SyncAudioStopAll() {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		AudioMgr.StopAll()
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncAudioPlaySfx(path string) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		AudioMgr.PlaySfx(path)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncAudioPlayMusic(path string) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		AudioMgr.PlayMusic(path)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncAudioPauseMusic() {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		AudioMgr.PauseMusic()
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncAudioResumeMusic() {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		AudioMgr.ResumeMusic()
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncAudioGetMusicTimer() float32 {
-	var __ret float32
-	done := make(chan struct{})
-	job := func() {
-		__ret = AudioMgr.GetMusicTimer()
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 float32
+	WaitMainThread(func() {
+		_ret1 = AudioMgr.GetMusicTimer()
+	})
+	return _ret1
 }
 func SyncAudioSetMusicTimer(time float32) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		AudioMgr.SetMusicTimer(time)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncAudioIsMusicPlaying() bool {
-	var __ret bool
-	done := make(chan struct{})
-	job := func() {
-		__ret = AudioMgr.IsMusicPlaying()
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 bool
+	WaitMainThread(func() {
+		_ret1 = AudioMgr.IsMusicPlaying()
+	})
+	return _ret1
 }
 func SyncAudioSetSfxVolume(volume float32) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		AudioMgr.SetSfxVolume(volume)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncAudioGetSfxVolume() float32 {
-	var __ret float32
-	done := make(chan struct{})
-	job := func() {
-		__ret = AudioMgr.GetSfxVolume()
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 float32
+	WaitMainThread(func() {
+		_ret1 = AudioMgr.GetSfxVolume()
+	})
+	return _ret1
 }
 func SyncAudioSetMusicVolume(volume float32) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		AudioMgr.SetMusicVolume(volume)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncAudioGetMusicVolume() float32 {
-	var __ret float32
-	done := make(chan struct{})
-	job := func() {
-		__ret = AudioMgr.GetMusicVolume()
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 float32
+	WaitMainThread(func() {
+		_ret1 = AudioMgr.GetMusicVolume()
+	})
+	return _ret1
 }
 func SyncAudioSetMasterVolume(volume float32) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		AudioMgr.SetMasterVolume(volume)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncAudioGetMasterVolume() float32 {
-	var __ret float32
-	done := make(chan struct{})
-	job := func() {
-		__ret = AudioMgr.GetMasterVolume()
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 float32
+	WaitMainThread(func() {
+		_ret1 = AudioMgr.GetMasterVolume()
+	})
+	return _ret1
 }
 
 // ICameraMgr
 func SyncCameraGetCameraPosition() Vec2 {
-	var __ret Vec2
-	done := make(chan struct{})
-	job := func() {
-		__ret = CameraMgr.GetCameraPosition()
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 Vec2
+	WaitMainThread(func() {
+		_ret1 = CameraMgr.GetCameraPosition()
+	})
+	return _ret1
 }
 func SyncCameraSetCameraPosition(position Vec2) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		CameraMgr.SetCameraPosition(position)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncCameraGetCameraZoom() Vec2 {
-	var __ret Vec2
-	done := make(chan struct{})
-	job := func() {
-		__ret = CameraMgr.GetCameraZoom()
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 Vec2
+	WaitMainThread(func() {
+		_ret1 = CameraMgr.GetCameraZoom()
+	})
+	return _ret1
 }
 func SyncCameraSetCameraZoom(size Vec2) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		CameraMgr.SetCameraZoom(size)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncCameraGetViewportRect() Rect2 {
-	var __ret Rect2
-	done := make(chan struct{})
-	job := func() {
-		__ret = CameraMgr.GetViewportRect()
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 Rect2
+	WaitMainThread(func() {
+		_ret1 = CameraMgr.GetViewportRect()
+	})
+	return _ret1
 }
 
 // IInputMgr
 func SyncInputGetMousePos() Vec2 {
-	var __ret Vec2
-	done := make(chan struct{})
-	job := func() {
-		__ret = InputMgr.GetMousePos()
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 Vec2
+	WaitMainThread(func() {
+		_ret1 = InputMgr.GetMousePos()
+	})
+	return _ret1
 }
 func SyncInputGetKey(key int64) bool {
-	var __ret bool
-	done := make(chan struct{})
-	job := func() {
-		__ret = InputMgr.GetKey(key)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 bool
+	WaitMainThread(func() {
+		_ret1 = InputMgr.GetKey(key)
+	})
+	return _ret1
 }
 func SyncInputGetMouseState(mouse_id int64) bool {
-	var __ret bool
-	done := make(chan struct{})
-	job := func() {
-		__ret = InputMgr.GetMouseState(mouse_id)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 bool
+	WaitMainThread(func() {
+		_ret1 = InputMgr.GetMouseState(mouse_id)
+	})
+	return _ret1
 }
 func SyncInputGetKeyState(key int64) int64 {
-	var __ret int64
-	done := make(chan struct{})
-	job := func() {
-		__ret = InputMgr.GetKeyState(key)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 int64
+	WaitMainThread(func() {
+		_ret1 = InputMgr.GetKeyState(key)
+	})
+	return _ret1
 }
 func SyncInputGetAxis(neg_action string, pos_action string) float32 {
-	var __ret float32
-	done := make(chan struct{})
-	job := func() {
-		__ret = InputMgr.GetAxis(neg_action, pos_action)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 float32
+	WaitMainThread(func() {
+		_ret1 = InputMgr.GetAxis(neg_action, pos_action)
+	})
+	return _ret1
 }
 func SyncInputIsActionPressed(action string) bool {
-	var __ret bool
-	done := make(chan struct{})
-	job := func() {
-		__ret = InputMgr.IsActionPressed(action)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 bool
+	WaitMainThread(func() {
+		_ret1 = InputMgr.IsActionPressed(action)
+	})
+	return _ret1
 }
 func SyncInputIsActionJustPressed(action string) bool {
-	var __ret bool
-	done := make(chan struct{})
-	job := func() {
-		__ret = InputMgr.IsActionJustPressed(action)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 bool
+	WaitMainThread(func() {
+		_ret1 = InputMgr.IsActionJustPressed(action)
+	})
+	return _ret1
 }
 func SyncInputIsActionJustReleased(action string) bool {
-	var __ret bool
-	done := make(chan struct{})
-	job := func() {
-		__ret = InputMgr.IsActionJustReleased(action)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 bool
+	WaitMainThread(func() {
+		_ret1 = InputMgr.IsActionJustReleased(action)
+	})
+	return _ret1
 }
 
 // IPhysicMgr
 func SyncPhysicRaycast(from Vec2, to Vec2, collision_mask int64) Object {
-	var __ret Object
-	done := make(chan struct{})
-	job := func() {
-		__ret = PhysicMgr.Raycast(from, to, collision_mask)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 Object
+	WaitMainThread(func() {
+		_ret1 = PhysicMgr.Raycast(from, to, collision_mask)
+	})
+	return _ret1
 }
 func SyncPhysicCheckCollision(from Vec2, to Vec2, collision_mask int64, collide_with_areas bool, collide_with_bodies bool) bool {
-	var __ret bool
-	done := make(chan struct{})
-	job := func() {
-		__ret = PhysicMgr.CheckCollision(from, to, collision_mask, collide_with_areas, collide_with_bodies)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 bool
+	WaitMainThread(func() {
+		_ret1 = PhysicMgr.CheckCollision(from, to, collision_mask, collide_with_areas, collide_with_bodies)
+	})
+	return _ret1
 }
 func SyncPhysicCheckTouchedCameraBoundary(obj Object, board_type int64) bool {
-	var __ret bool
-	done := make(chan struct{})
-	job := func() {
-		__ret = PhysicMgr.CheckTouchedCameraBoundary(obj, board_type)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 bool
+	WaitMainThread(func() {
+		_ret1 = PhysicMgr.CheckTouchedCameraBoundary(obj, board_type)
+	})
+	return _ret1
 }
 
 // IPlatformMgr
 func SyncPlatformSetWindowPosition(pos Vec2) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		PlatformMgr.SetWindowPosition(pos)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncPlatformGetWindowPosition() Vec2 {
-	var __ret Vec2
-	done := make(chan struct{})
-	job := func() {
-		__ret = PlatformMgr.GetWindowPosition()
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 Vec2
+	WaitMainThread(func() {
+		_ret1 = PlatformMgr.GetWindowPosition()
+	})
+	return _ret1
 }
 func SyncPlatformSetWindowSize(width int64, height int64) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		PlatformMgr.SetWindowSize(width, height)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncPlatformGetWindowSize() Vec2 {
-	var __ret Vec2
-	done := make(chan struct{})
-	job := func() {
-		__ret = PlatformMgr.GetWindowSize()
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 Vec2
+	WaitMainThread(func() {
+		_ret1 = PlatformMgr.GetWindowSize()
+	})
+	return _ret1
 }
 func SyncPlatformSetWindowTitle(title string) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		PlatformMgr.SetWindowTitle(title)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncPlatformGetWindowTitle() string {
-	var __ret string
-	done := make(chan struct{})
-	job := func() {
-		__ret = PlatformMgr.GetWindowTitle()
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 string
+	WaitMainThread(func() {
+		_ret1 = PlatformMgr.GetWindowTitle()
+	})
+	return _ret1
 }
 func SyncPlatformSetWindowFullscreen(enable bool) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		PlatformMgr.SetWindowFullscreen(enable)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncPlatformIsWindowFullscreen() bool {
-	var __ret bool
-	done := make(chan struct{})
-	job := func() {
-		__ret = PlatformMgr.IsWindowFullscreen()
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 bool
+	WaitMainThread(func() {
+		_ret1 = PlatformMgr.IsWindowFullscreen()
+	})
+	return _ret1
 }
 func SyncPlatformSetDebugMode(enable bool) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		PlatformMgr.SetDebugMode(enable)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncPlatformIsDebugMode() bool {
-	var __ret bool
-	done := make(chan struct{})
-	job := func() {
-		__ret = PlatformMgr.IsDebugMode()
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 bool
+	WaitMainThread(func() {
+		_ret1 = PlatformMgr.IsDebugMode()
+	})
+	return _ret1
 }
 func SyncPlatformGetTimeScale() float32 {
-	var __ret float32
-	done := make(chan struct{})
-	job := func() {
-		__ret = PlatformMgr.GetTimeScale()
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 float32
+	WaitMainThread(func() {
+		_ret1 = PlatformMgr.GetTimeScale()
+	})
+	return _ret1
 }
 func SyncPlatformSetTimeScale(time_scale float32) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		PlatformMgr.SetTimeScale(time_scale)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 
 // IResMgr
 func SyncResSetLoadMode(is_direct_mode bool) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		ResMgr.SetLoadMode(is_direct_mode)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncResGetLoadMode() bool {
-	var __ret bool
-	done := make(chan struct{})
-	job := func() {
-		__ret = ResMgr.GetLoadMode()
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 bool
+	WaitMainThread(func() {
+		_ret1 = ResMgr.GetLoadMode()
+	})
+	return _ret1
 }
 func SyncResGetBoundFromAlpha(p_path string) Rect2 {
-	var __ret Rect2
-	done := make(chan struct{})
-	job := func() {
-		__ret = ResMgr.GetBoundFromAlpha(p_path)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 Rect2
+	WaitMainThread(func() {
+		_ret1 = ResMgr.GetBoundFromAlpha(p_path)
+	})
+	return _ret1
 }
 func SyncResGetImageSize(p_path string) Vec2 {
-	var __ret Vec2
-	done := make(chan struct{})
-	job := func() {
-		__ret = ResMgr.GetImageSize(p_path)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 Vec2
+	WaitMainThread(func() {
+		_ret1 = ResMgr.GetImageSize(p_path)
+	})
+	return _ret1
 }
 func SyncResReadAllText(p_path string) string {
-	var __ret string
-	done := make(chan struct{})
-	job := func() {
-		__ret = ResMgr.ReadAllText(p_path)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 string
+	WaitMainThread(func() {
+		_ret1 = ResMgr.ReadAllText(p_path)
+	})
+	return _ret1
 }
 func SyncResHasFile(p_path string) bool {
-	var __ret bool
-	done := make(chan struct{})
-	job := func() {
-		__ret = ResMgr.HasFile(p_path)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 bool
+	WaitMainThread(func() {
+		_ret1 = ResMgr.HasFile(p_path)
+	})
+	return _ret1
 }
 
 // ISceneMgr
 func SyncSceneChangeSceneToFile(path string) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		SceneMgr.ChangeSceneToFile(path)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncSceneReloadCurrentScene() int64 {
-	var __ret int64
-	done := make(chan struct{})
-	job := func() {
-		__ret = SceneMgr.ReloadCurrentScene()
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 int64
+	WaitMainThread(func() {
+		_ret1 = SceneMgr.ReloadCurrentScene()
+	})
+	return _ret1
 }
 func SyncSceneUnloadCurrentScene() {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		SceneMgr.UnloadCurrentScene()
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 
 // ISpriteMgr
 func SyncSpriteSetDontDestroyOnLoad(obj Object) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		SpriteMgr.SetDontDestroyOnLoad(obj)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncSpriteSetProcess(obj Object, is_on bool) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		SpriteMgr.SetProcess(obj, is_on)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncSpriteSetPhysicProcess(obj Object, is_on bool) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		SpriteMgr.SetPhysicProcess(obj, is_on)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncSpriteSetChildPosition(obj Object, path string, pos Vec2) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		SpriteMgr.SetChildPosition(obj, path, pos)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncSpriteGetChildPosition(obj Object, path string) Vec2 {
-	var __ret Vec2
-	done := make(chan struct{})
-	job := func() {
-		__ret = SpriteMgr.GetChildPosition(obj, path)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 Vec2
+	WaitMainThread(func() {
+		_ret1 = SpriteMgr.GetChildPosition(obj, path)
+	})
+	return _ret1
 }
 func SyncSpriteSetChildRotation(obj Object, path string, rot float32) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		SpriteMgr.SetChildRotation(obj, path, rot)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncSpriteGetChildRotation(obj Object, path string) float32 {
-	var __ret float32
-	done := make(chan struct{})
-	job := func() {
-		__ret = SpriteMgr.GetChildRotation(obj, path)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 float32
+	WaitMainThread(func() {
+		_ret1 = SpriteMgr.GetChildRotation(obj, path)
+	})
+	return _ret1
 }
 func SyncSpriteSetChildScale(obj Object, path string, scale Vec2) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		SpriteMgr.SetChildScale(obj, path, scale)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncSpriteGetChildScale(obj Object, path string) Vec2 {
-	var __ret Vec2
-	done := make(chan struct{})
-	job := func() {
-		__ret = SpriteMgr.GetChildScale(obj, path)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 Vec2
+	WaitMainThread(func() {
+		_ret1 = SpriteMgr.GetChildScale(obj, path)
+	})
+	return _ret1
 }
 func SyncSpriteCheckCollision(obj Object, target Object, is_src_trigger bool, is_dst_trigger bool) bool {
-	var __ret bool
-	done := make(chan struct{})
-	job := func() {
-		__ret = SpriteMgr.CheckCollision(obj, target, is_src_trigger, is_dst_trigger)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 bool
+	WaitMainThread(func() {
+		_ret1 = SpriteMgr.CheckCollision(obj, target, is_src_trigger, is_dst_trigger)
+	})
+	return _ret1
 }
 func SyncSpriteCheckCollisionWithPoint(obj Object, point Vec2, is_trigger bool) bool {
-	var __ret bool
-	done := make(chan struct{})
-	job := func() {
-		__ret = SpriteMgr.CheckCollisionWithPoint(obj, point, is_trigger)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 bool
+	WaitMainThread(func() {
+		_ret1 = SpriteMgr.CheckCollisionWithPoint(obj, point, is_trigger)
+	})
+	return _ret1
 }
 func SyncSpriteCreateSprite(path string) Object {
-	var __ret Object
-	done := make(chan struct{})
-	job := func() {
-		__ret = SpriteMgr.CreateSprite(path)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 Object
+	WaitMainThread(func() {
+		_ret1 = SpriteMgr.CreateSprite(path)
+	})
+	return _ret1
 }
 func SyncSpriteCloneSprite(obj Object) Object {
-	var __ret Object
-	done := make(chan struct{})
-	job := func() {
-		__ret = SpriteMgr.CloneSprite(obj)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 Object
+	WaitMainThread(func() {
+		_ret1 = SpriteMgr.CloneSprite(obj)
+	})
+	return _ret1
 }
 func SyncSpriteDestroySprite(obj Object) bool {
-	var __ret bool
-	done := make(chan struct{})
-	job := func() {
-		__ret = SpriteMgr.DestroySprite(obj)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 bool
+	WaitMainThread(func() {
+		_ret1 = SpriteMgr.DestroySprite(obj)
+	})
+	return _ret1
 }
 func SyncSpriteIsSpriteAlive(obj Object) bool {
-	var __ret bool
-	done := make(chan struct{})
-	job := func() {
-		__ret = SpriteMgr.IsSpriteAlive(obj)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 bool
+	WaitMainThread(func() {
+		_ret1 = SpriteMgr.IsSpriteAlive(obj)
+	})
+	return _ret1
 }
 func SyncSpriteSetPosition(obj Object, pos Vec2) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		SpriteMgr.SetPosition(obj, pos)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncSpriteGetPosition(obj Object) Vec2 {
-	var __ret Vec2
-	done := make(chan struct{})
-	job := func() {
-		__ret = SpriteMgr.GetPosition(obj)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 Vec2
+	WaitMainThread(func() {
+		_ret1 = SpriteMgr.GetPosition(obj)
+	})
+	return _ret1
 }
 func SyncSpriteSetRotation(obj Object, rot float32) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		SpriteMgr.SetRotation(obj, rot)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncSpriteGetRotation(obj Object) float32 {
-	var __ret float32
-	done := make(chan struct{})
-	job := func() {
-		__ret = SpriteMgr.GetRotation(obj)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 float32
+	WaitMainThread(func() {
+		_ret1 = SpriteMgr.GetRotation(obj)
+	})
+	return _ret1
 }
 func SyncSpriteSetScale(obj Object, scale Vec2) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		SpriteMgr.SetScale(obj, scale)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncSpriteGetScale(obj Object) Vec2 {
-	var __ret Vec2
-	done := make(chan struct{})
-	job := func() {
-		__ret = SpriteMgr.GetScale(obj)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 Vec2
+	WaitMainThread(func() {
+		_ret1 = SpriteMgr.GetScale(obj)
+	})
+	return _ret1
 }
 func SyncSpriteSetRenderScale(obj Object, scale Vec2) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		SpriteMgr.SetRenderScale(obj, scale)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncSpriteGetRenderScale(obj Object) Vec2 {
-	var __ret Vec2
-	done := make(chan struct{})
-	job := func() {
-		__ret = SpriteMgr.GetRenderScale(obj)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 Vec2
+	WaitMainThread(func() {
+		_ret1 = SpriteMgr.GetRenderScale(obj)
+	})
+	return _ret1
 }
 func SyncSpriteSetColor(obj Object, color Color) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		SpriteMgr.SetColor(obj, color)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncSpriteGetColor(obj Object) Color {
-	var __ret Color
-	done := make(chan struct{})
-	job := func() {
-		__ret = SpriteMgr.GetColor(obj)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 Color
+	WaitMainThread(func() {
+		_ret1 = SpriteMgr.GetColor(obj)
+	})
+	return _ret1
 }
 func SyncSpriteSetTextureAltas(obj Object, path string, rect2 Rect2) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		SpriteMgr.SetTextureAltas(obj, path, rect2)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncSpriteSetTexture(obj Object, path string) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		SpriteMgr.SetTexture(obj, path)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncSpriteGetTexture(obj Object) string {
-	var __ret string
-	done := make(chan struct{})
-	job := func() {
-		__ret = SpriteMgr.GetTexture(obj)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 string
+	WaitMainThread(func() {
+		_ret1 = SpriteMgr.GetTexture(obj)
+	})
+	return _ret1
 }
 func SyncSpriteSetVisible(obj Object, visible bool) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		SpriteMgr.SetVisible(obj, visible)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncSpriteGetVisible(obj Object) bool {
-	var __ret bool
-	done := make(chan struct{})
-	job := func() {
-		__ret = SpriteMgr.GetVisible(obj)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 bool
+	WaitMainThread(func() {
+		_ret1 = SpriteMgr.GetVisible(obj)
+	})
+	return _ret1
 }
 func SyncSpriteGetZIndex(obj Object) int64 {
-	var __ret int64
-	done := make(chan struct{})
-	job := func() {
-		__ret = SpriteMgr.GetZIndex(obj)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 int64
+	WaitMainThread(func() {
+		_ret1 = SpriteMgr.GetZIndex(obj)
+	})
+	return _ret1
 }
 func SyncSpriteSetZIndex(obj Object, z int64) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		SpriteMgr.SetZIndex(obj, z)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncSpritePlayAnim(obj Object, p_name string, p_custom_scale float32, p_from_end bool) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		SpriteMgr.PlayAnim(obj, p_name, p_custom_scale, p_from_end)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncSpritePlayBackwardsAnim(obj Object, p_name string) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		SpriteMgr.PlayBackwardsAnim(obj, p_name)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncSpritePauseAnim(obj Object) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		SpriteMgr.PauseAnim(obj)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncSpriteStopAnim(obj Object) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		SpriteMgr.StopAnim(obj)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncSpriteIsPlayingAnim(obj Object) bool {
-	var __ret bool
-	done := make(chan struct{})
-	job := func() {
-		__ret = SpriteMgr.IsPlayingAnim(obj)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 bool
+	WaitMainThread(func() {
+		_ret1 = SpriteMgr.IsPlayingAnim(obj)
+	})
+	return _ret1
 }
 func SyncSpriteSetAnim(obj Object, p_name string) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		SpriteMgr.SetAnim(obj, p_name)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncSpriteGetAnim(obj Object) string {
-	var __ret string
-	done := make(chan struct{})
-	job := func() {
-		__ret = SpriteMgr.GetAnim(obj)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 string
+	WaitMainThread(func() {
+		_ret1 = SpriteMgr.GetAnim(obj)
+	})
+	return _ret1
 }
 func SyncSpriteSetAnimFrame(obj Object, p_frame int64) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		SpriteMgr.SetAnimFrame(obj, p_frame)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncSpriteGetAnimFrame(obj Object) int64 {
-	var __ret int64
-	done := make(chan struct{})
-	job := func() {
-		__ret = SpriteMgr.GetAnimFrame(obj)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 int64
+	WaitMainThread(func() {
+		_ret1 = SpriteMgr.GetAnimFrame(obj)
+	})
+	return _ret1
 }
 func SyncSpriteSetAnimSpeedScale(obj Object, p_speed_scale float32) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		SpriteMgr.SetAnimSpeedScale(obj, p_speed_scale)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncSpriteGetAnimSpeedScale(obj Object) float32 {
-	var __ret float32
-	done := make(chan struct{})
-	job := func() {
-		__ret = SpriteMgr.GetAnimSpeedScale(obj)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 float32
+	WaitMainThread(func() {
+		_ret1 = SpriteMgr.GetAnimSpeedScale(obj)
+	})
+	return _ret1
 }
 func SyncSpriteGetAnimPlayingSpeed(obj Object) float32 {
-	var __ret float32
-	done := make(chan struct{})
-	job := func() {
-		__ret = SpriteMgr.GetAnimPlayingSpeed(obj)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 float32
+	WaitMainThread(func() {
+		_ret1 = SpriteMgr.GetAnimPlayingSpeed(obj)
+	})
+	return _ret1
 }
 func SyncSpriteSetAnimCentered(obj Object, p_center bool) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		SpriteMgr.SetAnimCentered(obj, p_center)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncSpriteIsAnimCentered(obj Object) bool {
-	var __ret bool
-	done := make(chan struct{})
-	job := func() {
-		__ret = SpriteMgr.IsAnimCentered(obj)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 bool
+	WaitMainThread(func() {
+		_ret1 = SpriteMgr.IsAnimCentered(obj)
+	})
+	return _ret1
 }
 func SyncSpriteSetAnimOffset(obj Object, p_offset Vec2) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		SpriteMgr.SetAnimOffset(obj, p_offset)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncSpriteGetAnimOffset(obj Object) Vec2 {
-	var __ret Vec2
-	done := make(chan struct{})
-	job := func() {
-		__ret = SpriteMgr.GetAnimOffset(obj)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 Vec2
+	WaitMainThread(func() {
+		_ret1 = SpriteMgr.GetAnimOffset(obj)
+	})
+	return _ret1
 }
 func SyncSpriteSetAnimFlipH(obj Object, p_flip bool) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		SpriteMgr.SetAnimFlipH(obj, p_flip)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncSpriteIsAnimFlippedH(obj Object) bool {
-	var __ret bool
-	done := make(chan struct{})
-	job := func() {
-		__ret = SpriteMgr.IsAnimFlippedH(obj)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 bool
+	WaitMainThread(func() {
+		_ret1 = SpriteMgr.IsAnimFlippedH(obj)
+	})
+	return _ret1
 }
 func SyncSpriteSetAnimFlipV(obj Object, p_flip bool) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		SpriteMgr.SetAnimFlipV(obj, p_flip)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncSpriteIsAnimFlippedV(obj Object) bool {
-	var __ret bool
-	done := make(chan struct{})
-	job := func() {
-		__ret = SpriteMgr.IsAnimFlippedV(obj)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 bool
+	WaitMainThread(func() {
+		_ret1 = SpriteMgr.IsAnimFlippedV(obj)
+	})
+	return _ret1
 }
 func SyncSpriteSetVelocity(obj Object, velocity Vec2) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		SpriteMgr.SetVelocity(obj, velocity)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncSpriteGetVelocity(obj Object) Vec2 {
-	var __ret Vec2
-	done := make(chan struct{})
-	job := func() {
-		__ret = SpriteMgr.GetVelocity(obj)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 Vec2
+	WaitMainThread(func() {
+		_ret1 = SpriteMgr.GetVelocity(obj)
+	})
+	return _ret1
 }
 func SyncSpriteIsOnFloor(obj Object) bool {
-	var __ret bool
-	done := make(chan struct{})
-	job := func() {
-		__ret = SpriteMgr.IsOnFloor(obj)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 bool
+	WaitMainThread(func() {
+		_ret1 = SpriteMgr.IsOnFloor(obj)
+	})
+	return _ret1
 }
 func SyncSpriteIsOnFloorOnly(obj Object) bool {
-	var __ret bool
-	done := make(chan struct{})
-	job := func() {
-		__ret = SpriteMgr.IsOnFloorOnly(obj)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 bool
+	WaitMainThread(func() {
+		_ret1 = SpriteMgr.IsOnFloorOnly(obj)
+	})
+	return _ret1
 }
 func SyncSpriteIsOnWall(obj Object) bool {
-	var __ret bool
-	done := make(chan struct{})
-	job := func() {
-		__ret = SpriteMgr.IsOnWall(obj)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 bool
+	WaitMainThread(func() {
+		_ret1 = SpriteMgr.IsOnWall(obj)
+	})
+	return _ret1
 }
 func SyncSpriteIsOnWallOnly(obj Object) bool {
-	var __ret bool
-	done := make(chan struct{})
-	job := func() {
-		__ret = SpriteMgr.IsOnWallOnly(obj)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 bool
+	WaitMainThread(func() {
+		_ret1 = SpriteMgr.IsOnWallOnly(obj)
+	})
+	return _ret1
 }
 func SyncSpriteIsOnCeiling(obj Object) bool {
-	var __ret bool
-	done := make(chan struct{})
-	job := func() {
-		__ret = SpriteMgr.IsOnCeiling(obj)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 bool
+	WaitMainThread(func() {
+		_ret1 = SpriteMgr.IsOnCeiling(obj)
+	})
+	return _ret1
 }
 func SyncSpriteIsOnCeilingOnly(obj Object) bool {
-	var __ret bool
-	done := make(chan struct{})
-	job := func() {
-		__ret = SpriteMgr.IsOnCeilingOnly(obj)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 bool
+	WaitMainThread(func() {
+		_ret1 = SpriteMgr.IsOnCeilingOnly(obj)
+	})
+	return _ret1
 }
 func SyncSpriteGetLastMotion(obj Object) Vec2 {
-	var __ret Vec2
-	done := make(chan struct{})
-	job := func() {
-		__ret = SpriteMgr.GetLastMotion(obj)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 Vec2
+	WaitMainThread(func() {
+		_ret1 = SpriteMgr.GetLastMotion(obj)
+	})
+	return _ret1
 }
 func SyncSpriteGetPositionDelta(obj Object) Vec2 {
-	var __ret Vec2
-	done := make(chan struct{})
-	job := func() {
-		__ret = SpriteMgr.GetPositionDelta(obj)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 Vec2
+	WaitMainThread(func() {
+		_ret1 = SpriteMgr.GetPositionDelta(obj)
+	})
+	return _ret1
 }
 func SyncSpriteGetFloorNormal(obj Object) Vec2 {
-	var __ret Vec2
-	done := make(chan struct{})
-	job := func() {
-		__ret = SpriteMgr.GetFloorNormal(obj)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 Vec2
+	WaitMainThread(func() {
+		_ret1 = SpriteMgr.GetFloorNormal(obj)
+	})
+	return _ret1
 }
 func SyncSpriteGetWallNormal(obj Object) Vec2 {
-	var __ret Vec2
-	done := make(chan struct{})
-	job := func() {
-		__ret = SpriteMgr.GetWallNormal(obj)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 Vec2
+	WaitMainThread(func() {
+		_ret1 = SpriteMgr.GetWallNormal(obj)
+	})
+	return _ret1
 }
 func SyncSpriteGetRealVelocity(obj Object) Vec2 {
-	var __ret Vec2
-	done := make(chan struct{})
-	job := func() {
-		__ret = SpriteMgr.GetRealVelocity(obj)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 Vec2
+	WaitMainThread(func() {
+		_ret1 = SpriteMgr.GetRealVelocity(obj)
+	})
+	return _ret1
 }
 func SyncSpriteMoveAndSlide(obj Object) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		SpriteMgr.MoveAndSlide(obj)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncSpriteSetGravity(obj Object, gravity float32) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		SpriteMgr.SetGravity(obj, gravity)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncSpriteGetGravity(obj Object) float32 {
-	var __ret float32
-	done := make(chan struct{})
-	job := func() {
-		__ret = SpriteMgr.GetGravity(obj)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 float32
+	WaitMainThread(func() {
+		_ret1 = SpriteMgr.GetGravity(obj)
+	})
+	return _ret1
 }
 func SyncSpriteSetMass(obj Object, mass float32) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		SpriteMgr.SetMass(obj, mass)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncSpriteGetMass(obj Object) float32 {
-	var __ret float32
-	done := make(chan struct{})
-	job := func() {
-		__ret = SpriteMgr.GetMass(obj)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 float32
+	WaitMainThread(func() {
+		_ret1 = SpriteMgr.GetMass(obj)
+	})
+	return _ret1
 }
 func SyncSpriteAddForce(obj Object, force Vec2) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		SpriteMgr.AddForce(obj, force)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncSpriteAddImpulse(obj Object, impulse Vec2) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		SpriteMgr.AddImpulse(obj, impulse)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncSpriteSetCollisionLayer(obj Object, layer int64) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		SpriteMgr.SetCollisionLayer(obj, layer)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncSpriteGetCollisionLayer(obj Object) int64 {
-	var __ret int64
-	done := make(chan struct{})
-	job := func() {
-		__ret = SpriteMgr.GetCollisionLayer(obj)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 int64
+	WaitMainThread(func() {
+		_ret1 = SpriteMgr.GetCollisionLayer(obj)
+	})
+	return _ret1
 }
 func SyncSpriteSetCollisionMask(obj Object, mask int64) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		SpriteMgr.SetCollisionMask(obj, mask)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncSpriteGetCollisionMask(obj Object) int64 {
-	var __ret int64
-	done := make(chan struct{})
-	job := func() {
-		__ret = SpriteMgr.GetCollisionMask(obj)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 int64
+	WaitMainThread(func() {
+		_ret1 = SpriteMgr.GetCollisionMask(obj)
+	})
+	return _ret1
 }
 func SyncSpriteSetTriggerLayer(obj Object, layer int64) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		SpriteMgr.SetTriggerLayer(obj, layer)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncSpriteGetTriggerLayer(obj Object) int64 {
-	var __ret int64
-	done := make(chan struct{})
-	job := func() {
-		__ret = SpriteMgr.GetTriggerLayer(obj)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 int64
+	WaitMainThread(func() {
+		_ret1 = SpriteMgr.GetTriggerLayer(obj)
+	})
+	return _ret1
 }
 func SyncSpriteSetTriggerMask(obj Object, mask int64) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		SpriteMgr.SetTriggerMask(obj, mask)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncSpriteGetTriggerMask(obj Object) int64 {
-	var __ret int64
-	done := make(chan struct{})
-	job := func() {
-		__ret = SpriteMgr.GetTriggerMask(obj)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 int64
+	WaitMainThread(func() {
+		_ret1 = SpriteMgr.GetTriggerMask(obj)
+	})
+	return _ret1
 }
 func SyncSpriteSetColliderRect(obj Object, center Vec2, size Vec2) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		SpriteMgr.SetColliderRect(obj, center, size)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncSpriteSetColliderCircle(obj Object, center Vec2, radius float32) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		SpriteMgr.SetColliderCircle(obj, center, radius)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncSpriteSetColliderCapsule(obj Object, center Vec2, size Vec2) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		SpriteMgr.SetColliderCapsule(obj, center, size)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncSpriteSetCollisionEnabled(obj Object, enabled bool) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		SpriteMgr.SetCollisionEnabled(obj, enabled)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncSpriteIsCollisionEnabled(obj Object) bool {
-	var __ret bool
-	done := make(chan struct{})
-	job := func() {
-		__ret = SpriteMgr.IsCollisionEnabled(obj)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 bool
+	WaitMainThread(func() {
+		_ret1 = SpriteMgr.IsCollisionEnabled(obj)
+	})
+	return _ret1
 }
 func SyncSpriteSetTriggerRect(obj Object, center Vec2, size Vec2) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		SpriteMgr.SetTriggerRect(obj, center, size)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncSpriteSetTriggerCircle(obj Object, center Vec2, radius float32) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		SpriteMgr.SetTriggerCircle(obj, center, radius)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncSpriteSetTriggerCapsule(obj Object, center Vec2, size Vec2) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		SpriteMgr.SetTriggerCapsule(obj, center, size)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncSpriteSetTriggerEnabled(obj Object, trigger bool) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		SpriteMgr.SetTriggerEnabled(obj, trigger)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncSpriteIsTriggerEnabled(obj Object) bool {
-	var __ret bool
-	done := make(chan struct{})
-	job := func() {
-		__ret = SpriteMgr.IsTriggerEnabled(obj)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 bool
+	WaitMainThread(func() {
+		_ret1 = SpriteMgr.IsTriggerEnabled(obj)
+	})
+	return _ret1
 }
 
 // IUiMgr
 func SyncUiBindNode(obj Object, rel_path string) Object {
-	var __ret Object
-	done := make(chan struct{})
-	job := func() {
-		__ret = UiMgr.BindNode(obj, rel_path)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 Object
+	WaitMainThread(func() {
+		_ret1 = UiMgr.BindNode(obj, rel_path)
+	})
+	return _ret1
 }
 func SyncUiCreateNode(path string) Object {
-	var __ret Object
-	done := make(chan struct{})
-	job := func() {
-		__ret = UiMgr.CreateNode(path)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 Object
+	WaitMainThread(func() {
+		_ret1 = UiMgr.CreateNode(path)
+	})
+	return _ret1
 }
 func SyncUiCreateButton(path string, text string) Object {
-	var __ret Object
-	done := make(chan struct{})
-	job := func() {
-		__ret = UiMgr.CreateButton(path, text)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 Object
+	WaitMainThread(func() {
+		_ret1 = UiMgr.CreateButton(path, text)
+	})
+	return _ret1
 }
 func SyncUiCreateLabel(path string, text string) Object {
-	var __ret Object
-	done := make(chan struct{})
-	job := func() {
-		__ret = UiMgr.CreateLabel(path, text)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 Object
+	WaitMainThread(func() {
+		_ret1 = UiMgr.CreateLabel(path, text)
+	})
+	return _ret1
 }
 func SyncUiCreateImage(path string) Object {
-	var __ret Object
-	done := make(chan struct{})
-	job := func() {
-		__ret = UiMgr.CreateImage(path)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 Object
+	WaitMainThread(func() {
+		_ret1 = UiMgr.CreateImage(path)
+	})
+	return _ret1
 }
 func SyncUiCreateToggle(path string, value bool) Object {
-	var __ret Object
-	done := make(chan struct{})
-	job := func() {
-		__ret = UiMgr.CreateToggle(path, value)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 Object
+	WaitMainThread(func() {
+		_ret1 = UiMgr.CreateToggle(path, value)
+	})
+	return _ret1
 }
 func SyncUiCreateSlider(path string, value float32) Object {
-	var __ret Object
-	done := make(chan struct{})
-	job := func() {
-		__ret = UiMgr.CreateSlider(path, value)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 Object
+	WaitMainThread(func() {
+		_ret1 = UiMgr.CreateSlider(path, value)
+	})
+	return _ret1
 }
 func SyncUiCreateInput(path string, text string) Object {
-	var __ret Object
-	done := make(chan struct{})
-	job := func() {
-		__ret = UiMgr.CreateInput(path, text)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 Object
+	WaitMainThread(func() {
+		_ret1 = UiMgr.CreateInput(path, text)
+	})
+	return _ret1
 }
 func SyncUiDestroyNode(obj Object) bool {
-	var __ret bool
-	done := make(chan struct{})
-	job := func() {
-		__ret = UiMgr.DestroyNode(obj)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 bool
+	WaitMainThread(func() {
+		_ret1 = UiMgr.DestroyNode(obj)
+	})
+	return _ret1
 }
 func SyncUiGetType(obj Object) int64 {
-	var __ret int64
-	done := make(chan struct{})
-	job := func() {
-		__ret = UiMgr.GetType(obj)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 int64
+	WaitMainThread(func() {
+		_ret1 = UiMgr.GetType(obj)
+	})
+	return _ret1
 }
 func SyncUiSetText(obj Object, text string) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		UiMgr.SetText(obj, text)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncUiGetText(obj Object) string {
-	var __ret string
-	done := make(chan struct{})
-	job := func() {
-		__ret = UiMgr.GetText(obj)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 string
+	WaitMainThread(func() {
+		_ret1 = UiMgr.GetText(obj)
+	})
+	return _ret1
 }
 func SyncUiSetTexture(obj Object, path string) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		UiMgr.SetTexture(obj, path)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncUiGetTexture(obj Object) string {
-	var __ret string
-	done := make(chan struct{})
-	job := func() {
-		__ret = UiMgr.GetTexture(obj)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 string
+	WaitMainThread(func() {
+		_ret1 = UiMgr.GetTexture(obj)
+	})
+	return _ret1
 }
 func SyncUiSetColor(obj Object, color Color) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		UiMgr.SetColor(obj, color)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncUiGetColor(obj Object) Color {
-	var __ret Color
-	done := make(chan struct{})
-	job := func() {
-		__ret = UiMgr.GetColor(obj)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 Color
+	WaitMainThread(func() {
+		_ret1 = UiMgr.GetColor(obj)
+	})
+	return _ret1
 }
 func SyncUiSetFontSize(obj Object, size int64) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		UiMgr.SetFontSize(obj, size)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncUiGetFontSize(obj Object) int64 {
-	var __ret int64
-	done := make(chan struct{})
-	job := func() {
-		__ret = UiMgr.GetFontSize(obj)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 int64
+	WaitMainThread(func() {
+		_ret1 = UiMgr.GetFontSize(obj)
+	})
+	return _ret1
 }
 func SyncUiSetVisible(obj Object, visible bool) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		UiMgr.SetVisible(obj, visible)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncUiGetVisible(obj Object) bool {
-	var __ret bool
-	done := make(chan struct{})
-	job := func() {
-		__ret = UiMgr.GetVisible(obj)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 bool
+	WaitMainThread(func() {
+		_ret1 = UiMgr.GetVisible(obj)
+	})
+	return _ret1
 }
 func SyncUiSetInteractable(obj Object, interactable bool) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		UiMgr.SetInteractable(obj, interactable)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncUiGetInteractable(obj Object) bool {
-	var __ret bool
-	done := make(chan struct{})
-	job := func() {
-		__ret = UiMgr.GetInteractable(obj)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 bool
+	WaitMainThread(func() {
+		_ret1 = UiMgr.GetInteractable(obj)
+	})
+	return _ret1
 }
 func SyncUiSetRect(obj Object, rect Rect2) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		UiMgr.SetRect(obj, rect)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncUiGetRect(obj Object) Rect2 {
-	var __ret Rect2
-	done := make(chan struct{})
-	job := func() {
-		__ret = UiMgr.GetRect(obj)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 Rect2
+	WaitMainThread(func() {
+		_ret1 = UiMgr.GetRect(obj)
+	})
+	return _ret1
 }
 func SyncUiGetLayoutDirection(obj Object) int64 {
-	var __ret int64
-	done := make(chan struct{})
-	job := func() {
-		__ret = UiMgr.GetLayoutDirection(obj)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 int64
+	WaitMainThread(func() {
+		_ret1 = UiMgr.GetLayoutDirection(obj)
+	})
+	return _ret1
 }
 func SyncUiSetLayoutDirection(obj Object, value int64) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		UiMgr.SetLayoutDirection(obj, value)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncUiGetLayoutMode(obj Object) int64 {
-	var __ret int64
-	done := make(chan struct{})
-	job := func() {
-		__ret = UiMgr.GetLayoutMode(obj)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 int64
+	WaitMainThread(func() {
+		_ret1 = UiMgr.GetLayoutMode(obj)
+	})
+	return _ret1
 }
 func SyncUiSetLayoutMode(obj Object, value int64) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		UiMgr.SetLayoutMode(obj, value)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncUiGetAnchorsPreset(obj Object) int64 {
-	var __ret int64
-	done := make(chan struct{})
-	job := func() {
-		__ret = UiMgr.GetAnchorsPreset(obj)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 int64
+	WaitMainThread(func() {
+		_ret1 = UiMgr.GetAnchorsPreset(obj)
+	})
+	return _ret1
 }
 func SyncUiSetAnchorsPreset(obj Object, value int64) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		UiMgr.SetAnchorsPreset(obj, value)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncUiGetScale(obj Object) Vec2 {
-	var __ret Vec2
-	done := make(chan struct{})
-	job := func() {
-		__ret = UiMgr.GetScale(obj)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 Vec2
+	WaitMainThread(func() {
+		_ret1 = UiMgr.GetScale(obj)
+	})
+	return _ret1
 }
 func SyncUiSetScale(obj Object, value Vec2) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		UiMgr.SetScale(obj, value)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncUiGetPosition(obj Object) Vec2 {
-	var __ret Vec2
-	done := make(chan struct{})
-	job := func() {
-		__ret = UiMgr.GetPosition(obj)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 Vec2
+	WaitMainThread(func() {
+		_ret1 = UiMgr.GetPosition(obj)
+	})
+	return _ret1
 }
 func SyncUiSetPosition(obj Object, value Vec2) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		UiMgr.SetPosition(obj, value)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncUiGetSize(obj Object) Vec2 {
-	var __ret Vec2
-	done := make(chan struct{})
-	job := func() {
-		__ret = UiMgr.GetSize(obj)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 Vec2
+	WaitMainThread(func() {
+		_ret1 = UiMgr.GetSize(obj)
+	})
+	return _ret1
 }
 func SyncUiSetSize(obj Object, value Vec2) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		UiMgr.SetSize(obj, value)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncUiGetGlobalPosition(obj Object) Vec2 {
-	var __ret Vec2
-	done := make(chan struct{})
-	job := func() {
-		__ret = UiMgr.GetGlobalPosition(obj)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 Vec2
+	WaitMainThread(func() {
+		_ret1 = UiMgr.GetGlobalPosition(obj)
+	})
+	return _ret1
 }
 func SyncUiSetGlobalPosition(obj Object, value Vec2) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		UiMgr.SetGlobalPosition(obj, value)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncUiGetRotation(obj Object) float32 {
-	var __ret float32
-	done := make(chan struct{})
-	job := func() {
-		__ret = UiMgr.GetRotation(obj)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 float32
+	WaitMainThread(func() {
+		_ret1 = UiMgr.GetRotation(obj)
+	})
+	return _ret1
 }
 func SyncUiSetRotation(obj Object, value float32) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		UiMgr.SetRotation(obj, value)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }
 func SyncUiGetFlip(obj Object, horizontal bool) bool {
-	var __ret bool
-	done := make(chan struct{})
-	job := func() {
-		__ret = UiMgr.GetFlip(obj, horizontal)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 bool
+	WaitMainThread(func() {
+		_ret1 = UiMgr.GetFlip(obj, horizontal)
+	})
+	return _ret1
 }
 func SyncUiSetFlip(obj Object, horizontal bool, is_flip bool) {
-
-	done := make(chan struct{})
-	job := func() {
+	WaitMainThread(func() {
 		UiMgr.SetFlip(obj, horizontal, is_flip)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
+	})
 }

--- a/internal/engine/sync.go
+++ b/internal/engine/sync.go
@@ -6,81 +6,56 @@ import (
 
 // =============== factory ===================
 func SyncCreateUiNode[T any](path string) *T {
-	var __ret *T
-	done := make(chan struct{})
-	job := func() {
-		__ret = CreateUI[T](path)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 *T
+	WaitMainThread(func() {
+		_ret1 = CreateUI[T](path)
+	})
+	return _ret1
 }
 func SyncCreateEngineUiNode[T any](path string) *T {
-	var __ret *T
-	done := make(chan struct{})
-	job := func() {
-		__ret = CreateEngineUI[T](path)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 *T
+	WaitMainThread(func() {
+		_ret1 = CreateEngineUI[T](path)
+	})
+	return _ret1
 }
 
 func SyncCreateSprite[T any]() *T {
-	var __ret *T
-	done := make(chan struct{})
-	job := func() {
-		__ret = CreateSprite[T]()
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 *T
+	WaitMainThread(func() {
+		_ret1 = CreateSprite[T]()
+	})
+	return _ret1
 }
 
 func SyncCreateEmptySprite[T any]() *T {
-	var __ret *T
-	done := make(chan struct{})
-	job := func() {
-		__ret = CreateEmptySprite[T]()
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 *T
+	WaitMainThread(func() {
+		_ret1 = CreateEmptySprite[T]()
+	})
+	return _ret1
 }
 
 func SyncNewBackdropProxy(obj interface{}, path string, renderScale float64) *ProxySprite {
-	var __ret *ProxySprite
-	done := make(chan struct{})
-	job := func() {
-		__ret = newBackdropProxy(obj, path, renderScale)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return __ret
+	var _ret1 *ProxySprite
+	WaitMainThread(func() {
+		_ret1 = newBackdropProxy(obj, path, renderScale)
+	})
+	return _ret1
 }
 
 func newBackdropProxy(obj interface{}, path string, renderScale float64) *ProxySprite {
-	__ret := CreateEmptySprite[ProxySprite]()
-	__ret.Target = obj
-	__ret.SetZIndex(-1)
-	__ret.DisablePhysic()
-	__ret.UpdateTexture(path, renderScale)
-	return __ret
+	ret := CreateEmptySprite[ProxySprite]()
+	ret.Target = obj
+	ret.SetZIndex(-1)
+	ret.DisablePhysic()
+	ret.UpdateTexture(path, renderScale)
+	return ret
 }
 
 // =============== input ===================
 func SyncInputMousePressed() bool {
 	return SyncInputGetMouseState(0) || SyncInputGetMouseState(1)
-}
-
-// =============== time ===================
-func SyncGetCurrentTPS() float64 {
-	return 30 // TODO(tanjp) use engine api
 }
 
 // =============== window ===================
@@ -118,26 +93,18 @@ func WorldToScreen(x, y float64) (float64, float64) {
 }
 
 func SyncScreenToWorld(x, y float64) (float64, float64) {
-	var _x, _y float64
-	done := make(chan struct{})
-	job := func() {
-		_x, _y = ScreenToWorld(x, y)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return _x, _y
+	var _ret1, _ret2 float64
+	WaitMainThread(func() {
+		_ret1, _ret2 = ScreenToWorld(x, y)
+	})
+	return _ret1, _ret2
 }
 func SyncWorldToScreen(x, y float64) (float64, float64) {
-	var _x, _y float64
-	done := make(chan struct{})
-	job := func() {
-		_x, _y = WorldToScreen(x, y)
-		done <- struct{}{}
-	}
-	updateJobQueue <- job
-	<-done
-	return _x, _y
+	var _ret1, _ret2 float64
+	WaitMainThread(func() {
+		_ret1, _ret2 = WorldToScreen(x, y)
+	})
+	return _ret1, _ret2
 }
 
 func SyncGetCameraLocalPosition(x, y float64) (float64, float64) {

--- a/internal/time/time.go
+++ b/internal/time/time.go
@@ -1,15 +1,27 @@
 package time
 
-var (
-	realTimeSinceStartup float64
-	timeSinceLevelLoad   float64
-	deltaTime            float64
-	unscaledDeltaTime    float64
-	timeScale            float64
-	curFrame             int64
-	setTimeScaleCallback func(float64)
+import (
+	stime "time"
 )
 
+var (
+	unscaledTimeSinceLevelLoad float64
+	timeSinceLevelLoad         float64
+	deltaTime                  float64
+	unscaledDeltaTime          float64
+	timeScale                  float64
+	curFrame                   int64
+	setTimeScaleCallback       func(float64)
+	startTimestamp             stime.Time
+	fps                        float64
+)
+
+func RealTimeSinceStart() float64 {
+	return stime.Since(startTimestamp).Seconds()
+}
+func FPS() float64 {
+	return fps
+}
 func Frame() int64 {
 	return curFrame
 }
@@ -34,8 +46,8 @@ func UnscaledDeltaTime() float64 {
 }
 
 // no time scale
-func RealTimeSinceStartup() float64 {
-	return realTimeSinceStartup
+func UnscaledTimeSinceLevelLoad() float64 {
+	return unscaledTimeSinceLevelLoad
 }
 
 func TimeSinceLevelLoad() float64 {
@@ -43,15 +55,17 @@ func TimeSinceLevelLoad() float64 {
 }
 
 func Start(setTimeScaleCB func(float64)) {
-	Update(1, 0, 0, 0, 0)
+	Update(1, 0, 0, 0, 0, 30)
 	setTimeScaleCallback = setTimeScaleCB
+	startTimestamp = stime.Now()
 }
 
-func Update(scale float64, realDuration float64, duration float64, delta float64, unscaledDelta float64) {
+func Update(scale float64, realDuration float64, duration float64, delta float64, unscaledDelta float64, pfps float64) {
 	timeScale = scale
 	unscaledDeltaTime = unscaledDelta
-	realTimeSinceStartup = realDuration
+	unscaledTimeSinceLevelLoad = realDuration
 	timeSinceLevelLoad = duration
 	deltaTime = delta
 	curFrame += 1
+	fps = pfps
 }

--- a/internal/tools/tool.go
+++ b/internal/tools/tool.go
@@ -2,12 +2,7 @@ package tools
 
 import (
 	"strconv"
-	"time"
 )
-
-func GetCurrentTimeMs() int {
-	return (int)(time.Now().UnixNano() / 1e6)
-}
 
 func GetFloat(unk interface{}) (float64, bool) {
 	switch i := unk.(type) {

--- a/quote.go
+++ b/quote.go
@@ -16,7 +16,10 @@
 
 package spx
 
-import "github.com/goplus/spx/internal/ui"
+import (
+	"github.com/goplus/spx/internal/engine"
+	"github.com/goplus/spx/internal/ui"
+)
 
 const (
 	quotePadding     = 5.0
@@ -58,7 +61,7 @@ func (p *SpriteImpl) quote_(message, description string) {
 }
 
 func (p *SpriteImpl) waitStopQuote(secs float64) {
-	p.g.Wait(secs)
+	engine.Wait(secs)
 	p.doStopQuote()
 }
 

--- a/say.go
+++ b/say.go
@@ -19,6 +19,7 @@ package spx
 import (
 	"fmt"
 
+	"github.com/goplus/spx/internal/engine"
 	"github.com/goplus/spx/internal/ui"
 )
 
@@ -84,7 +85,7 @@ func (p *SpriteImpl) sayOrThink(msgv interface{}, style int) {
 }
 
 func (p *SpriteImpl) waitStopSay(secs float64) {
-	p.g.Wait(secs)
+	engine.Wait(secs)
 	p.doStopSay()
 }
 

--- a/sprite.go
+++ b/sprite.go
@@ -27,6 +27,7 @@ import (
 	"github.com/goplus/spx/internal/engine"
 	"github.com/goplus/spx/internal/gdi"
 	"github.com/goplus/spx/internal/math32"
+	"github.com/goplus/spx/internal/time"
 	"github.com/goplus/spx/internal/tools"
 )
 
@@ -87,6 +88,7 @@ type Sprite interface {
 	CostumeName() string
 	CostumeWidth() float64
 	DeleteThisClone()
+	DeltaTime() float64
 	Destroy()
 	Die()
 	DistanceTo(obj interface{}) float64
@@ -142,6 +144,7 @@ type Sprite interface {
 	Step__1(step int)
 	Step__2(step float64, animname string)
 	Think(msg interface{}, secs ...float64)
+	TimeSinceLevelLoad() float64
 	Touching(obj interface{}) bool
 	TouchingColor(color Color) bool
 	Turn(val interface{})
@@ -943,7 +946,7 @@ func (p *SpriteImpl) goAnimateInternal(name string, ani *aniConfig, isBlocking b
 		}
 	})
 	if isBlocking {
-		waitToDo(animwg.Wait)
+		engine.WaitToDo(animwg.Wait)
 	}
 	if isNeedPlayDefault {
 		p.playDefaultAnim()
@@ -1490,6 +1493,9 @@ func checkTouchingDirection(dir float64) int {
 }
 
 func (p *SpriteImpl) checkTouchingScreen(where int) (touching int) {
+	if p.proxy == nil {
+		return 0
+	}
 	value := engine.SyncPhysicCheckTouchedCameraBoundary(p.proxy.Id, int64(where))
 	if value {
 		return where
@@ -1704,4 +1710,14 @@ func (pself *SpriteImpl) onUpdate(delta float64) {
 	if pself.sayObj != nil {
 		pself.sayObj.refresh()
 	}
+}
+
+// ------------------------ time ----------------------------------------
+
+func (pself *SpriteImpl) DeltaTime() float64 {
+	return time.DeltaTime()
+}
+
+func (pself *SpriteImpl) TimeSinceLevelLoad() float64 {
+	return time.TimeSinceLevelLoad()
 }

--- a/tick.go
+++ b/tick.go
@@ -71,7 +71,7 @@ type tickMgr struct {
 // currentTPS is the current TPS (ticks per second),
 // that represents how many update function is called in a second.
 func (p *tickMgr) getCurrentTPS() float64 {
-	return engine.SyncGetCurrentTPS()
+	return engine.GetTPS()
 }
 
 func (p *tickMgr) init() {


### PR DESCRIPTION
Add the feature `WaitForNextFrame`, which can make the game visuals smoother.  https://github.com/goplus/spx/issues/443

The current implementation ensures that all coroutines complete execution for the current frame and enter a waiting state, thereby avoiding bugs where some sprite logic is not executed or only partially executed in a rendering frame.

The code style will have slight changes. Please see the example code below for details.
before:
```go
wait 0.05
changeYpos -10
```

after:
```go
delta := wait
changeYpos -200 * delta
```
or
```go

wait
changeYpos -200 * deltaTime
```



before: [05-Animation.zip](https://github.com/user-attachments/files/17944971/05-Animation.zip)


https://github.com/user-attachments/assets/768ea7c2-4061-426d-bc3b-2d5e8290acc6


after: [05-Animation_new.zip](https://github.com/user-attachments/files/17944979/05-Animation_new.zip)


https://github.com/user-attachments/assets/d30f11ae-d0c4-4f8a-81ea-04e67c3babd7

