### PR TITLE
Use semaphores to optimize the main loop

### DIFF
--- a/internal/engine/proxy.go
+++ b/internal/engine/proxy.go
@@ -42,12 +42,23 @@ func (pself *ProxySprite) UpdateTextureAltas(path string, rect2 Rect2, renderSca
 	pself.SetRenderScale(NewVec2(renderScale, renderScale))
 }
 
-func (pself *ProxySprite) UpdatePosRot(x, y float64, rot float64) {
+func (pself *ProxySprite) UpdateTransform(x, y float64, rot float64, scale64 float64, isSync bool) {
 	pself.x = x
 	pself.y = y
-	pself.SetPosition(Vec2{X: float32(x), Y: float32(y)})
 	rad := HeadingToRad(rot)
-	pself.SetRotation(rad)
+	pos := Vec2{X: float32(x), Y: float32(y)}
+	scale := float32(scale64)
+	if !isSync {
+		pself.SetPosition(pos)
+		pself.SetRotation(rad)
+		pself.SetScaleX(scale)
+	} else {
+		WaitMainThread(func() {
+			pself.SetPosition(pos)
+			pself.SetRotation(rad)
+			pself.SetScaleX(scale)
+		})
+	}
 }
 
 func (pself *ProxySprite) OnTriggerEnter(target ISpriter) {

--- a/internal/time/time.go
+++ b/internal/time/time.go
@@ -16,6 +16,10 @@ var (
 	fps                        float64
 )
 
+func Sleep(ms float64) {
+	stime.Sleep(stime.Microsecond * stime.Duration((ms * 1000)))
+}
+
 func RealTimeSinceStart() float64 {
 	return stime.Since(startTimestamp).Seconds()
 }

--- a/tutorial/02-Dragon/Dragon.spx
+++ b/tutorial/02-Dragon/Dragon.spx
@@ -8,6 +8,7 @@ onStart => {
 		turn rand(-30, 30)
 		step 5
 		if touching("Shark") {
+			waitNextFrame
 			score++
 			play chomp, true
 			step -100


### PR DESCRIPTION
1. Use semaphores to optimize the main loop, significantly increasing the number of times the main thread function can be called per frame （700 -> 30000）
2. When the sprite's position is dirty, synchronize the sprite's transform info with the engine to ensure the collision system works correctly

Fix: https://github.com/goplus/spx/issues/421
 

https://github.com/user-attachments/assets/8e7f54e2-c71a-43d2-a024-995781954c2a

