### PR TITLE
Reduce web engine size

### DIFF
--- a/pkg/gdspx/tools/build_engine.sh
+++ b/pkg/gdspx/tools/build_engine.sh
@@ -97,13 +97,35 @@ build_template() {
         cd $engine_dir || exit
 
         # build web editor
-        scons platform=web target=editor
+        scons platform=web target=editor \
+            debug_symbols="no" \
+            optimize=size \
+            use_volk=no \
+            deprecated=no \
+            minizip=no  \
+            openxr=false \
+            vulkan=false \
+            graphite=false \
+            disable_3d_physics=true \
+            disable_navigation=true \
+            module_msdfgen_enabled=false \
+            module_text_server_adv_enabled=false \
+            module_text_server_fb_enabled=true \
+            modules_enabled_by_default="no" \
+            module_gdscript_enabled="yes" \
+            module_text_server_fb_enabled="yes" \
+            module_freetype_enabled="yes" \
+            module_minimp3_enabled="yes" \
+            module_svg_enabled="yes" \
+            module_jpg_enabled="yes" \
+            module_ogg_enabled="yes" \
+            module_godot_physics_2d_enabled="yes" 
+
         cp bin/godot.web.editor.wasm32.zip bin/web_editor.zip
         cp bin/web_editor.zip $GOPATH/bin/gdspx$VERSION"_web.zip"
         if [ "$EDITOR_ONLY" = true ]; then
             exit 0
         fi 
-
         # build web templates
         scons platform=web target=template_release threads=no
         echo "Wait zip file to finished ..."


### PR DESCRIPTION
issue: https://github.com/goplus/spx/issues/527

#### 1. 最终参数解释说明：
```sh
    scons platform=web target=editor \
            debug_symbols="no" \  # 不需要debug 信息
            optimize=size \       # 优化选项
            use_volk=no \         # 不使用Vulkan
            deprecated=no \       # 废弃的API
            minizip=no  \         # 用不到zip
            openxr=false \        # 不需要 vr ar 之类的
            vulkan=false \        # 关闭Vulkan
            graphite=false \      # 2D 编辑器 不需要
            module_godot_physics_2d_enabled="yes" \  # 项目用到了2D物理模块
            disable_3d_physics=true \                # 3D 物理模块不需要，(3D也不需要，但是Editor 有依赖不能移除)
            disable_navigation=true \                # 不需要导航模块
            module_msdfgen_enabled=false \           # SDF generator 用不到
            module_text_server_adv_enabled=false \   # 字体高级特性 适配阿拉伯等国家，用不到
            module_text_server_fb_enabled=true \     # 字体 Fallback，不启用高级特性 就必须打开
            modules_enabled_by_default="no" \        # 默认所有Module 都关闭，手动开启必要的module
            module_gdscript_enabled="yes" \          # runtime 用到了，必须加上，否则需要修改engine代码
            module_freetype_enabled="yes" \          # 字体渲染加载 需要
            module_minimp3_enabled="yes" \           # MP3 项目必须支持的音频格式
            module_ogg_enabled="yes" \               # ogg 项目必须支持的音频格式
            module_svg_enabled="yes" \               # svg 项目必须支持的图片格式
            module_jpg_enabled="yes" \               # jpg 项目必须支持的图片格式
```

#### 2. 以下是测试下来的 不同编译参数得到的包体变化对比 

  |   
-- | -- 
build cmd | Size(MB)
target=template_release  （release模式） | 8.42 
target=template_release optimize=size debug_symbols=no vulkan=no use_volk=no openxr=no deprecated=no minizip=no | 8.36 
disable_3d="yes" | 7.52 
module_text_server_adv_enabled="no" module_text_server_fb_enabled="yes" | 6.95 
disable_advanced_gui="yes" | 6.59 |  
lto=true | 6.33 |  
disable_3d=true\    disable_3d_physics=true\    disable_navigation=true\    graphite=false\    module_msdfgen_enabled=false\    module_text_server_adv_enabled=false\    module_text_server_fb_enabled=true\    openxr=false\  vulkan=false |6.30 |   |  
modules_enabled_by_default="no"\    module_msdfgen_enabled=false\    module_text_server_adv_enabled=false\    module_text_server_fb_enabled=true\    disable_advanced_gui=true\    module_freetype_enabled="yes"\    module_svg_enabled="yes"\    module_webp_enabled="yes"\  module_godot_physics_2d_enabled="yes" |5.01 |   |  
target=editor (编辑器模式)| 30.08 |  
debug_symbols=no | 30.05 |  
optimize=size | 30.05 |  
optimize=size debug_symbols=no vulkan=no use_volk=no openxr=no deprecated=no minizip=no | 29.93 |  
debug_symbols="no"\    optimize=size\    use_volk=no\    deprecated=no\    minizip=no \    openxr=false\    vulkan=false\    graphite=false\    disable_3d_physics=true\    disable_navigation=true\    module_msdfgen_enabled=false\    module_text_server_adv_enabled=false\    module_text_server_fb_enabled=true |26.44 |   |  
modules_enabled_by_default="no"\    module_gdscript_enabled="yes"\    module_text_server_fb_enabled="yes"\    module_freetype_enabled="yes"\    module_minimp3_enabled="yes"\    module_svg_enabled="yes"\    module_jpg_enabled="yes"\    module_ogg_enabled="yes"\    module_godot_physics_2d_enabled="yes" | 24.03 |  


