### PR TITLE
Reuse linked list nodes in Queue[*WaitJob]

### DIFF
--- a/cmd/ispx/web/game.js
+++ b/cmd/ispx/web/game.js
@@ -1,5 +1,21 @@
 var Module = null
 
+if (!globalThis.__spxRuntimeErrorHooksInstalled) {
+    globalThis.__spxRuntimeErrorHooksInstalled = true;
+    globalThis.addEventListener('error', (event) => {
+        console.error('[spx-runtime] window.error', {
+            message: event.message,
+            filename: event.filename,
+            lineno: event.lineno,
+            colno: event.colno,
+            error: event.error,
+        });
+    });
+    globalThis.addEventListener('unhandledrejection', (event) => {
+        console.error('[spx-runtime] unhandledrejection', event.reason);
+    });
+}
+
 /**
  * @typedef {Object} FileMeta
  * @property {number} lastModified Last modified time in milliseconds since Unix epoch.

--- a/internal/cmd/codegen/generate/gdext/godot_js_spx.cpp.tmpl
+++ b/internal/cmd/codegen/generate/gdext/godot_js_spx.cpp.tmpl
@@ -35,6 +35,7 @@
 #include "core/extension/gdextension_interface.h"
 #include "scene/main/window.h"
 #include "modules/spx/spx_engine.h"
+#include "modules/spx/spx_sprite.h"
 {{ $view := . -}}
 
 {{ range $i, $name := $view.Mangers -}}
@@ -45,6 +46,116 @@
 {{- range $i, $name := $view.Mangers }}
 #define {{$name}}Mgr SpxEngine::get_singleton()->get_{{$name}}()
 {{- end }}
+
+namespace {
+
+void gdspx_batch_update_transforms_raw(const float *buffer_data, int32_t len) {
+	const int FIELDS_PER_SPRITE = 9;
+	const int HEADER_SIZE = 2;
+
+	if (buffer_data == nullptr || len < HEADER_SIZE) {
+		return;
+	}
+
+	int update_count = static_cast<int>(buffer_data[0]);
+	int delete_count = static_cast<int>(buffer_data[1]);
+	int expected_size = HEADER_SIZE + update_count * FIELDS_PER_SPRITE + delete_count;
+	if (len != expected_size) {
+		print_error("batch_update_transforms_raw: buffer size " + itos(len) +
+				" does not match expected size " + itos(expected_size) +
+				" (updateCount=" + itos(update_count) + ", deleteCount=" + itos(delete_count) + ")");
+		return;
+	}
+
+	int idx = HEADER_SIZE;
+	for (int i = 0; i < update_count; i++) {
+		auto sprite_id = static_cast<GdObj>(buffer_data[idx]);
+		auto x = buffer_data[idx + 1];
+		auto y = buffer_data[idx + 2];
+		auto rotation = buffer_data[idx + 3];
+		auto scale_x = buffer_data[idx + 4];
+		auto scale_y = buffer_data[idx + 5];
+		auto offset_x = buffer_data[idx + 6];
+		auto offset_y = buffer_data[idx + 7];
+		auto visible = buffer_data[idx + 8] != 0.0;
+
+		idx += FIELDS_PER_SPRITE;
+
+		SpxSprite *sprite = spriteMgr->get_sprite(sprite_id);
+		if (sprite == nullptr) {
+			continue;
+		}
+
+		sprite->set_position(GdVec2(x, -y));
+		sprite->set_rotation(rotation);
+		sprite->set_scale(GdVec2(scale_x, scale_y));
+		sprite->set_visible(visible);
+		sprite->on_set_visible(visible);
+		sprite->set_pivot(GdVec2(offset_x, -offset_y));
+	}
+
+	for (int i = 0; i < delete_count; i++) {
+		auto sprite_id = static_cast<GdObj>(buffer_data[idx]);
+		idx++;
+
+		SpxSprite *sprite = spriteMgr->get_sprite(sprite_id);
+		if (sprite != nullptr) {
+			sprite->set_block_signals(true);
+			sprite->queue_free();
+		}
+	}
+}
+
+void gdspx_batch_update_visuals_raw(const float *buffer_data, int32_t len) {
+	const int VISUAL_FIELDS_PER_SPRITE = 9;
+	const int HEADER_SIZE = 1;
+	const int FLAG_HAS_ZINDEX = 1;
+	const int FLAG_HAS_UV_REMAP = 2;
+
+	if (buffer_data == nullptr || len < HEADER_SIZE) {
+		return;
+	}
+
+	int count = static_cast<int>(buffer_data[0]);
+	int expected_size = HEADER_SIZE + count * VISUAL_FIELDS_PER_SPRITE;
+	if (len != expected_size) {
+		print_error("batch_update_visuals_raw: buffer size " + itos(len) +
+				" does not match expected size " + itos(expected_size) +
+				" (count=" + itos(count) + ")");
+		return;
+	}
+
+	int idx = HEADER_SIZE;
+	for (int i = 0; i < count; i++) {
+		auto sprite_id = static_cast<GdObj>(buffer_data[idx]);
+		auto render_scale_x = buffer_data[idx + 1];
+		auto render_scale_y = buffer_data[idx + 2];
+		auto z_index = static_cast<int>(buffer_data[idx + 3]);
+		auto flags = static_cast<int>(buffer_data[idx + 4]);
+		auto uv_x = buffer_data[idx + 5];
+		auto uv_y = buffer_data[idx + 6];
+		auto uv_w = buffer_data[idx + 7];
+		auto uv_h = buffer_data[idx + 8];
+
+		idx += VISUAL_FIELDS_PER_SPRITE;
+
+		SpxSprite *sprite = spriteMgr->get_sprite(sprite_id);
+		if (sprite == nullptr) {
+			continue;
+		}
+
+		sprite->set_render_scale(GdVec2(render_scale_x, render_scale_y));
+		if (flags & FLAG_HAS_ZINDEX) {
+			sprite->set_z_index(z_index);
+		}
+		if (flags & FLAG_HAS_UV_REMAP) {
+			String uv_param = "uv_remap";
+			sprite->set_material_params_vec4(SpxReturnStr(uv_param), GdVec4(uv_x, uv_y, uv_w, uv_h));
+		}
+	}
+}
+
+} // namespace
 
 
 extern "C" {
@@ -79,7 +190,19 @@ void gd{{ loadProcAddressName $f.Name }}(
 		{{- end -}}
 	);
 }
-{{- end -}}
-{{ end }}
+	{{- if eq (loadProcAddressName $f.Name) "spx_sprite_batch_update_transforms" }}
+EMSCRIPTEN_KEEPALIVE
+void gdspx_sprite_batch_update_transforms_raw(float *buffer_data, int32_t len) {
+	gdspx_batch_update_transforms_raw(buffer_data, len);
+}
+	{{- end -}}
+	{{- if eq (loadProcAddressName $f.Name) "spx_sprite_batch_update_visuals" }}
+EMSCRIPTEN_KEEPALIVE
+void gdspx_sprite_batch_update_visuals_raw(float *buffer_data, int32_t len) {
+	gdspx_batch_update_visuals_raw(buffer_data, len);
+}
+	{{- end -}}
+	{{- end -}}
+	{{ end }}
 
 }

--- a/internal/cmd/codegen/generate/webffi/generate.go
+++ b/internal/cmd/codegen/generate/webffi/generate.go
@@ -297,6 +297,49 @@ func getManagerInterface(function *clang.TypedefFunction) string {
 	return sb.String()
 }
 func getJsFuncBody(function *clang.TypedefFunction) string {
+	switch LoadProcAddressName(function.Name) {
+	case "spx_sprite_batch_update_transforms":
+		return `var _gdRawFuncPtr = Module._gdspx_sprite_batch_update_transforms_raw; 
+	
+	if (_gdRawFuncPtr && buffer && buffer.__gdspx_fast_array === true && buffer.type === 2) {
+		try {
+			var _arg0 = CopyFastArrayToWasm(buffer);
+			_gdRawFuncPtr(_arg0, buffer.count);
+			return;
+		} catch (_rawErr) {
+			console.error("[spx-webffi] raw batch_update_transforms failed", {
+				count: buffer.count,
+				dataLength: buffer.data ? buffer.data.length : null,
+				type: buffer.type,
+				error: _rawErr,
+			});
+		}
+	}
+	var _arg0 = ToGdArray(buffer);
+	_gdFuncPtr(_arg0);
+	FreeGdArray(_arg0); `
+	case "spx_sprite_batch_update_visuals":
+		return `var _gdRawFuncPtr = Module._gdspx_sprite_batch_update_visuals_raw; 
+	
+	if (_gdRawFuncPtr && buffer && buffer.__gdspx_fast_array === true && buffer.type === 2) {
+		try {
+			var _arg0 = CopyFastArrayToWasm(buffer);
+			_gdRawFuncPtr(_arg0, buffer.count);
+			return;
+		} catch (_rawErr) {
+			console.error("[spx-webffi] raw batch_update_visuals failed", {
+				count: buffer.count,
+				dataLength: buffer.data ? buffer.data.length : null,
+				type: buffer.type,
+				error: _rawErr,
+			});
+		}
+	}
+	var _arg0 = ToGdArray(buffer);
+	_gdFuncPtr(_arg0);
+	FreeGdArray(_arg0); `
+	}
+
 	sb := strings.Builder{}
 	prefixTab := "\t"
 	params := []string{}

--- a/internal/coroutine/queue.go
+++ b/internal/coroutine/queue.go
@@ -13,10 +13,41 @@ type Queue[T any] struct {
 	head  *node[T]
 	tail  *node[T]
 	count int
+	pool  sync.Pool
 }
 
 func NewQueue[T any]() *Queue[T] {
-	return &Queue[T]{}
+	q := &Queue[T]{}
+	q.pool.New = func() any {
+		return new(node[T])
+	}
+	return q
+}
+
+func (s *Queue[T]) ensurePool() {
+	if s.pool.New == nil {
+		s.pool.New = func() any {
+			return new(node[T])
+		}
+	}
+}
+
+func (s *Queue[T]) acquireNode(value T) *node[T] {
+	s.ensurePool()
+	n := s.pool.Get().(*node[T])
+	n.value = value
+	n.prev = nil
+	n.next = nil
+	return n
+}
+
+func (s *Queue[T]) releaseNode(n *node[T]) {
+	var zero T
+	n.value = zero
+	n.prev = nil
+	n.next = nil
+	s.ensurePool()
+	s.pool.Put(n)
 }
 
 // Move all tasks from the src queue to the current queue.
@@ -57,7 +88,7 @@ func (s *Queue[T]) PushBack(value T) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	newNode := &node[T]{value: value}
+	newNode := s.acquireNode(value)
 	if s.count == 0 {
 		s.head = newNode
 		s.tail = newNode
@@ -73,7 +104,7 @@ func (s *Queue[T]) PushFront(value T) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	newNode := &node[T]{value: value}
+	newNode := s.acquireNode(value)
 	if s.count == 0 {
 		s.head = newNode
 		s.tail = newNode
@@ -93,8 +124,9 @@ func (s *Queue[T]) PopFront() T {
 		panic("queue is empty")
 	}
 
-	value := s.head.value
-	s.head = s.head.next
+	n := s.head
+	value := n.value
+	s.head = n.next
 	s.count--
 
 	if s.count == 0 {
@@ -103,6 +135,7 @@ func (s *Queue[T]) PopFront() T {
 		s.head.prev = nil
 	}
 
+	s.releaseNode(n)
 	return value
 }
 
@@ -114,8 +147,9 @@ func (s *Queue[T]) PopBack() T {
 		panic("queue is empty")
 	}
 
-	value := s.tail.value
-	s.tail = s.tail.prev
+	n := s.tail
+	value := n.value
+	s.tail = n.prev
 	s.count--
 
 	if s.count == 0 {
@@ -124,5 +158,6 @@ func (s *Queue[T]) PopBack() T {
 		s.tail.next = nil
 	}
 
+	s.releaseNode(n)
 	return value
 }

--- a/internal/coroutine/queue_test.go
+++ b/internal/coroutine/queue_test.go
@@ -1,0 +1,34 @@
+package coroutine
+
+import "testing"
+
+func TestQueuePushPopPreservesOrder(t *testing.T) {
+	q := NewQueue[int]()
+	q.PushBack(1)
+	q.PushBack(2)
+	q.PushFront(0)
+
+	if got := q.PopFront(); got != 0 {
+		t.Fatalf("first PopFront = %d, want 0", got)
+	}
+	if got := q.PopFront(); got != 1 {
+		t.Fatalf("second PopFront = %d, want 1", got)
+	}
+	if got := q.PopBack(); got != 2 {
+		t.Fatalf("PopBack = %d, want 2", got)
+	}
+}
+
+func TestQueueSupportsZeroValueWithPooling(t *testing.T) {
+	var q Queue[int]
+
+	q.PushBack(7)
+	if got := q.PopFront(); got != 7 {
+		t.Fatalf("PopFront = %d, want 7", got)
+	}
+
+	q.PushFront(9)
+	if got := q.PopBack(); got != 9 {
+		t.Fatalf("PopBack = %d, want 9", got)
+	}
+}

--- a/internal/gdengine/binding/web/marshal.go
+++ b/internal/gdengine/binding/web/marshal.go
@@ -35,7 +35,15 @@ const (
 var (
 	jsObject     = js.Global().Get("Object")
 	jsUint8Array = js.Global().Get("Uint8Array")
+
+	fastGdArrayScratchByType = map[int32]*fastGdArrayScratch{}
 )
+
+type fastGdArrayScratch struct {
+	bytes   js.Value
+	wrapper js.Value
+	byteCap int
+}
 
 type GdArrayInfo struct {
 	Size int32
@@ -497,15 +505,33 @@ func bytesFromFloat32Slice(data []float32) []byte {
 	return unsafe.Slice((*byte)(unsafe.Pointer(unsafe.SliceData(data))), len(data)*4)
 }
 
+func getFastGdArrayScratch(arrayType int32) *fastGdArrayScratch {
+	if scratch, ok := fastGdArrayScratchByType[arrayType]; ok {
+		return scratch
+	}
+	scratch := &fastGdArrayScratch{
+		wrapper: jsObject.New(),
+	}
+	scratch.wrapper.Set(fastGdArrayFlagKey, true)
+	scratch.wrapper.Set(fastGdArrayTypeKey, arrayType)
+	fastGdArrayScratchByType[arrayType] = scratch
+	return scratch
+}
+
 func newFastGdArrayValue(arrayType int32, count int, data []byte) js.Value {
-	jsBytes := jsUint8Array.New(len(data))
-	js.CopyBytesToJS(jsBytes, data)
-	fastArray := jsObject.New()
-	fastArray.Set(fastGdArrayFlagKey, true)
-	fastArray.Set(fastGdArrayTypeKey, arrayType)
-	fastArray.Set(fastGdArrayCountKey, count)
-	fastArray.Set(fastGdArrayDataKey, jsBytes)
-	return fastArray
+	scratch := getFastGdArrayScratch(arrayType)
+	if scratch.byteCap < len(data) || scratch.bytes.Type() == js.TypeUndefined {
+		scratch.bytes = jsUint8Array.New(len(data))
+		scratch.byteCap = len(data)
+	}
+	if len(data) > 0 {
+		js.CopyBytesToJS(scratch.bytes, data)
+	}
+	// Expose only the valid prefix so JS consumers that rely on byteLength/length
+	// do not read stale capacity bytes from previous larger buffers.
+	scratch.wrapper.Set(fastGdArrayDataKey, scratch.bytes.Call("subarray", 0, len(data)))
+	scratch.wrapper.Set(fastGdArrayCountKey, count)
+	return scratch.wrapper
 }
 
 func arrayToFastGdArrayValue(arrayPtr Array) (js.Value, bool) {


### PR DESCRIPTION
Queue[*WaitJob] now reuses linked list nodes.

Pop clears node references before returning them to the pool, reducing high-frequency small-object allocations.
