### PR TITLE
Fix stage's onClick event

### DIFF
--- a/input.go
+++ b/input.go
@@ -277,6 +277,8 @@ type inputManager struct {
 const (
 	// minimum interval between two mouse click events
 	inputMouseClickIntervalMs = 50
+	inputGlobalClickTimerId   = -1 // global click cooldown
+	inputStageClickTimerId    = 0  // stage click cooldown
 )
 
 func (p *inputManager) init(g *Game) {


### PR DESCRIPTION
The stage's onClick event should only be triggered when it is not occluded by any sprite
issue: https://github.com/goplus/spx/issues/580
test project: [match3.zip](https://github.com/user-attachments/files/19755654/match3.zip)
