### PR TITLE
feat(ispx): add `BuildFS` function for flexible filesystem input

### DIFF
--- a/ispx/internal/memfs/memfs.go
+++ b/ispx/internal/memfs/memfs.go
@@ -15,7 +15,7 @@ const (
 	dirMode  = fs.FileMode(0o444) | fs.ModeDir
 )
 
-// FS implements [fs.ReadDirFS] using a map of files.
+// FS implements [fs.FS] using a map of files.
 type FS struct {
 	files map[string][]byte
 }
@@ -25,7 +25,7 @@ func New(files map[string][]byte) *FS {
 	return &FS{files: files}
 }
 
-// Open implements [fs.ReadDirFS].
+// Open implements [fs.FS].
 func (fsys *FS) Open(name string) (fs.File, error) {
 	if !fs.ValidPath(name) {
 		return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrInvalid}

--- a/ispx/ispx.go
+++ b/ispx/ispx.go
@@ -2,6 +2,7 @@ package ispx
 
 import (
 	"fmt"
+	"io/fs"
 	"sync"
 
 	"github.com/goplus/ixgo"
@@ -77,6 +78,11 @@ func XGot_Game_XGox_GetWidget[T any](sg ShapeGetter, name WidgetName) *T {
 
 // Build builds the spx code from the provided files into the interpreter.
 func Build(files map[string][]byte) error {
+	return BuildFS(memfs.New(files))
+}
+
+// BuildFS builds the spx code from the provided file system into the interpreter.
+func BuildFS(fsys fs.FS) error {
 	mu.Lock()
 	defer mu.Unlock()
 
@@ -90,9 +96,8 @@ func Build(files map[string][]byte) error {
 	// Release previous resources if any.
 	unsafeRelease()
 
-	fsys := memfs.New(files)
 	spxfs.RegisterSchema("", func(path string) (spxfs.Dir, error) {
-		return newSPXDir(fsys, path), nil
+		return newSpxDir(fsys, path), nil
 	})
 
 	source, err := xgobuild.BuildFSDir(ixgoCtx, newXGoParserFS(fsys), ".")

--- a/ispx/spxdir.go
+++ b/ispx/spxdir.go
@@ -14,8 +14,8 @@ type spxDir struct {
 	prefix string
 }
 
-// newSPXDir creates a new spx directory.
-func newSPXDir(fsys fs.FS, prefix string) spxfs.Dir {
+// newSpxDir creates a new spx directory.
+func newSpxDir(fsys fs.FS, prefix string) spxfs.Dir {
 	return &spxDir{fsys: fsys, prefix: prefix}
 }
 

--- a/ispx/spxdir_test.go
+++ b/ispx/spxdir_test.go
@@ -6,9 +6,9 @@ import (
 	"testing/fstest"
 )
 
-func TestNewSPXDir(t *testing.T) {
+func TestNewSpxDir(t *testing.T) {
 	fsys := fstest.MapFS{}
-	dir := newSPXDir(fsys, "")
+	dir := newSpxDir(fsys, "")
 	if dir == nil {
 		t.Fatal("expected non-nil dir")
 	}
@@ -21,7 +21,7 @@ func TestSpxDirOpen(t *testing.T) {
 	}
 
 	t.Run("WithoutPrefix", func(t *testing.T) {
-		dir := newSPXDir(fsys, "")
+		dir := newSpxDir(fsys, "")
 		rc, err := dir.Open("file.txt")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -38,7 +38,7 @@ func TestSpxDirOpen(t *testing.T) {
 	})
 
 	t.Run("WithPrefix", func(t *testing.T) {
-		dir := newSPXDir(fsys, "subdir")
+		dir := newSpxDir(fsys, "subdir")
 		rc, err := dir.Open("file.txt")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -55,7 +55,7 @@ func TestSpxDirOpen(t *testing.T) {
 	})
 
 	t.Run("FileNotFound", func(t *testing.T) {
-		dir := newSPXDir(fsys, "")
+		dir := newSpxDir(fsys, "")
 		_, err := dir.Open("nonexistent.txt")
 		if err == nil {
 			t.Fatal("expected error for nonexistent file")
@@ -65,7 +65,7 @@ func TestSpxDirOpen(t *testing.T) {
 
 func TestSpxDirClose(t *testing.T) {
 	fsys := fstest.MapFS{}
-	dir := newSPXDir(fsys, "")
+	dir := newSpxDir(fsys, "")
 	spxDir := dir.(*spxDir)
 	if err := spxDir.Close(); err != nil {
 		t.Errorf("unexpected error: %v", err)

--- a/ispx/xgoparserfs.go
+++ b/ispx/xgoparserfs.go
@@ -8,24 +8,24 @@ import (
 	xgoparser "github.com/goplus/xgo/parser"
 )
 
-// xgoParserFS wraps a [fs.ReadDirFS] to implement [xgoparser.FileSystem].
+// xgoParserFS wraps a [fs.FS] to implement [xgoparser.FileSystem].
 type xgoParserFS struct {
-	rdfs fs.ReadDirFS
+	fsys fs.FS
 }
 
 // newXGoParserFS creates a new XGo parser file system.
-func newXGoParserFS(rdfs fs.ReadDirFS) xgoparser.FileSystem {
-	return &xgoParserFS{rdfs: rdfs}
+func newXGoParserFS(fsys fs.FS) xgoparser.FileSystem {
+	return &xgoParserFS{fsys: fsys}
 }
 
 // ReadDir implements [xgoparser.FileSystem].
 func (pfs *xgoParserFS) ReadDir(dirname string) ([]fs.DirEntry, error) {
-	return fs.ReadDir(pfs.rdfs, dirname)
+	return fs.ReadDir(pfs.fsys, dirname)
 }
 
 // ReadFile implements [xgoparser.FileSystem].
 func (pfs *xgoParserFS) ReadFile(filename string) ([]byte, error) {
-	return fs.ReadFile(pfs.rdfs, filename)
+	return fs.ReadFile(pfs.fsys, filename)
 }
 
 // Join implements [xgoparser.FileSystem].


### PR DESCRIPTION
- Add `BuildFS` that accepts any `fs.FS` implementation
- Refactor `Build` to wrap `BuildFS` with `memfs`
- Generalize `xgoParserFS` to accept `fs.FS` instead of `fs.ReadDirFS`
- Update doc comments to reflect the interface changes

This allows callers to provide custom filesystem implementations instead of being limited to `map[string][]byte`.