### PR TITLE
Update icall => 2048

### DIFF
--- a/cmd/igox/main.go
+++ b/cmd/igox/main.go
@@ -18,7 +18,6 @@ import (
 	"github.com/goplus/ixgo"
 	"github.com/goplus/ixgo/xgobuild"
 	"github.com/goplus/mod/modfile"
-	_ "github.com/goplus/reflectx/icall/icall10240"
 	_ "github.com/goplus/reflectx/icall/icall2048"
 	_ "github.com/goplus/spx/v2"
 	"github.com/goplus/spx/v2/cmd/igox/zipfs"


### PR DESCRIPTION
After the support for merging calls to the same embedding method was implemented in IGOP (https://github.com/goplus/spx/pull/946), the number of ICALLs saw a significant decrease. Most projects are now concentrated around 900. Therefore, the ICALL threshold has been lowered to 2048 (igox contains 512 by default) to reserve a certain buffer space and improve the loading speed