### PR TITLE
Audio attenuation

### DIFF
--- a/audio.go
+++ b/audio.go
@@ -67,9 +67,9 @@ func (p *soundMgr) stopInstance(audioId soundId) {
 	audioMgr.Stop(audioId)
 }
 
-func (p *soundMgr) play(audioId engine.Object, media sound, isLoop, isWait bool) soundId {
+func (p *soundMgr) play(audioId engine.Object, media sound, isLoop, isWait bool, owner engine.Object, attenuation, maxDistance float64) soundId {
 	var curId soundId = 0
-	curId = audioMgr.Play(audioId, engine.ToAssetPath(media.Path))
+	curId = audioMgr.PlayWithAttenuation(audioId, engine.ToAssetPath(media.Path), owner, attenuation, maxDistance)
 	p.path2ids[media.Path] = append(p.path2ids[media.Path], curId)
 	if isLoop {
 		for _, id := range p.path2ids[media.Path] {

--- a/config.go
+++ b/config.go
@@ -141,6 +141,9 @@ type projConfig struct {
 
 	PathCellSizeX *int `json:"pathCellSizeX"` // Path finding cell width, default 16
 	PathCellSizeY *int `json:"pathCellSizeY"` // Path finding cell height, default 16
+	// audio volume scale = Math::pow(1.0f - dist / audioMaxDistance, audioAttenuation);
+	AudioMaxDistance *float64 `json:"audioMaxDistance"` // default 2000
+	AudioAttenuation *float64 `json:"audioAttenuation"` // default 0 indicates no attenuation will occur
 }
 
 func (p *projConfig) getBackdrops() []*backdropConfig {

--- a/internal/enginewrap/sync.gen.go
+++ b/internal/enginewrap/sync.gen.go
@@ -149,6 +149,13 @@ func (pself *audioMgrImpl) GetVolume(obj gdx.Object) float64 {
 	})
 	return _ret1
 }
+func (pself *audioMgrImpl) PlayWithAttenuation(obj gdx.Object, path string, owner_id gdx.Object, attenuation float64, max_distance float64) int64 {
+	var _ret1 int64
+	callInMainThread(func() {
+		_ret1 = gdx.AudioMgr.PlayWithAttenuation(obj, path, owner_id, attenuation, max_distance)
+	})
+	return _ret1
+}
 func (pself *audioMgrImpl) Play(obj gdx.Object, path string) int64 {
 	var _ret1 int64
 	callInMainThread(func() {

--- a/internal/enginewrap/sync_pure.gen.go
+++ b/internal/enginewrap/sync_pure.gen.go
@@ -117,6 +117,10 @@ func (pself *audioMgrImpl) GetVolume(obj gdx.Object) float64 {
 	var _ret1 float64
 	return _ret1
 }
+func (pself *audioMgrImpl) PlayWithAttenuation(obj gdx.Object, path string, owner_id gdx.Object, attenuation float64, max_distance float64) int64 {
+	var _ret1 int64
+	return _ret1
+}
 func (pself *audioMgrImpl) Play(obj gdx.Object, path string) int64 {
 	var _ret1 int64
 	return _ret1

--- a/pkg/gdspx/internal/ffi/ffi.gen.go
+++ b/pkg/gdspx/internal/ffi/ffi.gen.go
@@ -27,6 +27,7 @@ type GDExtensionInterface struct {
 	SpxAudioGetPan                           GDExtensionSpxAudioGetPan
 	SpxAudioSetVolume                        GDExtensionSpxAudioSetVolume
 	SpxAudioGetVolume                        GDExtensionSpxAudioGetVolume
+	SpxAudioPlayWithAttenuation              GDExtensionSpxAudioPlayWithAttenuation
 	SpxAudioPlay                             GDExtensionSpxAudioPlay
 	SpxAudioPause                            GDExtensionSpxAudioPause
 	SpxAudioResume                           GDExtensionSpxAudioResume
@@ -304,6 +305,7 @@ func (x *GDExtensionInterface) loadProcAddresses() {
 	x.SpxAudioGetPan = (GDExtensionSpxAudioGetPan)(dlsymGD("spx_audio_get_pan"))
 	x.SpxAudioSetVolume = (GDExtensionSpxAudioSetVolume)(dlsymGD("spx_audio_set_volume"))
 	x.SpxAudioGetVolume = (GDExtensionSpxAudioGetVolume)(dlsymGD("spx_audio_get_volume"))
+	x.SpxAudioPlayWithAttenuation = (GDExtensionSpxAudioPlayWithAttenuation)(dlsymGD("spx_audio_play_with_attenuation"))
 	x.SpxAudioPlay = (GDExtensionSpxAudioPlay)(dlsymGD("spx_audio_play"))
 	x.SpxAudioPause = (GDExtensionSpxAudioPause)(dlsymGD("spx_audio_pause"))
 	x.SpxAudioResume = (GDExtensionSpxAudioResume)(dlsymGD("spx_audio_resume"))

--- a/pkg/gdspx/internal/ffi/ffi_wrapper.gen.go
+++ b/pkg/gdspx/internal/ffi/ffi_wrapper.gen.go
@@ -93,6 +93,7 @@ type GDExtensionSpxAudioSetPan C.GDExtensionSpxAudioSetPan
 type GDExtensionSpxAudioGetPan C.GDExtensionSpxAudioGetPan
 type GDExtensionSpxAudioSetVolume C.GDExtensionSpxAudioSetVolume
 type GDExtensionSpxAudioGetVolume C.GDExtensionSpxAudioGetVolume
+type GDExtensionSpxAudioPlayWithAttenuation C.GDExtensionSpxAudioPlayWithAttenuation
 type GDExtensionSpxAudioPlay C.GDExtensionSpxAudioPlay
 type GDExtensionSpxAudioPause C.GDExtensionSpxAudioPause
 type GDExtensionSpxAudioResume C.GDExtensionSpxAudioResume
@@ -442,6 +443,24 @@ func CallAudioGetVolume(
 	C.cgo_callfn_GDExtensionSpxAudioGetVolume(arg0, arg1GdObj, &ret_val)
 
 	return (GdFloat)(ret_val)
+}
+func CallAudioPlayWithAttenuation(
+	obj GdObj,
+	path GdString,
+	owner_id GdObj,
+	attenuation GdFloat,
+	max_distance GdFloat,
+) GdInt {
+	arg0 := (C.GDExtensionSpxAudioPlayWithAttenuation)(api.SpxAudioPlayWithAttenuation)
+	arg1GdObj := (C.GdObj)(obj)
+	arg2GdString := (C.GdString)(path)
+	arg3GdObj := (C.GdObj)(owner_id)
+	arg4GdFloat := (C.GdFloat)(attenuation)
+	arg5GdFloat := (C.GdFloat)(max_distance)
+	var ret_val C.GdInt
+	C.cgo_callfn_GDExtensionSpxAudioPlayWithAttenuation(arg0, arg1GdObj, arg2GdString, arg3GdObj, arg4GdFloat, arg5GdFloat, &ret_val)
+
+	return (GdInt)(ret_val)
 }
 func CallAudioPlay(
 	obj GdObj,

--- a/pkg/gdspx/internal/ffi/ffi_wrapper.gen.h
+++ b/pkg/gdspx/internal/ffi/ffi_wrapper.gen.h
@@ -39,6 +39,9 @@ void cgo_callfn_GDExtensionSpxAudioSetVolume(const GDExtensionSpxAudioSetVolume 
 void cgo_callfn_GDExtensionSpxAudioGetVolume(const GDExtensionSpxAudioGetVolume fn, GdObj obj, GdFloat* ret_val) {
 	fn(obj,ret_val);
 }
+void cgo_callfn_GDExtensionSpxAudioPlayWithAttenuation(const GDExtensionSpxAudioPlayWithAttenuation fn, GdObj obj, GdString path, GdObj owner_id, GdFloat attenuation, GdFloat max_distance, GdInt* ret_val) {
+	fn(obj, path, owner_id, attenuation, max_distance,ret_val);
+}
 void cgo_callfn_GDExtensionSpxAudioPlay(const GDExtensionSpxAudioPlay fn, GdObj obj, GdString path, GdInt* ret_val) {
 	fn(obj, path,ret_val);
 }

--- a/pkg/gdspx/internal/ffi/gdextension_spx_ext.h
+++ b/pkg/gdspx/internal/ffi/gdextension_spx_ext.h
@@ -224,6 +224,7 @@ typedef void (*GDExtensionSpxAudioSetPan)(GdObj obj, GdFloat pan);
 typedef void (*GDExtensionSpxAudioGetPan)(GdObj obj, GdFloat* ret_value);
 typedef void (*GDExtensionSpxAudioSetVolume)(GdObj obj, GdFloat volume);
 typedef void (*GDExtensionSpxAudioGetVolume)(GdObj obj, GdFloat* ret_value);
+typedef void (*GDExtensionSpxAudioPlayWithAttenuation)(GdObj obj, GdString path,GdObj owner_id, GdFloat attenuation ,GdFloat max_distance , GdInt* ret_value);
 typedef void (*GDExtensionSpxAudioPlay)(GdObj obj, GdString path, GdInt* ret_value);
 typedef void (*GDExtensionSpxAudioPause)(GdInt aid);
 typedef void (*GDExtensionSpxAudioResume)(GdInt aid);

--- a/pkg/gdspx/internal/webffi/ffi.gen.go
+++ b/pkg/gdspx/internal/webffi/ffi.gen.go
@@ -31,6 +31,7 @@ type GDExtensionInterface struct {
 	SpxAudioGetPan                           js.Value
 	SpxAudioSetVolume                        js.Value
 	SpxAudioGetVolume                        js.Value
+	SpxAudioPlayWithAttenuation              js.Value
 	SpxAudioPlay                             js.Value
 	SpxAudioPause                            js.Value
 	SpxAudioResume                           js.Value
@@ -308,6 +309,7 @@ func (x *GDExtensionInterface) loadProcAddresses() {
 	x.SpxAudioGetPan = dlsymGD("gdspx_audio_get_pan")
 	x.SpxAudioSetVolume = dlsymGD("gdspx_audio_set_volume")
 	x.SpxAudioGetVolume = dlsymGD("gdspx_audio_get_volume")
+	x.SpxAudioPlayWithAttenuation = dlsymGD("gdspx_audio_play_with_attenuation")
 	x.SpxAudioPlay = dlsymGD("gdspx_audio_play")
 	x.SpxAudioPause = dlsymGD("gdspx_audio_pause")
 	x.SpxAudioResume = dlsymGD("gdspx_audio_resume")

--- a/pkg/gdspx/internal/wrap/manager_wrapper.gen.go
+++ b/pkg/gdspx/internal/wrap/manager_wrapper.gen.go
@@ -153,6 +153,17 @@ func (pself *audioMgr) GetVolume(obj Object) float64 {
 	retValue := CallAudioGetVolume(arg0)
 	return ToFloat64(retValue)
 }
+func (pself *audioMgr) PlayWithAttenuation(obj Object, path string, owner_id Object, attenuation float64, max_distance float64) int64 {
+	arg0 := ToGdObj(obj)
+	arg1Str := C.CString(path)
+	arg1 := (GdString)(arg1Str)
+	defer C.free(unsafe.Pointer(arg1Str))
+	arg2 := ToGdObj(owner_id)
+	arg3 := ToGdFloat(attenuation)
+	arg4 := ToGdFloat(max_distance)
+	retValue := CallAudioPlayWithAttenuation(arg0, arg1, arg2, arg3, arg4)
+	return ToInt64(retValue)
+}
 func (pself *audioMgr) Play(obj Object, path string) int64 {
 	arg0 := ToGdObj(obj)
 	arg1Str := C.CString(path)

--- a/pkg/gdspx/internal/wrap/manager_wrapper_web.gen.go
+++ b/pkg/gdspx/internal/wrap/manager_wrapper_web.gen.go
@@ -148,6 +148,15 @@ func (pself *audioMgr) GetVolume(obj Object) float64 {
 	_retValue := API.SpxAudioGetVolume.Invoke(arg0)
 	return JsToGdFloat(_retValue)
 }
+func (pself *audioMgr) PlayWithAttenuation(obj Object, path string, owner_id Object, attenuation float64, max_distance float64) int64 {
+	arg0 := JsFromGdObj(obj)
+	arg1 := JsFromGdString(path)
+	arg2 := JsFromGdObj(owner_id)
+	arg3 := JsFromGdFloat(attenuation)
+	arg4 := JsFromGdFloat(max_distance)
+	_retValue := API.SpxAudioPlayWithAttenuation.Invoke(arg0, arg1, arg2, arg3, arg4)
+	return JsToGdInt(_retValue)
+}
 func (pself *audioMgr) Play(obj Object, path string) int64 {
 	arg0 := JsFromGdObj(obj)
 	arg1 := JsFromGdString(path)

--- a/pkg/gdspx/pkg/engine/interface.gen.go
+++ b/pkg/gdspx/pkg/engine/interface.gen.go
@@ -37,6 +37,7 @@ type IAudioMgr interface {
 	GetPan(obj Object) float64
 	SetVolume(obj Object, volume float64)
 	GetVolume(obj Object) float64
+	PlayWithAttenuation(obj Object, path string, owner_id Object, attenuation float64, max_distance float64) int64
 	Play(obj Object, path string) int64
 	Pause(aid int64)
 	Resume(aid int64)

--- a/sprite.go
+++ b/sprite.go
@@ -1919,12 +1919,12 @@ const (
 
 func (p *SpriteImpl) playAudio(name SoundName, loop bool) soundId {
 	p.checkAudioId()
-	return p.g.playSound(p.audioId, name, loop)
+	return p.g.playSound(p.syncSprite, p.audioId, name, loop, p.g.audioAttenuation, p.g.audioMaxDistance)
 }
 
 func (p *SpriteImpl) Play__0(name SoundName, loop bool) {
 	p.checkAudioId()
-	p.g.playSound(p.audioId, name, loop)
+	p.g.playSound(p.syncSprite, p.audioId, name, loop, p.g.audioAttenuation, p.g.audioMaxDistance)
 }
 
 func (p *SpriteImpl) Play__1(name SoundName) {
@@ -1933,7 +1933,7 @@ func (p *SpriteImpl) Play__1(name SoundName) {
 
 func (p *SpriteImpl) PlayAndWait(name SoundName) {
 	p.checkAudioId()
-	p.g.playSoundAndWait(p.audioId, name)
+	p.g.playSoundAndWait(p.syncSprite, p.audioId, name, p.g.audioAttenuation, p.g.audioMaxDistance)
 }
 
 func (p *SpriteImpl) PausePlaying(name SoundName) {


### PR DESCRIPTION
> https://github.com/goplus/spx/issues/876

formula: 

```c
audio_multiplier = Math::pow(1.0f - dist / audioMaxDistance, audioAttenuation);
```

Sprite-played sounds are affected by their distance from the camera, while sound effects played in the game (main.spx) ignore distance influence.


proj config : index.json
``` go
	AudioMaxDistance *float64 `json:"audioMaxDistance"` // default 2000
	AudioAttenuation *float64 `json:"audioAttenuation"` // default 0
```

eg: 
1. The distance between the sprite and the camera is ​250.
2. audioMaxDistance = 1000 and audioAttenuation = 1.
3. Final audio volume multiplier = std::pow(1.0f - 250.0f / 1000.0f, 1.0f) = std::pow(0.75f, 1.0f) = ​0.75​ .