### PR TITLE
Rename TurnTo__10 => TurnTo__a

### DIFF
--- a/sprite.go
+++ b/sprite.go
@@ -166,8 +166,8 @@ type Sprite interface {
 	TurnTo__7(target specialObj, speed float64)
 	TurnTo__8(target Sprite, speed float64, animation SpriteAnimationName)
 	TurnTo__9(target SpriteName, speed float64, animation SpriteAnimationName)
-	TurnTo__10(dir Direction, speed float64, animation SpriteAnimationName)
-	TurnTo__11(target specialObj, speed float64, animation SpriteAnimationName)
+	TurnTo__a(dir Direction, speed float64, animation SpriteAnimationName)
+	TurnTo__b(target specialObj, speed float64, animation SpriteAnimationName)
 	Visible() bool
 	Xpos() float64
 	Ypos() float64
@@ -1334,10 +1334,10 @@ func (p *SpriteImpl) TurnTo__8(target Sprite, speed float64, animation SpriteAni
 func (p *SpriteImpl) TurnTo__9(target SpriteName, speed float64, animation SpriteAnimationName) {
 	p.doTurnTo(target, speed, animation)
 }
-func (p *SpriteImpl) TurnTo__10(dir Direction, speed float64, animation SpriteAnimationName) {
+func (p *SpriteImpl) TurnTo__a(dir Direction, speed float64, animation SpriteAnimationName) {
 	p.doTurnTo(dir, speed, animation)
 }
-func (p *SpriteImpl) TurnTo__11(target specialObj, speed float64, animation SpriteAnimationName) {
+func (p *SpriteImpl) TurnTo__b(target specialObj, speed float64, animation SpriteAnimationName) {
 	p.doTurnTo(target, speed, animation)
 }
 


### PR DESCRIPTION
The overload suffix in xgo only supports [0-9a-z], so it cannot be written as TurnTo__10 and must be written as TurnTo__a.

https://github.com/goplus/gogen/blob/26541284c242b79404a5225a14bba4a2c14291cb/import.go#L378