### PR TITLE
refactor(ispx): rewrite `memfs` to implement standard `io/fs` interfaces

### DIFF
--- a/ispx/go.mod
+++ b/ispx/go.mod
@@ -9,13 +9,13 @@ require (
 	github.com/goplus/mod v0.17.1
 	github.com/goplus/reflectx v1.5.0
 	github.com/goplus/spx/v2 v2.0.0-pre.42
+	github.com/goplus/xgo v1.5.2
 )
 
 require (
 	github.com/gopherjs/gopherjs v0.0.0-20200217142428-fce0ec30dd00 // indirect
 	github.com/goplus/gogen v1.19.5 // indirect
 	github.com/goplus/spbase v0.1.0 // indirect
-	github.com/goplus/xgo v1.5.2 // indirect
 	github.com/h2non/filetype v1.1.3 // indirect
 	github.com/petermattis/goid v0.0.0-20250721140440-ea1c0173183e // indirect
 	github.com/pkg/errors v0.9.1 // indirect

--- a/ispx/internal/memfs/memfs.go
+++ b/ispx/internal/memfs/memfs.go
@@ -1,226 +1,255 @@
 package memfs
 
 import (
-	"bytes"
 	"io"
 	"io/fs"
+	"maps"
 	"path"
-	"path/filepath"
-	"sort"
+	"slices"
 	"strings"
 	"time"
 )
 
-// MemFs is an in-memory file system that stores files as a map of paths to byte slices.
-// It is safe for concurrent use. Chrooted instances share the underlying file map.
-type MemFs struct {
+const (
+	fileMode = fs.FileMode(0o444)
+	dirMode  = fs.FileMode(0o444) | fs.ModeDir
+)
+
+// FS implements [fs.ReadDirFS] using a map of files.
+type FS struct {
 	files map[string][]byte
-	root  string
 }
 
-// memDirEntry implements the fs.DirEntry interface
-type memDirEntry struct {
-	name  string
-	isDir bool
-	size  int64
+// New creates a new [FS].
+func New(files map[string][]byte) *FS {
+	return &FS{files: files}
 }
 
-func (e *memDirEntry) Name() string {
-	return e.name
-}
-
-func (e *memDirEntry) IsDir() bool {
-	return e.isDir
-}
-
-func (e *memDirEntry) Type() fs.FileMode {
-	if e.isDir {
-		return fs.ModeDir
+// Open implements [fs.ReadDirFS].
+func (fsys *FS) Open(name string) (fs.File, error) {
+	if !fs.ValidPath(name) {
+		return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrInvalid}
 	}
-	return 0
+
+	// Check if it's a file.
+	if content, ok := fsys.files[name]; ok {
+		return &file{
+			name:    name,
+			content: content,
+		}, nil
+	}
+
+	// Check if it's a directory.
+	if fsys.hasDir(name) {
+		return &dir{
+			fsys: fsys,
+			name: name,
+		}, nil
+	}
+
+	return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrNotExist}
 }
 
-func (e *memDirEntry) Info() (fs.FileInfo, error) {
-	return &memFileInfo{
-		name:  e.name,
-		size:  e.size,
-		isDir: e.isDir,
+// ReadDir implements [fs.ReadDirFS].
+func (fsys *FS) ReadDir(name string) ([]fs.DirEntry, error) {
+	if !fs.ValidPath(name) {
+		return nil, &fs.PathError{Op: "readdir", Path: name, Err: fs.ErrInvalid}
+	}
+
+	prefix := ""
+	if name != "." {
+		prefix = name + "/"
+	}
+
+	// Map entry names to whether they are directories (true = dir, false = file).
+	// If an entry appears both as a file and a directory prefix, it's a directory.
+	entries := make(map[string]bool)
+	for p := range fsys.files {
+		after, ok := strings.CutPrefix(p, prefix)
+		if !ok {
+			continue
+		}
+		entryName, _, isDir := strings.Cut(after, "/")
+		if entryName == "" {
+			continue
+		}
+		if isDir || !entries[entryName] {
+			entries[entryName] = isDir
+		}
+	}
+
+	// Check if the directory exists. The root directory always exists.
+	if name != "." && len(entries) == 0 {
+		return nil, &fs.PathError{Op: "readdir", Path: name, Err: fs.ErrNotExist}
+	}
+
+	des := make([]fs.DirEntry, 0, len(entries))
+	for _, entryName := range slices.Sorted(maps.Keys(entries)) {
+		isDir := entries[entryName]
+		de := &dirEntry{name: entryName}
+		if isDir {
+			de.mode = dirMode
+		} else {
+			de.mode = fileMode
+			de.size = int64(len(fsys.files[prefix+entryName]))
+		}
+		des = append(des, de)
+	}
+	return des, nil
+}
+
+// Stat implements [fs.StatFS].
+func (fsys *FS) Stat(name string) (fs.FileInfo, error) {
+	if !fs.ValidPath(name) {
+		return nil, &fs.PathError{Op: "stat", Path: name, Err: fs.ErrInvalid}
+	}
+
+	// Check if it's a file.
+	if content, ok := fsys.files[name]; ok {
+		return &fileInfo{
+			name: path.Base(name),
+			size: int64(len(content)),
+			mode: fileMode,
+		}, nil
+	}
+
+	// Check if it's a directory.
+	if fsys.hasDir(name) {
+		return &fileInfo{
+			name: path.Base(name),
+			mode: dirMode,
+		}, nil
+	}
+
+	return nil, &fs.PathError{Op: "stat", Path: name, Err: fs.ErrNotExist}
+}
+
+// hasDir reports whether name exists as a directory.
+func (fsys *FS) hasDir(name string) bool {
+	if name == "." {
+		return true
+	}
+	prefix := name + "/"
+	for p := range fsys.files {
+		if strings.HasPrefix(p, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// file implements [fs.File].
+type file struct {
+	name    string
+	content []byte
+	offset  int64
+}
+
+// Stat implements [fs.File].
+func (f *file) Stat() (fs.FileInfo, error) {
+	return &fileInfo{
+		name: path.Base(f.name),
+		size: int64(len(f.content)),
+		mode: fileMode,
 	}, nil
 }
 
-// memFileInfo implements the fs.FileInfo interface
-type memFileInfo struct {
-	name  string
-	size  int64
-	isDir bool
-}
-
-func (fi *memFileInfo) Name() string { return fi.name }
-func (fi *memFileInfo) Size() int64  { return fi.size }
-func (fi *memFileInfo) Mode() fs.FileMode {
-	if fi.isDir {
-		return fs.ModeDir | 0755
+// Read implements [fs.File].
+func (f *file) Read(b []byte) (int, error) {
+	if f.offset >= int64(len(f.content)) {
+		return 0, io.EOF
 	}
-	return 0644
-}
-func (fi *memFileInfo) ModTime() time.Time { return time.Time{} }
-func (fi *memFileInfo) IsDir() bool        { return fi.isDir }
-func (fi *memFileInfo) Sys() any           { return nil }
 
-// NewMemFs creates a new in-memory file system
-func NewMemFs(files map[string][]byte) *MemFs {
-	return &MemFs{
-		files: files,
-	}
+	n := copy(b, f.content[f.offset:])
+	f.offset += int64(n)
+	return n, nil
 }
 
-// Chroot creates a new MemFs with a different root
-func (m *MemFs) Chroot(root string) (*MemFs, error) {
-	return &MemFs{
-		files: m.files,
-		root:  root,
+// Close implements [fs.File].
+func (f *file) Close() error {
+	return nil
+}
+
+// dir implements [fs.ReadDirFile].
+type dir struct {
+	fsys    *FS
+	name    string
+	entries []fs.DirEntry
+	offset  int
+}
+
+// Stat implements [fs.File].
+func (d *dir) Stat() (fs.FileInfo, error) {
+	return &fileInfo{
+		name: path.Base(d.name),
+		mode: dirMode,
 	}, nil
 }
 
-// ReadDir lists directory entries under dirname
-func (m *MemFs) ReadDir(dirname string) ([]fs.DirEntry, error) {
-	dirname = path.Clean(path.Join(m.root, dirname))
-	if !strings.HasSuffix(dirname, "/") {
-		dirname += "/"
-	}
-	if dirname == "/" {
-		dirname = "./"
-	}
-
-	// used for deduplication
-	seen := make(map[string]*memDirEntry)
-
-	for name, content := range m.files {
-		// skip files that are not under the target directory
-		if !strings.HasPrefix(name, dirname) && dirname != "./" {
-			continue
-		}
-
-		// special handling for the root directory
-		var relativePath string
-		if dirname == "./" {
-			relativePath = name
-		} else {
-			relativePath = strings.TrimPrefix(name, dirname)
-		}
-
-		// if the relative path is empty, skip (it's the directory itself)
-		if relativePath == "" {
-			continue
-		}
-
-		// check whether it's a direct child
-		parts := strings.SplitN(relativePath, "/", 2)
-		if len(parts) == 0 {
-			continue
-		}
-
-		entryName := parts[0]
-
-		// determine whether it's a file or a directory
-		isDir := len(parts) > 1 && parts[1] != ""
-
-		if existing, exists := seen[entryName]; exists {
-			// if already exists and currently determined to be a directory, update to directory
-			if isDir && !existing.isDir {
-				existing.isDir = true
-			}
-		} else {
-			var size int64
-			if !isDir {
-				size = int64(len(content))
-			}
-
-			seen[entryName] = &memDirEntry{
-				name:  entryName,
-				isDir: isDir,
-				size:  size,
-			}
-		}
-	}
-
-	if len(seen) == 0 {
-		return nil, fs.ErrNotExist
-	}
-	// convert map entries to a slice and sort
-	dirEntries := make([]fs.DirEntry, 0, len(seen))
-	for _, entry := range seen {
-		dirEntries = append(dirEntries, entry)
-	}
-
-	sort.Slice(dirEntries, func(i, j int) bool {
-		return dirEntries[i].Name() < dirEntries[j].Name()
-	})
-
-	return dirEntries, nil
+// Read implements [fs.File].
+func (d *dir) Read([]byte) (int, error) {
+	return 0, &fs.PathError{Op: "read", Path: d.name, Err: fs.ErrInvalid}
 }
 
-// ReadFile returns the file content for filename
-func (m *MemFs) ReadFile(filename string) ([]byte, error) {
-	filename = path.Clean(path.Join(m.root, filename))
-	data, ok := m.files[filename]
-	if !ok {
-		return nil, fs.ErrNotExist
-	}
-	// Return a copy to prevent external modification
-	result := make([]byte, len(data))
-	copy(result, data)
-	return result, nil
-}
-
-// Join joins path elements
-func (m *MemFs) Join(elem ...string) string {
-	return path.Join(elem...)
-}
-
-// Base returns the last element of path
-func (m *MemFs) Base(filename string) string {
-	return filepath.Base(filename)
-}
-
-// Abs returns an absolute representation of path
-func (m *MemFs) Abs(p string) (string, error) {
-	return filepath.Abs(p)
-}
-
-type readSeekCloser struct {
-	*bytes.Reader
-}
-
-func (rsc *readSeekCloser) Close() error {
+// Close implements [fs.File].
+func (d *dir) Close() error {
 	return nil
 }
 
-// Open opens a file for reading
-func (m *MemFs) Open(file string) (io.ReadCloser, error) {
-	file = path.Clean(path.Join(m.root, file))
-	data, ok := m.files[file]
-	if !ok {
-		return nil, fs.ErrNotExist
+// ReadDir implements [fs.ReadDirFile].
+func (d *dir) ReadDir(n int) ([]fs.DirEntry, error) {
+	if d.entries == nil {
+		entries, err := d.fsys.ReadDir(d.name)
+		if err != nil {
+			return nil, err
+		}
+		d.entries = entries
 	}
 
-	// Return a new reader with Seek support
-	return &readSeekCloser{bytes.NewReader(data)}, nil
+	if n <= 0 {
+		entries := d.entries[d.offset:]
+		d.offset = len(d.entries)
+		return entries, nil
+	}
+
+	if d.offset >= len(d.entries) {
+		return nil, io.EOF
+	}
+
+	end := min(d.offset+n, len(d.entries))
+	entries := d.entries[d.offset:end]
+	d.offset = end
+	return entries, nil
 }
 
-// Close closes the file system (no-op for MemFs)
-func (m *MemFs) Close() error {
-	return nil
+// fileInfo implements [fs.FileInfo].
+type fileInfo struct {
+	name string
+	size int64
+	mode fs.FileMode
 }
 
-// AddFile adds or updates a file in the file system
-func (m *MemFs) AddFile(filename string, data []byte) {
-	filename = path.Clean(filename)
-	m.files[filename] = data
+func (fi *fileInfo) Name() string       { return fi.name }
+func (fi *fileInfo) Size() int64        { return fi.size }
+func (fi *fileInfo) Mode() fs.FileMode  { return fi.mode }
+func (fi *fileInfo) ModTime() time.Time { return time.Unix(0, 0) }
+func (fi *fileInfo) IsDir() bool        { return fi.mode.IsDir() }
+func (fi *fileInfo) Sys() any           { return nil }
+
+// dirEntry implements [fs.DirEntry].
+type dirEntry struct {
+	name string
+	size int64
+	mode fs.FileMode
 }
 
-// RemoveFile removes a file from the file system
-func (m *MemFs) RemoveFile(filename string) {
-	filename = path.Clean(filename)
-	delete(m.files, filename)
+func (de *dirEntry) Name() string      { return de.name }
+func (de *dirEntry) IsDir() bool       { return de.mode.IsDir() }
+func (de *dirEntry) Type() fs.FileMode { return de.mode.Type() }
+func (de *dirEntry) Info() (fs.FileInfo, error) {
+	return &fileInfo{
+		name: de.name,
+		size: de.size,
+		mode: de.mode,
+	}, nil
 }

--- a/ispx/internal/memfs/memfs_test.go
+++ b/ispx/internal/memfs/memfs_test.go
@@ -1,0 +1,768 @@
+package memfs
+
+import (
+	"errors"
+	"io"
+	"io/fs"
+	"testing"
+	"testing/fstest"
+)
+
+func TestNew(t *testing.T) {
+	files := map[string][]byte{
+		"file.txt":         []byte("hello"),
+		"subdir/file.txt":  []byte("world"),
+		"subdir/sub/a.txt": []byte("a"),
+	}
+	fsys := New(files)
+	if fsys == nil {
+		t.Fatal("expected non-nil FS")
+	}
+	if fsys.files == nil {
+		t.Fatal("expected non-nil files map")
+	}
+	if err := fstest.TestFS(fsys, "file.txt", "subdir/file.txt", "subdir/sub/a.txt"); err != nil {
+		t.Errorf("fstest.TestFS failed: %v", err)
+	}
+}
+
+func TestFSOpen(t *testing.T) {
+	t.Run("File", func(t *testing.T) {
+		fsys := New(map[string][]byte{
+			"file.txt": []byte("hello"),
+		})
+		f, err := fsys.Open("file.txt")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		defer f.Close()
+
+		data, err := io.ReadAll(f)
+		if err != nil {
+			t.Fatalf("failed to read: %v", err)
+		}
+		if string(data) != "hello" {
+			t.Errorf("got %q, want %q", string(data), "hello")
+		}
+	})
+
+	t.Run("Directory", func(t *testing.T) {
+		fsys := New(map[string][]byte{
+			"subdir/file.txt": []byte("world"),
+		})
+		f, err := fsys.Open("subdir")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		defer f.Close()
+
+		fi, err := f.Stat()
+		if err != nil {
+			t.Fatalf("failed to stat: %v", err)
+		}
+		if !fi.IsDir() {
+			t.Error("expected directory")
+		}
+	})
+
+	t.Run("RootDirectory", func(t *testing.T) {
+		fsys := New(map[string][]byte{
+			"file.txt": []byte("hello"),
+		})
+		f, err := fsys.Open(".")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		defer f.Close()
+
+		fi, err := f.Stat()
+		if err != nil {
+			t.Fatalf("failed to stat: %v", err)
+		}
+		if !fi.IsDir() {
+			t.Error("expected directory")
+		}
+	})
+
+	t.Run("NotExist", func(t *testing.T) {
+		fsys := New(map[string][]byte{})
+		_, err := fsys.Open("nonexistent.txt")
+		if err == nil {
+			t.Fatal("expected error for nonexistent file")
+		}
+		var pathErr *fs.PathError
+		if !errors.As(err, &pathErr) {
+			t.Fatalf("expected *fs.PathError, got %T", err)
+		}
+		if pathErr.Err != fs.ErrNotExist {
+			t.Errorf("got %v, want %v", pathErr.Err, fs.ErrNotExist)
+		}
+	})
+
+	t.Run("InvalidPath", func(t *testing.T) {
+		fsys := New(map[string][]byte{})
+		_, err := fsys.Open("../invalid")
+		if err == nil {
+			t.Fatal("expected error for invalid path")
+		}
+		var pathErr *fs.PathError
+		if !errors.As(err, &pathErr) {
+			t.Fatalf("expected *fs.PathError, got %T", err)
+		}
+		if pathErr.Err != fs.ErrInvalid {
+			t.Errorf("got %v, want %v", pathErr.Err, fs.ErrInvalid)
+		}
+	})
+}
+
+func TestFSReadDir(t *testing.T) {
+	t.Run("RootDirectory", func(t *testing.T) {
+		fsys := New(map[string][]byte{
+			"a.txt":            []byte("a"),
+			"b.txt":            []byte("bb"),
+			"subdir/c.txt":     []byte("ccc"),
+			"subdir/d.txt":     []byte("dddd"),
+			"subdir/sub/e.txt": []byte("eeeee"),
+		})
+		entries, err := fsys.ReadDir(".")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(entries) != 3 {
+			t.Fatalf("got %d entries, want 3", len(entries))
+		}
+
+		expected := []struct {
+			name  string
+			isDir bool
+		}{
+			{"a.txt", false},
+			{"b.txt", false},
+			{"subdir", true},
+		}
+		for i, e := range expected {
+			if entries[i].Name() != e.name {
+				t.Errorf("entry %d: got name %q, want %q", i, entries[i].Name(), e.name)
+			}
+			if entries[i].IsDir() != e.isDir {
+				t.Errorf("entry %d: got isDir %v, want %v", i, entries[i].IsDir(), e.isDir)
+			}
+		}
+	})
+
+	t.Run("Subdirectory", func(t *testing.T) {
+		fsys := New(map[string][]byte{
+			"subdir/c.txt":     []byte("ccc"),
+			"subdir/d.txt":     []byte("dddd"),
+			"subdir/sub/e.txt": []byte("eeeee"),
+		})
+		entries, err := fsys.ReadDir("subdir")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(entries) != 3 {
+			t.Fatalf("got %d entries, want 3", len(entries))
+		}
+
+		expected := []struct {
+			name  string
+			isDir bool
+		}{
+			{"c.txt", false},
+			{"d.txt", false},
+			{"sub", true},
+		}
+		for i, e := range expected {
+			if entries[i].Name() != e.name {
+				t.Errorf("entry %d: got name %q, want %q", i, entries[i].Name(), e.name)
+			}
+			if entries[i].IsDir() != e.isDir {
+				t.Errorf("entry %d: got isDir %v, want %v", i, entries[i].IsDir(), e.isDir)
+			}
+		}
+	})
+
+	t.Run("NotExist", func(t *testing.T) {
+		fsys := New(map[string][]byte{})
+		_, err := fsys.ReadDir("nonexistent")
+		if err == nil {
+			t.Fatal("expected error for nonexistent directory")
+		}
+		var pathErr *fs.PathError
+		if !errors.As(err, &pathErr) {
+			t.Fatalf("expected *fs.PathError, got %T", err)
+		}
+		if pathErr.Err != fs.ErrNotExist {
+			t.Errorf("got %v, want %v", pathErr.Err, fs.ErrNotExist)
+		}
+	})
+
+	t.Run("InvalidPath", func(t *testing.T) {
+		fsys := New(map[string][]byte{})
+		_, err := fsys.ReadDir("../invalid")
+		if err == nil {
+			t.Fatal("expected error for invalid path")
+		}
+		var pathErr *fs.PathError
+		if !errors.As(err, &pathErr) {
+			t.Fatalf("expected *fs.PathError, got %T", err)
+		}
+		if pathErr.Err != fs.ErrInvalid {
+			t.Errorf("got %v, want %v", pathErr.Err, fs.ErrInvalid)
+		}
+	})
+}
+
+func TestFSStat(t *testing.T) {
+	t.Run("File", func(t *testing.T) {
+		fsys := New(map[string][]byte{
+			"file.txt": []byte("hello"),
+		})
+		fi, err := fsys.Stat("file.txt")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if fi.Name() != "file.txt" {
+			t.Errorf("got name %q, want %q", fi.Name(), "file.txt")
+		}
+		if fi.Size() != 5 {
+			t.Errorf("got size %d, want 5", fi.Size())
+		}
+		if fi.IsDir() {
+			t.Error("expected file, not directory")
+		}
+		if fi.Mode() != fileMode {
+			t.Errorf("got mode %v, want %v", fi.Mode(), fileMode)
+		}
+	})
+
+	t.Run("FileInSubdirectory", func(t *testing.T) {
+		fsys := New(map[string][]byte{
+			"subdir/file.txt": []byte("world"),
+		})
+		fi, err := fsys.Stat("subdir/file.txt")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if fi.Name() != "file.txt" {
+			t.Errorf("got name %q, want %q", fi.Name(), "file.txt")
+		}
+		if fi.Size() != 5 {
+			t.Errorf("got size %d, want 5", fi.Size())
+		}
+	})
+
+	t.Run("Directory", func(t *testing.T) {
+		fsys := New(map[string][]byte{
+			"subdir/file.txt": []byte("world"),
+		})
+		fi, err := fsys.Stat("subdir")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if fi.Name() != "subdir" {
+			t.Errorf("got name %q, want %q", fi.Name(), "subdir")
+		}
+		if !fi.IsDir() {
+			t.Error("expected directory")
+		}
+		if fi.Mode() != dirMode {
+			t.Errorf("got mode %v, want %v", fi.Mode(), dirMode)
+		}
+	})
+
+	t.Run("RootDirectory", func(t *testing.T) {
+		fsys := New(map[string][]byte{
+			"file.txt": []byte("hello"),
+		})
+		fi, err := fsys.Stat(".")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if fi.Name() != "." {
+			t.Errorf("got name %q, want %q", fi.Name(), ".")
+		}
+		if !fi.IsDir() {
+			t.Error("expected directory")
+		}
+	})
+
+	t.Run("NotExist", func(t *testing.T) {
+		fsys := New(map[string][]byte{})
+		_, err := fsys.Stat("nonexistent.txt")
+		if err == nil {
+			t.Fatal("expected error for nonexistent file")
+		}
+		var pathErr *fs.PathError
+		if !errors.As(err, &pathErr) {
+			t.Fatalf("expected *fs.PathError, got %T", err)
+		}
+		if pathErr.Err != fs.ErrNotExist {
+			t.Errorf("got %v, want %v", pathErr.Err, fs.ErrNotExist)
+		}
+	})
+
+	t.Run("InvalidPath", func(t *testing.T) {
+		fsys := New(map[string][]byte{})
+		_, err := fsys.Stat("../invalid")
+		if err == nil {
+			t.Fatal("expected error for invalid path")
+		}
+		var pathErr *fs.PathError
+		if !errors.As(err, &pathErr) {
+			t.Fatalf("expected *fs.PathError, got %T", err)
+		}
+		if pathErr.Err != fs.ErrInvalid {
+			t.Errorf("got %v, want %v", pathErr.Err, fs.ErrInvalid)
+		}
+	})
+}
+
+func TestFSHasDir(t *testing.T) {
+	t.Run("RootDirectory", func(t *testing.T) {
+		fsys := New(map[string][]byte{})
+		if !fsys.hasDir(".") {
+			t.Error("expected root directory to exist")
+		}
+	})
+
+	t.Run("ExistingDirectory", func(t *testing.T) {
+		fsys := New(map[string][]byte{
+			"subdir/file.txt": []byte("hello"),
+		})
+		if !fsys.hasDir("subdir") {
+			t.Error("expected subdir to exist")
+		}
+	})
+
+	t.Run("NestedDirectory", func(t *testing.T) {
+		fsys := New(map[string][]byte{
+			"a/b/c/file.txt": []byte("hello"),
+		})
+		if !fsys.hasDir("a") {
+			t.Error("expected a to exist")
+		}
+		if !fsys.hasDir("a/b") {
+			t.Error("expected a/b to exist")
+		}
+		if !fsys.hasDir("a/b/c") {
+			t.Error("expected a/b/c to exist")
+		}
+	})
+
+	t.Run("NonExistentDirectory", func(t *testing.T) {
+		fsys := New(map[string][]byte{
+			"subdir/file.txt": []byte("hello"),
+		})
+		if fsys.hasDir("nonexistent") {
+			t.Error("expected nonexistent directory to not exist")
+		}
+	})
+
+	t.Run("FileNotDirectory", func(t *testing.T) {
+		fsys := New(map[string][]byte{
+			"file.txt": []byte("hello"),
+		})
+		if fsys.hasDir("file.txt") {
+			t.Error("expected file to not be a directory")
+		}
+	})
+
+	t.Run("SimilarPrefix", func(t *testing.T) {
+		fsys := New(map[string][]byte{
+			"subdir-other/file.txt": []byte("hello"),
+		})
+		if fsys.hasDir("subdir") {
+			t.Error("expected subdir to not exist when only subdir-other exists")
+		}
+	})
+}
+
+func TestFileStat(t *testing.T) {
+	fsys := New(map[string][]byte{
+		"file.txt": []byte("hello"),
+	})
+	f, err := fsys.Open("file.txt")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer f.Close()
+
+	fi, err := f.Stat()
+	if err != nil {
+		t.Fatalf("failed to stat: %v", err)
+	}
+	if fi.Name() != "file.txt" {
+		t.Errorf("got name %q, want %q", fi.Name(), "file.txt")
+	}
+	if fi.Size() != 5 {
+		t.Errorf("got size %d, want 5", fi.Size())
+	}
+	if fi.IsDir() {
+		t.Error("expected file, not directory")
+	}
+}
+
+func TestFileRead(t *testing.T) {
+	t.Run("ReadAll", func(t *testing.T) {
+		fsys := New(map[string][]byte{
+			"file.txt": []byte("hello world"),
+		})
+		f, err := fsys.Open("file.txt")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		defer f.Close()
+
+		data, err := io.ReadAll(f)
+		if err != nil {
+			t.Fatalf("failed to read: %v", err)
+		}
+		if string(data) != "hello world" {
+			t.Errorf("got %q, want %q", string(data), "hello world")
+		}
+	})
+
+	t.Run("ReadPartial", func(t *testing.T) {
+		fsys := New(map[string][]byte{
+			"file.txt": []byte("hello world"),
+		})
+		f, err := fsys.Open("file.txt")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		defer f.Close()
+
+		buf := make([]byte, 5)
+		n, err := f.Read(buf)
+		if err != nil {
+			t.Fatalf("failed to read: %v", err)
+		}
+		if n != 5 {
+			t.Errorf("got %d bytes, want 5", n)
+		}
+		if string(buf) != "hello" {
+			t.Errorf("got %q, want %q", string(buf), "hello")
+		}
+
+		n, err = f.Read(buf)
+		if err != nil {
+			t.Fatalf("failed to read: %v", err)
+		}
+		if n != 5 {
+			t.Errorf("got %d bytes, want 5", n)
+		}
+		if string(buf) != " worl" {
+			t.Errorf("got %q, want %q", string(buf), " worl")
+		}
+	})
+
+	t.Run("ReadEOF", func(t *testing.T) {
+		fsys := New(map[string][]byte{
+			"file.txt": []byte("hello world"),
+		})
+		f, err := fsys.Open("file.txt")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		defer f.Close()
+
+		_, err = io.ReadAll(f)
+		if err != nil {
+			t.Fatalf("failed to read: %v", err)
+		}
+
+		buf := make([]byte, 1)
+		n, err := f.Read(buf)
+		if n != 0 {
+			t.Errorf("got %d bytes, want 0", n)
+		}
+		if err != io.EOF {
+			t.Errorf("got %v, want io.EOF", err)
+		}
+	})
+}
+
+func TestFileClose(t *testing.T) {
+	fsys := New(map[string][]byte{
+		"file.txt": []byte("hello"),
+	})
+	f, err := fsys.Open("file.txt")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestDirStat(t *testing.T) {
+	t.Run("Subdirectory", func(t *testing.T) {
+		fsys := New(map[string][]byte{
+			"subdir/file.txt": []byte("hello"),
+		})
+		f, err := fsys.Open("subdir")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		defer f.Close()
+
+		fi, err := f.Stat()
+		if err != nil {
+			t.Fatalf("failed to stat: %v", err)
+		}
+		if fi.Name() != "subdir" {
+			t.Errorf("got name %q, want %q", fi.Name(), "subdir")
+		}
+		if fi.Size() != 0 {
+			t.Errorf("got size %d, want 0", fi.Size())
+		}
+		if !fi.IsDir() {
+			t.Error("expected directory")
+		}
+		if fi.Mode() != dirMode {
+			t.Errorf("got mode %v, want %v", fi.Mode(), dirMode)
+		}
+	})
+
+	t.Run("RootDirectory", func(t *testing.T) {
+		fsys := New(map[string][]byte{
+			"file.txt": []byte("hello"),
+		})
+		f, err := fsys.Open(".")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		defer f.Close()
+
+		fi, err := f.Stat()
+		if err != nil {
+			t.Fatalf("failed to stat: %v", err)
+		}
+		if fi.Name() != "." {
+			t.Errorf("got name %q, want %q", fi.Name(), ".")
+		}
+		if !fi.IsDir() {
+			t.Error("expected directory")
+		}
+	})
+
+	t.Run("NestedDirectory", func(t *testing.T) {
+		fsys := New(map[string][]byte{
+			"a/b/c/file.txt": []byte("hello"),
+		})
+		f, err := fsys.Open("a/b")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		defer f.Close()
+
+		fi, err := f.Stat()
+		if err != nil {
+			t.Fatalf("failed to stat: %v", err)
+		}
+		if fi.Name() != "b" {
+			t.Errorf("got name %q, want %q", fi.Name(), "b")
+		}
+		if !fi.IsDir() {
+			t.Error("expected directory")
+		}
+	})
+}
+
+func TestDirRead(t *testing.T) {
+	fsys := New(map[string][]byte{
+		"subdir/file.txt": []byte("hello"),
+	})
+	f, err := fsys.Open("subdir")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer f.Close()
+
+	buf := make([]byte, 1)
+	_, err = f.Read(buf)
+	if err == nil {
+		t.Fatal("expected error when reading directory")
+	}
+	var pathErr *fs.PathError
+	if !errors.As(err, &pathErr) {
+		t.Fatalf("expected *fs.PathError, got %T", err)
+	}
+	if pathErr.Err != fs.ErrInvalid {
+		t.Errorf("got %v, want %v", pathErr.Err, fs.ErrInvalid)
+	}
+}
+
+func TestDirClose(t *testing.T) {
+	fsys := New(map[string][]byte{
+		"subdir/file.txt": []byte("hello"),
+	})
+	f, err := fsys.Open("subdir")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestDirReadDir(t *testing.T) {
+	t.Run("ReadAll", func(t *testing.T) {
+		fsys := New(map[string][]byte{
+			"subdir/a.txt": []byte("a"),
+			"subdir/b.txt": []byte("bb"),
+			"subdir/c.txt": []byte("ccc"),
+		})
+		f, err := fsys.Open("subdir")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		defer f.Close()
+
+		dirFile := f.(fs.ReadDirFile)
+		entries, err := dirFile.ReadDir(-1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(entries) != 3 {
+			t.Fatalf("got %d entries, want 3", len(entries))
+		}
+	})
+
+	t.Run("ReadPartial", func(t *testing.T) {
+		fsys := New(map[string][]byte{
+			"subdir/a.txt": []byte("a"),
+			"subdir/b.txt": []byte("bb"),
+			"subdir/c.txt": []byte("ccc"),
+		})
+		f, err := fsys.Open("subdir")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		defer f.Close()
+
+		dirFile := f.(fs.ReadDirFile)
+		entries, err := dirFile.ReadDir(2)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(entries) != 2 {
+			t.Fatalf("got %d entries, want 2", len(entries))
+		}
+
+		entries, err = dirFile.ReadDir(2)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(entries) != 1 {
+			t.Fatalf("got %d entries, want 1", len(entries))
+		}
+
+		entries, err = dirFile.ReadDir(2)
+		if err != io.EOF {
+			t.Fatalf("got %v, want io.EOF", err)
+		}
+		if len(entries) != 0 {
+			t.Fatalf("got %d entries, want 0", len(entries))
+		}
+	})
+}
+
+func TestFileInfo(t *testing.T) {
+	fsys := New(map[string][]byte{
+		"file.txt": []byte("hello"),
+	})
+	fi, err := fsys.Stat("file.txt")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if fi.Name() != "file.txt" {
+		t.Errorf("got name %q, want %q", fi.Name(), "file.txt")
+	}
+	if fi.Size() != 5 {
+		t.Errorf("got size %d, want 5", fi.Size())
+	}
+	if fi.Mode() != fileMode {
+		t.Errorf("got mode %v, want %v", fi.Mode(), fileMode)
+	}
+	if fi.ModTime().IsZero() {
+		t.Error("expected non-zero mod time")
+	}
+	if fi.IsDir() {
+		t.Error("expected file, not directory")
+	}
+	if fi.Sys() != nil {
+		t.Errorf("got sys %v, want nil", fi.Sys())
+	}
+}
+
+func TestDirEntry(t *testing.T) {
+	t.Run("FileEntry", func(t *testing.T) {
+		fsys := New(map[string][]byte{
+			"file.txt": []byte("hello"),
+		})
+		entries, err := fsys.ReadDir(".")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		var fileEntry fs.DirEntry
+		for _, e := range entries {
+			if e.Name() == "file.txt" {
+				fileEntry = e
+				break
+			}
+		}
+		if fileEntry == nil {
+			t.Fatal("file.txt entry not found")
+		}
+
+		if fileEntry.IsDir() {
+			t.Error("expected file, not directory")
+		}
+		if fileEntry.Type() != fileMode.Type() {
+			t.Errorf("got type %v, want %v", fileEntry.Type(), fileMode.Type())
+		}
+
+		fi, err := fileEntry.Info()
+		if err != nil {
+			t.Fatalf("failed to get info: %v", err)
+		}
+		if fi.Name() != "file.txt" {
+			t.Errorf("got name %q, want %q", fi.Name(), "file.txt")
+		}
+		if fi.Size() != 5 {
+			t.Errorf("got size %d, want 5", fi.Size())
+		}
+	})
+
+	t.Run("DirEntry", func(t *testing.T) {
+		fsys := New(map[string][]byte{
+			"subdir/file.txt": []byte("world"),
+		})
+		entries, err := fsys.ReadDir(".")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		var dirEntry fs.DirEntry
+		for _, e := range entries {
+			if e.Name() == "subdir" {
+				dirEntry = e
+				break
+			}
+		}
+		if dirEntry == nil {
+			t.Fatal("subdir entry not found")
+		}
+
+		if !dirEntry.IsDir() {
+			t.Error("expected directory")
+		}
+		if dirEntry.Type() != dirMode.Type() {
+			t.Errorf("got type %v, want %v", dirEntry.Type(), dirMode.Type())
+		}
+	})
+}

--- a/ispx/ispx.go
+++ b/ispx/ispx.go
@@ -26,7 +26,6 @@ func init() {
 var (
 	mu          sync.Mutex
 	ixgoCtx     *ixgo.Context
-	ixgoFS      *memfs.MemFs
 	ixgoInterp  *ixgo.Interp
 	ixgoRunning bool
 	ixgoRunID   int64
@@ -91,12 +90,12 @@ func Build(files map[string][]byte) error {
 	// Release previous resources if any.
 	unsafeRelease()
 
-	fs := memfs.NewMemFs(files)
+	fsys := memfs.New(files)
 	spxfs.RegisterSchema("", func(path string) (spxfs.Dir, error) {
-		return fs.Chroot(path)
+		return newSPXDir(fsys, path), nil
 	})
 
-	source, err := xgobuild.BuildFSDir(ixgoCtx, fs, "")
+	source, err := xgobuild.BuildFSDir(ixgoCtx, newXGoParserFS(fsys), ".")
 	if err != nil {
 		return fmt.Errorf("failed to build XGo source: %w", err)
 	}
@@ -111,7 +110,6 @@ func Build(files map[string][]byte) error {
 		return fmt.Errorf("failed to create interp: %w", err)
 	}
 
-	ixgoFS = fs
 	ixgoInterp = interp
 	return nil
 }
@@ -159,9 +157,5 @@ func unsafeRelease() {
 	if ixgoInterp != nil {
 		ixgoInterp.UnsafeRelease()
 		ixgoInterp = nil
-	}
-	if ixgoFS != nil {
-		ixgoFS.Close()
-		ixgoFS = nil
 	}
 }

--- a/ispx/spxdir.go
+++ b/ispx/spxdir.go
@@ -1,0 +1,34 @@
+package ispx
+
+import (
+	"io"
+	"io/fs"
+	"path"
+
+	spxfs "github.com/goplus/spx/v2/fs"
+)
+
+// spxDir wraps a [fs.FS] to implement [spxfs.Dir].
+type spxDir struct {
+	fsys   fs.FS
+	prefix string
+}
+
+// newSPXDir creates a new spx directory.
+func newSPXDir(fsys fs.FS, prefix string) spxfs.Dir {
+	return &spxDir{fsys: fsys, prefix: prefix}
+}
+
+// Open implements [spxfs.Dir].
+func (d *spxDir) Open(file string) (io.ReadCloser, error) {
+	name := file
+	if d.prefix != "" {
+		name = path.Join(d.prefix, file)
+	}
+	return d.fsys.Open(name)
+}
+
+// Close implements [spxfs.Dir].
+func (d *spxDir) Close() error {
+	return nil
+}

--- a/ispx/spxdir_test.go
+++ b/ispx/spxdir_test.go
@@ -1,0 +1,73 @@
+package ispx
+
+import (
+	"io"
+	"testing"
+	"testing/fstest"
+)
+
+func TestNewSPXDir(t *testing.T) {
+	fsys := fstest.MapFS{}
+	dir := newSPXDir(fsys, "")
+	if dir == nil {
+		t.Fatal("expected non-nil dir")
+	}
+}
+
+func TestSpxDirOpen(t *testing.T) {
+	fsys := fstest.MapFS{
+		"file.txt":        &fstest.MapFile{Data: []byte("hello")},
+		"subdir/file.txt": &fstest.MapFile{Data: []byte("world")},
+	}
+
+	t.Run("WithoutPrefix", func(t *testing.T) {
+		dir := newSPXDir(fsys, "")
+		rc, err := dir.Open("file.txt")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		defer rc.Close()
+
+		data, err := io.ReadAll(rc)
+		if err != nil {
+			t.Fatalf("failed to read: %v", err)
+		}
+		if string(data) != "hello" {
+			t.Errorf("got %q, want %q", string(data), "hello")
+		}
+	})
+
+	t.Run("WithPrefix", func(t *testing.T) {
+		dir := newSPXDir(fsys, "subdir")
+		rc, err := dir.Open("file.txt")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		defer rc.Close()
+
+		data, err := io.ReadAll(rc)
+		if err != nil {
+			t.Fatalf("failed to read: %v", err)
+		}
+		if string(data) != "world" {
+			t.Errorf("got %q, want %q", string(data), "world")
+		}
+	})
+
+	t.Run("FileNotFound", func(t *testing.T) {
+		dir := newSPXDir(fsys, "")
+		_, err := dir.Open("nonexistent.txt")
+		if err == nil {
+			t.Fatal("expected error for nonexistent file")
+		}
+	})
+}
+
+func TestSpxDirClose(t *testing.T) {
+	fsys := fstest.MapFS{}
+	dir := newSPXDir(fsys, "")
+	spxDir := dir.(*spxDir)
+	if err := spxDir.Close(); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}

--- a/ispx/xgoparserfs.go
+++ b/ispx/xgoparserfs.go
@@ -1,0 +1,44 @@
+package ispx
+
+import (
+	"errors"
+	"io/fs"
+	"path"
+
+	xgoparser "github.com/goplus/xgo/parser"
+)
+
+// xgoParserFS wraps a [fs.ReadDirFS] to implement [xgoparser.FileSystem].
+type xgoParserFS struct {
+	rdfs fs.ReadDirFS
+}
+
+// newXGoParserFS creates a new XGo parser file system.
+func newXGoParserFS(rdfs fs.ReadDirFS) xgoparser.FileSystem {
+	return &xgoParserFS{rdfs: rdfs}
+}
+
+// ReadDir implements [xgoparser.FileSystem].
+func (pfs *xgoParserFS) ReadDir(dirname string) ([]fs.DirEntry, error) {
+	return fs.ReadDir(pfs.rdfs, dirname)
+}
+
+// ReadFile implements [xgoparser.FileSystem].
+func (pfs *xgoParserFS) ReadFile(filename string) ([]byte, error) {
+	return fs.ReadFile(pfs.rdfs, filename)
+}
+
+// Join implements [xgoparser.FileSystem].
+func (pfs *xgoParserFS) Join(elem ...string) string {
+	return path.Join(elem...)
+}
+
+// Base implements [xgoparser.FileSystem].
+func (pfs *xgoParserFS) Base(filename string) string {
+	return path.Base(filename)
+}
+
+// Abs implements [xgoparser.FileSystem].
+func (pfs *xgoParserFS) Abs(path string) (string, error) {
+	return "", errors.ErrUnsupported
+}


### PR DESCRIPTION
- Rewrite `memfs.FS` to properly implement `fs.ReadDirFS` and `fs.StatFS`
- Replace custom `Chroot` method with new `spxDir` adapter for `spxfs.Dir`
- Add `xgoParserFS` adapter for `xgoparser.FileSystem`
- Remove unused methods: `Join`, `Base`, `Abs`, `AddFile`, `RemoveFile`
- Use `fs.PathError` for consistent error handling
- Add comprehensive tests with `fstest.TestFS` validation