### PR TITLE
refactor(ispx): rename `gdspx.wasm` to `ispx.wasm` and simplify build script

### DIFF
--- a/cmd/gox/install.sh
+++ b/cmd/gox/install.sh
@@ -38,13 +38,7 @@ if [ "$OS" = "Windows_NT" ]; then
 else
    go build -ldflags="-checklinkname=0" -o $appname
 fi 
-if [ "$OS" = "Windows_NT" ]; then
-    IFS=';' read -r first_gopath _ <<< "$(go env GOPATH)"
-    GOPATH="$first_gopath"
-else
-    IFS=':' read -r first_gopath _ <<< "$(go env GOPATH)"
-    GOPATH="$first_gopath"
-fi
+GOPATH="$(go env GOPATH)"
 
 
 if [ ! -f "$appname" ]; then

--- a/cmd/gox/pkg/command/build.go
+++ b/cmd/gox/pkg/command/build.go
@@ -196,7 +196,7 @@ func (pself *CmdTool) BuildWasm() error {
 	if err := os.MkdirAll(webBuildDir, 0755); err != nil {
 		return fmt.Errorf("failed to create web build directory: %w", err)
 	}
-	filePath := path.Join(webBuildDir, "gdspx.wasm")
+	filePath := path.Join(webBuildDir, "ispx.wasm")
 
 	// 2. Execute build inside GoDir
 	return pself.withGoDir(func() error {

--- a/cmd/gox/pkg/command/env.go
+++ b/cmd/gox/pkg/command/env.go
@@ -243,7 +243,7 @@ func (pself *CmdTool) SetupEnv(version string, fs embed.FS, fsRelDir string, pro
 
 // getWasmPath returns the path to the wasm file
 func (pself *CmdTool) getWasmPath() string {
-	filePath := path.Join(pself.GoBinPath, "gdspx.wasm")
+	filePath := path.Join(pself.GoBinPath, "ispx.wasm")
 	return filePath
 }
 

--- a/cmd/gox/pkg/command/export.go
+++ b/cmd/gox/pkg/command/export.go
@@ -84,7 +84,7 @@ func (pself *CmdTool) ExportMinigame() error {
 
 	// handle WASM files based on build mode
 	godotEditorWasm := filepath.Join(rawWebDir, "engine.wasm")
-	gdspxWasm := filepath.Join(rawWebDir, "gdspx.wasm")
+	ispxWasm := filepath.Join(rawWebDir, "ispx.wasm")
 
 	if buildMode == "fast" {
 		// fast build: move WASM files directly without compression
@@ -92,8 +92,8 @@ func (pself *CmdTool) ExportMinigame() error {
 			return fmt.Errorf("failed to move %s: %w", godotEditorWasm, err)
 		}
 
-		if err := pself.moveFile(gdspxWasm, filepath.Join(engineDir, "gdspx.wasm")); err != nil {
-			return fmt.Errorf("failed to move %s: %w", gdspxWasm, err)
+		if err := pself.moveFile(ispxWasm, filepath.Join(engineDir, "ispx.wasm")); err != nil {
+			return fmt.Errorf("failed to move %s: %w", ispxWasm, err)
 		}
 	} else {
 		// normal build: compress WASM files
@@ -107,9 +107,9 @@ func (pself *CmdTool) ExportMinigame() error {
 			return fmt.Errorf("failed to compress %s: %w", godotEditorWasm, err)
 		}
 
-		fmt.Printf("compress %s...\n", gdspxWasm)
-		if err := pself.compressBrotli(gdspxWasm); err != nil {
-			return fmt.Errorf("failed to compress %s: %w", gdspxWasm, err)
+		fmt.Printf("compress %s...\n", ispxWasm)
+		if err := pself.compressBrotli(ispxWasm); err != nil {
+			return fmt.Errorf("failed to compress %s: %w", ispxWasm, err)
 		}
 
 		// move compressed files to engine directory
@@ -248,8 +248,8 @@ func (pself *CmdTool) exportWebCommon(mode string) error {
 
 	pack.PackProject(pself.TargetDir, filepath.Join(pself.WebDir, "game.zip"))
 	//pack.PackEngineRes(pself.ProjectFS, pself.WebDir)
-	util.CopyFile(pself.getWasmPath(), filepath.Join(pself.WebDir, "gdspx.wasm"))
-	util.CopyFile(pself.getWasmPath()+".br", filepath.Join(pself.WebDir, "gdspx.wasm.br"))
+	util.CopyFile(pself.getWasmPath(), filepath.Join(pself.WebDir, "ispx.wasm"))
+	util.CopyFile(pself.getWasmPath()+".br", filepath.Join(pself.WebDir, "ispx.wasm.br"))
 	pack.SaveEngineHash(pself.WebDir)
 	return nil
 }

--- a/cmd/gox/pkg/pack/pack.go
+++ b/cmd/gox/pkg/pack/pack.go
@@ -144,7 +144,7 @@ func computeHash(filePath string) (string, error) {
 }
 func SaveEngineHash(webDir string) {
 	// calc and save wasm hash
-	files := []string{"gdspx.wasm", "engine.wasm"}
+	files := []string{"ispx.wasm", "engine.wasm"}
 	outpuString := `
 function GetEngineHashes() { 
 	return {

--- a/cmd/gox/template/platform/web/game.js
+++ b/cmd/gox/template/platform/web/game.js
@@ -349,7 +349,7 @@ class GameApp {
         } else {
             if (this.useAssetCache) {
                 const engineCacheResult = await this.storageManager.checkEngineCache(GetEngineHashes());
-                this.gameConfig.wasmGdspx = engineCacheResult.wasmGdspx;
+                this.gameConfig.wasmIspx = engineCacheResult.wasmIspx;
                 this.gameConfig.wasmEngine = engineCacheResult.wasmEngine;
             } else {
                 if (!this.gameConfig.wasmEngine) {
@@ -403,7 +403,7 @@ class GameApp {
     //------------------ logic wasm ------------------
     async loadLogicWasm() {
         // load wasm
-        let url = this.config.assetURLs["gdspx.wasm"];
+        let url = this.config.assetURLs["ispx.wasm"];
         if (isWasmCompressed) {
             url += ".br"
         }
@@ -422,7 +422,7 @@ class GameApp {
             });
         } else {
             if (this.useAssetCache) {
-                const { instance } = await WebAssembly.instantiate(this.gameConfig.wasmGdspx, this.go.importObject);
+                const { instance } = await WebAssembly.instantiate(this.gameConfig.wasmIspx, this.go.importObject);
                 this.logicWasmInstance = instance;
             } else {
                 const { instance } = await WebAssembly.instantiateStreaming(fetch(url), this.go.importObject);

--- a/cmd/gox/template/platform/web/runner.html
+++ b/cmd/gox/template/platform/web/runner.html
@@ -181,7 +181,7 @@
 				"assetURLs": {
 					"engine.zip": "/engine.zip",
 					"game.zip": "/game.zip",
-					"gdspx.wasm": "/gdspx.wasm",
+					"ispx.wasm": "/ispx.wasm",
 					"engine.wasm": "/engine.wasm",
 				},
 				"recordingOnGameStart": false,

--- a/cmd/gox/template/platform/web/storage.manager.js
+++ b/cmd/gox/template/platform/web/storage.manager.js
@@ -185,10 +185,10 @@ class StorageManager {
     
     async checkEngineCache(hashes) {
         this.logVerbose("curHashes ", hashes)
-        const wasmGdspx = await this.checkCacheAsset(hashes, "gdspx.wasm");
+        const wasmIspx = await this.checkCacheAsset(hashes, "ispx.wasm");
         const wasmEngine = await this.checkCacheAsset(hashes, "engine.wasm");
-        console.log("checkEngineCache ", wasmGdspx, wasmEngine)
-        return { wasmGdspx, wasmEngine };
+        console.log("checkEngineCache ", wasmIspx, wasmEngine)
+        return { wasmIspx, wasmEngine };
     }
 
     async checkCacheAsset(hashes, assetName) {

--- a/cmd/gox/template/platform/webminigame/js/runner.js
+++ b/cmd/gox/template/platform/webminigame/js/runner.js
@@ -41,7 +41,7 @@ class GameRunner {
             "assetURLs": {
                 "engine.zip": "engine/engine.zip",
                 "game.zip": "engine/game.zip",
-                "gdspx.wasm": "engine/gdspx.wasm",
+                "ispx.wasm": "engine/ispx.wasm",
                 "engine.wasm": "engine/engine.wasm",
             },
         };

--- a/cmd/gox/template/platform/webminiprogram/index.html
+++ b/cmd/gox/template/platform/webminiprogram/index.html
@@ -217,7 +217,7 @@
 				"useAssetCache": true,
 				"assetURLs": {
 					"engine.zip": urlPrefix + "engine.zip",
-					"gdspx.wasm": urlPrefix + "gdspx.wasm",
+					"ispx.wasm": urlPrefix + "ispx.wasm",
 					"engine.wasm": urlPrefix + "engine.wasm",
 				},
 				"onSpxReady": null,

--- a/cmd/gox/template/platform/webworker/go.wasm.loader.js
+++ b/cmd/gox/template/platform/webworker/go.wasm.loader.js
@@ -199,7 +199,7 @@ async function loadGoWasmModule() {
     let assetURLs = Module["gameAssetURLs"];
     // Initialize Go WASM module
     await goBridge.initialize({
-      wasmPath: assetURLs["gdspx.wasm"],
+      wasmPath: assetURLs["ispx.wasm"],
       timeout: 15000,
       enableDebug: false
     });

--- a/docs/zh/dev/engine/web_minigame_go_wasm_adapter.md
+++ b/docs/zh/dev/engine/web_minigame_go_wasm_adapter.md
@@ -144,7 +144,7 @@ await go.run(compatibleInstance);
 // loader.js 中的关键部分
 async function loadGoWASM() {
   // load wasm
-  let url = config.assetURLs["gdspx.wasm"];
+  let url = config.assetURLs["ispx.wasm"];
   const go = new Go();
   
   // 在微信小程序环境中加载 WASM

--- a/docs/zh/dev/wxgame_go_wasm_adapter.md
+++ b/docs/zh/dev/wxgame_go_wasm_adapter.md
@@ -144,7 +144,7 @@ await go.run(compatibleInstance);
 // loader.js 中的关键部分
 async function loadGoWASM() {
   // load wasm
-  let url = config.assetURLs["gdspx.wasm"];
+  let url = config.assetURLs["ispx.wasm"];
   const go = new Go();
   
   // 在微信小程序环境中加载 WASM

--- a/ispx/build.sh
+++ b/ispx/build.sh
@@ -1,238 +1,39 @@
 #!/bin/bash
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-cd $SCRIPT_DIR
+set -e
 
-# Pin Go toolchain version
-export GOTOOLCHAIN=go1.24.4
+cd "$(dirname "${BASH_SOURCE[0]}")"
 
-# Detect system type
-SYSTEM="$(uname -s)"
+GOPATH="$(go env GOPATH)"
 
-# Set GOPATH
-if [ "$OS" = "Windows_NT" ]; then
-    IFS=';' read -r first_gopath _ <<< "$(go env GOPATH)"
-    GOPATH="$first_gopath"
-else
-    IFS=':' read -r first_gopath _ <<< "$(go env GOPATH)"
-    GOPATH="$first_gopath"
-fi
+# Build Wasm
+echo "Building ispx.wasm..."
+GOOS=js GOARCH=wasm go build -trimpath -ldflags "-s -w -checklinkname=0" -o ispx.wasm ./cmd/ispx
+cp ispx.wasm "$GOPATH/bin/ispx.wasm"
+echo "Installed ispx.wasm to $GOPATH/bin/"
 
-# Parse arguments
-BUILD_PC_ONLY=false
-OPT_WASM=false
-
-for arg in "$@"; do
-    case "$arg" in
-        --pc)
-            BUILD_PC_ONLY=true
-            ;;
-        --opt)
-            OPT_WASM=true
-            ;;
-    esac
-done
-
-# Function to install and check binaryen
-install_binaryen() {
-    # Check if wasm-opt is installed
-    if command -v wasm-opt &> /dev/null; then
-        echo "wasm-opt is already installed"
-        return 0
-    else
-        echo "wasm-opt not detected, trying to install binaryen..."
-
-        # Install binaryen based on the system type
-        case "$SYSTEM" in
-            Linux)
-                # Detect Linux distribution
-                if [ -f /etc/os-release ]; then
-                    . /etc/os-release
-                    if [[ "$ID" == "ubuntu" || "$ID" == "debian" ]]; then
-                        echo "Detected Ubuntu/Debian system, installing binaryen with apt"
-                        sudo apt-get update && sudo apt-get install -y binaryen
-                    elif [[ "$ID" == "fedora" || "$ID" == "rhel" || "$ID" == "centos" ]]; then
-                        echo "Detected Fedora/RHEL/CentOS system, installing binaryen with dnf/yum"
-                        sudo dnf install -y binaryen || sudo yum install -y binaryen
-                    else
-                        echo "Unrecognized Linux distribution, trying to install with apt"
-                        sudo apt-get update && sudo apt-get install -y binaryen
-                    fi
-                else
-                    echo "Unable to determine Linux distribution, trying to install with apt"
-                    sudo apt-get update && sudo apt-get install -y binaryen
-                fi
-                ;;
-            Darwin)
-                echo "Detected macOS system, installing binaryen with Homebrew"
-                brew install binaryen
-                ;;
-            *)
-                echo "Unrecognized operating system: $SYSTEM, cannot automatically install binaryen"
-                ;;
-        esac
-
-        # Check again if installation was successful
-        if command -v wasm-opt &> /dev/null; then
-            echo "binaryen installation successful"
-            return 0
-        else
-            echo "binaryen installation failed, will use basic compilation version"
-            return 1
-        fi
-    fi
-}
-
-# Function to compress wasm file with brotli
-compress_with_brotli() {
-    local input_file="$1"
-    local output_file="$2"
-
-    if [ -z "$input_file" ] || [ -z "$output_file" ]; then
-        echo "Error: compress_with_brotli requires input and output file parameters"
-        return 1
-    fi
-
-    if [ ! -f "$input_file" ]; then
-        echo "Error: Input file $input_file does not exist"
-        return 1
-    fi
-
-    # Check if brotli is installed
-    local brotli_installed=false
-    if command -v brotli &> /dev/null; then
-        echo "brotli is already installed"
-        brotli_installed=true
-    else
-        echo "brotli not detected, trying to install..."
-
-        # Install brotli based on the system type
-        case "$SYSTEM" in
-            Linux)
-                # Detect Linux distribution
-                if [ -f /etc/os-release ]; then
-                    . /etc/os-release
-                    if [[ "$ID" == "ubuntu" || "$ID" == "debian" ]]; then
-                        echo "Detected Ubuntu/Debian system, installing brotli with apt"
-                        sudo apt-get update && sudo apt-get install -y brotli
-                    elif [[ "$ID" == "fedora" || "$ID" == "rhel" || "$ID" == "centos" ]]; then
-                        echo "Detected Fedora/RHEL/CentOS system, installing brotli with dnf/yum"
-                        sudo dnf install -y brotli || sudo yum install -y brotli
-                    else
-                        echo "Unrecognized Linux distribution, trying to install with apt"
-                        sudo apt-get update && sudo apt-get install -y brotli
-                    fi
-                else
-                    echo "Unable to determine Linux distribution, trying to install with apt"
-                    sudo apt-get update && sudo apt-get install -y brotli
-                fi
-                ;;
-            Darwin)
-                echo "Detected macOS system, installing brotli with Homebrew"
-                brew install brotli
-                ;;
-            *)
-                echo "Unrecognized operating system: $SYSTEM, cannot automatically install brotli"
-                ;;
-        esac
-
-        # Check again if installation was successful
-        if command -v brotli &> /dev/null; then
-            echo "brotli installation successful"
-            brotli_installed=true
-        else
-            echo "brotli installation failed, will skip compression step"
-        fi
-    fi
-
-    if $brotli_installed; then
-        echo "Compressing $input_file with brotli..."
-        brotli -q 11 -o "$output_file" "$input_file"
-        if [ $? -eq 0 ]; then
-            echo "$output_file has been created"
-            return 0
-        else
-            echo "Error: brotli compression failed"
-            return 1
-        fi
-    else
-        echo "brotli not available, skipping compression"
-        return 1
-    fi
-}
-
-# Function to build PC platform shared library
-build_ispx_pc() {
-    echo "Building ispx for PC..."
-
-    # Get architecture
-    GOARCH=$(go env GOARCH)
-
-    if [ "$OS" = "Windows_NT" ]; then
-        # Windows: build DLL with proper naming
-        GOOS_NAME="windows"
-        EXT=".dll"
-        LDFLAGS="-checklinkname=0 -extldflags=-Wl,--allow-multiple-definition"
-    elif [ "$(uname)" = "Darwin" ]; then
-        # macOS: build dylib with proper naming
-        GOOS_NAME="darwin"
-        EXT=".dylib"
+# Build PC shared library
+echo "Building PC shared library..."
+GOARCH="$(go env GOARCH)"
+case "$(uname -s)" in
+    Darwin)
+        LIB_NAME="gdspx-darwin-${GOARCH}.dylib"
         LDFLAGS="-checklinkname=0"
-    else
-        # Linux: build so with proper naming
-        GOOS_NAME="linux"
-        EXT=".so"
+        ;;
+    Linux)
+        LIB_NAME="gdspx-linux-${GOARCH}.so"
         LDFLAGS="-checklinkname=0 -extldflags=-Wl,--allow-multiple-definition"
-    fi
-
-    LIB_NAME="gdspx-${GOOS_NAME}-${GOARCH}${EXT}"
-    go build -ldflags="$LDFLAGS" -buildmode=c-shared -o "$LIB_NAME" ./cmd/ispxpc
-
-    if [ -f "$LIB_NAME" ]; then
-        cp -f "$LIB_NAME" "$GOPATH/bin/"
-        echo "Installed $LIB_NAME to $GOPATH/bin/"
-    else
-        echo "Error: $LIB_NAME build failed"
+        ;;
+    MINGW*|CYGWIN*|MSYS*)
+        LIB_NAME="gdspx-windows-${GOARCH}.dll"
+        LDFLAGS="-checklinkname=0 -extldflags=-Wl,--allow-multiple-definition"
+        ;;
+    *)
+        echo "Unsupported OS: $(uname -s)"
         exit 1
-    fi
-}
+        ;;
+esac
+go build -buildmode c-shared -ldflags "$LDFLAGS" -o "$LIB_NAME" ./cmd/ispxpc
+cp "$LIB_NAME" "$GOPATH/bin/"
+echo "Installed $LIB_NAME to $GOPATH/bin/"
 
-# Function to build wasm
-build_wasm() {
-    if [ "$OPT_WASM" = true ]; then
-        # Try to install/check binaryen
-        if install_binaryen; then
-            echo "Building wasm with optimization..."
-            GOOS=js GOARCH=wasm go build -trimpath -ldflags "-s -w -checklinkname=0" -o gdspx_raw.wasm ./cmd/ispx
-            wasm-opt -Oz --enable-bulk-memory -o gdspx.wasm gdspx_raw.wasm
-
-            # Compress with brotli
-            compress_with_brotli "gdspx.wasm" "gdspx.wasm.br"
-            cp -f gdspx.wasm.br $GOPATH/bin/gdspx.wasm.br
-
-            # Clean up temporary file
-            rm -f gdspx_raw.wasm
-        else
-            echo "binaryen not available, skipping optimization step, using basic compilation..."
-            GOOS=js GOARCH=wasm go build -ldflags -checklinkname=0 -o gdspx.wasm ./cmd/ispx
-        fi
-    else
-        echo "Building wasm with basic version..."
-        GOOS=js GOARCH=wasm go build -ldflags -checklinkname=0 -o gdspx.wasm ./cmd/ispx
-    fi
-
-    echo "gdspx.wasm has been created"
-    cp gdspx.wasm $GOPATH/bin/gdspx.wasm
-}
-
-# Main build logic
-echo "Building ispx..."
-go mod tidy
-
-if [ "$BUILD_PC_ONLY" = true ]; then
-    # Only build PC
-    build_ispx_pc
-else
-    # Build wasm + PC
-    build_wasm
-    build_ispx_pc
-fi
+echo "Done!"

--- a/pkg/gdspx/tools/common/setup_env.sh
+++ b/pkg/gdspx/tools/common/setup_env.sh
@@ -12,13 +12,7 @@ setup_global_variables() {
     VERSION=$(cat $SCRIPT_DIR/version)
     ENGINE_GIT_TAG="spx"$VERSION
     ENGINE_VERSION=4.4.1.stable
-    if [ "$OS" = "Windows_NT" ]; then
-        IFS=';' read -r first_gopath _ <<< "$(go env GOPATH)"
-        GOPATH="$first_gopath"
-    else
-        IFS=':' read -r first_gopath _ <<< "$(go env GOPATH)"
-        GOPATH="$first_gopath"
-    fi
+    GOPATH="$(go env GOPATH)"
 
     PROJ_DIR=$SCRIPT_DIR/..
     ENGINE_DIR=$PROJ_DIR/godot

--- a/pkg/gdspx/tools/make_util.sh
+++ b/pkg/gdspx/tools/make_util.sh
@@ -146,15 +146,10 @@ do_exportweb() {
 do_prepare_export() {
     # Check GOPATH
     if [ -z "$GOPATH" ]; then
-        # If GOPATH is not set, attempt to get it
         if command -v go > /dev/null; then
-            if [ "$OS" = "Windows_NT" ]; then
-                IFS=';' read -r GOPATH _ <<< "$(go env GOPATH)"
-            else
-                IFS=':' read -r GOPATH _ <<< "$(go env GOPATH)"
-            fi
+            GOPATH="$(go env GOPATH)"
         fi
-        
+
         if [ -z "$GOPATH" ]; then
             echo "Error: GOPATH is not set"
             return 1
@@ -214,9 +209,9 @@ do_compresswasm() {
     TEMP_VERSION=$(cat "$CURRENT_PATH/cmd/gox/template/version") 
     dstdir="$GOPATH/bin/gdspxrt"$TEMP_VERSION"_web"
     rm -rf "$dstdir/engine.wasm.br"
-    rm -rf "$dstdir/../gdspx.wasm.br"
+    rm -rf "$dstdir/../ispx.wasm.br"
     compress_with_brotli "$dstdir/engine.wasm" "$dstdir/engine.wasm.br"
-    compress_with_brotli "$dstdir/../gdspx.wasm" "$dstdir/../gdspx.wasm.br"
+    compress_with_brotli "$dstdir/../ispx.wasm" "$dstdir/../ispx.wasm.br"
 }
 
 # Define a function for the exportpack functionality


### PR DESCRIPTION
Rename the interpreter Wasm file from `gdspx.wasm` to `ispx.wasm` for consistency with the `ispx` module naming, and simplify related build infrastructure.

Wasm renaming (14 files):
- Update asset keys in web templates and runner code
- Rename `wasmGdspx` variable to `wasmIspx` in `storage.manager.js`
- Update `getWasmPath()` and export functions in `cmd/gox`
- Update hash computation file list in `pack.go`
- Update documentation examples

Build script simplification:
- Reduce `ispx/build.sh` from 239 to 40 lines
- Remove auto-install logic for binaryen and brotli
- Remove `--opt` and `--pc` flags (optimization is CI-only concern)
- Remove redundant multiple GOPATH entry handling from:
  - `ispx/build.sh`
  - `cmd/gox/install.sh`
  - `pkg/gdspx/tools/common/setup_env.sh`
  - `pkg/gdspx/tools/make_util.sh`
- Use space-separated Go flags per official style guide

The `gdspx-*.dylib/dll/so` shared library names are intentionally kept as they refer to the Godot spx GDExtension, not the interpreter.