### PR TITLE
Fix API2.0 Crash Spx Bug

### DIFF
--- a/game.go
+++ b/game.go
@@ -441,7 +441,7 @@ func (p *Game) startLoad(fs spxfs.Dir, cfg *Config) {
 }
 
 func (p *Game) canBindSprite(name string) bool {
-	return hasAsset("sprites/" + name + "/index.json")
+	return hasAsset("sprites/"+name+"/index.json") && p.typs[name] != nil
 }
 
 func (p *Game) loadSprite(sprite Sprite, name string, gamer reflect.Value) error {


### PR DESCRIPTION
The user may define variables with the same name as the sprite (starting with a lowercase letter). The Godot engine's path loading is case-insensitive, which may result in repeatedly loading the same sprite multiple times

[03-Clone.zip](https://github.com/user-attachments/files/22039520/03-Clone.zip)

<img width="973" height="690" alt="image" src="https://github.com/user-attachments/assets/eb781015-ee48-41c7-be7f-a655f7ab7f6c" />


