### PR TITLE
Fix sprite bound size == zero  when onStart

### DIFF
--- a/gdspx.go
+++ b/gdspx.go
@@ -252,8 +252,11 @@ func syncInitSpritePhysicInfo(sprite *SpriteImpl, syncProxy *engine.Sprite) {
 		syncProxy.SetTriggerEnabled(false)
 	}
 }
-
 func syncGetCostumeBoundByAlpha(p *SpriteImpl, pscale float64) (mathf.Vec2, mathf.Vec2) {
+	return getCostumeBoundByAlpha(p, pscale, true)
+}
+
+func getCostumeBoundByAlpha(p *SpriteImpl, pscale float64, isSync bool) (mathf.Vec2, mathf.Vec2) {
 	cs := p.costumes[p.costumeIndex_]
 	var rect mathf.Rect2
 	// GetBoundFromAlpha is very slow, so we should cache the result
@@ -266,7 +269,11 @@ func syncGetCostumeBoundByAlpha(p *SpriteImpl, pscale float64) (mathf.Vec2, math
 			rect = cache
 		} else {
 			assetPath := engine.ToAssetPath(cs.path)
-			rect = engine.SyncGetBoundFromAlpha(assetPath)
+			if isSync {
+				rect = engine.SyncGetBoundFromAlpha(assetPath)
+			} else {
+				rect = resMgr.GetBoundFromAlpha(assetPath)
+			}
 		}
 		cachedBounds_[cs.path] = rect
 	}

--- a/sprite.go
+++ b/sprite.go
@@ -1774,6 +1774,12 @@ func (p *SpriteImpl) Bounds() *mathf.Rect2 {
 	applyRenderOffset(p, &x, &y)
 
 	if p.triggerType != physicColliderNone {
+		if p.triggerType == physicColliderAuto && p.syncSprite == nil {
+			// if sprite's proxy is not created, use the sync version to get the bound
+			center, size := getCostumeBoundByAlpha(p, p.scale, false)
+			p.triggerCenter = center
+			p.triggerSize = size
+		}
 		x += p.triggerCenter.X
 		y += p.triggerCenter.Y
 		w = p.triggerSize.X


### PR DESCRIPTION
issue: https://github.com/goplus/spx/issues/732
test project: [test.zip](https://github.com/user-attachments/files/21422126/test.zip)


```go

onStart => {
	setXYpos 484, 0
	println xpos  // should print 484 ,but print 0
	wait 1
	println xpos
}
```

