### PR TITLE
chore(ci): add pseudo-versioned web runtime artifacts

### DIFF
--- a/.github/scripts/pseudo_version.go
+++ b/.github/scripts/pseudo_version.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"golang.org/x/mod/module"
+	"golang.org/x/mod/semver"
+)
+
+const majorVersion = "v2"
+
+func main() {
+	target := "HEAD"
+	if len(os.Args) > 1 && os.Args[1] != "" {
+		target = os.Args[1]
+	}
+
+	fullSHA := mustGit("rev-parse", target)
+
+	exactTags := gitLines("tag", "--points-at", fullSHA, "--list", majorVersion+".*")
+	if exactTag := highestTag(exactTags); exactTag != "" {
+		fmt.Println(exactTag)
+		return
+	}
+
+	baseVersion := highestTag(gitLines("tag", "--merged", fullSHA, "--list", majorVersion+".*"))
+
+	commitTimeText := mustGit("show", "-s", "--format=%cI", fullSHA)
+	commitTime, err := time.Parse(time.RFC3339, commitTimeText)
+	if err != nil {
+		fail("parse commit time %q: %v", commitTimeText, err)
+	}
+
+	shortSHA := mustGit("rev-parse", "--short=12", fullSHA)
+	fmt.Println(module.PseudoVersion(majorVersion, baseVersion, commitTime.UTC(), shortSHA))
+}
+
+func gitLines(args ...string) []string {
+	out, err := gitOutput(args...)
+	if err != nil {
+		return nil
+	}
+
+	return strings.Fields(out)
+}
+
+func mustGit(args ...string) string {
+	out, err := gitOutput(args...)
+	if err != nil {
+		fail("git %s: %v\n%s", strings.Join(args, " "), err, out)
+	}
+	return out
+}
+
+func gitOutput(args ...string) (string, error) {
+	out, err := exec.Command("git", args...).CombinedOutput()
+	return strings.TrimSpace(string(out)), err
+}
+
+func highestTag(tags []string) string {
+	highest := ""
+	for _, tag := range tags {
+		if !strings.HasPrefix(tag, majorVersion+".") {
+			continue
+		}
+		if !semver.IsValid(tag) {
+			continue
+		}
+		if semver.Compare(tag, highest) > 0 {
+			highest = tag
+		}
+	}
+	return highest
+}
+
+func fail(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, format+"\n", args...)
+	os.Exit(1)
+}

--- a/.github/workflows/web_runtime_artifact.yml
+++ b/.github/workflows/web_runtime_artifact.yml
@@ -1,0 +1,99 @@
+name: 🧪 Web Runtime Artifact
+
+on:
+  push:
+    branches:
+      - dev
+  workflow_dispatch:
+    inputs:
+      target:
+        description: Branch name or full commit SHA to build
+        required: true
+        type: string
+
+concurrency:
+  group: web-runtime-artifact-${{ github.event_name == 'workflow_dispatch' && inputs.target || github.sha }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Validate manual target
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          TARGET: ${{ inputs.target }}
+        run: |
+          if [[ "${TARGET}" =~ ^[0-9a-f]{40}$ ]]; then
+            exit 0
+          fi
+
+          if [[ "${TARGET}" == refs/* ]]; then
+            echo "workflow_dispatch target must be a branch name or full commit SHA" >&2
+            exit 1
+          fi
+
+          if ! git check-ref-format --branch "${TARGET}" >/dev/null 2>&1; then
+            echo "invalid workflow_dispatch target: ${TARGET}" >&2
+            exit 1
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.target || github.sha }}
+
+      - name: Get dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install \
+            gcc \
+            libgl1-mesa-dev \
+            libegl1-mesa-dev \
+            libgles2-mesa-dev \
+            libx11-dev \
+            xorg-dev \
+            libasound2-dev \
+            libopenal-dev \
+            binaryen \
+            unzip
+
+      - name: Setup go/xgo & engine
+        uses: ./.github/actions/deps
+
+      - name: Compute pseudo version
+        id: version
+        run: |
+          VERSION="$(go run ./.github/scripts/pseudo_version.go HEAD)"
+          echo "VERSION=${VERSION}"
+          echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
+
+      - name: Build web bundle
+        run: make export-web
+
+      - name: Prepare runtime artifact
+        run: |
+          rm -rf web-runtime-artifact
+          mkdir -p web-runtime-artifact
+          unzip -oq spx_web.zip -d web-runtime-artifact
+
+      - name: Upload runtime directory artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: spx-web-runtime-${{ steps.version.outputs.version }}
+          path: web-runtime-artifact/
+          retention-days: 90
+          compression-level: 0
+
+      - name: Upload `spx_web.zip` artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: spx-web-zip-${{ steps.version.outputs.version }}
+          path: spx_web.zip
+          retention-days: 90
+          compression-level: 0


### PR DESCRIPTION
Add a workflow to build per-commit web runtime artifacts for `dev` pushes and manual dispatches.

The workflow computes the canonical Go pseudo-version from the checked out commit, exports `spx_web.zip`, and uploads both the extracted runtime files and the original zip as versioned artifacts for downstream consumers.