### PR TITLE
Restart Engine When Crash

### DIFF
--- a/cmd/gox/template/platform/web/game.js
+++ b/cmd/gox/template/platform/web/game.js
@@ -181,8 +181,8 @@ class GameApp {
      * @returns Promise<void>
      */
     async initGame(files) {
-        this.updateEngineFiles(files);
-        this.buildGame(files);
+        await profiler.profile('updateEngineFiles', () => this.updateEngineFiles(files));
+        await profiler.profile('buildGame', () => this.buildGame(files));
     }
 
     /**
@@ -341,19 +341,12 @@ class GameApp {
             this.config.onProgress(value);
         }
     }
-    // async unpackData(game) {
-    //     await this.unpackEngineData(game)
-    //     await this.unpackGameData(game)
-    // }
 
     async unpackEngineData(game) {
         let packUrl = this.assetURLs[this.packName]
         let pckData = await (await fetch(packUrl)).arrayBuffer()
         await game.unpackEngineData(this.persistentPath, this.packName, pckData)
     }
-    // async unpackGameData(game) {
-    //     await game.unpackGameData(this.persistentPath, this.projectDataName, this.projectData)
-    // }
 
     callWorkerFunction(funcName, ...args) {
         this.workerMessageManager.callWorkerFunction(funcName, ...args)

--- a/cmd/gox/template/platform/web/index.html
+++ b/cmd/gox/template/platform/web/index.html
@@ -223,6 +223,11 @@
 			})
 			runnerWindow.onGameExit(function (code) {
 				console.error("onGameExit", code)
+				initEngine();
+			})
+			runnerWindow.addEventListener("godot-wasm-crash", e => {
+				console.error("Caught Godot crash:", e.detail);
+				initEngine();
 			})
 			runnerWindow.spxIsForceDebugLog = true
 

--- a/cmd/gox/template/platform/web/runner.html
+++ b/cmd/gox/template/platform/web/runner.html
@@ -53,7 +53,6 @@
 		let gameApp = null
 		let isShowEditor = false
 		let onGameError = null
-		let lastGameApp = null
 
 		window.spxIsProxyThreadMode = false
 		let onGameExit = null
@@ -96,6 +95,7 @@
 
 		window.gdspx_on_runtime_exit = function (code) {
 			if (onGameExit != null) {
+				gameApp = null
 				onGameExit(code)
 			}
 		}
@@ -106,8 +106,12 @@
 
 		window.initEngine = async (assetURLs = null, config = {}) => {
 			isShowEditor = false
-			lastGameApp = null
 			
+			if (gameApp != null) {
+				await gameApp.ResetGame();
+				return;
+			}
+
 			if(EnginePackMode == "worker"){
 				window.setAIDescription = function (description) {
 					gameApp.callWorkerFunction("setAIDescription", description)
@@ -145,11 +149,6 @@
 			}
 
 			Object.assign(finalConfig, config);
-
-			if (gameApp != null) {
-				await gameApp.ResetGame();
-			}
-
 			gameApp = new GameApp(finalConfig);
 			await gameApp.InitEngine();
 		}
@@ -184,13 +183,11 @@
 
 		// Returns the recorded video as a Blob.
 		window.getRecordedVideo = () => {
-			let app = gameApp || lastGameApp
-			if (app == null) {
+			if (gameApp == null) {
 				console.error("gameApp is null, should call startGame first")
 				return null
 			}
-			lastGameApp = null
-			return app.getRecordedVideo()
+			return gameApp.getRecordedVideo()
 		}
 
 		// Captures the current game screen and returns its binary data as a Blob.
@@ -212,13 +209,11 @@
 		}
 
 		window.downloadRecordedVideo = (filename) => {
-			let app = gameApp || lastGameApp
-			if (app == null) {
+			if (gameApp == null) {
 				console.error("gameApp is null, should call startGame first")
 				return null
 			}
-			lastGameApp = null
-			app.downloadRecordedVideo(filename)
+			gameApp.downloadRecordedVideo(filename)
 		}
 
 		window.stopGame = async () => {

--- a/cmd/igox/main.go
+++ b/cmd/igox/main.go
@@ -143,7 +143,7 @@ func NewSpxRunner() *SpxRunner {
 	ctx.Lookup = func(root, path string) (dir string, found bool) {
 		err := fmt.Errorf("Failed to resolve package import %q", path)
 		js.Global().Call("gdspx_ext_on_runtime_panic", err.Error())
-		js.Global().Call("gdspx_ext_request_exit", 1)
+		js.Global().Call("gdspx_ext_request_reset", 1)
 		return
 	}
 	ctx.SetPanic(logWithPanicInfo)
@@ -307,7 +307,7 @@ func (r *SpxRunner) Run(this js.Value, args []js.Value) any {
 		if runErr != nil {
 			fmt.Printf("Failed to run XGo source (code %d): %v\n", code, runErr)
 			js.Global().Call("gdspx_ext_on_runtime_panic", runErr.Error())
-			js.Global().Call("gdspx_ext_request_exit", 1)
+			js.Global().Call("gdspx_ext_request_reset", 1)
 			return
 		}
 

--- a/config.go
+++ b/config.go
@@ -185,8 +185,8 @@ type costumeSetItem struct {
 
 type costumeSet struct {
 	Path             string           `json:"path"`
-	ImageWidth       int              `json:"imageWidth"`
-	ImageHeight      int              `json:"imageHeight"`
+	ImageWidth       float64          `json:"imageWidth"`
+	ImageHeight      float64          `json:"imageHeight"`
 	FaceRight        float64          `json:"faceRight"` // turn face to right
 	BitmapResolution int              `json:"bitmapResolution"`
 	Nx               int              `json:"nx"`
@@ -212,8 +212,8 @@ type costumeConfig struct {
 	Path             string  `json:"path"`
 	X                float64 `json:"x"`
 	Y                float64 `json:"y"`
-	ImageWidth       int     `json:"imageWidth"`
-	ImageHeight      int     `json:"imageHeight"`
+	ImageWidth       float64 `json:"imageWidth"`
+	ImageHeight      float64 `json:"imageHeight"`
 	FaceRight        float64 `json:"faceRight"` // turn face to right
 	BitmapResolution int     `json:"bitmapResolution"`
 }

--- a/spbase.go
+++ b/spbase.go
@@ -68,8 +68,8 @@ const (
 type costumeSetImage struct {
 	path   string
 	rc     costumeSetRect
-	width  int
-	height int
+	width  float64
+	height float64
 	nx     int
 }
 
@@ -162,11 +162,11 @@ func newCostume(base string, c *costumeConfig) *costume {
 	return value
 }
 
-func resolveImageSize(cfgWidth, cfgHeight int, path string) mathf.Vec2 {
+func resolveImageSize(cfgWidth, cfgHeight float64, path string) mathf.Vec2 {
 	if cfgWidth > 0 && cfgHeight > 0 {
 		return mathf.Vec2{
-			X: float64(cfgWidth),
-			Y: float64(cfgHeight),
+			X: cfgWidth,
+			Y: cfgHeight,
 		}
 	}
 	return getImageSizeCached(path)


### PR DESCRIPTION
```	start := time.Now()
	for i, n := 0, v.NumField(); i < n; i++ {
		name, val := getFieldPtrOrAlloc(g, v, i)
		switch fld := val.(type) {
		case Sprite:
			if g.canBindSprite(name) {
				if err := g.loadSprite(fld, name, v); err != nil {
					panic(err)
				}
			}
			// p.sprs[name] = fld (has been set by loadSprite)
		}
	}
	interval := time.Since(start).Seconds() * 1000
	fmt.Println("Load sprites took", fmt.Sprintf("%.2f", interval), "ms")
```

这段代码缓存前：Load sprites took 1191.98 ms
缓存后：Load sprites took 598.42 ms



动画懒加载等（https://github.com/goplus/godot/pull/200
https://github.com/goplus/spx/pull/1017）：
Load sprites took 173.10 ms

重新运行游戏： RunGame Start → RunGame Done: 267.86 ms

https://github.com/user-attachments/assets/0fe52598-787f-4163-8f8c-feb38552cd5c




