### PR TITLE
Fix `make init` fails due to missing `nothreads` web template

### DIFF
--- a/pkg/gdspx/tools/build_engine.sh
+++ b/pkg/gdspx/tools/build_engine.sh
@@ -208,6 +208,8 @@ download_editor() {
     cp -f $filename "$template_dir/web_dlink_release.zip"
     cp -f $filename "$template_dir/web_debug.zip"
     cp -f $filename "$template_dir/web_release.zip"
+    cp -f $filename "$template_dir/web_nothreads_debug.zip"
+    cp -f $filename "$template_dir/web_nothreads_release.zip"
     
     platform_name=$platform
     local binary_postfix=""


### PR DESCRIPTION
Fix `make init` failing on new machines:
<img width="1469" height="488" alt="image" src="https://github.com/user-attachments/assets/77121cf0-df12-453a-adc7-8882d8c7a458" />
