### PR TITLE
Feat: Collision detection optimization

### DIFF
--- a/config.go
+++ b/config.go
@@ -124,8 +124,9 @@ type projConfig struct {
 
 	WindowScale float64 `json:"windowScale"`
 
-	CollisionByShape bool `json:"collisionByShape"` // whether to use collision by shape or pixel
-	FullScreen       bool `json:"fullscreen"`
+	AutoSetCollisionLayer *bool `json:"autoSetCollisionLayer"` // whether to auto set collision layer, default true
+	CollisionByShape      bool  `json:"collisionByShape"`      // whether to use collision by shape or pixel, default false
+	FullScreen            bool  `json:"fullscreen"`            // whether to use fullscreen, default false
 }
 
 func (p *projConfig) getBackdrops() []*backdropConfig {

--- a/gdspx.go
+++ b/gdspx.go
@@ -215,6 +215,7 @@ func (*Game) syncUpdatePhysic() {
 }
 
 func syncInitSpritePhysicInfo(sprite *SpriteImpl, syncProxy *engine.Sprite) {
+	sprite.initCollisionParams()
 	// update collision layers
 	syncProxy.SetTriggerLayer(sprite.triggerLayer)
 	syncProxy.SetTriggerMask(sprite.triggerMask)


### PR DESCRIPTION

test project :[test.zip](https://github.com/user-attachments/files/21681681/test.zip)

相关配置：
index.json
``` go
// whether to auto set collision layer, default true
AutoSetCollisionLayer *bool `json:"autoSetCollisionLayer"` 
```

实现细节：
```
这里将精灵的idx % maxCollisionLayerIdx, 作为真正的layer, 这意味着 多个精灵共享相同的layer
同样的，他们的mask也是共享的，取所有target的layer的并集，这对性能有影响，但是对程序的正确性没有影响
因为碰撞事件会被 onTouchStart 那边进行过滤
```

demo:
SmallEnemy.spx :
```go
onTouchStart "Bullet", => {
	if life > 0 {
        life --
        if life <= 0 {
            die
        }
    }
}
```

Bullet.spx
### 1. 情况1 :  子弹和敌人互相碰撞
```go
onTouchStart "SmallEnemy", => {
	destroy
}

//  init sprite collision info Bullet 1 2
//  init sprite collision info SmallEnemy 2 1
```

### 2. 情况2： 子弹和敌人互相碰撞， 且子弹会和子弹进行碰撞
```go
onTouchStart => {
	destroy
}
//  init sprite collision info Bullet 1 3
//  init sprite collision info SmallEnemy 2 1
```


### 2. 情况3：敌人可以检测到子弹的碰撞， 但是子弹不会触发任何碰撞事件
```go
// no onTouchFunction
//  init sprite collision info Bullet 1 0
//  init sprite collision info SmallEnemy 2 1
```



https://github.com/user-attachments/assets/5c78f0b6-cd79-4167-87bf-36bf5faeb5e5



