### PR TITLE
fix: plug runtime memory retention leaks

### DIFF
--- a/internal/cmd/codegen/generate/ffi/generate.go
+++ b/internal/cmd/codegen/generate/ffi/generate.go
@@ -336,6 +336,21 @@ func getManagerFuncBody(function *clang.TypedefFunction) string {
 			sb.WriteString("\n" + prefixTab)
 			sb.WriteString(argName + " := " + "(GdString)(" + argName + "Str) \n")
 			sb.WriteString("\tdefer " + "C.free(unsafe.Pointer(" + argName + "Str))")
+		case "GdArray":
+			sb.WriteString(argName + "Info := ")
+			sb.WriteString("ToGdArrayInfo(")
+			sb.WriteString(arg.Name)
+			sb.WriteString(")")
+			sb.WriteString("\n" + prefixTab)
+			sb.WriteString("if " + argName + "Info != nil {\n")
+			sb.WriteString(prefixTab + "\tdefer " + argName + "Info.Free()\n")
+			sb.WriteString(prefixTab + "}\n")
+			sb.WriteString(prefixTab)
+			sb.WriteString(argName + " := GdArray(nil)\n")
+			sb.WriteString(prefixTab)
+			sb.WriteString("if " + argName + "Info != nil {\n")
+			sb.WriteString(prefixTab + "\t" + argName + " = " + argName + "Info.Raw()\n")
+			sb.WriteString(prefixTab + "}")
 
 		default:
 			sb.WriteString(argName + " := ")

--- a/internal/coroutine/coro.go
+++ b/internal/coroutine/coro.go
@@ -423,10 +423,21 @@ func (p *Coroutines) WaitYield(me Thread) {
 
 func WaitForChan[T any](p *Coroutines, ch chan T, data *T) {
 	me := p.Current()
+	if me == nil {
+		*data = <-ch
+		return
+	}
 	// Delegate channel receive to separate goroutine to prevent blocking the scheduler.
 	go func() {
-		*data = <-ch
-		p.markIdleAndResume(me)
+		select {
+		case value := <-ch:
+			if p.isThreadCanceled(me) {
+				return
+			}
+			*data = value
+			p.markIdleAndResume(me)
+		case <-me.Context().Done():
+		}
 	}()
 	p.blockAndYield(me)
 }

--- a/internal/coroutine/coro_test.go
+++ b/internal/coroutine/coro_test.go
@@ -1,7 +1,9 @@
 package coroutine
 
 import (
+	"runtime"
 	"testing"
+	"time"
 
 	"github.com/goplus/spx/v2/internal/engine/platform"
 )
@@ -18,5 +20,93 @@ func TestWaitMainThreadFastPathOnMainThread(t *testing.T) {
 
 	if !called {
 		t.Fatal("WaitMainThread should execute immediately on the main thread")
+	}
+}
+
+func TestWaitForChanReceivesValue(t *testing.T) {
+	co := New(nil)
+	ch := make(chan int)
+	done := make(chan struct{})
+
+	co.CreateAndStart(false, nil, func(me Thread) int {
+		defer close(done)
+		var value int
+		WaitForChan(co, ch, &value)
+		if value != 7 {
+			t.Fatalf("expected received value 7, got %d", value)
+		}
+		return 0
+	})
+
+	deadline := time.Now().Add(time.Second)
+	for {
+		co.waitMutex.Lock()
+		waitingCount := len(co.waiting)
+		co.waitMutex.Unlock()
+		if waitingCount > 0 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("coroutine did not enter wait state")
+		}
+		runtime.Gosched()
+	}
+
+	ch <- 7
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("coroutine did not resume after channel receive")
+	}
+}
+
+func TestWaitForChanDoesNotKeepReceiverAfterCancel(t *testing.T) {
+	co := New(nil)
+	ch := make(chan int)
+	done := make(chan struct{})
+	var th Thread
+
+	th = co.CreateAndStart(false, nil, func(me Thread) int {
+		defer close(done)
+		var value int
+		WaitForChan(co, ch, &value)
+		return 0
+	})
+
+	deadline := time.Now().Add(time.Second)
+	for {
+		co.waitMutex.Lock()
+		waiting := co.waiting[th]
+		co.waitMutex.Unlock()
+		if waiting {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("coroutine did not enter wait state")
+		}
+		runtime.Gosched()
+	}
+
+	co.StopIf(func(candidate Thread) bool {
+		return candidate == th
+	})
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("coroutine did not exit after cancel")
+	}
+
+	deadline = time.Now().Add(time.Second)
+	for {
+		select {
+		case ch <- 1:
+		case <-time.After(20 * time.Millisecond):
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("channel receiver should eventually exit after cancel")
+		}
 	}
 }

