### PR TITLE
Fix monitor target nil error

### DIFF
--- a/game.go
+++ b/game.go
@@ -392,6 +392,9 @@ func getFieldPtrOrAlloc(g *Game, v reflect.Value, i int) (name string, val any) 
 }
 
 func findFieldPtr(v reflect.Value, name string, from int) any {
+	if v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
 	t := v.Type()
 	for i, n := from, v.NumField(); i < n; i++ {
 		tFld := t.Field(i)
@@ -404,6 +407,9 @@ func findFieldPtr(v reflect.Value, name string, from int) any {
 }
 
 func findObjPtr(v reflect.Value, name string, from int) any {
+	if v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
 	t := v.Type()
 	for i, n := from, v.NumField(); i < n; i++ {
 		tFld := t.Field(i)


### PR DESCRIPTION
The embedding mechanism causes all sprite references in the Game to become pointers, which subsequently triggers a panic when the widget attempts to retrieve values through reflection.

test project:[test.zip](https://github.com/user-attachments/files/22021563/test.zip)


```
~/projects/robot/spx/demos/16_Dragon $ spx run 
Running command: go mod tidy
[DEBUG] handleBuildPhase: command=run, tags=0x14000028320
[DEBUG] Checking BuildDll conditions
[DEBUG] Executing BuildDll
2025/08/28 17:00:50 genGo tagStr: -tags=simulation
Running command: xgo go -tags=simulation
GenGo . ...
Running command: go mod tidy
build dll arch= amd64 -tags=simulation
Running command: go build -tags=simulation -o /Users/tjp/projects/robot/spx/demos/16_Dragon/project/lib/gdspx-darwin-amd64.dylib -buildmode=c-shared
build dll arch= arm64 -tags=simulation
Running command: go build -tags=simulation -o /Users/tjp/projects/robot/spx/demos/16_Dragon/project/lib/gdspx-darwin-arm64.dylib -buildmode=c-shared
Running command: /Users/tjp/go/bin/gdspxrt2.1.9 --path /Users/tjp/projects/robot/spx/demos/16_Dragon/.temp --gdextpath /Users/tjp/projects/robot/spx/demos/16_Dragon/.temp/runtime.gdextension
In directory: /Users/tjp/projects/robot/spx/demos/16_Dragon/.temp
Godot Engine v4.4.1.stable.custom_build.710bad2c9 (2025-08-28 06:40:30 UTC) - https://godotengine.org
Metal 3.2 - Forward+ - Using Device #0: Apple - Apple M4 (Apple9)

*main.Dragon
getTarget: score 2
panic: reflect: call of reflect.Value.NumField on ptr Value

goroutine 20 [running]:
reflect.flag.mustBe(...)
        /usr/local/go/src/reflect/value.go:218
reflect.Value.NumField({0x10e86de20?, 0x140002022f8?, 0x1400002f498?})
        /usr/local/go/src/reflect/value.go:1929 +0x90
github.com/goplus/spx/v2.findFieldPtr({0x10e86de20?, 0x140002022f8?, 0x10e7840f8?}, {0x14000222737, 0x5}, 0x2)
        /Users/tjp/projects/robot/spx/game.go:396 +0x80
github.com/goplus/spx/v2.getValueRef({0x10e86de20?, 0x140002022f8?, 0x14000059808?}, {0x14000222737, 0x5}, 0x2)
        /Users/tjp/projects/robot/spx/monitor.go:121 +0x88
github.com/goplus/spx/v2.buildMonitorEval({0x10e84a2e0?, 0x14000202008?, 0x10e6e8c28?}, {0x14000222720?, 0x1400002f788?}, {0x14000222730, 0xc})
        /Users/tjp/projects/robot/spx/monitor.go:145 +0x104
github.com/goplus/spx/v2.newMonitor({0x10e84a2e0?, 0x14000202008?, 0x10e6e8c24?}, 0x14000209020)
        /Users/tjp/projects/robot/spx/monitor.go:71 +0x160
github.com/goplus/spx/v2.(*Game).addSpecialShape(0x14000202008, {0x10e84a2e0?, 0x14000202008?, 0x10e84a2e0?}, 0x14000209020, {0x140000a04b0, 0x2, 0x3})
        /Users/tjp/projects/robot/spx/game.go:688 +0x28c
github.com/goplus/spx/v2.(*Game).loadIndex(0x14000202008, {0x10e84a2e0?, 0x14000202008?, 0x14000202008?}, 0x140000bc000)
        /Users/tjp/projects/robot/spx/game.go:556 +0x98c
github.com/goplus/spx/v2.(*Game).endLoad(0x14000202008?, {0x10e84a2e0?, 0x14000202008?, 0x10e78d214?}, 0x5?)
        /Users/tjp/projects/robot/spx/game.go:655 +0xa4
github.com/goplus/spx/v2.Gopt_Game_Run({0x10e879fe8, 0x14000202008}, {0x10e7c7ac0, 0x10e872230}, {0x0, 0x0, 0x0?})
        /Users/tjp/projects/robot/spx/game.go:354 +0xa5c
github.com/goplus/spx/v2.(*Game).OnEngineStart.func1()
        /Users/tjp/projects/robot/spx/gdspx.go:59 +0xd0
created by github.com/goplus/spx/v2.(*Game).OnEngineStart in goroutine 17
        /Users/tjp/projects/robot/spx/gdspx.go:63 +0x84
2025/08/28 17:00:53 Command /Users/tjp/go/bin/gdspxrt2.1.9 failed: signal: abort trap
```
