### PR TITLE
Support Path Finding

### DIFF
--- a/cmd/igox/pkg/github.com/goplus/spx/v2/pkg/gdspx/pkg/engine/export.go
+++ b/cmd/igox/pkg/github.com/goplus/spx/v2/pkg/gdspx/pkg/engine/export.go
@@ -285,6 +285,8 @@ func init() {
 			"KeyYen":          {reflect.TypeOf(q.KeyYen), constant.MakeInt64(int64(q.KeyYen))},
 			"KeyZ":            {reflect.TypeOf(q.KeyZ), constant.MakeInt64(int64(q.KeyZ))},
 		},
-		UntypedConsts: map[string]ixgo.UntypedConst{},
+		UntypedConsts: map[string]ixgo.UntypedConst{
+			"Float2IntFactor": {"untyped int", constant.MakeInt64(int64(q.Float2IntFactor))},
+		},
 	})
 }

--- a/game.go
+++ b/game.go
@@ -1867,12 +1867,6 @@ func (p *Game) ExitTilemapEditMode() {
 	extMgr.ExitTilemapEditorMode()
 }
 
-func (p *Game) GetLayerPointPath(x_from, y_from, x_to, y_to float64) []float64 {
-	arr := extMgr.GetLayerPointPath(mathf.NewVec2(x_from, y_from), mathf.NewVec2(x_to, y_to))
-	result := arr.([]float32)
-	return f32Tof64(result)
-}
-
 func (p *Game) CreatePureSprite(texture_path string, x, y float64, zindex int64) {
 	extMgr.CreatePureSprite(engine.ToAssetPath(texture_path), mathf.NewVec2(x, y), zindex)
 }
@@ -1880,6 +1874,20 @@ func (p *Game) CreatePureSprite(texture_path string, x, y float64, zindex int64)
 func (p *Game) SetTileMapOffset(index int64, x, y float64) {
 	extMgr.SetLayerOffset(index, mathf.NewVec2(x, y))
 
+}
+
+func (p *Game) SetupPathFinder__0() {
+	extMgr.SetupPathFinder()
+}
+
+func (p *Game) SetupPathFinder__1(x_grid_size, y_grid_size, x_cell_size, y_cell_size float64, with_debug bool) {
+	extMgr.SetupPathFinderWithSize(mathf.NewVec2(x_grid_size, y_grid_size), mathf.NewVec2(x_cell_size, y_cell_size), with_debug)
+}
+
+func (p *Game) FindPath(x_from, y_from, x_to, y_to float64) []float64 {
+	arr := extMgr.FindPath(mathf.NewVec2(x_from, y_from), mathf.NewVec2(x_to, y_to))
+	result := arr.([]float32)
+	return f32Tof64(result)
 }
 
 // -----------------------------------------------------------------------------

--- a/internal/enginewrap/sync.gen.go
+++ b/internal/enginewrap/sync.gen.go
@@ -413,13 +413,6 @@ func (pself *extMgrImpl) CloseDrawTiles() {
 		gdx.ExtMgr.CloseDrawTiles()
 	})
 }
