### PR TITLE
refactor: prefer typed params for API funcs

### DIFF
--- a/camera.go
+++ b/camera.go
@@ -59,9 +59,9 @@ func (c *Camera) worldToScreen(point *math32.Vector2) *math32.Vector2 {
 }
 */
 
-func (c *Camera) On(obj interface{}) {
+func (c *Camera) on(obj interface{}) {
 	switch v := obj.(type) {
-	case string:
+	case SpriteName:
 		sp := c.g.findSprite(v)
 		if sp == nil {
 			log.Println("Camera.On: sprite not found -", v)
@@ -81,6 +81,22 @@ func (c *Camera) On(obj interface{}) {
 		panic("Camera.On: unexpected parameter")
 	}
 	c.on_ = obj
+}
+
+func (c *Camera) On__0(sprite Sprite) {
+	c.on(sprite)
+}
+
+func (c *Camera) On__1(sprite *SpriteImpl) {
+	c.on(sprite)
+}
+
+func (c *Camera) On__2(sprite SpriteName) {
+	c.on(sprite)
+}
+
+func (c *Camera) On__3(obj specialObj) {
+	c.on(obj)
 }
 
 func (c *Camera) updateOnObj() {

--- a/event.go
+++ b/event.go
@@ -213,17 +213,17 @@ func (p *eventSinkMgr) doWhenIReceive(msg string, data interface{}, wait bool) {
 	})
 }
 
-func (p *eventSinkMgr) doWhenBackdropChanged(name string, wait bool) {
+func (p *eventSinkMgr) doWhenBackdropChanged(name BackdropName, wait bool) {
 	p.allWhenBackdropChanged.call(wait, name, func(ev *eventSink) {
-		ev.sink.(func(string))(name)
+		ev.sink.(func(BackdropName))(name)
 	})
 }
 
 // -------------------------------------------------------------------------------------
 type IEventSinks interface {
 	OnAnyKey(onKey func(key Key))
-	OnBackdrop__0(onBackdrop func(name string))
-	OnBackdrop__1(name string, onBackdrop func())
+	OnBackdrop__0(onBackdrop func(name BackdropName))
+	OnBackdrop__1(name BackdropName, onBackdrop func())
 	OnClick(onClick func())
 	OnKey__0(key Key, onKey func())
 	OnKey__1(keys []Key, onKey func(Key))
@@ -361,7 +361,7 @@ func (p *eventSinks) OnMsg__1(msg string, onMsg func()) {
 	}
 }
 
-func (p *eventSinks) OnBackdrop__0(onBackdrop func(name string)) {
+func (p *eventSinks) OnBackdrop__0(onBackdrop func(name BackdropName)) {
 	p.allWhenBackdropChanged = &eventSink{
 		prev:  p.allWhenBackdropChanged,
 		pthis: p.pthis,
@@ -369,18 +369,18 @@ func (p *eventSinks) OnBackdrop__0(onBackdrop func(name string)) {
 	}
 }
 
-func (p *eventSinks) OnBackdrop__1(name string, onBackdrop func()) {
+func (p *eventSinks) OnBackdrop__1(name BackdropName, onBackdrop func()) {
 	p.allWhenBackdropChanged = &eventSink{
 		prev:  p.allWhenBackdropChanged,
 		pthis: p.pthis,
-		sink: func(name string) {
+		sink: func(name BackdropName) {
 			if debugEvent {
 				log.Println("==> onBackdrop", name, nameOf(p.pthis))
 			}
 			onBackdrop()
 		},
 		cond: func(data interface{}) bool {
-			return data.(string) == name
+			return data.(BackdropName) == name
 		},
 	}
 }

--- a/monitor.go
+++ b/monitor.go
@@ -37,7 +37,7 @@ import (
 // Monitor class.
 type Monitor struct {
 	game    *Game
-	name    string
+	name    WidgetName
 	size    float64
 	target  string
 	val     string
@@ -304,7 +304,7 @@ func (p *Monitor) hit(hc hitContext) (hr hitResult, ok bool) {
 
 // -------------------------------------------------------------------------------------
 // IWidget
-func (pself *Monitor) GetName() string {
+func (pself *Monitor) GetName() WidgetName {
 	return pself.name
 }
 

--- a/spbase.go
+++ b/spbase.go
@@ -174,7 +174,7 @@ func (p *imageLoaderByCostumeSet) load(fs spxfs.Dir, pt *imagePoint) (gdi.Image,
 // -------------------------------------------------------------------------------------
 
 type costume struct {
-	name             string
+	name             SpriteCostumeName
 	img              delayloadImage
 	faceRight        float64
 	bitmapResolution int
@@ -296,7 +296,7 @@ func initCSPart(p *baseObj, img *costumeSetImage, faceRight float64, bitmapResol
 	}
 }
 
-func addCostumeWith(p *baseObj, name string, img *costumeSetImage, faceRight float64, i, bitmapResolution int) {
+func addCostumeWith(p *baseObj, name SpriteCostumeName, img *costumeSetImage, faceRight float64, i, bitmapResolution int) {
 	c := newCostumeWith(name, img, faceRight, i, bitmapResolution)
 	p.costumes = append(p.costumes, c)
 }
@@ -334,7 +334,7 @@ func (p *baseObj) initFrom(src *baseObj) {
 	p.costumeIndex_ = src.costumeIndex_
 }
 
-func (p *baseObj) findCostume(name string) int {
+func (p *baseObj) findCostume(name SpriteCostumeName) int {
 	for i, c := range p.costumes {
 		if c.name == name {
 			return i
@@ -345,7 +345,7 @@ func (p *baseObj) findCostume(name string) int {
 
 func (p *baseObj) goSetCostume(val interface{}) bool {
 	switch v := val.(type) {
-	case string:
+	case SpriteCostumeName:
 		return p.setCostumeByName(v)
 	case int:
 		return p.setCostumeByIndex(v)
@@ -373,8 +373,7 @@ func (p *baseObj) setCostumeByIndex(idx int) bool {
 	}
 	return false
 }
-
-func (p *baseObj) setCostumeByName(name string) bool {
+func (p *baseObj) setCostumeByName(name SpriteCostumeName) bool {
 	if idx := p.findCostume(name); idx >= 0 {
 		return p.setCostumeByIndex(idx)
 	}
@@ -393,7 +392,7 @@ func (p *baseObj) getCostumeIndex() int {
 	return p.costumeIndex_
 }
 
-func (p *baseObj) getCostumeName() string {
+func (p *baseObj) getCostumeName() SpriteCostumeName {
 	return p.costumes[p.costumeIndex_].name
 }
 

--- a/widget.go
+++ b/widget.go
@@ -1,7 +1,7 @@
 package spx
 
 type Widget interface {
-	GetName() string
+	GetName() WidgetName
 	Visible() bool
 	Show()
 	Hide()
@@ -19,3 +19,5 @@ type Widget interface {
 	SetSize(size float64)
 	ChangeSize(delta float64)
 }
+
+type WidgetName = string


### PR DESCRIPTION
- Introduce `SpriteName`, `SpriteCostumeName`, `SpriteAnimationName`, `SoundName`, `BackdropName`, `WidgetName`.
- Prefer func overloading over using `interface{}` or variadic params as optional params.