### PR TITLE
refactor(internal/coroutine): remove unused `ErrAbortThread`

### DIFF
--- a/internal/coroutine/coro.go
+++ b/internal/coroutine/coro.go
@@ -9,11 +9,8 @@ import (
 	"unsafe"
 )
 
-var (
-	// ErrCannotYieldANonrunningThread represents an "can not yield a non-running thread" error.
-	ErrCannotYieldANonrunningThread = errors.New("can not yield a non-running thread")
-	ErrAbortThread                  = errors.New("abort thread")
-)
+// ErrCannotYieldANonrunningThread represents an "can not yield a non-running thread" error.
+var ErrCannotYieldANonrunningThread = errors.New("can not yield a non-running thread")
 
 // -------------------------------------------------------------------------------------
 


### PR DESCRIPTION
This follows up on #495.