### PR TITLE
PC ai support

### DIFF
--- a/cmd/gox/main.go
+++ b/cmd/gox/main.go
@@ -23,6 +23,12 @@ var (
 	//go:embed template/go.mod.template
 	gomodtemplate string
 
+	//go:embed template/aipack/initai.go.template
+	initAiGoTemplate string
+
+	//go:embed template/aipack/gop.mod.template
+	gopModTemplate string
+
 	//go:embed appname.txt
 	appName string
 
@@ -46,6 +52,8 @@ func main() {
 	cmd.RunSh = runSh
 	cmd.MainSh = mainSh
 	cmd.GoModTemplate = gomodtemplate
+	cmd.InitAiGoTemplate = initAiGoTemplate
+	cmd.GopModTemplate = gopModTemplate
 
 	// Initialize the Args field if not already initialized
 	cmd.RunCmd(appName, appName, cmd.Version, projectFS, "template/project", "project")

--- a/cmd/gox/pkg/command/args.go
+++ b/cmd/gox/pkg/command/args.go
@@ -7,6 +7,9 @@ import (
 	"strings"
 )
 
+// default ai pack tags
+var DefaultAiPackVersion = "v0.0.0-20251014030930-ac405dbe65e9"
+
 type ExtraArgs struct {
 	CmdName         string
 	Path            *string
@@ -28,6 +31,7 @@ type ExtraArgs struct {
 	Movie           *bool
 	GoEnv           *string // Portable Go environment directory
 	IxgoGen         *bool   // Use xgobuild library for code generation (new method)
+	AiPack          *string // AI pack version (e.g., v0.0.0-20251014030930-ac405dbe65e9)
 }
 
 func (e *ExtraArgs) String() []string {
@@ -116,6 +120,7 @@ func (cmd *CmdTool) initializeFlags() *bool {
 	cmd.Args.Movie = f.Bool("movie", false, "record movie mode")
 	cmd.Args.GoEnv = f.String("goenv", "", "portable Go environment directory (e.g., ./cmd/portable-go)")
 	cmd.Args.IxgoGen = f.Bool("ixgogen", false, "use xgobuild library for code generation (default: use xgo CLI)")
+	cmd.Args.AiPack = f.String("aipack", "", "AI pack version (e.g., v0.0.0-20251014030930-ac405dbe65e9)")
 	return help
 }
 
@@ -142,6 +147,9 @@ func (cmd *CmdTool) parseCommandLineArgs(help *bool, ext ...string) error {
 		return fmt.Errorf("unknown command: %s", cmd.Args.CmdName)
 	}
 
+	if cmd.Args.AiPack != nil && *cmd.Args.AiPack == "default" {
+		cmd.Args.AiPack = &DefaultAiPackVersion
+	}
 	return nil
 }
 

--- a/cmd/gox/pkg/command/build.go
+++ b/cmd/gox/pkg/command/build.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"fmt"
 	"log"
 	"os"
 	"path"
@@ -188,6 +189,11 @@ func (pself *CmdTool) genGoUsingXgobuild(rawdir, spxProjPath string) string {
 	util.RunGolang(nil, "mod", "tidy")
 	os.Chdir(rawdir)
 
+	// Add init.go for AI pack if specified
+	if pself.Args.AiPack != nil && *pself.Args.AiPack != "" {
+		pself.addAiInitFile()
+	}
+
 	// Return tags string for subsequent build steps
 	tagStr := ""
 	if *pself.Args.Tags != "" {
@@ -223,5 +229,29 @@ func (pself *CmdTool) genGoUsingXgoCLI(rawdir, spxProjPath string) string {
 	util.RunGolang(nil, "mod", "tidy")
 
 	os.Chdir(rawdir)
+
+	// Add init.go for AI pack if specified
+	if pself.Args.AiPack != nil && *pself.Args.AiPack != "" {
+		pself.addAiInitFile()
+	}
+
 	return tagStr
+}
+
+// addAiInitFile adds the AI initialization file to the go directory
+func (pself *CmdTool) addAiInitFile() {
+	initGoPath := filepath.Join(pself.GoDir, "init.go")
+
+	// Check if init.go already exists
+	if _, err := os.Stat(initGoPath); err == nil {
+		fmt.Println("Warning: init.go already exists, skipping AI init file creation")
+		return
+	}
+
+	// Write the init.go template
+	if err := os.WriteFile(initGoPath, []byte(pself.InitAiGoTemplate), 0644); err != nil {
+		fmt.Printf("Warning: failed to write init.go: %v\n", err)
+	} else {
+		fmt.Printf("✅ Added AI init file: %s\n", initGoPath)
+	}
 }

--- a/cmd/gox/pkg/command/cmd.go
+++ b/cmd/gox/pkg/command/cmd.go
@@ -49,7 +49,9 @@ type CmdTool struct {
 	RuntimePckPath string
 	RuntimeCmdPath string
 
-	GoModTemplate string
+	GoModTemplate    string
+	InitAiGoTemplate string // AI pack init.go template
+	GopModTemplate   string // AI pack gop.mod template
 
 	// Code generation mode
 	// true: use xgobuild library (new method)
@@ -277,7 +279,11 @@ func (cmd *CmdTool) executeRune() error {
 
 // executeRun handles the run command execution
 func (cmd *CmdTool) executeRun() error {
-	if cmd.Args.Tags != nil && strings.Contains(*cmd.Args.Tags, "pure_engine") {
+	if cmd.Args.AiPack != nil && *cmd.Args.AiPack != "" {
+		// For AI pack mode, run with AI mode
+		args := cmd.Args.String()
+		return cmd.RunWithAiMode(args...)
+	} else if cmd.Args.Tags != nil && strings.Contains(*cmd.Args.Tags, "pure_engine") {
 		// For pure_engine mode, run the Go binary directly
 		args := cmd.Args.String()
 		return cmd.RunPureEngine(args...)

--- a/cmd/gox/pkg/command/run.go
+++ b/cmd/gox/pkg/command/run.go
@@ -130,3 +130,7 @@ func (pself *CmdTool) RunPureEngine(pargs ...string) error {
 	os.Chdir(rawdir)
 	return util.RunCommandInDir(pself.TargetDir, binaryPath, pargs...)
 }
+
+func (pself *CmdTool) RunWithAiMode(pargs ...string) error {
+	return pself.RunPackMode(pargs...)
+}

--- a/cmd/gox/template/aipack/gop.mod.template
+++ b/cmd/gox/template/aipack/gop.mod.template
@@ -1,0 +1,7 @@
+gop 1.3
+
+project .spx Game github.com/goplus/spx/v2 math
+
+class -embed .spx SpriteImpl
+
+import github.com/goplus/builder/tools/ai

--- a/cmd/gox/template/aipack/initai.go.template
+++ b/cmd/gox/template/aipack/initai.go.template
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/goplus/builder/tools/ai"
+	"github.com/goplus/builder/tools/ai/httptrans"
+)
+
+func setupAITransport() {
+	// Get configuration from environment variables
+	endpoint := os.Getenv("SPX_AI_ENDPOINT")
+	if endpoint == "" {
+		endpoint = "http://localhost:8080/api/ai/interaction"
+		fmt.Printf("⚠️  Using default endpoint: %s\n", endpoint)
+		fmt.Println("   Set SPX_AI_ENDPOINT environment variable to customize")
+	}
+
+	token := os.Getenv("SPX_AI_TOKEN")
+	if token == "" {
+		fmt.Println("⚠️  No SPX_AI_TOKEN environment variable set")
+		fmt.Println("   Set SPX_AI_TOKEN environment variable for authentication")
+	}
+
+	// Create HTTP transport
+	transport := httptrans.New(
+		httptrans.WithEndpoint(endpoint),
+		httptrans.WithTokenProvider(func() string {
+			return token
+		}),
+	)
+
+	// Set as default transport
+	ai.SetDefaultTransport(transport)
+
+	descriptive := os.Getenv("SPX_AI_DESCRIPTION")
+	ai.SetDefaultKnowledgeBase(map[string]any{
+		"AI-generated descriptive summary of the game world": descriptive,
+	})
+}
+
+func init() {
+	setupAITransport()
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/goplus/spx/v2
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/goplus/spbase v0.1.0


### PR DESCRIPTION
test project: [test.zip](https://github.com/user-attachments/files/23000225/test.zip)



spx run --aipack="aipack's version"

eg:
```
spx run --aipack=v0.0.0-20251014030930-ac405dbe65e9
spx run --aipack="default"  # Use the default AI pack version embedded in SPX
```


The AI package's endpoint and token are configured via environment variables
```go
endpoint := os.Getenv("SPX_AI_ENDPOINT")
token := os.Getenv("SPX_AI_TOKEN")
descriptive := os.Getenv("SPX_AI_DESCRIPTION")
```