-func (pself *extMgrImpl) GetLayerPointPath(p_from Vec2, p_to Vec2) gdx.Array {
-	var _ret1 gdx.Array
-	callInMainThread(func() {
-		_ret1 = gdx.ExtMgr.GetLayerPointPath(p_from, p_to)
-	})
-	return _ret1
-}
 func (pself *extMgrImpl) ExitTilemapEditorMode() {
 	callInMainThread(func() {
 		gdx.ExtMgr.ExitTilemapEditorMode()
@@ -434,6 +427,23 @@ func (pself *extMgrImpl) CreatePureSprite(texture_path string, pos Vec2, zindex 
 	callInMainThread(func() {
 		gdx.ExtMgr.CreatePureSprite(texture_path, pos, zindex)
 	})
+}
+func (pself *extMgrImpl) SetupPathFinderWithSize(grid_size Vec2, cell_size Vec2, with_debug bool) {
+	callInMainThread(func() {
+		gdx.ExtMgr.SetupPathFinderWithSize(grid_size, cell_size, with_debug)
+	})
+}
+func (pself *extMgrImpl) SetupPathFinder() {
+	callInMainThread(func() {
+		gdx.ExtMgr.SetupPathFinder()
+	})
+}
+func (pself *extMgrImpl) FindPath(p_from Vec2, p_to Vec2) gdx.Array {
+	var _ret1 gdx.Array
+	callInMainThread(func() {
+		_ret1 = gdx.ExtMgr.FindPath(p_from, p_to)
+	})
+	return _ret1
 }
 
 // IInputMgr

--- a/internal/enginewrap/sync_pure.gen.go
+++ b/internal/enginewrap/sync_pure.gen.go
@@ -196,17 +196,19 @@ func (pself *extMgrImpl) GetLayerOffset(index int64) Vec2 {
 func (pself *extMgrImpl) PlaceTiles(positions gdx.Array, texture_path string) {}
 func (pself *extMgrImpl) PlaceTilesWithLayer(positions gdx.Array, texture_path string, layer_index int64) {
 }
-func (pself *extMgrImpl) PlaceTile(pos Vec2, texture_path string)                             {}
-func (pself *extMgrImpl) PlaceTileWithLayer(pos Vec2, texture_path string, layer_index int64) {}
-func (pself *extMgrImpl) EraseTile(pos Vec2)                                                  {}
-func (pself *extMgrImpl) CloseDrawTiles()                                                     {}
-func (pself *extMgrImpl) GetLayerPointPath(p_from Vec2, p_to Vec2) gdx.Array {
+func (pself *extMgrImpl) PlaceTile(pos Vec2, texture_path string)                                 {}
+func (pself *extMgrImpl) PlaceTileWithLayer(pos Vec2, texture_path string, layer_index int64)     {}
+func (pself *extMgrImpl) EraseTile(pos Vec2)                                                      {}
+func (pself *extMgrImpl) CloseDrawTiles()                                                         {}
+func (pself *extMgrImpl) ExitTilemapEditorMode()                                                  {}
+func (pself *extMgrImpl) ClearPureSprites()                                                       {}
+func (pself *extMgrImpl) CreatePureSprite(texture_path string, pos Vec2, zindex int64)            {}
+func (pself *extMgrImpl) SetupPathFinderWithSize(grid_size Vec2, cell_size Vec2, with_debug bool) {}
+func (pself *extMgrImpl) SetupPathFinder()                                                        {}
+func (pself *extMgrImpl) FindPath(p_from Vec2, p_to Vec2) gdx.Array {
 	var _ret1 gdx.Array
 	return _ret1
 }
-func (pself *extMgrImpl) ExitTilemapEditorMode()                                       {}
-func (pself *extMgrImpl) ClearPureSprites()                                            {}
-func (pself *extMgrImpl) CreatePureSprite(texture_path string, pos Vec2, zindex int64) {}
 
 // IInputMgr
 func (pself *inputMgrImpl) GetMousePos() Vec2 {

--- a/pkg/gdspx/internal/ffi/ffi.gen.go
+++ b/pkg/gdspx/internal/ffi/ffi.gen.go
@@ -75,10 +75,12 @@ type GDExtensionInterface struct {
 	SpxExtPlaceTileWithLayer                 GDExtensionSpxExtPlaceTileWithLayer
 	SpxExtEraseTile                          GDExtensionSpxExtEraseTile
 	SpxExtCloseDrawTiles                     GDExtensionSpxExtCloseDrawTiles
-	SpxExtGetLayerPointPath                  GDExtensionSpxExtGetLayerPointPath
 	SpxExtExitTilemapEditorMode              GDExtensionSpxExtExitTilemapEditorMode
 	SpxExtClearPureSprites                   GDExtensionSpxExtClearPureSprites
 	SpxExtCreatePureSprite                   GDExtensionSpxExtCreatePureSprite
+	SpxExtSetupPathFinderWithSize            GDExtensionSpxExtSetupPathFinderWithSize
+	SpxExtSetupPathFinder                    GDExtensionSpxExtSetupPathFinder
+	SpxExtFindPath                           GDExtensionSpxExtFindPath
 	SpxInputGetMousePos                      GDExtensionSpxInputGetMousePos
 	SpxInputGetKey                           GDExtensionSpxInputGetKey
 	SpxInputGetMouseState                    GDExtensionSpxInputGetMouseState
@@ -350,10 +352,12 @@ func (x *GDExtensionInterface) loadProcAddresses() {
 	x.SpxExtPlaceTileWithLayer = (GDExtensionSpxExtPlaceTileWithLayer)(dlsymGD("spx_ext_place_tile_with_layer"))
 	x.SpxExtEraseTile = (GDExtensionSpxExtEraseTile)(dlsymGD("spx_ext_erase_tile"))
 	x.SpxExtCloseDrawTiles = (GDExtensionSpxExtCloseDrawTiles)(dlsymGD("spx_ext_close_draw_tiles"))
-	x.SpxExtGetLayerPointPath = (GDExtensionSpxExtGetLayerPointPath)(dlsymGD("spx_ext_get_layer_point_path"))
 	x.SpxExtExitTilemapEditorMode = (GDExtensionSpxExtExitTilemapEditorMode)(dlsymGD("spx_ext_exit_tilemap_editor_mode"))
 	x.SpxExtClearPureSprites = (GDExtensionSpxExtClearPureSprites)(dlsymGD("spx_ext_clear_pure_sprites"))
 	x.SpxExtCreatePureSprite = (GDExtensionSpxExtCreatePureSprite)(dlsymGD("spx_ext_create_pure_sprite"))
+	x.SpxExtSetupPathFinderWithSize = (GDExtensionSpxExtSetupPathFinderWithSize)(dlsymGD("spx_ext_setup_path_finder_with_size"))
+	x.SpxExtSetupPathFinder = (GDExtensionSpxExtSetupPathFinder)(dlsymGD("spx_ext_setup_path_finder"))
+	x.SpxExtFindPath = (GDExtensionSpxExtFindPath)(dlsymGD("spx_ext_find_path"))
 	x.SpxInputGetMousePos = (GDExtensionSpxInputGetMousePos)(dlsymGD("spx_input_get_mouse_pos"))
 	x.SpxInputGetKey = (GDExtensionSpxInputGetKey)(dlsymGD("spx_input_get_key"))
 	x.SpxInputGetMouseState = (GDExtensionSpxInputGetMouseState)(dlsymGD("spx_input_get_mouse_state"))

--- a/pkg/gdspx/internal/ffi/ffi_wrapper.gen.go
+++ b/pkg/gdspx/internal/ffi/ffi_wrapper.gen.go
@@ -141,10 +141,12 @@ type GDExtensionSpxExtPlaceTile C.GDExtensionSpxExtPlaceTile
 type GDExtensionSpxExtPlaceTileWithLayer C.GDExtensionSpxExtPlaceTileWithLayer
 type GDExtensionSpxExtEraseTile C.GDExtensionSpxExtEraseTile
 type GDExtensionSpxExtCloseDrawTiles C.GDExtensionSpxExtCloseDrawTiles
-type GDExtensionSpxExtGetLayerPointPath C.GDExtensionSpxExtGetLayerPointPath
 type GDExtensionSpxExtExitTilemapEditorMode C.GDExtensionSpxExtExitTilemapEditorMode
 type GDExtensionSpxExtClearPureSprites C.GDExtensionSpxExtClearPureSprites
 type GDExtensionSpxExtCreatePureSprite C.GDExtensionSpxExtCreatePureSprite
+type GDExtensionSpxExtSetupPathFinderWithSize C.GDExtensionSpxExtSetupPathFinderWithSize
+type GDExtensionSpxExtSetupPathFinder C.GDExtensionSpxExtSetupPathFinder
+type GDExtensionSpxExtFindPath C.GDExtensionSpxExtFindPath
 type GDExtensionSpxInputGetMousePos C.GDExtensionSpxInputGetMousePos
 type GDExtensionSpxInputGetKey C.GDExtensionSpxInputGetKey
 type GDExtensionSpxInputGetMouseState C.GDExtensionSpxInputGetMouseState
@@ -893,18 +895,6 @@ func CallExtCloseDrawTiles() {
 
 	C.cgo_callfn_GDExtensionSpxExtCloseDrawTiles(arg0)
 }
-func CallExtGetLayerPointPath(
-	p_from GdVec2,
-	p_to GdVec2,
-) GdArray {
-	arg0 := (C.GDExtensionSpxExtGetLayerPointPath)(api.SpxExtGetLayerPointPath)
-	arg1GdVec2 := (C.GdVec2)(p_from)
-	arg2GdVec2 := (C.GdVec2)(p_to)
-	var ret_val C.GdArray
-	C.cgo_callfn_GDExtensionSpxExtGetLayerPointPath(arg0, arg1GdVec2, arg2GdVec2, &ret_val)
-
-	return GdArray(ret_val)
-}
 func CallExtExitTilemapEditorMode() {
 	arg0 := (C.GDExtensionSpxExtExitTilemapEditorMode)(api.SpxExtExitTilemapEditorMode)
 
@@ -927,6 +917,36 @@ func CallExtCreatePureSprite(
 
 	C.cgo_callfn_GDExtensionSpxExtCreatePureSprite(arg0, arg1GdString, arg2GdVec2, arg3GdInt)
 
+}
+func CallExtSetupPathFinderWithSize(
+	grid_size GdVec2,
+	cell_size GdVec2,
+	with_debug GdBool,
+) {
+	arg0 := (C.GDExtensionSpxExtSetupPathFinderWithSize)(api.SpxExtSetupPathFinderWithSize)
+	arg1GdVec2 := (C.GdVec2)(grid_size)
+	arg2GdVec2 := (C.GdVec2)(cell_size)
+	arg3GdBool := (C.GdBool)(with_debug)
+
+	C.cgo_callfn_GDExtensionSpxExtSetupPathFinderWithSize(arg0, arg1GdVec2, arg2GdVec2, arg3GdBool)
+
+}
+func CallExtSetupPathFinder() {
+	arg0 := (C.GDExtensionSpxExtSetupPathFinder)(api.SpxExtSetupPathFinder)
+
+	C.cgo_callfn_GDExtensionSpxExtSetupPathFinder(arg0)
+}
+func CallExtFindPath(
+	p_from GdVec2,
+	p_to GdVec2,
+) GdArray {
+	arg0 := (C.GDExtensionSpxExtFindPath)(api.SpxExtFindPath)
+	arg1GdVec2 := (C.GdVec2)(p_from)
+	arg2GdVec2 := (C.GdVec2)(p_to)
+	var ret_val C.GdArray
+	C.cgo_callfn_GDExtensionSpxExtFindPath(arg0, arg1GdVec2, arg2GdVec2, &ret_val)
+
+	return GdArray(ret_val)
 }
 func CallInputGetMousePos() GdVec2 {
 	arg0 := (C.GDExtensionSpxInputGetMousePos)(api.SpxInputGetMousePos)

--- a/pkg/gdspx/internal/ffi/ffi_wrapper.gen.h
+++ b/pkg/gdspx/internal/ffi/ffi_wrapper.gen.h
@@ -183,9 +183,6 @@ void cgo_callfn_GDExtensionSpxExtEraseTile(const GDExtensionSpxExtEraseTile fn, 
 void cgo_callfn_GDExtensionSpxExtCloseDrawTiles(const GDExtensionSpxExtCloseDrawTiles fn) {
 	fn();
 }
-void cgo_callfn_GDExtensionSpxExtGetLayerPointPath(const GDExtensionSpxExtGetLayerPointPath fn, GdVec2 p_from, GdVec2 p_to, GdArray* ret_val) {
-	fn(p_from, p_to,ret_val);
-}
 void cgo_callfn_GDExtensionSpxExtExitTilemapEditorMode(const GDExtensionSpxExtExitTilemapEditorMode fn) {
 	fn();
 }
@@ -194,6 +191,15 @@ void cgo_callfn_GDExtensionSpxExtClearPureSprites(const GDExtensionSpxExtClearPu
 }
 void cgo_callfn_GDExtensionSpxExtCreatePureSprite(const GDExtensionSpxExtCreatePureSprite fn, GdString texture_path, GdVec2 pos, GdInt zindex) {
 	fn(texture_path, pos, zindex);
+}
+void cgo_callfn_GDExtensionSpxExtSetupPathFinderWithSize(const GDExtensionSpxExtSetupPathFinderWithSize fn, GdVec2 grid_size, GdVec2 cell_size, GdBool with_debug) {
+	fn(grid_size, cell_size, with_debug);
+}
+void cgo_callfn_GDExtensionSpxExtSetupPathFinder(const GDExtensionSpxExtSetupPathFinder fn) {
+	fn();
+}
+void cgo_callfn_GDExtensionSpxExtFindPath(const GDExtensionSpxExtFindPath fn, GdVec2 p_from, GdVec2 p_to, GdArray* ret_val) {
+	fn(p_from, p_to,ret_val);
 }
 void cgo_callfn_GDExtensionSpxInputGetMousePos(const GDExtensionSpxInputGetMousePos fn, GdVec2* ret_val) {
 	fn(ret_val);

--- a/pkg/gdspx/internal/ffi/gdextension_spx_ext.h
+++ b/pkg/gdspx/internal/ffi/gdextension_spx_ext.h
@@ -274,10 +274,12 @@ typedef void (*GDExtensionSpxExtPlaceTile)(GdVec2 pos, GdString texture_path);
 typedef void (*GDExtensionSpxExtPlaceTileWithLayer)(GdVec2 pos, GdString texture_path, GdInt layer_index);
 typedef void (*GDExtensionSpxExtEraseTile)(GdVec2 pos);
 typedef void (*GDExtensionSpxExtCloseDrawTiles)();
-typedef void (*GDExtensionSpxExtGetLayerPointPath)(GdVec2 p_from, GdVec2 p_to, GdArray* ret_value);
 typedef void (*GDExtensionSpxExtExitTilemapEditorMode)();
 typedef void (*GDExtensionSpxExtClearPureSprites)();
 typedef void (*GDExtensionSpxExtCreatePureSprite)(GdString texture_path, GdVec2 pos, GdInt zindex);
+typedef void (*GDExtensionSpxExtSetupPathFinderWithSize)(GdVec2 grid_size, GdVec2 cell_size, GdBool with_debug);
+typedef void (*GDExtensionSpxExtSetupPathFinder)();
+typedef void (*GDExtensionSpxExtFindPath)(GdVec2 p_from, GdVec2 p_to, GdArray* ret_value);
 // SpxInput
 typedef void (*GDExtensionSpxInputGetMousePos)(GdVec2* ret_value);
 typedef void (*GDExtensionSpxInputGetKey)(GdInt key, GdBool* ret_value);

--- a/pkg/gdspx/internal/webffi/ffi.gen.go
+++ b/pkg/gdspx/internal/webffi/ffi.gen.go
@@ -79,10 +79,12 @@ type GDExtensionInterface struct {
 	SpxExtPlaceTileWithLayer                 js.Value
 	SpxExtEraseTile                          js.Value
 	SpxExtCloseDrawTiles                     js.Value
-	SpxExtGetLayerPointPath                  js.Value
 	SpxExtExitTilemapEditorMode              js.Value
 	SpxExtClearPureSprites                   js.Value
 	SpxExtCreatePureSprite                   js.Value
+	SpxExtSetupPathFinderWithSize            js.Value
+	SpxExtSetupPathFinder                    js.Value
+	SpxExtFindPath                           js.Value
 	SpxInputGetMousePos                      js.Value
 	SpxInputGetKey                           js.Value
 	SpxInputGetMouseState                    js.Value
@@ -354,10 +356,12 @@ func (x *GDExtensionInterface) loadProcAddresses() {
 	x.SpxExtPlaceTileWithLayer = dlsymGD("gdspx_ext_place_tile_with_layer")
 	x.SpxExtEraseTile = dlsymGD("gdspx_ext_erase_tile")
 	x.SpxExtCloseDrawTiles = dlsymGD("gdspx_ext_close_draw_tiles")
-	x.SpxExtGetLayerPointPath = dlsymGD("gdspx_ext_get_layer_point_path")
 	x.SpxExtExitTilemapEditorMode = dlsymGD("gdspx_ext_exit_tilemap_editor_mode")
 	x.SpxExtClearPureSprites = dlsymGD("gdspx_ext_clear_pure_sprites")
 	x.SpxExtCreatePureSprite = dlsymGD("gdspx_ext_create_pure_sprite")
+	x.SpxExtSetupPathFinderWithSize = dlsymGD("gdspx_ext_setup_path_finder_with_size")
+	x.SpxExtSetupPathFinder = dlsymGD("gdspx_ext_setup_path_finder")
+	x.SpxExtFindPath = dlsymGD("gdspx_ext_find_path")
 	x.SpxInputGetMousePos = dlsymGD("gdspx_input_get_mouse_pos")
 	x.SpxInputGetKey = dlsymGD("gdspx_input_get_key")
 	x.SpxInputGetMouseState = dlsymGD("gdspx_input_get_mouse_state")

--- a/pkg/gdspx/internal/wrap/manager_wrapper.gen.go
+++ b/pkg/gdspx/internal/wrap/manager_wrapper.gen.go
@@ -387,12 +387,6 @@ func (pself *extMgr) EraseTile(pos Vec2) {
 func (pself *extMgr) CloseDrawTiles() {
 	CallExtCloseDrawTiles()
 }
-func (pself *extMgr) GetLayerPointPath(p_from Vec2, p_to Vec2) Array {
-	arg0 := ToGdVec2(p_from)
-	arg1 := ToGdVec2(p_to)
-	retValue := CallExtGetLayerPointPath(arg0, arg1)
-	return ToArray(retValue)
-}
 func (pself *extMgr) ExitTilemapEditorMode() {
 	CallExtExitTilemapEditorMode()
 }
@@ -406,6 +400,21 @@ func (pself *extMgr) CreatePureSprite(texture_path string, pos Vec2, zindex int6
 	arg1 := ToGdVec2(pos)
 	arg2 := ToGdInt(zindex)
 	CallExtCreatePureSprite(arg0, arg1, arg2)
+}
+func (pself *extMgr) SetupPathFinderWithSize(grid_size Vec2, cell_size Vec2, with_debug bool) {
+	arg0 := ToGdVec2(grid_size)
+	arg1 := ToGdVec2(cell_size)
+	arg2 := ToGdBool(with_debug)
+	CallExtSetupPathFinderWithSize(arg0, arg1, arg2)
+}
+func (pself *extMgr) SetupPathFinder() {
+	CallExtSetupPathFinder()
+}
+func (pself *extMgr) FindPath(p_from Vec2, p_to Vec2) Array {
+	arg0 := ToGdVec2(p_from)
+	arg1 := ToGdVec2(p_to)
+	retValue := CallExtFindPath(arg0, arg1)
+	return ToArray(retValue)
 }
 func (pself *inputMgr) GetMousePos() Vec2 {
 	retValue := CallInputGetMousePos()

--- a/pkg/gdspx/internal/wrap/manager_wrapper_web.gen.go
+++ b/pkg/gdspx/internal/wrap/manager_wrapper_web.gen.go
@@ -366,12 +366,6 @@ func (pself *extMgr) EraseTile(pos Vec2) {
 func (pself *extMgr) CloseDrawTiles() {
 	API.SpxExtCloseDrawTiles.Invoke()
 }
-func (pself *extMgr) GetLayerPointPath(p_from Vec2, p_to Vec2) Array {
-	arg0 := JsFromGdVec2(p_from)
-	arg1 := JsFromGdVec2(p_to)
-	_retValue := API.SpxExtGetLayerPointPath.Invoke(arg0, arg1)
-	return JsToGdArray(_retValue)
-}
 func (pself *extMgr) ExitTilemapEditorMode() {
 	API.SpxExtExitTilemapEditorMode.Invoke()
 }
@@ -383,6 +377,21 @@ func (pself *extMgr) CreatePureSprite(texture_path string, pos Vec2, zindex int6
 	arg1 := JsFromGdVec2(pos)
 	arg2 := JsFromGdInt(zindex)
 	API.SpxExtCreatePureSprite.Invoke(arg0, arg1, arg2)
+}
+func (pself *extMgr) SetupPathFinderWithSize(grid_size Vec2, cell_size Vec2, with_debug bool) {
+	arg0 := JsFromGdVec2(grid_size)
+	arg1 := JsFromGdVec2(cell_size)
+	arg2 := JsFromGdBool(with_debug)
+	API.SpxExtSetupPathFinderWithSize.Invoke(arg0, arg1, arg2)
+}
+func (pself *extMgr) SetupPathFinder() {
+	API.SpxExtSetupPathFinder.Invoke()
+}
+func (pself *extMgr) FindPath(p_from Vec2, p_to Vec2) Array {
+	arg0 := JsFromGdVec2(p_from)
+	arg1 := JsFromGdVec2(p_to)
+	_retValue := API.SpxExtFindPath.Invoke(arg0, arg1)
+	return JsToGdArray(_retValue)
 }
 func (pself *inputMgr) GetMousePos() Vec2 {
 	_retValue := API.SpxInputGetMousePos.Invoke()

--- a/pkg/gdspx/pkg/engine/interface.gen.go
+++ b/pkg/gdspx/pkg/engine/interface.gen.go
@@ -91,10 +91,12 @@ type IExtMgr interface {
 	PlaceTileWithLayer(pos Vec2, texture_path string, layer_index int64)
 	EraseTile(pos Vec2)
 	CloseDrawTiles()
-	GetLayerPointPath(p_from Vec2, p_to Vec2) Array
 	ExitTilemapEditorMode()
 	ClearPureSprites()
 	CreatePureSprite(texture_path string, pos Vec2, zindex int64)
+	SetupPathFinderWithSize(grid_size Vec2, cell_size Vec2, with_debug bool)
+	SetupPathFinder()
+	FindPath(p_from Vec2, p_to Vec2) Array
 }
 
 type IInputMgr interface {


### PR DESCRIPTION
例：SetupPathFinder(50, 50, 16, 16, true)
a. 初始化grid大小（50，50）实际物理尺寸为grid*cell的大小
b. 初始化cell大小（16，16）
c. true参数为带debug可视化：鼠标左键放置出发点，右键放置目标点，然后拖拽实时生成路径
GetPointPath函数返回路径点坐标向量
[test_DrawTiles+FindPath.zip](https://github.com/user-attachments/files/22354285/test_DrawTiles%2BFindPath.zip)


https://github.com/user-attachments/assets/82cccb4d-06d8-488e-ae6b-e25ce464616d