--- a/internal/gdengine/binding/native/gdextension_interface.go
+++ b/internal/gdengine/binding/native/gdextension_interface.go
@@ -131,6 +131,13 @@ type ArrayInfoImpl struct {
 	needsFree bool
 }
 
+func (a *ArrayInfoImpl) Raw() GdArray {
+	if a == nil {
+		return nil
+	}
+	return GdArray(a.gdArray)
+}
+
 func ToGdBool(val bool) GdBool {
 	if val {
 		return GdBool(1)
@@ -767,7 +774,7 @@ func (a *ArrayInfoImpl) ToStrings() []string {
 	}
 	return result
 }
-func ToGdArray(slice interface{}) GdArray {
+func ToGdArrayInfo(slice interface{}) *ArrayInfoImpl {
 	var info *ArrayInfoImpl = nil
 	switch v := slice.(type) {
 	case []int64:
@@ -790,6 +797,14 @@ func ToGdArray(slice interface{}) GdArray {
 		info = createGdArrayFromBytes(v)
 	default:
 		panic(fmt.Sprintf("unsupported array type: %T", slice))
+	}
+	return info
+}
+
+func ToGdArray(slice interface{}) GdArray {
+	info := ToGdArrayInfo(slice)
+	if info == nil {
+		return nil
 	}
 	return GdArray(info.gdArray)
 }

--- a/internal/gdengine/impl/manager_native.gen.go
+++ b/internal/gdengine/impl/manager_native.gen.go
@@ -562,7 +562,14 @@ func (pself *physicsMgr) CheckCollisionCircle(pos Vec2, radius float64, collisio
 func (pself *physicsMgr) RaycastWithDetails(from Vec2, to Vec2, ignore_sprites Array, collision_mask int64, collide_with_areas bool, collide_with_bodies bool) Array {
 	arg0 := ToGdVec2(from)
 	arg1 := ToGdVec2(to)
-	arg2 := ToGdArray(ignore_sprites)
+	arg2Info := ToGdArrayInfo(ignore_sprites)
+	if arg2Info != nil {
+		defer arg2Info.Free()
+	}
+	arg2 := GdArray(nil)
+	if arg2Info != nil {
+		arg2 = arg2Info.Raw()
+	}
 	arg3 := ToGdInt(collision_mask)
 	arg4 := ToGdBool(collide_with_areas)
 	arg5 := ToGdBool(collide_with_bodies)
@@ -781,7 +788,14 @@ func (pself *sceneMgr) CreateStaticSprite(texture_path string, pos Vec2, degree 
 	arg5 := ToGdVec2(pivot)
 	arg6 := ToGdInt(collider_type)
 	arg7 := ToGdVec2(collider_pivot)
-	arg8 := ToGdArray(collider_params)
+	arg8Info := ToGdArrayInfo(collider_params)
+	if arg8Info != nil {
+		defer arg8Info.Free()
+	}
+	arg8 := GdArray(nil)
+	if arg8Info != nil {
+		arg8 = arg8Info.Raw()
+	}
 	retValue := CallSceneCreateStaticSprite(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
 	return ToObject(retValue)
 }
@@ -1417,7 +1431,14 @@ func (pself *spriteMgr) SetColliderCapsule(obj Object, center Vec2, size Vec2) {
 func (pself *spriteMgr) SetColliderPolygon(obj Object, center Vec2, points Array) {
 	arg0 := ToGdObj(obj)
 	arg1 := ToGdVec2(center)
-	arg2 := ToGdArray(points)
+	arg2Info := ToGdArrayInfo(points)
+	if arg2Info != nil {
+		defer arg2Info.Free()
+	}
+	arg2 := GdArray(nil)
+	if arg2Info != nil {
+		arg2 = arg2Info.Raw()
+	}
 	CallSpriteSetColliderPolygon(arg0, arg1, arg2)
 }
 func (pself *spriteMgr) SetCollisionEnabled(obj Object, enabled bool) {
@@ -1451,7 +1472,14 @@ func (pself *spriteMgr) SetTriggerCapsule(obj Object, center Vec2, size Vec2) {
 func (pself *spriteMgr) SetTriggerPolygon(obj Object, center Vec2, points Array) {
 	arg0 := ToGdObj(obj)
 	arg1 := ToGdVec2(center)
-	arg2 := ToGdArray(points)
+	arg2Info := ToGdArrayInfo(points)
+	if arg2Info != nil {
+		defer arg2Info.Free()
+	}
+	arg2 := GdArray(nil)
+	if arg2Info != nil {
+		arg2 = arg2Info.Raw()
+	}
 	CallSpriteSetTriggerPolygon(arg0, arg1, arg2)
 }
 func (pself *spriteMgr) SetTriggerEnabled(obj Object, trigger bool) {
@@ -1495,15 +1523,36 @@ func (pself *spriteMgr) GetPixelCollisionSamplingStep() int64 {
 	return ToInt64(retValue)
 }
 func (pself *spriteMgr) BatchUpdateTransforms(buffer Array) {
-	arg0 := ToGdArray(buffer)
+	arg0Info := ToGdArrayInfo(buffer)
+	if arg0Info != nil {
+		defer arg0Info.Free()
+	}
+	arg0 := GdArray(nil)
+	if arg0Info != nil {
+		arg0 = arg0Info.Raw()
+	}
 	CallSpriteBatchUpdateTransforms(arg0)
 }
 func (pself *spriteMgr) BatchUpdateVisuals(buffer Array) {
-	arg0 := ToGdArray(buffer)
+	arg0Info := ToGdArrayInfo(buffer)
+	if arg0Info != nil {
+		defer arg0Info.Free()
+	}
+	arg0 := GdArray(nil)
+	if arg0Info != nil {
+		arg0 = arg0Info.Raw()
+	}
 	CallSpriteBatchUpdateVisuals(arg0)
 }
 func (pself *spriteMgr) BatchRetrievePositions(objs Array) Array {
-	arg0 := ToGdArray(objs)
+	arg0Info := ToGdArrayInfo(objs)
+	if arg0Info != nil {
+		defer arg0Info.Free()
+	}
+	arg0 := GdArray(nil)
+	if arg0Info != nil {
+		arg0 = arg0Info.Raw()
+	}
 	retValue := CallSpriteBatchRetrievePositions(arg0)
 	return ToArray(retValue)
 }
@@ -1529,7 +1578,14 @@ func (pself *tilemapMgr) SetTileWithCollisionInfo(texture_path string, collision
 	arg0Str := C.CString(texture_path)
 	arg0 := (GdString)(arg0Str)
 	defer C.free(unsafe.Pointer(arg0Str))
-	arg1 := ToGdArray(collision_points)
+	arg1Info := ToGdArrayInfo(collision_points)
+	if arg1Info != nil {
+		defer arg1Info.Free()
+	}
+	arg1 := GdArray(nil)
+	if arg1Info != nil {
+		arg1 = arg1Info.Raw()
+	}
 	CallTilemapSetTileWithCollisionInfo(arg0, arg1)
 }
 func (pself *tilemapMgr) SetLayerOffset(index int64, offset Vec2) {
@@ -1543,14 +1599,28 @@ func (pself *tilemapMgr) GetLayerOffset(index int64) Vec2 {
 	return ToVec2(retValue)
 }
 func (pself *tilemapMgr) PlaceTiles(positions Array, texture_path string) {
-	arg0 := ToGdArray(positions)
+	arg0Info := ToGdArrayInfo(positions)
+	if arg0Info != nil {
+		defer arg0Info.Free()
+	}
+	arg0 := GdArray(nil)
+	if arg0Info != nil {
+		arg0 = arg0Info.Raw()
+	}
 	arg1Str := C.CString(texture_path)
 	arg1 := (GdString)(arg1Str)
 	defer C.free(unsafe.Pointer(arg1Str))
 	CallTilemapPlaceTiles(arg0, arg1)
 }
 func (pself *tilemapMgr) PlaceTilesWithLayer(positions Array, texture_path string, layer_index int64) {
-	arg0 := ToGdArray(positions)
+	arg0Info := ToGdArrayInfo(positions)
+	if arg0Info != nil {
+		defer arg0Info.Free()
+	}
+	arg0 := GdArray(nil)
+	if arg0Info != nil {
+		arg0 = arg0Info.Raw()
+	}
 	arg1Str := C.CString(texture_path)
 	arg1 := (GdString)(arg1Str)
 	defer C.free(unsafe.Pointer(arg1Str))

--- a/pkg/spx/pkg/engine/event.go
+++ b/pkg/spx/pkg/engine/event.go
@@ -67,7 +67,10 @@ func (e *Event0) Trigger() {
 	for i := range count {
 		e.tempActions[i]()
 	}
+	e.mutex.Lock()
+	clearEventTempActions(e.tempActions)
 	e.tempIds = e.tempIds[:0]
+	e.mutex.Unlock()
 }
 
 type Action1[T any] func(data T)
@@ -133,7 +136,10 @@ func (e *Event1[T]) Trigger(data T) {
 	for i := range count {
 		e.tempActions[i](data)
 	}
+	e.mutex.Lock()
+	clearEventTempActions(e.tempActions)
 	e.tempIds = e.tempIds[:0]
+	e.mutex.Unlock()
 }
 
 type Action2[T1 any, T2 any] func(data1 T1, data2 T2)
@@ -198,5 +204,15 @@ func (e *Event2[T1, T2]) Trigger(data1 T1, data2 T2) {
 	for i := range count {
 		e.tempActions[i](data1, data2)
 	}
+	e.mutex.Lock()
+	clearEventTempActions(e.tempActions)
 	e.tempIds = e.tempIds[:0]
+	e.mutex.Unlock()
+}
+
+func clearEventTempActions[T any](actions []T) {
+	var zero T
+	for i := range actions {
+		actions[i] = zero
+	}
 }

--- a/pkg/spx/pkg/engine/event_test.go
+++ b/pkg/spx/pkg/engine/event_test.go
@@ -1,0 +1,39 @@
+package engine
+
+import "testing"
+
+func TestEvent0TriggerClearsTempActions(t *testing.T) {
+	ev := NewEvent0()
+	ev.Subscribe(func() {})
+	ev.Subscribe(func() {})
+
+	ev.Trigger()
+
+	for i, action := range ev.tempActions {
+		if action != nil {
+			t.Fatalf("tempActions[%d] should be cleared after trigger", i)
+		}
+	}
+	if len(ev.tempIds) != 0 {
+		t.Fatalf("tempIds should be cleared after trigger, got %d", len(ev.tempIds))
+	}
+}
+
+func TestEvent2TriggerClearsShrunkTempActions(t *testing.T) {
+	ev := NewEvent2[int, int]()
+	firstID := ev.Subscribe(func(int, int) {})
+	ev.Subscribe(func(int, int) {})
+
+	ev.Trigger(1, 2)
+	ev.Unsubscribe(firstID)
+	ev.Trigger(3, 4)
+
+	for i, action := range ev.tempActions {
+		if action != nil {
+			t.Fatalf("tempActions[%d] should be cleared after trigger", i)
+		}
+	}
+	if len(ev.tempIds) != 0 {
+		t.Fatalf("tempIds should be cleared after trigger, got %d", len(ev.tempIds))
+	}
+}


### PR DESCRIPTION

This PR fixes several runtime-side memory retention issues found while investigating steady memory growth in `make run DEMO_INDEX=8`.

- fixed native `GdArray` input argument ownership so temporary C buffers are released after FFI calls
- updated the FFI code generator to emit `ToGdArrayInfo(...)` + `defer Free()` for array inputs
- fixed `WaitForChan` so its helper goroutine exits when the coroutine context is canceled
- cleared cached event callback snapshots after each trigger to avoid retaining stale closures
- added regression tests for coroutine cancel behavior and event temp-action cleanup
