### PR TITLE
Fix error when drawing empty text

### DIFF
--- a/monitor.go
+++ b/monitor.go
@@ -191,7 +191,9 @@ func (p *Monitor) draw(dc drawContext) {
 			w = stmDefaultW
 		}
 		drawRoundRect(dc, x, y, w, h, p.color, p.color)
-		render.Draw(dc.Image, int(x+((w-textW)/2)), int(y), color.White, 0)
+		if val != "" {
+			render.Draw(dc.Image, int(x+((w-textW)/2)), int(y), color.White, 0)
+		}
 	default:
 		font := getOrCreateFont(int(p.size * 12))
 		labelRender := gdi.NewTextRender(font, 0x80000, 0)
@@ -213,7 +215,9 @@ func (p *Monitor) draw(dc drawContext) {
 		w := labelW + textRectW + hGap*2
 		h := labelH + vGap*2
 		drawRoundRect(dc, x, y, w, h, stmBackground, stmBackgroundPen)
-		labelRender.Draw(dc.Image, int(x+hGap), int(y+vGap), color.Black, 0)
+		if p.label != "" {
+			labelRender.Draw(dc.Image, int(x+hGap), int(y+vGap), color.Black, 0)
+		}
 
 		textGap2Right := -1.0
 		textGapV := 2.0
@@ -224,8 +228,9 @@ func (p *Monitor) draw(dc drawContext) {
 		y2 := y + textGapV
 		h2 := h - textGapV*2
 		drawRoundRect(dc, x2, y2, w2, h2, stmValueground, stmValueRectPen)
-		textRender.Draw(dc.Image, int(x2+(w2-textW)/2+textPaddingOffset), int(y+vGap+(labelH-textH)/2), color.White, 0)
-
+		if val != "" {
+			textRender.Draw(dc.Image, int(x2+(w2-textW)/2+textPaddingOffset), int(y+vGap+(labelH-textH)/2), color.White, 0)
+		}
 	}
 }
 


### PR DESCRIPTION
When SPX runs in a browser with tag `canvas`, it panics if the label or value for the `Monitor` widget is an empty string. This occurs because the text-rendering operation by [canvas](https://github.com/goplus/canvas/blob/7e376755f874742425c54583cdc1cc579259d3f0/gc_js.go#L259) fails with empty content. This PR prevents such failures by checking for non-empty text content.

Example project: [issue-1287.zip](https://github.com/user-attachments/files/18668696/issue-1287.zip)

Related Builder issue: https://github.com/goplus/builder/issues/1287

Panic log:

```
panic: JavaScript error: Failed to execute 'getImageData' on 'CanvasRenderingContext2D': The source width is 0.

goroutine 12 [running]:
syscall/js.Value.Call({{}, 0x7ff8000100000192, 0x4646200}, {0x200ee3, 0xc}, {0x25276b8, 0x4, 0x4})
	syscall/js/js.go:397 +0x31
github.com/goplus/canvas.(*WebContext2D).Image(0x47ee450)
	github.com/goplus/canvas@v0.1.0/gc_js.go:259 +0x4
github.com/goplus/spx/internal/gdi.TextRender.Draw({0x47ef8c0, 0x4580120, 0x0, 0x80000, 0x0, 0xc, 0x0, 0x1, {0x0, 0x0}, ...}, ...)
	github.com/goplus/spx@v1.1.1-0.20241231062359-381fc67db3e1/internal/gdi/gdi_canvas.go:65 +0x1b
github.com/goplus/spx.(*Monitor).draw(0x3554780, {0x3554600})
	github.com/goplus/spx@v1.1.1-0.20241231062359-381fc67db3e1/monitor.go:227 +0x3b
github.com/goplus/spx.(*Game).onDraw(0x4548580, {0x3554600})
	github.com/goplus/spx@v1.1.1-0.20241231062359-381fc67db3e1/game.go:1140 +0x12
github.com/goplus/spx.(*Game).Draw(0x4548580, 0x2f40700)
	github.com/goplus/spx@v1.1.1-0.20241231062359-381fc67db3e1/game.go:683 +0x4
github.com/hajimehoshi/ebiten/v2.(*gameForUI).DrawOffscreen(0x45315e0)
	github.com/hajimehoshi/ebiten/v2@v2.8.0-alpha.3/gameforui.go:118 +0x6
github.com/hajimehoshi/ebiten/v2/internal/ui.(*context).drawGame(0x2f40300, {0x3b03f0, 0x3645e60}, 0x24bcfc0, 0x0)
	github.com/hajimehoshi/ebiten/v2@v2.8.0-alpha.3/internal/ui/context.go:191 +0x13
github.com/hajimehoshi/ebiten/v2/internal/ui.(*context).updateFrameImpl(0x2f40300, {0x3b03f0, 0x3645e60}, 0x1, 0x407d400000000000, 0x4075f00000000000, 0x3ff0000000000000, 0x24bcfc0, 0x0)
	github.com/hajimehoshi/ebiten/v2@v2.8.0-alpha.3/internal/ui/context.go:165 +0x3f
github.com/hajimehoshi/ebiten/v2/internal/ui.(*context).updateFrame(0x2f40300, {0x3b03f0, 0x3645e60}, 0x407d400000000000, 0x4075f00000000000, 0x3ff0000000000000, 0x24bcfc0)
	github.com/hajimehoshi/ebiten/v2@v2.8.0-alpha.3/internal/ui/context.go:73 +0x3
github.com/hajimehoshi/ebiten/v2/internal/ui.(*UserInterface).updateImpl(0x24bcfc0, 0x0)
	github.com/hajimehoshi/ebiten/v2@v2.8.0-alpha.3/internal/ui/ui_js.go:350 +0x15
github.com/hajimehoshi/ebiten/v2/internal/ui.(*UserInterface).update(0x24bcfc0)
	github.com/hajimehoshi/ebiten/v2@v2.8.0-alpha.3/internal/ui/ui_js.go:323 +0x12
github.com/hajimehoshi/ebiten/v2/internal/ui.(*UserInterface).loopGame.func1()
	github.com/hajimehoshi/ebiten/v2@v2.8.0-alpha.3/internal/ui/ui_js.go:392 +0xe
created by github.com/hajimehoshi/ebiten/v2/internal/ui.(*UserInterface).loopGame in goroutine 1
	github.com/hajimehoshi/ebiten/v2@v2.8.0-alpha.3/internal/ui/ui_js.go:418 +0x10
```