### PR TITLE
Add worker mode cd/cd tools

### DIFF
--- a/.github/workflows/release_web.yml
+++ b/.github/workflows/release_web.yml
@@ -49,3 +49,41 @@ jobs:
           tag_name: ${{ github.event.release.tag_name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  web-build-worker:
+    name: 🌐 Web Worker Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Get dependencies
+        run: sudo apt-get update && sudo apt-get install gcc libgl1-mesa-dev libegl1-mesa-dev libgles2-mesa-dev libx11-dev xorg-dev libasound2-dev libopenal-dev binaryen
+        if: ${{ runner.os == 'Linux' }}
+
+      - name: Setup go/xgo & engine
+        uses: ./.github/actions/deps
+
+      - name: Build worker release pack
+        run: |
+          make setup-web MODE=worker
+          make export-web MODE=worker
+          if [ ! -f "spx_web_worker.zip" ]; then
+            echo "spx_web_worker.zip not found"
+            exit 1
+          fi
+
+      - name: Upload Web Worker Build Results
+        uses: actions/upload-artifact@v4
+        with:
+          name: web-worker-release
+          path: spx_web_worker.zip
+          retention-days: 14
+
+      - name: Publish to GitHub Release
+        if: github.event_name == 'release'
+        uses: softprops/action-gh-release@v2
+        with:
+          files: spx_web_worker.zip
+          tag_name: ${{ github.event.release.tag_name }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/cmd/gox/pkg/impl/init.go
+++ b/cmd/gox/pkg/impl/init.go
@@ -12,7 +12,7 @@ import (
 )
 
 func downloadPack(dstDir, tagName, postfix string) error {
-	urlHeader := "https://github.com/JiepengTan/godot/releases/download/"
+	urlHeader := "https://github.com/goplus/godot/releases/download/"
 	fileName := tagName + postfix
 	url := urlHeader + tagName + "/" + fileName
 	// download pc

--- a/pkg/gdspx/tools/build_engine.sh
+++ b/pkg/gdspx/tools/build_engine.sh
@@ -145,145 +145,32 @@ build_template() {
 
 download_editor() {
     setup_global_variables
-    local platform=$PLATFORM
-    local arch=$ARCH
-    local tmp_dir=$SCRIPT_DIR/bin
-    local dst_dir=$GOPATH/bin
-    local url_prefix="https://github.com/goplus/godot/releases/download/spx$VERSION/"
-    mkdir -p "$tmp_dir"
-    mkdir -p "$dst_dir"
-    echo "download to $dst_dir"
-    # download engine pack
-    local url=""
+    local saved_platform=$PLATFORM
+    echo "===>Download task 1/2 ....downloading pc via download_engine..."
+    download_engine || exit
 
-    local template_dir="$TEMPLATE_DIR"
-    
-    # Check if web zip files exist and download if they don't
-    local web_pack_file="$dst_dir/gdspx"$VERSION"_webpack.zip"
-    local web_editor_file="$dst_dir/gdspx"$VERSION"_web.zip"
-    
-    echo "===>Download task 1/5 ....web template..."
-    if [ -f "$web_pack_file" ]; then
-        echo "Web template file already exists, skipping download"
-    else
-        echo "Downloading web template..."
-        curl -L -o "$web_pack_file" $url_prefix"web.zip" || exit
-    fi
-    
-    echo "===>Download task 2/5 ....web editor..."
-    if [ -f "$web_editor_file" ]; then
-        echo "Web editor file already exists, skipping download"
-    else
-        echo "Downloading web editor..."
-        curl -L -o "$web_editor_file" $url_prefix"editor-web.zip" || exit
-    fi
-    
-    local filename="$web_pack_file"
-    cp -f $filename "$template_dir/web_dlink_debug.zip"
-    cp -f $filename "$template_dir/web_dlink_release.zip"
-    cp -f $filename "$template_dir/web_debug.zip"
-    cp -f $filename "$template_dir/web_release.zip"
-    cp -f $filename "$template_dir/web_nothreads_debug.zip"
-    cp -f $filename "$template_dir/web_nothreads_release.zip"
-    
-    platform_name=$platform
-    local binary_postfix=""
-    if [ "$platform" = "linux" ]; then
-        platform_name="linuxbsd"
-    elif [ "$platform" = "windows" ]; then
-        binary_postfix=".exe"
-    fi
+    export PLATFORM=web
+    echo "===>Download task 2/2 ....downloading web via download_engine..."
+    download_engine || exit
+    export PLATFORM=$saved_platform
 
-    local zip_name="editor-$platform-"$arch".zip"
-    local binary_name="godot.$platform_name.editor.$arch$binary_postfix"
-    local final_binary="$dst_dir/gdspx$VERSION"$binary_postfix
-    url=$url_prefix$zip_name
-    
-    echo "===>Download task 3/5 ....pc editor..."
-    # Check if editor binary already exists
-    if [ -f "$final_binary" ]; then
-        echo "Editor binary already exists, skipping download"
-    else
-        echo "Downloading pc editor..."
-        curl -L -o "$dst_dir/$zip_name" "$url" || exit
-        unzip -o "$dst_dir/$zip_name" -d "$tmp_dir" > /dev/null 2>&1  || exit
-        cp -f "$tmp_dir/$binary_name" "$dst_dir/gdspx$VERSION"$binary_postfix  || exit
-        rm -rf "$dst_dir/$zip_name"
-    fi
-
-    # download template
-    zip_name="$platform-"$arch".zip"
-    binary_name="godot.$platform_name.template_release.$arch$binary_postfix"
-    local template_binary="$dst_dir/gdspxrt$VERSION"$binary_postfix
-
-    url=$url_prefix$zip_name
-    
-    echo "===>Download task 4/5 ....pc template..."
-    # Check if template binary already exists
-    if [ -f "$template_binary" ]; then
-        echo "Template binary already exists, skipping download"
-    else
-        echo "Downloading pc template..."
-        curl -L -o "$dst_dir/$zip_name" "$url" || exit
-        unzip -o "$dst_dir/$zip_name" -d "$tmp_dir" > /dev/null 2>&1  || exit
-        cp -f "$tmp_dir/$binary_name" "$template_binary"  || exit
-    fi
-
-    local filename="$template_binary"
-    # copy to build template dir
-    if [ "$platform" = "linux" ]; then
-        cp "$filename" "$template_dir/linux_debug.arm32"
-        cp "$filename" "$template_dir/linux_debug.arm64"
-        cp "$filename" "$template_dir/linux_debug.x86_32"
-        cp "$filename" "$template_dir/linux_debug.x86_64"
-        cp "$filename" "$template_dir/linux_release.arm32"
-        cp "$filename" "$template_dir/linux_release.arm64"
-        cp "$filename" "$template_dir/linux_release.x86_32"
-        cp "$filename" "$template_dir/linux_release.x86_64"
-
-    elif [ "$platform" = "windows" ]; then
-        cp "$filename" "$template_dir/windows_debug_x86_32_console.exe"
-        cp "$filename" "$template_dir/windows_debug_x86_32.exe"
-        cp "$filename" "$template_dir/windows_debug_x86_64_console.exe"
-        cp "$filename" "$template_dir/windows_debug_x86_64.exe"
-        cp "$filename" "$template_dir/windows_release_x86_32_console.exe"
-        cp "$filename" "$template_dir/windows_release_x86_32.exe"
-        cp "$filename" "$template_dir/windows_release_x86_64_console.exe"
-        cp "$filename" "$template_dir/windows_release_x86_64.exe"
-
-    elif [ "$platform" = "macos" ]; then
-        echo "===>Download task 5/5 ....macOS template..."
-        local macos_zip="$template_dir/macos.zip"
-        if [ -f "$macos_zip" ]; then
-            echo "macOS template already exists, skipping download"
-        else
-            echo "Downloading macOS template..."
-            curl -L -o "$macos_zip" $url_prefix"macos.zip" || exit
-        fi
-    else 
-        echo "Unsupported platform for editor download: $platform"
-        exit 1
-    fi
-    echo "===>Download task done ...."
-
-    # Clean up temporary files if they exist
-    [ -f "$dst_dir/$zip_name" ] && rm -f "$dst_dir/$zip_name"
-    [ -f "$tmp_dir/$zip_name" ] && rm -f "$tmp_dir/$zip_name"
-    [ -d "$tmp_dir" ] && rm -rf "$tmp_dir"
-
+    echo "===>Download task 2/2 done ...."
     # List final files
-    echo "Files in $dst_dir:"
-    ls -l "$dst_dir"
-    echo "Files in $template_dir:"
-    ls -l "$template_dir"
+    echo "Files in $GOPATH/bin:"
+    ls -l "$GOPATH/bin"
 }
 
 download_engine() {
     setup_global_variables
     local platform=$PLATFORM
+    local arch=$ARCH
     local template_dir="$TEMPLATE_DIR"
     local url_prefix="https://github.com/goplus/godot/releases/download/spx$VERSION/"
+    local tmp_dir=$SCRIPT_DIR/bin
+    local dst_dir=$GOPATH/bin
 
+    mkdir -p "$tmp_dir"
+    mkdir -p "$dst_dir"
     mkdir -p "$template_dir"
     echo "Downloading engine templates for platform: $platform"
     echo "Template directory: $template_dir"
@@ -291,7 +178,7 @@ download_engine() {
 
     if [ "$platform" = "android" ]; then
         local android_zip="$template_dir/android.zip"
-        local tmp_dir=$(mktemp -d)
+        local android_tmp_dir=$(mktemp -d)
 
         echo "===> Downloading Android engine templates..."
         if [ -f "$android_zip" ]; then
@@ -304,32 +191,32 @@ download_engine() {
             echo "Download successful, extracting Android templates..."
 
             # Extract android templates to template directory
-            unzip -o "$android_zip" -d "$tmp_dir" > /dev/null 2>&1
+            unzip -o "$android_zip" -d "$android_tmp_dir" > /dev/null 2>&1
 
             # Copy all APK files and android_source.zip to template directory
-            if [ -f "$tmp_dir/android_debug.apk" ]; then
-                cp -f "$tmp_dir/android_debug.apk" "$template_dir/"
+            if [ -f "$android_tmp_dir/android_debug.apk" ]; then
+                cp -f "$android_tmp_dir/android_debug.apk" "$template_dir/"
                 echo "Copied android_debug.apk"
             fi
 
-            if [ -f "$tmp_dir/android_release.apk" ]; then
-                cp -f "$tmp_dir/android_release.apk" "$template_dir/"
+            if [ -f "$android_tmp_dir/android_release.apk" ]; then
+                cp -f "$android_tmp_dir/android_release.apk" "$template_dir/"
                 echo "Copied android_release.apk"
             fi
 
-            if [ -f "$tmp_dir/android_source.zip" ]; then
-                cp -f "$tmp_dir/android_source.zip" "$template_dir/"
+            if [ -f "$android_tmp_dir/android_source.zip" ]; then
+                cp -f "$android_tmp_dir/android_source.zip" "$template_dir/"
                 echo "Copied android_source.zip"
             fi
 
             # Clean up
-            rm -rf "$tmp_dir"
+            rm -rf "$android_tmp_dir"
             rm -f "$android_zip"
 
             echo "Android engine templates downloaded and extracted successfully!"
         else
             echo "Error: Failed to download Android templates from ${url_prefix}android.zip"
-            rm -rf "$tmp_dir"
+            rm -rf "$android_tmp_dir"
             exit 1
         fi
 
@@ -350,9 +237,166 @@ download_engine() {
             exit 1
         fi
 
+    elif [ "$platform" = "web" ]; then
+        # Get mode parameter (default: normal)
+        local web_mode="${MODE:-normal}"
+
+        # Validate mode
+        if [[ "$web_mode" != "normal" && "$web_mode" != "worker" && "$web_mode" != "minigame" && "$web_mode" != "miniprogram" ]]; then
+            echo "Error: Invalid mode '$web_mode'. Supported modes: normal, worker, minigame, miniprogram"
+            echo "Usage: $0 -g -p web [-m mode]"
+            exit 1
+        fi
+
+        # Template package names from godot CI based on mode
+        local template_name=""
+        case "$web_mode" in
+            normal)
+                template_name="web.zip"
+                ;;
+            worker)
+                template_name="web-worker.zip"
+                ;;
+            minigame)
+                template_name="web-minigame.zip"
+                ;;
+            miniprogram)
+                template_name="web-miniprogram.zip"
+                ;;
+        esac
+
+        echo "===> Setting up web $web_mode templates..."
+        echo "Mode: $web_mode"
+        echo "Version: $VERSION"
+        echo "URL Prefix: $url_prefix"
+        echo "Template Name: $template_name"
+        echo "Template Directory: $template_dir"
+
+        # Download template if not exists
+        # For normal mode, use webpack.zip to match download_editor naming convention
+        if [ "$web_mode" = "normal" ]; then
+            local template_file="$dst_dir/gdspx${VERSION}_webpack.zip"
+        else
+            local template_file="$dst_dir/gdspx${VERSION}_web${web_mode}.zip"
+        fi
+        if [ -f "$template_file" ]; then
+            echo "Web $web_mode template already exists, skipping download"
+        else
+            echo "Downloading web $web_mode template..."
+            echo "URL: ${url_prefix}${template_name}"
+            if curl -L -o "$template_file" "${url_prefix}${template_name}"; then
+                echo "Download successful: $template_file"
+            else
+                echo "Error: Failed to download web $web_mode template"
+                echo "Make sure the godot release contains: $template_name"
+                exit 1
+            fi
+        fi
+
+        # Setup template directory structure with mode-specific templates
+        echo "===> Setting up template directory structure..." "$template_file" "$template_dir"
+
+        cp -f "$template_file" "$template_dir/web_dlink_nothreads_debug.zip"
+        cp -f "$template_file" "$template_dir/web_dlink_nothreads_release.zip"
+        cp -f "$template_file" "$template_dir/web_nothreads_debug.zip"
+        cp -f "$template_file" "$template_dir/web_nothreads_release.zip"
+        cp -f "$template_file" "$template_dir/web_dlink_debug.zip"
+        cp -f "$template_file" "$template_dir/web_dlink_release.zip"
+        cp -f "$template_file" "$template_dir/web_debug.zip"
+        cp -f "$template_file" "$template_dir/web_release.zip"
+
+        echo "===> Web $web_mode setup complete"
+        echo "  - Template downloaded: $template_file"
+        echo "  - Templates installed to: $template_dir"
+        echo "  - Mode: $web_mode"
+
+    elif [ "$platform" = "linux" ] || [ "$platform" = "windows" ] || [ "$platform" = "macos" ]; then
+        # PC platform: download editor and template
+        platform_name=$platform
+        local binary_postfix=""
+        if [ "$platform" = "linux" ]; then
+            platform_name="linuxbsd"
+        elif [ "$platform" = "windows" ]; then
+            binary_postfix=".exe"
+        fi
+
+        # Download PC editor
+        local zip_name="editor-$platform-"$arch".zip"
+        local binary_name="godot.$platform_name.editor.$arch$binary_postfix"
+        local final_binary="$dst_dir/gdspx$VERSION"$binary_postfix
+        local url=$url_prefix$zip_name
+        
+        echo "===> Downloading PC editor..."
+        # Check if editor binary already exists
+        if [ -f "$final_binary" ]; then
+            echo "Editor binary already exists, skipping download"
+        else
+            echo "Downloading pc editor..."
+            curl -L -o "$dst_dir/$zip_name" "$url" || exit
+            unzip -o "$dst_dir/$zip_name" -d "$tmp_dir" > /dev/null 2>&1  || exit
+            cp -f "$tmp_dir/$binary_name" "$dst_dir/gdspx$VERSION"$binary_postfix  || exit
+            rm -rf "$dst_dir/$zip_name"
+        fi
+
+        # Download PC template
+        zip_name="$platform-"$arch".zip"
+        binary_name="godot.$platform_name.template_release.$arch$binary_postfix"
+        local template_binary="$dst_dir/gdspxrt$VERSION"$binary_postfix
+
+        url=$url_prefix$zip_name
+        
+        echo "===> Downloading PC template..."
+        # Check if template binary already exists
+        if [ -f "$template_binary" ]; then
+            echo "Template binary already exists, skipping download"
+        else
+            echo "Downloading pc template..."
+            curl -L -o "$dst_dir/$zip_name" "$url" || exit
+            unzip -o "$dst_dir/$zip_name" -d "$tmp_dir" > /dev/null 2>&1  || exit
+            cp -f "$tmp_dir/$binary_name" "$template_binary"  || exit
+        fi
+
+        local filename="$template_binary"
+        # copy to build template dir
+        if [ "$platform" = "linux" ]; then
+            cp "$filename" "$template_dir/linux_debug.arm32"
+            cp "$filename" "$template_dir/linux_debug.arm64"
+            cp "$filename" "$template_dir/linux_debug.x86_32"
+            cp "$filename" "$template_dir/linux_debug.x86_64"
+            cp "$filename" "$template_dir/linux_release.arm32"
+            cp "$filename" "$template_dir/linux_release.arm64"
+            cp "$filename" "$template_dir/linux_release.x86_32"
+            cp "$filename" "$template_dir/linux_release.x86_64"
+
+        elif [ "$platform" = "windows" ]; then
+            cp "$filename" "$template_dir/windows_debug_x86_32_console.exe"
+            cp "$filename" "$template_dir/windows_debug_x86_32.exe"
+            cp "$filename" "$template_dir/windows_debug_x86_64_console.exe"
+            cp "$filename" "$template_dir/windows_debug_x86_64.exe"
+            cp "$filename" "$template_dir/windows_release_x86_32_console.exe"
+            cp "$filename" "$template_dir/windows_release_x86_32.exe"
+            cp "$filename" "$template_dir/windows_release_x86_64_console.exe"
+            cp "$filename" "$template_dir/windows_release_x86_64.exe"
+
+        elif [ "$platform" = "macos" ]; then
+            echo "===> Downloading macOS template..."
+            local macos_zip="$template_dir/macos.zip"
+            if [ -f "$macos_zip" ]; then
+                echo "macOS template already exists, skipping download"
+            else
+                echo "Downloading macOS template..."
+                curl -L -o "$macos_zip" $url_prefix"macos.zip" || exit
+            fi
+        fi
+
+        # Clean up temporary files if they exist
+        [ -f "$dst_dir/$zip_name" ] && rm -f "$dst_dir/$zip_name"
+        [ -f "$tmp_dir/$zip_name" ] && rm -f "$tmp_dir/$zip_name"
+        [ -d "$tmp_dir" ] && rm -rf "$tmp_dir"
+
     else
         echo "Error: Unsupported platform for download_engine: $platform"
-        echo "Supported platforms: android, ios"
+        echo "Supported platforms: android, ios, web, linux, windows, macos"
         exit 1
     fi
 


### PR DESCRIPTION
Related PR: https://github.com/goplus/godot/pull/206

- Unify the engine download method: via the `download_engine` function in `pkg\gdspx\tools\build_engine.sh`.
- Unify the export-webexport method, supporting four modes—`normal`, `worker`, `minigame`, and `miniprogram`—to facilitate unified exports for other modes in the future.

The corresponding CI/CD results can be viewed at the link:  https://github.com/JiepengTan/spx/releases/download/spx2.0.49/spx_web_worker.zip