### PR TITLE
Feat: bridge wrap code support array type

### DIFF
--- a/cmd/igox/pkg/github.com/goplus/spx/v2/export.go
+++ b/cmd/igox/pkg/github.com/goplus/spx/v2/export.go
@@ -18,6 +18,7 @@ func init() {
 		Path: "github.com/goplus/spx/v2",
 		Deps: map[string]string{
 			"encoding/json":                     "json",
+			"errors":                            "errors",
 			"flag":                              "flag",
 			"fmt":                               "fmt",
 			"github.com/goplus/spbase/mathf":    "mathf",

--- a/cmd/igox/pkg/github.com/goplus/spx/v2/pkg/gdspx/pkg/engine/export.go
+++ b/cmd/igox/pkg/github.com/goplus/spx/v2/pkg/gdspx/pkg/engine/export.go
@@ -51,7 +51,9 @@ func init() {
 			"Sprite":             reflect.TypeOf((*q.Sprite)(nil)).Elem(),
 			"UiNode":             reflect.TypeOf((*q.UiNode)(nil)).Elem(),
 		},
-		AliasTypes: map[string]reflect.Type{},
+		AliasTypes: map[string]reflect.Type{
+			"Array": reflect.TypeOf((*q.Array)(nil)).Elem(),
+		},
 		Vars: map[string]reflect.Value{
 			"AudioMgr":           reflect.ValueOf(&q.AudioMgr),
 			"CameraMgr":          reflect.ValueOf(&q.CameraMgr),

--- a/internal/enginewrap/sync.gen.go
+++ b/internal/enginewrap/sync.gen.go
@@ -431,6 +431,11 @@ func (pself *physicMgrImpl) SetCollisionSystemType(is_collision_by_alpha bool) {
 }
 
 // IPlatformMgr
+func (pself *platformMgrImpl) SetStretchMode(enable bool) {
+	callInMainThread(func() {
+		gdx.PlatformMgr.SetStretchMode(enable)
+	})
+}
 func (pself *platformMgrImpl) SetWindowPosition(pos Vec2) {
 	callInMainThread(func() {
 		gdx.PlatformMgr.SetWindowPosition(pos)

--- a/internal/enginewrap/sync_pure.gen.go
+++ b/internal/enginewrap/sync_pure.gen.go
@@ -236,6 +236,7 @@ func (pself *physicMgrImpl) CheckTouchedCameraBoundary(obj gdx.Object, board_typ
 func (pself *physicMgrImpl) SetCollisionSystemType(is_collision_by_alpha bool) {}
 
 // IPlatformMgr
+func (pself *platformMgrImpl) SetStretchMode(enable bool) {}
 func (pself *platformMgrImpl) SetWindowPosition(pos Vec2) {}
 func (pself *platformMgrImpl) GetWindowPosition() Vec2 {
 	var _ret1 Vec2

--- a/pkg/gdspx/cmd/codegen/generate/common/funcs.go
+++ b/pkg/gdspx/cmd/codegen/generate/common/funcs.go
@@ -98,6 +98,11 @@ func GoArgumentType(t clang.PrimativeType, name string) string {
 			return "*Uint64T"
 		}
 		return "Uint64T"
+	case "GdArray":
+		if t.IsPointer {
+			return "*GdArray"
+		}
+		return "GdArray"
 	default:
 		if t.IsPointer {
 			return fmt.Sprintf("*%s", n)
@@ -170,6 +175,12 @@ func GoReturnType(t clang.PrimativeType) string {
 		} else {
 			return ""
 		}
+	case "GdArray":
+		if t.IsPointer {
+			return "*GdArray"
+		} else {
+			return "GdArray"
+		}
 	default:
 		if t.IsPointer {
 			return fmt.Sprintf("*%s", n)
@@ -223,6 +234,12 @@ func CgoCastArgument(a clang.Argument, defaultName string) string {
 				}
 			} else {
 				panic(fmt.Sprintf("unhandled type: %s", t.CStyleString()))
+			}
+		case "GdArray":
+			if t.IsPointer {
+				return fmt.Sprintf("(*C.GdArray)(%s)", goVarName)
+			} else {
+				return fmt.Sprintf("(*C.GdArray)(&%s)", goVarName)
 			}
 		default:
 			if t.IsPointer {
@@ -329,6 +346,12 @@ func CgoCastReturnType(t clang.PrimativeType, argName string) string {
 			return fmt.Sprintf("(*float32)(%s)", argName)
 		} else {
 			return fmt.Sprintf("float32(%s)", argName)
+		}
+	case "GdArray":
+		if t.IsPointer {
+			return fmt.Sprintf("(*GdArray)(%s)", argName)
+		} else {
+			return fmt.Sprintf("GdArray(%s)", argName)
 		}
 	default:
 		if t.IsPointer {
@@ -443,6 +466,7 @@ func GetManagers(ast clang.CHeaderFileAST) []string {
 		"GdString": "string",
 		"GdBool":   "bool",
 		"GdColor":  "Color",
+		"GdArray":  "Array",
 	}
 	return managers
 }

--- a/pkg/gdspx/cmd/codegen/generate/ffi/generate.go
+++ b/pkg/gdspx/cmd/codegen/generate/ffi/generate.go
@@ -400,6 +400,9 @@ func GetGdxFuncParamTypeString(typeName string) string {
 	if name == "Object" {
 		return "gdx." + name
 	}
+	if name == "Array" {
+		return "gdx.Array"
+	}
 	return name
 }
 func genSyncPureApiWrapFunction(function *clang.TypedefFunction) string {

--- a/pkg/gdspx/cmd/codegen/generate/gdext/gdextension_spx_ext.h.tmpl
+++ b/pkg/gdspx/cmd/codegen/generate/gdext/gdextension_spx_ext.h.tmpl
@@ -52,6 +52,23 @@ typedef Vector2 GdVec2;
 typedef Color GdColor;
 typedef Rect2 GdRect2;
 
+typedef struct {
+    int32_t size;
+    int32_t type;
+    void* data;
+} GdArrayInfo;
+
+typedef GdArrayInfo* GdArray;
+
+typedef enum  {
+    GD_ARRAY_TYPE_UNKNOWN = 0,
+    GD_ARRAY_TYPE_INT64 = 1,
+    GD_ARRAY_TYPE_FLOAT = 2,
+	GD_ARRAY_TYPE_BOOL = 3,
+	GD_ARRAY_TYPE_STRING = 4,
+	GD_ARRAY_TYPE_BYTE = 5,
+	GD_ARRAY_TYPE_GDOBJ = 6,
+} GdArrayType;
 
 typedef struct {
 	// 0 is return value

--- a/pkg/gdspx/internal/ffi/ffi.gen.go
+++ b/pkg/gdspx/internal/ffi/ffi.gen.go
@@ -73,6 +73,7 @@ type GDExtensionInterface struct {
 	SpxPhysicCheckTouchedCameraBoundaries    GDExtensionSpxPhysicCheckTouchedCameraBoundaries
 	SpxPhysicCheckTouchedCameraBoundary      GDExtensionSpxPhysicCheckTouchedCameraBoundary
 	SpxPhysicSetCollisionSystemType          GDExtensionSpxPhysicSetCollisionSystemType
+	SpxPlatformSetStretchMode                GDExtensionSpxPlatformSetStretchMode
 	SpxPlatformSetWindowPosition             GDExtensionSpxPlatformSetWindowPosition
 	SpxPlatformGetWindowPosition             GDExtensionSpxPlatformGetWindowPosition
 	SpxPlatformSetWindowSize                 GDExtensionSpxPlatformSetWindowSize
@@ -309,6 +310,7 @@ func (x *GDExtensionInterface) loadProcAddresses() {
 	x.SpxPhysicCheckTouchedCameraBoundaries = (GDExtensionSpxPhysicCheckTouchedCameraBoundaries)(dlsymGD("spx_physic_check_touched_camera_boundaries"))
 	x.SpxPhysicCheckTouchedCameraBoundary = (GDExtensionSpxPhysicCheckTouchedCameraBoundary)(dlsymGD("spx_physic_check_touched_camera_boundary"))
 	x.SpxPhysicSetCollisionSystemType = (GDExtensionSpxPhysicSetCollisionSystemType)(dlsymGD("spx_physic_set_collision_system_type"))
+	x.SpxPlatformSetStretchMode = (GDExtensionSpxPlatformSetStretchMode)(dlsymGD("spx_platform_set_stretch_mode"))
 	x.SpxPlatformSetWindowPosition = (GDExtensionSpxPlatformSetWindowPosition)(dlsymGD("spx_platform_set_window_position"))
 	x.SpxPlatformGetWindowPosition = (GDExtensionSpxPlatformGetWindowPosition)(dlsymGD("spx_platform_get_window_position"))
 	x.SpxPlatformSetWindowSize = (GDExtensionSpxPlatformSetWindowSize)(dlsymGD("spx_platform_set_window_size"))

--- a/pkg/gdspx/internal/ffi/ffi_wrapper.gen.go
+++ b/pkg/gdspx/internal/ffi/ffi_wrapper.gen.go
@@ -21,6 +21,17 @@ import "C"
 
 // C type aliases
 // enums
+type GdArrayType C.GdArrayType
+
+const (
+	GD_ARRAY_TYPE_UNKNOWN GdArrayType = 0
+	GD_ARRAY_TYPE_INT64               = 1
+	GD_ARRAY_TYPE_FLOAT               = 2
+	GD_ARRAY_TYPE_BOOL                = 3
+	GD_ARRAY_TYPE_STRING              = 4
+	GD_ARRAY_TYPE_BYTE                = 5
+	GD_ARRAY_TYPE_GDOBJ               = 6
+)
 
 // C function aliases
 type GDExtensionSpxGlobalRegisterCallbacks C.GDExtensionSpxGlobalRegisterCallbacks
@@ -128,6 +139,7 @@ type GDExtensionSpxPhysicCheckCollision C.GDExtensionSpxPhysicCheckCollision
 type GDExtensionSpxPhysicCheckTouchedCameraBoundaries C.GDExtensionSpxPhysicCheckTouchedCameraBoundaries
 type GDExtensionSpxPhysicCheckTouchedCameraBoundary C.GDExtensionSpxPhysicCheckTouchedCameraBoundary
 type GDExtensionSpxPhysicSetCollisionSystemType C.GDExtensionSpxPhysicSetCollisionSystemType
+type GDExtensionSpxPlatformSetStretchMode C.GDExtensionSpxPlatformSetStretchMode
 type GDExtensionSpxPlatformSetWindowPosition C.GDExtensionSpxPlatformSetWindowPosition
 type GDExtensionSpxPlatformGetWindowPosition C.GDExtensionSpxPlatformGetWindowPosition
 type GDExtensionSpxPlatformSetWindowSize C.GDExtensionSpxPlatformSetWindowSize
@@ -826,6 +838,15 @@ func CallPhysicSetCollisionSystemType(
 	arg1GdBool := (C.GdBool)(is_collision_by_alpha)
 
 	C.cgo_callfn_GDExtensionSpxPhysicSetCollisionSystemType(arg0, arg1GdBool)
+
+}
+func CallPlatformSetStretchMode(
+	enable GdBool,
+) {
+	arg0 := (C.GDExtensionSpxPlatformSetStretchMode)(api.SpxPlatformSetStretchMode)
+	arg1GdBool := (C.GdBool)(enable)
+
+	C.cgo_callfn_GDExtensionSpxPlatformSetStretchMode(arg0, arg1GdBool)
 
 }
 func CallPlatformSetWindowPosition(

--- a/pkg/gdspx/internal/ffi/ffi_wrapper.gen.h
+++ b/pkg/gdspx/internal/ffi/ffi_wrapper.gen.h
@@ -177,6 +177,9 @@ void cgo_callfn_GDExtensionSpxPhysicCheckTouchedCameraBoundary(const GDExtension
 void cgo_callfn_GDExtensionSpxPhysicSetCollisionSystemType(const GDExtensionSpxPhysicSetCollisionSystemType fn, GdBool is_collision_by_alpha) {
 	fn(is_collision_by_alpha);
 }
+void cgo_callfn_GDExtensionSpxPlatformSetStretchMode(const GDExtensionSpxPlatformSetStretchMode fn, GdBool enable) {
+	fn(enable);
+}
 void cgo_callfn_GDExtensionSpxPlatformSetWindowPosition(const GDExtensionSpxPlatformSetWindowPosition fn, GdVec2 pos) {
 	fn(pos);
 }

--- a/pkg/gdspx/internal/ffi/gdextension_spx_ext.h
+++ b/pkg/gdspx/internal/ffi/gdextension_spx_ext.h
@@ -52,6 +52,23 @@ typedef Vector2 GdVec2;
 typedef Color GdColor;
 typedef Rect2 GdRect2;
 
+typedef struct {
+    int32_t size;
+    int32_t type;
+    void* data;
+} GdArrayInfo;
+
+typedef GdArrayInfo* GdArray;
+
+typedef enum  {
+    GD_ARRAY_TYPE_UNKNOWN = 0,
+    GD_ARRAY_TYPE_INT64 = 1,
+    GD_ARRAY_TYPE_FLOAT = 2,
+	GD_ARRAY_TYPE_BOOL = 3,
+	GD_ARRAY_TYPE_STRING = 4,
+	GD_ARRAY_TYPE_BYTE = 5,
+	GD_ARRAY_TYPE_GDOBJ = 6,
+} GdArrayType;
 
 typedef struct {
 	// 0 is return value
@@ -258,6 +275,7 @@ typedef void (*GDExtensionSpxPhysicCheckTouchedCameraBoundaries)(GdObj obj, GdIn
 typedef void (*GDExtensionSpxPhysicCheckTouchedCameraBoundary)(GdObj obj,GdInt board_type, GdBool* ret_value);
 typedef void (*GDExtensionSpxPhysicSetCollisionSystemType)(GdBool is_collision_by_alpha);
 // SpxPlatform
+typedef void (*GDExtensionSpxPlatformSetStretchMode)(GdBool enable);
 typedef void (*GDExtensionSpxPlatformSetWindowPosition)(GdVec2 pos);
 typedef void (*GDExtensionSpxPlatformGetWindowPosition)(GdVec2* ret_value);
 typedef void (*GDExtensionSpxPlatformSetWindowSize)(GdInt width, GdInt height);

--- a/pkg/gdspx/internal/webffi/ffi.gen.go
+++ b/pkg/gdspx/internal/webffi/ffi.gen.go
@@ -77,6 +77,7 @@ type GDExtensionInterface struct {
 	SpxPhysicCheckTouchedCameraBoundaries    js.Value
 	SpxPhysicCheckTouchedCameraBoundary      js.Value
 	SpxPhysicSetCollisionSystemType          js.Value
+	SpxPlatformSetStretchMode                js.Value
 	SpxPlatformSetWindowPosition             js.Value
 	SpxPlatformGetWindowPosition             js.Value
 	SpxPlatformSetWindowSize                 js.Value
@@ -313,6 +314,7 @@ func (x *GDExtensionInterface) loadProcAddresses() {
 	x.SpxPhysicCheckTouchedCameraBoundaries = dlsymGD("gdspx_physic_check_touched_camera_boundaries")
 	x.SpxPhysicCheckTouchedCameraBoundary = dlsymGD("gdspx_physic_check_touched_camera_boundary")
 	x.SpxPhysicSetCollisionSystemType = dlsymGD("gdspx_physic_set_collision_system_type")
+	x.SpxPlatformSetStretchMode = dlsymGD("gdspx_platform_set_stretch_mode")
 	x.SpxPlatformSetWindowPosition = dlsymGD("gdspx_platform_set_window_position")
 	x.SpxPlatformGetWindowPosition = dlsymGD("gdspx_platform_get_window_position")
 	x.SpxPlatformSetWindowSize = dlsymGD("gdspx_platform_set_window_size")

--- a/pkg/gdspx/internal/wrap/manager_wrapper.gen.go
+++ b/pkg/gdspx/internal/wrap/manager_wrapper.gen.go
@@ -385,6 +385,10 @@ func (pself *physicMgr) SetCollisionSystemType(is_collision_by_alpha bool) {
 	arg0 := ToGdBool(is_collision_by_alpha)
 	CallPhysicSetCollisionSystemType(arg0)
 }
+func (pself *platformMgr) SetStretchMode(enable bool) {
+	arg0 := ToGdBool(enable)
+	CallPlatformSetStretchMode(arg0)
+}
 func (pself *platformMgr) SetWindowPosition(pos Vec2) {
 	arg0 := ToGdVec2(pos)
 	CallPlatformSetWindowPosition(arg0)

--- a/pkg/gdspx/internal/wrap/manager_wrapper_web.gen.go
+++ b/pkg/gdspx/internal/wrap/manager_wrapper_web.gen.go
@@ -364,6 +364,10 @@ func (pself *physicMgr) SetCollisionSystemType(is_collision_by_alpha bool) {
 	arg0 := JsFromGdBool(is_collision_by_alpha)
 	API.SpxPhysicSetCollisionSystemType.Invoke(arg0)
 }
+func (pself *platformMgr) SetStretchMode(enable bool) {
+	arg0 := JsFromGdBool(enable)
+	API.SpxPlatformSetStretchMode.Invoke(arg0)
+}
 func (pself *platformMgr) SetWindowPosition(pos Vec2) {
 	arg0 := JsFromGdVec2(pos)
 	API.SpxPlatformSetWindowPosition.Invoke(arg0)

--- a/pkg/gdspx/pkg/engine/builtin_types.go
+++ b/pkg/gdspx/pkg/engine/builtin_types.go
@@ -2,3 +2,4 @@ package engine
 
 type Node int64
 type Object int64
+type Array = any

--- a/pkg/gdspx/pkg/engine/interface.gen.go
+++ b/pkg/gdspx/pkg/engine/interface.gen.go
@@ -98,6 +98,7 @@ type IPhysicMgr interface {
 }
 
 type IPlatformMgr interface {
+	SetStretchMode(enable bool)
 	SetWindowPosition(pos Vec2)
 	GetWindowPosition() Vec2
 	SetWindowSize(width int64, height int64)


### PR DESCRIPTION
Go JS C++ automatic wrapper code generation support for passing Array array types: Currently supported types include: 
- []Int64  = 1
- []Float  = 2
- []Bool   = 3
- []String = 4
- []Byte   = 5
- []GdObj  = 6

eg: 
```cpp
	GdArray check_collision_rect(GdVec2 pos, GdVec2 size);
	GdArray check_collision_circle(GdVec2 pos, GdFloat radius);};
```

```go
func testArray() {
	va1 := physicMgr.CheckCollisionRect(mathf.NewVec2(-1, 2), mathf.NewVec2(2, 4))
	fmt.Printf("testArray1==> %v \n", va1)
	va2 := physicMgr.CheckCollisionCircle(mathf.NewVec2(-1, 6), 1)
	fmt.Printf("testArray2==> %v \n", va2)
}
```