### PR TITLE
Auto-scale rendering to match the window size in the web platform

### DIFF
--- a/game.go
+++ b/game.go
@@ -487,8 +487,10 @@ func (p *Game) loadIndex(g reflect.Value, proj *projConfig) (err error) {
 	}
 
 	// fullscreen when on mobile platform
-	if platform.IsMobile() || proj.FullScreen {
-		platformMgr.SetWindowFullscreen(true)
+	if platform.IsMobile() || proj.FullScreen || platform.IsWeb() {
+		if proj.FullScreen || platform.IsMobile() {
+			platformMgr.SetWindowFullscreen(true)
+		}
 		winSize := platformMgr.GetWindowSize()
 		scale := math.Min(winSize.X/float64(p.windowWidth_), winSize.Y/float64(p.windowHeight_))
 		p.windowScale = scale


### PR DESCRIPTION
issue: https://github.com/goplus/spx/issues/624
Auto-scale rendering to match the window size in the web platform

before:
![image](https://github.com/user-attachments/assets/564bb7f8-eab3-4dd1-bd85-133e91b950e6)

after:
![image](https://github.com/user-attachments/assets/55a7173c-b123-44e5-98a1-62a91a96ce9e)


before:
![Image](https://github.com/user-attachments/assets/b14ead9b-aaeb-419f-9d9b-45e060ffe9ca)

after:
![image](https://github.com/user-attachments/assets/31678d58-0b1c-4097-a85d-b03c119b1d37)



