### PR TITLE
refactor: redefine `Key` from an alias of `ebiten.Key` to a general `int` type

### DIFF
--- a/game.go
+++ b/game.go
@@ -705,7 +705,7 @@ func (p *Game) handleEvent(event event) {
 		p.updateMousePos()
 		p.doWhenLeftButtonDown(ev)
 	case *eventKeyDown:
-		p.sinkMgr.doWhenKeyPressed(ev.Key)
+		p.sinkMgr.doWhenKeyPressed(Key(ev.Key))
 	case *eventStart:
 		p.sinkMgr.doWhenStart()
 	}

--- a/input.go
+++ b/input.go
@@ -22,110 +22,110 @@ import (
 	"github.com/hajimehoshi/ebiten/v2"
 )
 
-type Key = ebiten.Key
+type Key int
 
 const (
-	Key0            Key = ebiten.Key0
-	Key1            Key = ebiten.Key1
-	Key2            Key = ebiten.Key2
-	Key3            Key = ebiten.Key3
-	Key4            Key = ebiten.Key4
-	Key5            Key = ebiten.Key5
-	Key6            Key = ebiten.Key6
-	Key7            Key = ebiten.Key7
-	Key8            Key = ebiten.Key8
-	Key9            Key = ebiten.Key9
-	KeyA            Key = ebiten.KeyA
-	KeyB            Key = ebiten.KeyB
-	KeyC            Key = ebiten.KeyC
-	KeyD            Key = ebiten.KeyD
-	KeyE            Key = ebiten.KeyE
-	KeyF            Key = ebiten.KeyF
-	KeyG            Key = ebiten.KeyG
-	KeyH            Key = ebiten.KeyH
-	KeyI            Key = ebiten.KeyI
-	KeyJ            Key = ebiten.KeyJ
-	KeyK            Key = ebiten.KeyK
-	KeyL            Key = ebiten.KeyL
-	KeyM            Key = ebiten.KeyM
-	KeyN            Key = ebiten.KeyN
-	KeyO            Key = ebiten.KeyO
-	KeyP            Key = ebiten.KeyP
-	KeyQ            Key = ebiten.KeyQ
-	KeyR            Key = ebiten.KeyR
-	KeyS            Key = ebiten.KeyS
-	KeyT            Key = ebiten.KeyT
-	KeyU            Key = ebiten.KeyU
-	KeyV            Key = ebiten.KeyV
-	KeyW            Key = ebiten.KeyW
-	KeyX            Key = ebiten.KeyX
-	KeyY            Key = ebiten.KeyY
-	KeyZ            Key = ebiten.KeyZ
-	KeyApostrophe   Key = ebiten.KeyApostrophe
-	KeyBackslash    Key = ebiten.KeyBackslash
-	KeyBackspace    Key = ebiten.KeyBackspace
-	KeyCapsLock     Key = ebiten.KeyCapsLock
-	KeyComma        Key = ebiten.KeyComma
-	KeyDelete       Key = ebiten.KeyDelete
-	KeyDown         Key = ebiten.KeyDown
-	KeyEnd          Key = ebiten.KeyEnd
-	KeyEnter        Key = ebiten.KeyEnter
-	KeyEqual        Key = ebiten.KeyEqual
-	KeyEscape       Key = ebiten.KeyEscape
-	KeyF1           Key = ebiten.KeyF1
-	KeyF2           Key = ebiten.KeyF2
-	KeyF3           Key = ebiten.KeyF3
-	KeyF4           Key = ebiten.KeyF4
-	KeyF5           Key = ebiten.KeyF5
-	KeyF6           Key = ebiten.KeyF6
-	KeyF7           Key = ebiten.KeyF7
-	KeyF8           Key = ebiten.KeyF8
-	KeyF9           Key = ebiten.KeyF9
-	KeyF10          Key = ebiten.KeyF10
-	KeyF11          Key = ebiten.KeyF11
-	KeyF12          Key = ebiten.KeyF12
-	KeyGraveAccent  Key = ebiten.KeyGraveAccent
-	KeyHome         Key = ebiten.KeyHome
-	KeyInsert       Key = ebiten.KeyInsert
-	KeyKP0          Key = ebiten.KeyKP0
-	KeyKP1          Key = ebiten.KeyKP1
-	KeyKP2          Key = ebiten.KeyKP2
-	KeyKP3          Key = ebiten.KeyKP3
-	KeyKP4          Key = ebiten.KeyKP4
-	KeyKP5          Key = ebiten.KeyKP5
-	KeyKP6          Key = ebiten.KeyKP6
-	KeyKP7          Key = ebiten.KeyKP7
-	KeyKP8          Key = ebiten.KeyKP8
-	KeyKP9          Key = ebiten.KeyKP9
-	KeyKPDecimal    Key = ebiten.KeyKPDecimal
-	KeyKPDivide     Key = ebiten.KeyKPDivide
-	KeyKPEnter      Key = ebiten.KeyKPEnter
-	KeyKPEqual      Key = ebiten.KeyKPEqual
-	KeyKPMultiply   Key = ebiten.KeyKPMultiply
-	KeyKPSubtract   Key = ebiten.KeyKPSubtract
-	KeyLeft         Key = ebiten.KeyLeft
-	KeyLeftBracket  Key = ebiten.KeyLeftBracket
-	KeyMenu         Key = ebiten.KeyMenu
-	KeyMinus        Key = ebiten.KeyMinus
-	KeyNumLock      Key = ebiten.KeyNumLock
-	KeyPageDown     Key = ebiten.KeyPageDown
-	KeyPageUp       Key = ebiten.KeyPageUp
-	KeyPause        Key = ebiten.KeyPause
-	KeyPeriod       Key = ebiten.KeyPeriod
-	KeyPrintScreen  Key = ebiten.KeyPrintScreen
-	KeyRight        Key = ebiten.KeyRight
-	KeyRightBracket Key = ebiten.KeyRightBracket
-	KeyScrollLock   Key = ebiten.KeyScrollLock
-	KeySemicolon    Key = ebiten.KeySemicolon
-	KeySlash        Key = ebiten.KeySlash
-	KeySpace        Key = ebiten.KeySpace
-	KeyTab          Key = ebiten.KeyTab
-	KeyUp           Key = ebiten.KeyUp
-	KeyAlt          Key = ebiten.KeyAlt
-	KeyControl      Key = ebiten.KeyControl
-	KeyShift        Key = ebiten.KeyShift
-	KeyMax          Key = ebiten.KeyMax
-	KeyAny          Key = -1
+	Key0            = Key(ebiten.Key0)
+	Key1            = Key(ebiten.Key1)
+	Key2            = Key(ebiten.Key2)
+	Key3            = Key(ebiten.Key3)
+	Key4            = Key(ebiten.Key4)
+	Key5            = Key(ebiten.Key5)
+	Key6            = Key(ebiten.Key6)
+	Key7            = Key(ebiten.Key7)
+	Key8            = Key(ebiten.Key8)
+	Key9            = Key(ebiten.Key9)
+	KeyA            = Key(ebiten.KeyA)
+	KeyB            = Key(ebiten.KeyB)
+	KeyC            = Key(ebiten.KeyC)
+	KeyD            = Key(ebiten.KeyD)
+	KeyE            = Key(ebiten.KeyE)
+	KeyF            = Key(ebiten.KeyF)
+	KeyG            = Key(ebiten.KeyG)
+	KeyH            = Key(ebiten.KeyH)
+	KeyI            = Key(ebiten.KeyI)
+	KeyJ            = Key(ebiten.KeyJ)
+	KeyK            = Key(ebiten.KeyK)
+	KeyL            = Key(ebiten.KeyL)
+	KeyM            = Key(ebiten.KeyM)
+	KeyN            = Key(ebiten.KeyN)
+	KeyO            = Key(ebiten.KeyO)
+	KeyP            = Key(ebiten.KeyP)
+	KeyQ            = Key(ebiten.KeyQ)
+	KeyR            = Key(ebiten.KeyR)
+	KeyS            = Key(ebiten.KeyS)
+	KeyT            = Key(ebiten.KeyT)
+	KeyU            = Key(ebiten.KeyU)
+	KeyV            = Key(ebiten.KeyV)
+	KeyW            = Key(ebiten.KeyW)
+	KeyX            = Key(ebiten.KeyX)
+	KeyY            = Key(ebiten.KeyY)
+	KeyZ            = Key(ebiten.KeyZ)
+	KeyApostrophe   = Key(ebiten.KeyApostrophe)
+	KeyBackslash    = Key(ebiten.KeyBackslash)
+	KeyBackspace    = Key(ebiten.KeyBackspace)
+	KeyCapsLock     = Key(ebiten.KeyCapsLock)
+	KeyComma        = Key(ebiten.KeyComma)
+	KeyDelete       = Key(ebiten.KeyDelete)
+	KeyDown         = Key(ebiten.KeyDown)
+	KeyEnd          = Key(ebiten.KeyEnd)
+	KeyEnter        = Key(ebiten.KeyEnter)
+	KeyEqual        = Key(ebiten.KeyEqual)
+	KeyEscape       = Key(ebiten.KeyEscape)
+	KeyF1           = Key(ebiten.KeyF1)
+	KeyF2           = Key(ebiten.KeyF2)
+	KeyF3           = Key(ebiten.KeyF3)
+	KeyF4           = Key(ebiten.KeyF4)
+	KeyF5           = Key(ebiten.KeyF5)
+	KeyF6           = Key(ebiten.KeyF6)
+	KeyF7           = Key(ebiten.KeyF7)
+	KeyF8           = Key(ebiten.KeyF8)
+	KeyF9           = Key(ebiten.KeyF9)
+	KeyF10          = Key(ebiten.KeyF10)
+	KeyF11          = Key(ebiten.KeyF11)
+	KeyF12          = Key(ebiten.KeyF12)
+	KeyGraveAccent  = Key(ebiten.KeyGraveAccent)
+	KeyHome         = Key(ebiten.KeyHome)
+	KeyInsert       = Key(ebiten.KeyInsert)
+	KeyKP0          = Key(ebiten.KeyKP0)
+	KeyKP1          = Key(ebiten.KeyKP1)
+	KeyKP2          = Key(ebiten.KeyKP2)
+	KeyKP3          = Key(ebiten.KeyKP3)
+	KeyKP4          = Key(ebiten.KeyKP4)
+	KeyKP5          = Key(ebiten.KeyKP5)
+	KeyKP6          = Key(ebiten.KeyKP6)
+	KeyKP7          = Key(ebiten.KeyKP7)
+	KeyKP8          = Key(ebiten.KeyKP8)
+	KeyKP9          = Key(ebiten.KeyKP9)
+	KeyKPDecimal    = Key(ebiten.KeyKPDecimal)
+	KeyKPDivide     = Key(ebiten.KeyKPDivide)
+	KeyKPEnter      = Key(ebiten.KeyKPEnter)
+	KeyKPEqual      = Key(ebiten.KeyKPEqual)
+	KeyKPMultiply   = Key(ebiten.KeyKPMultiply)
+	KeyKPSubtract   = Key(ebiten.KeyKPSubtract)
+	KeyLeft         = Key(ebiten.KeyLeft)
+	KeyLeftBracket  = Key(ebiten.KeyLeftBracket)
+	KeyMenu         = Key(ebiten.KeyMenu)
+	KeyMinus        = Key(ebiten.KeyMinus)
+	KeyNumLock      = Key(ebiten.KeyNumLock)
+	KeyPageDown     = Key(ebiten.KeyPageDown)
+	KeyPageUp       = Key(ebiten.KeyPageUp)
+	KeyPause        = Key(ebiten.KeyPause)
+	KeyPeriod       = Key(ebiten.KeyPeriod)
+	KeyPrintScreen  = Key(ebiten.KeyPrintScreen)
+	KeyRight        = Key(ebiten.KeyRight)
+	KeyRightBracket = Key(ebiten.KeyRightBracket)
+	KeyScrollLock   = Key(ebiten.KeyScrollLock)
+	KeySemicolon    = Key(ebiten.KeySemicolon)
+	KeySlash        = Key(ebiten.KeySlash)
+	KeySpace        = Key(ebiten.KeySpace)
+	KeyTab          = Key(ebiten.KeyTab)
+	KeyUp           = Key(ebiten.KeyUp)
+	KeyAlt          = Key(ebiten.KeyAlt)
+	KeyControl      = Key(ebiten.KeyControl)
+	KeyShift        = Key(ebiten.KeyShift)
+	KeyMax          = Key(ebiten.KeyMax)
+	KeyAny          = Key(-1)
 )
 
 // -------------------------------------------------------------------------------------
@@ -252,7 +252,7 @@ func (i *inputMgr) updateKeyboard() {
 		if ebiten.IsKeyPressed(key) {
 			n := i.keyStates[key]
 			if n > 0 {
-				if !isStateKey(key) {
+				if !isStateKey(Key(key)) {
 					n--
 				}
 			}
@@ -287,7 +287,7 @@ func isKeyPressed(key Key) bool {
 		}
 		return false
 	}
-	return ebiten.IsKeyPressed(key)
+	return ebiten.IsKeyPressed(ebiten.Key(key))
 }
 
 // -------------------------------------------------------------------------------------


### PR DESCRIPTION
Since goplus/gogen doesn't yet support `go/types.Alias` (a Go 1.22 feature), spxls in Go+ Builder fails when doing multi-key bindings (see https://github.com/goplus/builder/issues/1199#issuecomment-2572750795).

This represents the simplest approach to fix the issue mentiond.