### PR TITLE
refactor(ispx): remove deprecated JS binding aliases and update callers

### DIFF
--- a/cmd/gox/template/platform/web/game.js
+++ b/cmd/gox/template/platform/web/game.js
@@ -232,7 +232,7 @@ class GameApp {
             }
         });
         if (!this.workerMode) {
-            const res = window.ixgo_build(nonAssetFiles);
+            const res = window.ispx_build(nonAssetFiles);
             if (res instanceof Error) throw res;
         }else{
             this.nonAssetFiles = nonAssetFiles;
@@ -284,7 +284,7 @@ class GameApp {
             return
         }
 
-        this.game.requestReset()
+        window.ispx_stop()
 
         if(this.recordingOnGameStart && this.autoDownloadRecordedVideo){
             let fileName = `spx_${new Date().getTime()}.webm`;
@@ -395,7 +395,7 @@ class GameApp {
             // register global functions
             Module = game.rtenv;
             FFI = self;
-            const res = window.ixgo_run();
+            const res = window.ispx_start();
             if (res instanceof Error) throw res;
         }
     }

--- a/cmd/gox/template/platform/web/runner.html
+++ b/cmd/gox/template/platform/web/runner.html
@@ -156,14 +156,14 @@
 			}
 
 			if(EnginePackMode == "worker"){
-				window.setAIDescription = function (description) {
-					gameApp.callWorkerFunction("setAIDescription", description)
+				window.xbuilder_set_ai_description = function (description) {
+					gameApp.callWorkerFunction("xbuilder_set_ai_description", description)
 				}
-				window.setAIInteractionAPIEndpoint = function (endpoint) {
-					gameApp.callWorkerFunction("setAIInteractionAPIEndpoint", endpoint)
+				window.xbuilder_set_ai_interaction_api_endpoint = function (endpoint) {
+					gameApp.callWorkerFunction("xbuilder_set_ai_interaction_api_endpoint", endpoint)
 				}
-				window.setAIInteractionAPITokenProvider = function (tokenProviderFunction) {
-					gameApp.callWorkerFunction("setAIInteractionAPITokenProvider", tokenProviderFunction)
+				window.xbuilder_set_ai_interaction_api_token_provider = function (tokenProviderFunction) {
+					gameApp.callWorkerFunction("xbuilder_set_ai_interaction_api_token_provider", tokenProviderFunction)
 				}
 
 				window.onWasmLoaded = function () {}

--- a/cmd/gox/template/platform/webworker/go.wasm.loader.js
+++ b/cmd/gox/template/platform/webworker/go.wasm.loader.js
@@ -118,8 +118,8 @@ function tryRunGoWasm() {
   if (self.goBridge && self.goBridge.isReady) {
     try {
       // If Go WASM is ready, can call related functions to process data
-      self.goBridge.callGoFunctionSafe('ixgo_build', Module["gameProjectData"]);
-      self.goBridge.callGoFunctionSafe('ixgo_run');
+      self.goBridge.callGoFunctionSafe('ispx_build', Module["gameProjectData"]);
+      self.goBridge.callGoFunctionSafe('ispx_start');
       callMainThread('onGameStarted');
     } catch (error) {
       console.error(`[Worker ${workerId}] Error calling Go function to process project data:`, error);

--- a/ispx/js.go
+++ b/ispx/js.go
@@ -22,12 +22,6 @@ func init() {
 	js.Global().Set("ispx_build", jsFuncOfWithError(ispxBuild))
 	js.Global().Set("ispx_start", jsFuncOfWithError(ispxStart))
 	js.Global().Set("ispx_stop", jsFuncOfWithError(ispxStop))
-
-	// Deprecated: Use ispx_build and ispx_start instead.
-	//
-	// FIXME: Remove these aliases in future releases.
-	js.Global().Set("ixgo_build", jsFuncOfWithError(ispxBuild))
-	js.Global().Set("ixgo_run", jsFuncOfWithError(ispxStart))
 }
 
 // defaultIXGoContextLookup is the default [ixgo.Context.Lookup] when none is


### PR DESCRIPTION
Remove deprecated JS binding aliases and update all frontend code to use the new naming conventions:

- Remove `ixgo_build` and `ixgo_run` aliases from `ispx/js.go`
- Update `game.js` to use `ispx_build`, `ispx_start`, and `ispx_stop`
- Update `go.wasm.loader.js` to use `ispx_build` and `ispx_start`
- Rename AI-related JS bindings from camelCase to snake_case with `xbuilder_` prefix in `runner.html`

The `ispx_*` bindings provide a consistent naming convention for the interpreter API, and `xbuilder_set_ai_*` bindings clearly indicate they are XBuilder-specific extensions.