### PR TITLE
chore: clean up gitignore generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,43 +1,43 @@
-.vscode
-.gop
-.gocache
-.DS_Store
-sprite.txt
-game.txt
-gop.mod
-go.work
-go.json
-gop.json
-gop_autogen.go
-xgo_autogen.go
-_gsc
-_test
-haiyang/
-feijidazhan/
-.idea
+# Editors and local workspace
+/.vscode/
+/.idea/
 *.code-workspace
-*.wasm
-mv.sh
 
-# Binaries for programs and plugins
+# OS files
+.DS_Store
+
+# Local tool caches and generated workspace files
+/.gop/
+/.gocache/
+/_gsc/
+/_test/
+/gop.mod
+/go.work
+/go.json
+/gop.json
+/gop_autogen.go
+/xgo_autogen.go
+
+# Local scratch files
+/sprite.txt
+/game.txt
+/mv.sh
+/CLAUDE.md
+
+# Build outputs
 *.exe
 *.exe~
 *.dll
 *.so
 *.dylib
-
-# Test binary, built with `go test -c`
+*.wasm
 *.test
-
-# Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
-# Dependency directories (remove the comment below to include it)
-# vendor/
+# Temp directories
+/**/.temp/
+/.tmp/
 
-/godot
-/bin
-/**/.temp
-/.tmp
-CLAUDE.md
-internal/gdengine/binding/native/_temp_output.h
+# Repo-local generated artifacts
+/bin/
+/godot/

--- a/cmd/gox/main.go
+++ b/cmd/gox/main.go
@@ -17,9 +17,6 @@ var (
 	//go:embed template/version
 	version string
 
-	//go:embed template/.gitignore.txt
-	gitignoreTxt string
-
 	//go:embed template/go.mod.template
 	gomodtemplate string
 
@@ -42,7 +39,6 @@ func main() {
 	cmd.ProjectFS = projectFS
 	cmd.PlatformFS = platformFS
 	cmd.Version = strings.TrimSpace(version)
-	cmd.GitignoreTxt = gitignoreTxt
 	cmd.RunSh = runSh
 	cmd.MainSh = mainSh
 	cmd.GoModTemplate = gomodtemplate

--- a/cmd/gox/pkg/command/cmd.go
+++ b/cmd/gox/pkg/command/cmd.go
@@ -29,11 +29,10 @@ type CmdTool struct {
 	GoBinPath      string
 
 	// Resource files
-	ProjectFS    embed.FS // Embedded project filesystem
-	PlatformFS   embed.FS // Embedded platform filesystem
-	GitignoreTxt string   // Gitignore template content
-	RunSh        string   // Run script content
-	MainSh       string   // Main script content
+	ProjectFS  embed.FS // Embedded project filesystem
+	PlatformFS embed.FS // Embedded platform filesystem
+	RunSh      string   // Run script content
+	MainSh     string   // Main script content
 
 	// Build and runtime information
 	ServerPort int    // Server port for web operations

--- a/cmd/gox/pkg/command/env.go
+++ b/cmd/gox/pkg/command/env.go
@@ -426,12 +426,6 @@ func (pself *CmdTool) Clear() error {
 	if err := os.RemoveAll(path.Join(pself.TargetDir, ".temp")); err != nil {
 		return fmt.Errorf("failed to remove project directory: %w", err)
 	}
-	// Remove the gitignore file
-	gitignorePath := path.Join(pself.ProjectDir, "../.gitignore")
-	if err := os.Remove(gitignorePath); err != nil && !os.IsNotExist(err) {
-		// Only return an error if the file exists and couldn't be removed
-		return fmt.Errorf("failed to remove gitignore file: %w", err)
-	}
 	// Remove go.mod
 	if err := os.RemoveAll(path.Join(pself.TargetDir, "go.sum")); err != nil {
 		return fmt.Errorf("failed to remove project directory: %w", err)

--- a/cmd/gox/pkg/command/export.go
+++ b/cmd/gox/pkg/command/export.go
@@ -225,9 +225,6 @@ func (pself *CmdTool) exportWebCommon(mode string) error {
 	println("==> _exportWeb", dstPath)
 	// copy project files
 	util.CopyDir(pself.ProjectFS, "template/project", pself.ProjectDir, true)
-	dir := pself.TargetDir
-	util.SetupFile(false, filepath.Join(dir, ".gitignore"), pself.GitignoreTxt)
-	os.Rename(filepath.Join(dir, ".gitignore.txt"), filepath.Join(dir, ".gitignore"))
 
 	os.Rename(filepath.Join(dstPath, "godot.editor.html"), filepath.Join(dstPath, "index.html"))
 

--- a/cmd/gox/template/.gitignore.txt
+++ b/cmd/gox/template/.gitignore.txt
@@ -1,1 +1,0 @@
-/project

--- a/cmd/gox/template/project/.gitignore.txt
+++ b/cmd/gox/template/project/.gitignore.txt
@@ -17,6 +17,7 @@
 /go.mod
 /go.sum
 /gdspx.gdextension
+/gdspx.gdextension.uid
 /main.go
 /main.tscn
 /project.godot
@@ -25,6 +26,5 @@
 /go
 
 # user specify ignores
-# ...
 /assets/**/*.import
 /runtime.gdextension.txt

--- a/internal/.gitignore
+++ b/internal/.gitignore
@@ -6,7 +6,6 @@ go.work.sum
 *library.gdextension
 
 # Directories
-/godot
 /builds
 /webtools
 /bin
@@ -15,5 +14,4 @@ go.work.sum
 
 # Files
 cmd/_debug_parsed_ast.json
-ffi/_temp_output.h
-ffi/_temp_output*.h
+gdengine/binding/native/_temp_output.h

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,4 +1,4 @@
+/**/project
 /**/.gitignore
-!/.gitignore
 *.mod
 *.sum

--- a/tutorial/.gitignore
+++ b/tutorial/.gitignore
@@ -1,6 +1,4 @@
 /**/project
-/web_10
 /**/.gitignore
 *.mod
 *.sum
-


### PR DESCRIPTION
This PR cleans up how `gox` generates and uses `.gitignore` files, and simplifies the repo-side ignore layout around generated tutorial/test assets.