### PR TITLE
Fix pure anim(step,glide...) render dirty flag incorrect bug

### DIFF
--- a/sprite.go
+++ b/sprite.go
@@ -863,10 +863,10 @@ func doAnimation(p *SpriteImpl, info *animState) {
 		if info.IsCanceled {
 			return
 		}
-		p.isCostumeDirty = false
 		if !p.hasAnim(animName) {
 			return
 		}
+		p.isCostumeDirty = false
 		p.syncSprite.PlayAnim(animName, info.Speed, info.IsLoop, false)
 	})
 	if info.OnStart != nil && info.OnStart.Play != "" {


### PR DESCRIPTION
issue: https://github.com/goplus/spx/issues/733
test project: [test.zip](https://github.com/user-attachments/files/21422602/test.zip)

The reason is that when setting the size, it marks the sprite's `isCostumeDirty = true`. During the `render update`, if the state `isCostumeDirty == true` is detected, it synchronizes the sprite state from Go to Godot. There is a `time gap` in this process. If `isCostumeDirty` is set to `false` during this period, the state in Go will not be correctly synchronized to Godot.

The bug above was caused by this exact scenario: after `setSize` was called, the `glide` interface was immediately invoked, which incorrectly set `isCostumeDirty` to `false`, leading to this issue. If a wait 0.1 is inserted in between, it allows the update to synchronize the Go state to Godot, which is why it works correctly

```

onMsg "waitc", => {
	show
	setSize 0.05
	println " wait gloide"
	wait 0.1
	glide "a", 0.01
	turnTo a.heading
	step 300
	hide
}

```
