### PR TITLE
Fix animation custume offset

### DIFF
--- a/gdspx.go
+++ b/gdspx.go
@@ -318,14 +318,19 @@ func applyRenderOffset(p *SpriteImpl, cx, cy *float64) {
 }
 
 func registerAnimToEngine(spriteName string, animName string, animCfg *aniConfig, costumes []*costume, isCostumeSet bool) {
+	// TODO(jiepengtan): here we should optimize the implementation, it's better to use json to map, avoid manually writing parsing code
 	sb := strings.Builder{}
 	from, to := animCfg.IFrameFrom, animCfg.IFrameTo
 	if from >= len(costumes) {
 		log.Panicf("animation key [%s] from [%d] is out of costumes length [%d]", animName, from, len(costumes))
 		return
 	}
+	splitTag := "|"
 	if isCostumeSet {
 		assetPath := engine.ToAssetPath(costumes[0].path)
+		if strings.Contains(assetPath, splitTag) {
+			panic("assetPath is invalid, should not contains " + splitTag + " " + costumes[0].path)
+		}
 		sb.WriteString(assetPath)
 		sb.WriteString(";")
 		ary := make([]int, 0)
@@ -348,7 +353,13 @@ func registerAnimToEngine(spriteName string, animName string, animCfg *aniConfig
 	} else {
 		for i := from; i <= to; i++ {
 			assetPath := engine.ToAssetPath(costumes[i].path)
+			if strings.Contains(assetPath, splitTag) {
+				panic("assetPath is invalid, should not contains " + splitTag + " " + costumes[i].path)
+			}
+			costume := costumes[i]
 			sb.WriteString(assetPath)
+			halfSize := mathf.Vec2.Mulf(costume.imageSize, 0.5)
+			sb.WriteString(splitTag + fmt.Sprintf("%f,%f", costume.center.X-halfSize.X, -costume.center.Y+halfSize.Y))
 			if i != to {
 				sb.WriteString(";")
 			}

--- a/spbase.go
+++ b/spbase.go
@@ -64,6 +64,7 @@ type costume struct {
 	name          SpriteCostumeName
 	width, height int
 	center        mathf.Vec2 // center point
+	imageSize     mathf.Vec2
 
 	faceRight        float64
 	bitmapResolution int
@@ -83,6 +84,7 @@ func newCostumeWithSize(width, height int) *costume {
 	}
 	value.posX = 0
 	value.posY = 0
+	value.imageSize = mathf.NewVec2(float64(width), float64(height))
 	value.center.X = float64(value.width) / 2
 	value.center.Y = float64(value.height) / 2
 	value.altasUVRect = mathf.NewVec4(0, 0, 1, 1)
@@ -96,6 +98,7 @@ func newCostumeWith(name string, img *costumeSetImage, faceRight float64, i, bit
 		faceRight: faceRight, bitmapResolution: bitmapResolution,
 	}
 	imageSize := getCustomeAssetSize(img.path)
+	value.imageSize = imageSize
 	value.width = int(imageSize.X) / img.nx
 	value.height = int(imageSize.Y)
 	value.posX = i * value.width
@@ -129,6 +132,7 @@ func newCostume(base string, c *costumeConfig) *costume {
 		path:             path,
 	}
 	imageSize := getCustomeAssetSize(path)
+	value.imageSize = imageSize
 	value.width = int(imageSize.X)
 	value.height = int(imageSize.Y)
 	value.posX = 0


### PR DESCRIPTION
Issue: https://github.com/goplus/spx/issues/688
test project: [test.zip](https://github.com/user-attachments/files/20754614/test.zip)
```
var (
	count int
)

onStart => {
	clone 
}

onCloned => {
	setSize 2
	setXpos -100
}

onClick => {
	if count == 0 {
		say "play animation", 1
		animate "animation"
	} else {
		say "done"
		say "switch costumes", 1
		setCostume "倭瓜-0A3"
		wait 0.1
		nextCostume
		wait 0.1
		nextCostume
		wait 0.1
		nextCostume
		wait 0.1
		nextCostume
		wait 0.1
		nextCostume
		wait 0.1
		nextCostume
		wait 0.1
		setCostume "倭瓜-0A3"
		say "done"
	}
	count = (count + 1) % 2
}

```

https://github.com/user-attachments/assets/10ee5fba-09c8-40c5-9ca4-591b6388a139

