### PR TITLE
chore(ci): publish web runtime bundle to GHCR

### DIFF
--- a/.github/workflows/web_runtime_artifact.yml
+++ b/.github/workflows/web_runtime_artifact.yml
@@ -18,8 +18,6 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
     steps:
       - name: Validate manual target
         if: github.event_name == 'workflow_dispatch'
@@ -65,19 +63,34 @@ jobs:
       - name: Setup go/xgo & engine
         uses: ./.github/actions/deps
 
+      - name: Setup ORAS
+        uses: oras-project/setup-oras@v1
+
       - name: Compute pseudo version
-        id: version
         run: |
-          VERSION="$(go run ./.github/scripts/pseudo_version.go HEAD)"
-          echo "VERSION=${VERSION}"
-          echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
+          SPX_VERSION="$(go run ./.github/scripts/pseudo_version.go HEAD)"
+          echo "SPX_VERSION=${SPX_VERSION}"
+          echo "SPX_VERSION=${SPX_VERSION}" >> "${GITHUB_ENV}"
 
       - name: Build web bundle
         run: make export-web
 
-      - name: Upload `spx_web.zip` artifact
-        uses: actions/upload-artifact@v7
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
         with:
-          name: spx-web-zip-${{ steps.version.outputs.version }}
-          path: spx_web.zip
-          archive: false
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Publish `spx_web.zip` to GitHub Container Registry
+        run: |
+          REVISION="$(git rev-parse HEAD)"
+          oras push \
+            --artifact-type application/vnd.goplus.spx.web.bundle.v1 \
+            --annotation "org.opencontainers.image.source=https://github.com/${GITHUB_REPOSITORY}" \
+            --annotation "org.opencontainers.image.revision=${REVISION}" \
+            --annotation "org.opencontainers.image.version=${SPX_VERSION}" \
+            --annotation "org.opencontainers.image.title=spx_web.zip" \
+            --annotation "org.opencontainers.image.description=spx web runtime bundle" \
+            "ghcr.io/${GITHUB_REPOSITORY}:web-zip-${SPX_VERSION#v}" \
+            spx_web.zip:application/zip


### PR DESCRIPTION
Publish `spx_web.zip` from `web_runtime_artifact` to GitHub Container Registry so per-commit web runtimes can be pulled from a stable OCI reference instead of downloaded as a GitHub Actions artifact.

Install ORAS for artifact pushes, export `SPX_VERSION` through `GITHUB_ENV`, and tag the published bundle as
`web-zip-<version-without-v-prefix>` while preserving the canonical Go version in OCI annotations.