### PR TITLE
Fix sched bug: to prevent frame drops, break the for loop if it runs too long and continue it in the next frame

### DIFF
--- a/game.go
+++ b/game.go
@@ -73,7 +73,6 @@ var (
 var (
 	isSchedInMain bool
 	mainSchedTime time.Time
-	lastSchedTime time.Time
 )
 
 func SetDebug(flags dbgFlags) {
@@ -207,7 +206,6 @@ func (p *Game) initGame(sprites []Sprite) *Game {
 
 // Gopt_Game_Main is required by Go+ compiler as the entry of a .gmx project.
 func Gopt_Game_Main(game Gamer, sprites ...Sprite) {
-	lastSchedTime = time.Now()
 	g := game.initGame(sprites)
 	g.gamer_ = game
 	engine.Main(game)
@@ -860,11 +858,10 @@ func Sched() int {
 			panic("Main execution timed out. Please check if there is an infinite loop in the code.")
 		}
 	} else {
-		if now.Sub(lastSchedTime) >= 3e7 {
-			if me := gco.Current(); me != nil {
-				gco.Sched(me)
+		if me := gco.Current(); me != nil {
+			if me.IsSchedTimeout() {
+				engine.WaitNextFrame()
 			}
-			lastSchedTime = now
 		}
 	}
 	return 0


### PR DESCRIPTION
test project: [tutorial/02-Dragon](https://github.com/user-attachments/files/19833808/test.zip)


In `SPX1`, since coroutines have no concept of frames, Yield can be used to voluntarily yield execution and prevent infinite loops. 
In contrast, `SPX2` introduces the concept of frames, so Yield should be replaced with `WaitNextFrame` to achieve the same effect