### PR TITLE
Add repeat, repeatUtil, forever, Optimize the scheduling of infinite loops

### DIFF
--- a/internal/engine/coro.go
+++ b/internal/engine/coro.go
@@ -27,6 +27,10 @@ func Wait(secs float64) float64 {
 	return time.TimeSinceLevelLoad() - startTime
 }
 
+func WaitYield() {
+	gco.WaitYield(gco.Current())
+}
+
 func WaitNextFrame() float64 {
 	gco.WaitNextFrame()
 	return time.DeltaTime()

--- a/internal/time/time.go
+++ b/internal/time/time.go
@@ -14,6 +14,7 @@ var (
 	setTimeScaleCallback       func(float64)
 	startTimestamp             stime.Time
 	fps                        float64
+	curFrameRealTimeSinceStart float64
 )
 
 func Sleep(ms float64) {
@@ -22,6 +23,14 @@ func Sleep(ms float64) {
 
 func RealTimeSinceStart() float64 {
 	return stime.Since(startTimestamp).Seconds()
+}
+
+func RealTimeSinceCurFrame() float64 {
+	return RealTimeSinceStart() - curFrameRealTimeSinceStart
+}
+
+func RealTimeSinceCurFrameMs() float64 {
+	return (RealTimeSinceStart() - curFrameRealTimeSinceStart) * 1000
 }
 func FPS() float64 {
 	return fps
@@ -72,4 +81,5 @@ func Update(scale float64, realDuration float64, duration float64, delta float64
 	deltaTime = delta
 	curFrame += 1
 	fps = pfps
+	curFrameRealTimeSinceStart = RealTimeSinceStart()
 }


### PR DESCRIPTION
test project1: [loop.zip](https://github.com/user-attachments/files/19885541/loop.zip)


```go
import "fmt"
var myIdx int
onStart => {
	setXpos(-100)
	idx := 0
	clone 
	forever => {
		say fmt.Sprintf("%d", idx)
		idx++
	}
}

onCloned => {
	setXpos(100)
	wait 1
	myIdx = 0
	repeat 100, => {
		say fmt.Sprintf("%d", myIdx)
		myIdx++
	}
	wait 1
	repeatUntil => myIdx >= 200,=> {
		say fmt.Sprintf("until %d", myIdx)
		myIdx++
	}

	wait 1
	say "clear"
	wait 1
	forever => {
		myIdx++
		println("myIdx", myIdx)
	}
}

onCloned => {
	waitUtil => myIdx >= 300
	say fmt.Sprintf("waitUtil %d done", myIdx)
	myIdx++
	wait 1
	say "infinite for loop"
	for{
		myIdx++
	}
}	
```

https://github.com/user-attachments/assets/60500bf8-a5a6-49e6-97ec-fabf1fb3d59f




complex test project: https://github.com/realdream-ai/spx_demos/tree/main/14_ShenGongBao
Optimize the scheduling of infinite loops 
eg:
![image](https://github.com/user-attachments/assets/b7282c3f-19bf-4458-b973-c4d90ea0b880)


https://github.com/user-attachments/assets/dcc5b102-a6e2-4ec3-b26f-bc90af75988c



