### PR TITLE
Simplify the installation of the engine environment

### DIFF
--- a/.github/actions/deps/action.yml
+++ b/.github/actions/deps/action.yml
@@ -19,6 +19,13 @@ runs:
         xgo-version: ${{ inputs.xgo-version }}
 
     - name: Prepare engine
-      run: make setup
+      run: |
+        echo "===> setup engine runtime "
+        make setup
+        echo "===> download engine editor"
+        make download-engine MODE=editor   
+        echo "===> download web engine & setup web engine normal mode"
+        make download-engine PLATFORM=web MODE=normal
+        make setup-web MODE=normal
       shell: bash
 

--- a/Makefile
+++ b/Makefile
@@ -51,14 +51,10 @@ list-demos: ## List all demos with index
 # ============================================
 setup: ## Initialize the user environment
 	chmod +x ./pkg/gdspx/tools/*.sh && \
-	echo "===> Step 1/4: Install spx" && \
+	echo "===> Step 1/2: Install spx" && \
 	make install && \
-	echo "===> Step 2/4: Download engine" && \
+	echo "===> Step 2/2: Download engine" && \
 	make download && \
-	echo "===> Step 3/4: Export runtime package" && \
-	make export-pack && \
-	echo "===> Step 4/4: Prepare web template" && \
-	./pkg/gdspx/tools/make_util.sh extrawebtemplate && \
 	echo "===> setup done"
 
 
@@ -100,21 +96,23 @@ install: ## Install spx command
 	$(INSTALL_CMD)
 
 download: ## Download engines
-	make install && ./pkg/gdspx/tools/build_engine.sh -e -d
+	echo "" && ./pkg/gdspx/tools/build_engine.sh -e -d
 
 download-engine: ## Download engine templates for specific platform. Usage: make download-engine PLATFORM=android|ios|web [MODE=normal|worker|minigame|miniprogram]
-ifndef PLATFORM
-	$(error PLATFORM is not set! Usage: make download-engine PLATFORM=android or PLATFORM=ios or PLATFORM=web [MODE=mode])
-endif
+
 	@echo "Downloading engine templates for platform: $(PLATFORM)"
 	@if [ "$(PLATFORM)" = "web" ]; then \
 		if [ -n "$(MODE)" ]; then \
-			./pkg/gdspx/tools/build_engine.sh -p $(PLATFORM) -g -m $(MODE); \
+			MODE_ENV="$(MODE)" ./pkg/gdspx/tools/build_engine.sh -p "$(PLATFORM)" -g -m "$(MODE)"; \
 		else \
-			./pkg/gdspx/tools/build_engine.sh -p $(PLATFORM) -g; \
+			./pkg/gdspx/tools/build_engine.sh -p "$(PLATFORM)" -g; \
 		fi \
 	else \
-		./pkg/gdspx/tools/build_engine.sh -p $(PLATFORM) -g; \
+		if [ -n "$(MODE)" ]; then \
+			MODE_ENV="$(MODE)" ./pkg/gdspx/tools/build_engine.sh -p "$(PLATFORM)" -g -m "$(MODE)"; \
+		else \
+			./pkg/gdspx/tools/build_engine.sh -p "$(PLATFORM)" -g; \
+		fi \
 	fi 
 
 

--- a/cmd/gox/install.sh
+++ b/cmd/gox/install.sh
@@ -53,8 +53,10 @@ if [ ! -f "$appname" ]; then
 fi
 
 mv $appname $GOPATH/bin/
-go env -w GOFLAGS="-buildvcs=false"
+
+# build wasm
 if [ "$1" = "--web" ]; then
+    go env -w GOFLAGS="-buildvcs=false"
     cd ../igox || exit
     ./build.sh "$2"
     cp gdspx.wasm $GOPATH/bin/gdspx.wasm

--- a/cmd/gox/pkg/impl/init.go
+++ b/cmd/gox/pkg/impl/init.go
@@ -63,8 +63,6 @@ func CheckAndGetAppPath(gobinDir, tag, version string, customGoEnv bool) (string
 		if customGoEnv {
 			return binPostfix, cmdPath, nil
 		}
-		println("Engine is not exist , please download or build engine from source ...", cmdPath)
-		os.Exit(1)
 	} else if err != nil {
 		return binPostfix, "", err
 	} else {

--- a/pkg/gdspx/tools/make_util.sh
+++ b/pkg/gdspx/tools/make_util.sh
@@ -223,7 +223,7 @@ do_compresswasm() {
 do_exportpack() {
     do_prepare_export
     echo "Starting exportpack..."
-   
+    
     echo "exporting pck..."
     spx export 
     
@@ -241,6 +241,24 @@ do_exportpack() {
     fi
     # Clean up
     rm -rf "$CURRENT_PATH/.tmp"
+    TEMP_VERSION=$(cat "$CURRENT_PATH/cmd/gox/template/version")
+    OUTPUT_PCK="$GOPATH/bin/gdspxrt$TEMP_VERSION.pck"
+    
+    # Check if files exist before creating zip
+    if [ ! -f "$OUTPUT_PCK" ]; then
+        echo "Error: $OUTPUT_PCK does not exist"
+        return 1
+    fi
+    if [ ! -f "$GOPATH/bin/runtime.gdextension" ]; then
+        echo "Error: $GOPATH/bin/runtime.gdextension does not exist"
+        return 1
+    fi
+    TEMP_PCK="$GOPATH/bin/gdspxrt.pck"
+    DST_ZIP="$GOPATH/bin/gdspxrt.pck.$TEMP_VERSION.zip"
+    cp "$OUTPUT_PCK" "$TEMP_PCK"
+    rm -rf "$DST_ZIP"
+    zip -j "$DST_ZIP" "$TEMP_PCK" "$GOPATH/bin/runtime.gdextension"
+    rm -rf "$TEMP_PCK"
     return 0
 }
 


### PR DESCRIPTION
简化了初始化的引擎环境设置： 
- 目前只需要依赖 gdspxrt  , gdspxrt.pck , 以及 runtime.gdextension 三个文件
- 不再需要下载editor 模式的 引擎，以及 web 相关 engine

如果需要默认设置好 web环境 ，则需要执行  .github\actions\deps\action.yml 中的命令
```bash
echo "===> setup engine runtime "
make setup
echo "===> download engine editor"
make download-engine MODE=editor   
echo "===> download web engine & setup web engine normal mode"
make download-engine PLATFORM=web MODE=normal
make setup-web MODE=normal
```

**重要**： 当引擎相关的资源(eg: shader)更新, 需要
1. 调用 make export-pck  会在本地构建一个  gdspxrt.pck.*.zip 到GOPATH/bin 目录
2. 将这个新构建的  gdspxrt.pck.*.zip 上传到  https://github.com/goplus/spx/releases/tag/v2.0.0-pre.30   的release 页面中 

同时需要更新 pkg\gdspx\tools\build_engine.sh  文件中的  PCK_VERSION 变量为新的资源版本号
eg: 如果打包出来的 是 gdspxrt.pck.2.0.50.zip  那么 PCK_VERSION  需要设置为 2.0.50