### PR TITLE
Replace ClampFloat64 with mathf.Clamp and remove redundant helper

### DIFF
--- a/component_transform.go
+++ b/component_transform.go
@@ -20,7 +20,6 @@ import (
 	"math"
 
 	"github.com/goplus/spbase/mathf"
-	"github.com/goplus/spx/v2/internal/base/valueutil"
 	spxlog "github.com/goplus/spx/v2/internal/log"
 	engine "github.com/goplus/spx/v2/pkg/spx/pkg/engine"
 )
@@ -304,8 +303,8 @@ func (t *transformComponent) fixWorldRange(x, y float64) (float64, float64) {
 	maxW := float64(worldW)/2.0 + float64(rect.Size.X)
 	maxH := float64(worldH)/2.0 + float64(rect.Size.Y)
 
-	x = valueutil.ClampFloat64(x, -maxW, maxW)
-	y = valueutil.ClampFloat64(y, -maxH, maxH)
+	x = mathf.Clamp(x, -maxW, maxW)
+	y = mathf.Clamp(y, -maxH, maxH)
 
 	return x, y
 }

--- a/internal/base/valueutil/valueutil.go
+++ b/internal/base/valueutil/valueutil.go
@@ -16,17 +16,6 @@
 
 package valueutil
 
-// ClampFloat64 constrains a float64 value to the specified range.
-func ClampFloat64(val, min, max float64) float64 {
-	if val < min {
-		return min
-	}
-	if val > max {
-		return max
-	}
-	return val
-}
-
 // OrDefault returns defaultValue when pval is nil.
 func OrDefault[T any](pval *T, defaultValue T) T {
 	if pval == nil {

--- a/internal/base/valueutil/valueutil_test.go
+++ b/internal/base/valueutil/valueutil_test.go
@@ -2,18 +2,6 @@ package valueutil
 
 import "testing"
 
-func TestClampFloat64(t *testing.T) {
-	if got := ClampFloat64(5, 0, 3); got != 3 {
-		t.Fatalf("ClampFloat64 upper bound = %v, want 3", got)
-	}
-	if got := ClampFloat64(-1, 0, 3); got != 0 {
-		t.Fatalf("ClampFloat64 lower bound = %v, want 0", got)
-	}
-	if got := ClampFloat64(2, 0, 3); got != 2 {
-		t.Fatalf("ClampFloat64 in-range = %v, want 2", got)
-	}
-}
-
 func TestOrDefault(t *testing.T) {
 	if got := OrDefault[int](nil, 42); got != 42 {
 		t.Fatalf("OrDefault(nil) = %v, want 42", got)


### PR DESCRIPTION
Replaced the position clamping logic in component_transform.go with mathf.Clamp to align with the existing math utilities used across the codebase.