### PR TITLE
Fix tilemap data parser

### DIFF
--- a/game.go
+++ b/game.go
@@ -1910,8 +1910,8 @@ func (p *Game) setTileMapOffset(index int64, x, y float64) {
 
 }
 
-func (p *Game) createDecorators(texture_path string, x, y float64, zindex int64) {
-	extMgr.CreatePureSprite(engine.ToAssetPath(texture_path), mathf.NewVec2(x, y), zindex)
+func (p *Game) createDecorators(texturePath string, x, y float64, zindex int64) {
+	extMgr.CreatePureSprite(engine.ToAssetPath(texturePath), mathf.NewVec2(x, y), zindex)
 }
 
 // Path Finding

--- a/tilemap.go
+++ b/tilemap.go
@@ -39,6 +39,7 @@ func (p *tilemapMgr) init(g *Game, fs spxfs.Dir, path string) {
 		panic(fmt.Sprintf("Failed to load tilemap JSON file %s: %v", path, err))
 	}
 	p.datas = &data
+	tm.ConvertData(&data)
 }
 
 func (p *tilemapMgr) loadTilemaps(datas *tm.TscnMapData) {
@@ -47,15 +48,15 @@ func (p *tilemapMgr) loadTilemaps(datas *tm.TscnMapData) {
 }
 func (p *tilemapMgr) loadDecorators(datas *tm.TscnMapData) {
 	for _, item := range datas.Decorators {
-		p.g.createDecorators(item.TexturePath, item.Position.X, -item.Position.Y, int64(item.ZIndex))
+		p.g.createDecorators(item.Path, item.Position.X, item.Position.Y, int64(item.ZIndex))
 	}
 }
 
 func (p *tilemapMgr) loadSprites(datas *tm.TscnMapData) {
 	for _, item := range datas.Sprites {
-		sp, ok := p.g.sprs[item.PrefabPath]
+		sp, ok := p.g.sprs[item.Path]
 		if ok {
-			x, y := item.Position.X, -item.Position.Y
+			x, y := item.Position.X, item.Position.Y
 			doClone(sp, nil, true, func(sprite *SpriteImpl) {
 				sprite.SetXYpos(x, y)
 			})


### PR DESCRIPTION
1. Avoided the conversion from Godot coordinate system to SPX coordinate system
2. Simplified the parsing of tileData (may result in larger tilemap data)
3. Standardized naming: prefab => sprite