### PR TITLE
Fix #813 awake call after onstart

### DIFF
--- a/event.go
+++ b/event.go
@@ -93,6 +93,7 @@ func (p *eventSink) call(wait bool, data any, doSth func(*eventSink)) {
 
 type eventSinkMgr struct {
 	allWhenStart           *eventSink
+	allWhenAwake           *eventSink
 	allWhenKeyPressed      *eventSink
 	allWhenSwipe           *eventSink
 	allWhenIReceive        *eventSink
@@ -110,6 +111,7 @@ type eventSinkMgr struct {
 
 func (p *eventSinkMgr) reset() {
 	p.allWhenStart = nil
+	p.allWhenAwake = nil
 	p.allWhenKeyPressed = nil
 	p.allWhenSwipe = nil
 	p.allWhenIReceive = nil
@@ -127,6 +129,7 @@ func (p *eventSinkMgr) reset() {
 
 func (p *eventSinkMgr) doDeleteClone(this any) {
 	p.allWhenStart = p.allWhenStart.doDeleteClone(this)
+	p.allWhenAwake = p.allWhenAwake.doDeleteClone(this)
 	p.allWhenKeyPressed = p.allWhenKeyPressed.doDeleteClone(this)
 	p.allWhenSwipe = p.allWhenSwipe.doDeleteClone(this)
 	p.allWhenIReceive = p.allWhenIReceive.doDeleteClone(this)
@@ -151,6 +154,15 @@ func (p *eventSinkMgr) doWhenStart() {
 			ev.sink.(func())()
 		})
 	}
+}
+
+func (p *eventSinkMgr) doWhenAwake() {
+	p.allWhenAwake.syncCall(nil, func(ev *eventSink) {
+		if debugEvent {
+			log.Println("==> onAwake", nameOf(ev.pthis))
+		}
+		ev.sink.(func())()
+	})
 }
 
 func (p *eventSinkMgr) doWhenTimer(time float64) {
@@ -300,6 +312,14 @@ func (p *eventSinks) OnStart(onStart func()) {
 		prev:  p.allWhenStart,
 		pthis: p.pthis,
 		sink:  onStart,
+	}
+}
+
+func (p *eventSinks) onAwake(onAwake func()) {
+	p.allWhenAwake = &eventSink{
+		prev:  p.allWhenAwake,
+		pthis: p.pthis,
+		sink:  onAwake,
 	}
 }
 

--- a/game.go
+++ b/game.go
@@ -565,7 +565,7 @@ func (p *Game) loadIndex(g reflect.Value, proj *projConfig) (err error) {
 	for _, ini := range inits {
 		spr := spriteOf(ini)
 		if spr != nil {
-			spr.OnStart(func() {
+			spr.onAwake(func() {
 				spr.awake()
 			})
 		}
@@ -876,6 +876,7 @@ func (p *Game) handleEvent(event event) {
 	case *eventKeyDown:
 		p.sinkMgr.doWhenKeyPressed(ev.Key)
 	case *eventStart:
+		p.sinkMgr.doWhenAwake()
 		p.sinkMgr.doWhenStart()
 	case *eventTimer:
 		p.sinkMgr.doWhenTimer(ev.Time)


### PR DESCRIPTION
https://github.com/goplus/spx/issues/813

Essentially, it's caused by the timing and the scheduling order of goroutines. Although onAwake is called before onStart, the actual wake-up time of goroutines is non-deterministic, which occasionally leads to onStart being called before onAwake. The onAwake method (which triggers playDefaultAnimation) consequently interrupts the execution of `step`.