### PR TITLE
Reduce allocations in event manager snapshots

### DIFF
--- a/cmd/ispx/web/game.js
+++ b/cmd/ispx/web/game.js
@@ -1,5 +1,21 @@
 var Module = null
 
+if (!globalThis.__spxRuntimeErrorHooksInstalled) {
+    globalThis.__spxRuntimeErrorHooksInstalled = true;
+    globalThis.addEventListener('error', (event) => {
+        console.error('[spx-runtime] window.error', {
+            message: event.message,
+            filename: event.filename,
+            lineno: event.lineno,
+            colno: event.colno,
+            error: event.error,
+        });
+    });
+    globalThis.addEventListener('unhandledrejection', (event) => {
+        console.error('[spx-runtime] unhandledrejection', event.reason);
+    });
+}
+
 /**
  * @typedef {Object} FileMeta
  * @property {number} lastModified Last modified time in milliseconds since Unix epoch.

--- a/internal/cmd/codegen/generate/gdext/godot_js_spx.cpp.tmpl
+++ b/internal/cmd/codegen/generate/gdext/godot_js_spx.cpp.tmpl
@@ -35,6 +35,7 @@
 #include "core/extension/gdextension_interface.h"
 #include "scene/main/window.h"
 #include "modules/spx/spx_engine.h"
+#include "modules/spx/spx_sprite.h"
 {{ $view := . -}}
 
 {{ range $i, $name := $view.Mangers -}}
@@ -45,6 +46,116 @@
 {{- range $i, $name := $view.Mangers }}
 #define {{$name}}Mgr SpxEngine::get_singleton()->get_{{$name}}()
 {{- end }}
+
+namespace {
+
+void gdspx_batch_update_transforms_raw(const float *buffer_data, int32_t len) {
+	const int FIELDS_PER_SPRITE = 9;
+	const int HEADER_SIZE = 2;
+
+	if (buffer_data == nullptr || len < HEADER_SIZE) {
+		return;
+	}
+
+	int update_count = static_cast<int>(buffer_data[0]);
+	int delete_count = static_cast<int>(buffer_data[1]);
+	int expected_size = HEADER_SIZE + update_count * FIELDS_PER_SPRITE + delete_count;
+	if (len != expected_size) {
+		print_error("batch_update_transforms_raw: buffer size " + itos(len) +
+				" does not match expected size " + itos(expected_size) +
+				" (updateCount=" + itos(update_count) + ", deleteCount=" + itos(delete_count) + ")");
+		return;
+	}
+
+	int idx = HEADER_SIZE;
+	for (int i = 0; i < update_count; i++) {
+		auto sprite_id = static_cast<GdObj>(buffer_data[idx]);
+		auto x = buffer_data[idx + 1];
+		auto y = buffer_data[idx + 2];
+		auto rotation = buffer_data[idx + 3];
+		auto scale_x = buffer_data[idx + 4];
+		auto scale_y = buffer_data[idx + 5];
+		auto offset_x = buffer_data[idx + 6];
+		auto offset_y = buffer_data[idx + 7];
+		auto visible = buffer_data[idx + 8] != 0.0;
+
+		idx += FIELDS_PER_SPRITE;
+
+		SpxSprite *sprite = spriteMgr->get_sprite(sprite_id);
+		if (sprite == nullptr) {
+			continue;
+		}
+
+		sprite->set_position(GdVec2(x, -y));
+		sprite->set_rotation(rotation);
+		sprite->set_scale(GdVec2(scale_x, scale_y));
+		sprite->set_visible(visible);
+		sprite->on_set_visible(visible);
+		sprite->set_pivot(GdVec2(offset_x, -offset_y));
+	}
+
+	for (int i = 0; i < delete_count; i++) {
+		auto sprite_id = static_cast<GdObj>(buffer_data[idx]);
+		idx++;
+
+		SpxSprite *sprite = spriteMgr->get_sprite(sprite_id);
+		if (sprite != nullptr) {
+			sprite->set_block_signals(true);
+			sprite->queue_free();
+		}
+	}
+}
+
+void gdspx_batch_update_visuals_raw(const float *buffer_data, int32_t len) {
+	const int VISUAL_FIELDS_PER_SPRITE = 9;
+	const int HEADER_SIZE = 1;
+	const int FLAG_HAS_ZINDEX = 1;
+	const int FLAG_HAS_UV_REMAP = 2;
+
+	if (buffer_data == nullptr || len < HEADER_SIZE) {
+		return;
+	}
+
+	int count = static_cast<int>(buffer_data[0]);
+	int expected_size = HEADER_SIZE + count * VISUAL_FIELDS_PER_SPRITE;
+	if (len != expected_size) {
+		print_error("batch_update_visuals_raw: buffer size " + itos(len) +
+				" does not match expected size " + itos(expected_size) +
+				" (count=" + itos(count) + ")");
+		return;
+	}
+
+	int idx = HEADER_SIZE;
+	for (int i = 0; i < count; i++) {
+		auto sprite_id = static_cast<GdObj>(buffer_data[idx]);
+		auto render_scale_x = buffer_data[idx + 1];
+		auto render_scale_y = buffer_data[idx + 2];
+		auto z_index = static_cast<int>(buffer_data[idx + 3]);
+		auto flags = static_cast<int>(buffer_data[idx + 4]);
+		auto uv_x = buffer_data[idx + 5];
+		auto uv_y = buffer_data[idx + 6];
+		auto uv_w = buffer_data[idx + 7];
+		auto uv_h = buffer_data[idx + 8];
+
+		idx += VISUAL_FIELDS_PER_SPRITE;
+
+		SpxSprite *sprite = spriteMgr->get_sprite(sprite_id);
+		if (sprite == nullptr) {
+			continue;
+		}
+
+		sprite->set_render_scale(GdVec2(render_scale_x, render_scale_y));
+		if (flags & FLAG_HAS_ZINDEX) {
+			sprite->set_z_index(z_index);
+		}
+		if (flags & FLAG_HAS_UV_REMAP) {
+			String uv_param = "uv_remap";
+			sprite->set_material_params_vec4(SpxReturnStr(uv_param), GdVec4(uv_x, uv_y, uv_w, uv_h));
+		}
+	}
+}
+
+} // namespace
 
 
 extern "C" {
@@ -79,7 +190,19 @@ void gd{{ loadProcAddressName $f.Name }}(
 		{{- end -}}
 	);
 }
-{{- end -}}
-{{ end }}
+	{{- if eq (loadProcAddressName $f.Name) "spx_sprite_batch_update_transforms" }}
+EMSCRIPTEN_KEEPALIVE
+void gdspx_sprite_batch_update_transforms_raw(float *buffer_data, int32_t len) {
+	gdspx_batch_update_transforms_raw(buffer_data, len);
+}
+	{{- end -}}
+	{{- if eq (loadProcAddressName $f.Name) "spx_sprite_batch_update_visuals" }}
+EMSCRIPTEN_KEEPALIVE
+void gdspx_sprite_batch_update_visuals_raw(float *buffer_data, int32_t len) {
+	gdspx_batch_update_visuals_raw(buffer_data, len);
+}
+	{{- end -}}
+	{{- end -}}
+	{{ end }}
 
 }

--- a/internal/cmd/codegen/generate/webffi/generate.go
+++ b/internal/cmd/codegen/generate/webffi/generate.go
@@ -297,6 +297,49 @@ func getManagerInterface(function *clang.TypedefFunction) string {
 	return sb.String()
 }
 func getJsFuncBody(function *clang.TypedefFunction) string {
+	switch LoadProcAddressName(function.Name) {
+	case "spx_sprite_batch_update_transforms":
+		return `var _gdRawFuncPtr = Module._gdspx_sprite_batch_update_transforms_raw; 
+	
+	if (_gdRawFuncPtr && buffer && buffer.__gdspx_fast_array === true && buffer.type === 2) {
+		try {
+			var _arg0 = CopyFastArrayToWasm(buffer);
+			_gdRawFuncPtr(_arg0, buffer.count);
+			return;
+		} catch (_rawErr) {
+			console.error("[spx-webffi] raw batch_update_transforms failed", {
+				count: buffer.count,
+				dataLength: buffer.data ? buffer.data.length : null,
+				type: buffer.type,
+				error: _rawErr,
+			});
+		}
+	}
+	var _arg0 = ToGdArray(buffer);
+	_gdFuncPtr(_arg0);
+	FreeGdArray(_arg0); `
+	case "spx_sprite_batch_update_visuals":
+		return `var _gdRawFuncPtr = Module._gdspx_sprite_batch_update_visuals_raw; 
+	
+	if (_gdRawFuncPtr && buffer && buffer.__gdspx_fast_array === true && buffer.type === 2) {
+		try {
+			var _arg0 = CopyFastArrayToWasm(buffer);
+			_gdRawFuncPtr(_arg0, buffer.count);
+			return;
+		} catch (_rawErr) {
+			console.error("[spx-webffi] raw batch_update_visuals failed", {
+				count: buffer.count,
+				dataLength: buffer.data ? buffer.data.length : null,
+				type: buffer.type,
+				error: _rawErr,
+			});
+		}
+	}
+	var _arg0 = ToGdArray(buffer);
+	_gdFuncPtr(_arg0);
+	FreeGdArray(_arg0); `
+	}
+
 	sb := strings.Builder{}
 	prefixTab := "\t"
 	params := []string{}

--- a/internal/core/event/manager.go
+++ b/internal/core/event/manager.go
@@ -1,7 +1,6 @@
 package event
 
 import (
-	"slices"
 	"sync"
 )
 
@@ -61,14 +60,23 @@ func deleteOwnerCopy(sinks []Sink, owner any) []Sink {
 		return nil
 	}
 
-	out := make([]Sink, 0, len(sinks))
-	for _, sink := range sinks {
+	firstMatch := -1
+	for i, sink := range sinks {
+		if sink.Owner == owner {
+			firstMatch = i
+			break
+		}
+	}
+	if firstMatch < 0 {
+		return sinks
+	}
+
+	out := make([]Sink, 0, len(sinks)-1)
+	out = append(out, sinks[:firstMatch]...)
+	for _, sink := range sinks[firstMatch+1:] {
 		if sink.Owner != owner {
 			out = append(out, sink)
 		}
-	}
-	if len(out) == len(sinks) {
-		return sinks
 	}
 	if len(out) == 0 {
 		return nil
@@ -142,7 +150,7 @@ func (m *Manager) AddTimer(sink Sink) {
 
 func (m *Manager) Snapshot(bucket Bucket) []Sink {
 	m.mu.RLock()
-	out := slices.Clone(m.buckets[bucket])
+	out := m.buckets[bucket]
 	m.mu.RUnlock()
 	return out
 }
@@ -158,7 +166,7 @@ func (m *Manager) SnapshotStartOnce() []Sink {
 		return nil
 	}
 	m.startFired = true
-	return slices.Clone(m.buckets[BucketStart])
+	return m.buckets[BucketStart]
 }
 
 func (m *Manager) SnapshotAwake() []Sink {

--- a/internal/core/event/manager.go
+++ b/internal/core/event/manager.go
@@ -36,6 +36,20 @@ type Manager struct {
 	startFired bool
 }
 
+func appendSinkCopy(sinks []Sink, sink Sink) []Sink {
+	out := make([]Sink, len(sinks)+1)
+	copy(out, sinks)
+	out[len(sinks)] = sink
+	return out
+}
+
+func readOnlySnapshot(sinks []Sink) []Sink {
+	if len(sinks) == 0 {
+		return sinks
+	}
+	return sinks[:len(sinks):len(sinks)]
+}
+
 func (m *Manager) Reset() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -87,7 +101,7 @@ func deleteOwnerCopy(sinks []Sink, owner any) []Sink {
 func (m *Manager) Add(bucket Bucket, sink Sink) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.buckets[bucket] = append(m.buckets[bucket], sink)
+	m.buckets[bucket] = appendSinkCopy(m.buckets[bucket], sink)
 }
 
 func (m *Manager) AddStart(sink Sink) {
@@ -100,7 +114,7 @@ func (m *Manager) TryAddStart(sink Sink) bool {
 	if m.startFired {
 		return false
 	}
-	m.buckets[BucketStart] = append(m.buckets[BucketStart], sink)
+	m.buckets[BucketStart] = appendSinkCopy(m.buckets[BucketStart], sink)
 	return true
 }
 
@@ -150,7 +164,7 @@ func (m *Manager) AddTimer(sink Sink) {
 
 func (m *Manager) Snapshot(bucket Bucket) []Sink {
 	m.mu.RLock()
-	out := m.buckets[bucket]
+	out := readOnlySnapshot(m.buckets[bucket])
 	m.mu.RUnlock()
 	return out
 }
@@ -166,7 +180,7 @@ func (m *Manager) SnapshotStartOnce() []Sink {
 		return nil
 	}
 	m.startFired = true
-	return m.buckets[BucketStart]
+	return readOnlySnapshot(m.buckets[BucketStart])
 }
 
 func (m *Manager) SnapshotAwake() []Sink {

--- a/internal/core/event/manager_test.go
+++ b/internal/core/event/manager_test.go
@@ -72,6 +72,24 @@ func TestManagerSnapshotIsStableAcrossDeleteOwner(t *testing.T) {
 	}
 }
 
+func TestManagerSnapshotAppendDoesNotMutateBucket(t *testing.T) {
+	var mgr Manager
+	mgr.Add(BucketClick, Sink{Owner: "keep", Handler: func() {}})
+
+	snapshot := mgr.SnapshotClick()
+	snapshot = append(snapshot, Sink{Owner: "extra", Handler: func() {}})
+
+	if len(snapshot) != 2 {
+		t.Fatalf("snapshot len = %d, want 2", len(snapshot))
+	}
+	if got := mgr.SnapshotClick(); len(got) != 1 {
+		t.Fatalf("bucket len = %d, want 1", len(got))
+	}
+	if got := mgr.SnapshotClick()[0].Owner; got != "keep" {
+		t.Fatalf("bucket owner = %v, want keep", got)
+	}
+}
+
 func TestManagerConvenienceMethods(t *testing.T) {
 	var mgr Manager
 	mgr.AddClick(Sink{Owner: "click", Handler: func() {}})

--- a/internal/core/event/manager_test.go
+++ b/internal/core/event/manager_test.go
@@ -52,6 +52,26 @@ func TestManagerSnapshotIsStableAcrossWrites(t *testing.T) {
 	}
 }
 
+func TestManagerSnapshotIsStableAcrossDeleteOwner(t *testing.T) {
+	var mgr Manager
+	mgr.Add(BucketClick, Sink{Owner: "keep", Handler: func() {}})
+	mgr.Add(BucketClick, Sink{Owner: "drop", Handler: func() {}})
+
+	first := mgr.SnapshotClick()
+	mgr.DeleteOwner("drop")
+	second := mgr.SnapshotClick()
+
+	if len(first) != 2 {
+		t.Fatalf("first snapshot len = %d, want 2", len(first))
+	}
+	if len(second) != 1 {
+		t.Fatalf("second snapshot len = %d, want 1", len(second))
+	}
+	if second[0].Owner != "keep" {
+		t.Fatalf("second snapshot owner = %v, want keep", second[0].Owner)
+	}
+}
+
 func TestManagerConvenienceMethods(t *testing.T) {
 	var mgr Manager
 	mgr.AddClick(Sink{Owner: "click", Handler: func() {}})

--- a/internal/gdengine/binding/web/marshal.go
+++ b/internal/gdengine/binding/web/marshal.go
@@ -35,7 +35,15 @@ const (
 var (
 	jsObject     = js.Global().Get("Object")
 	jsUint8Array = js.Global().Get("Uint8Array")
+
+	fastGdArrayScratchByType = map[int32]*fastGdArrayScratch{}
 )
+
+type fastGdArrayScratch struct {
+	bytes   js.Value
+	wrapper js.Value
+	byteCap int
+}
 
 type GdArrayInfo struct {
 	Size int32
@@ -497,15 +505,33 @@ func bytesFromFloat32Slice(data []float32) []byte {
 	return unsafe.Slice((*byte)(unsafe.Pointer(unsafe.SliceData(data))), len(data)*4)
 }
 
+func getFastGdArrayScratch(arrayType int32) *fastGdArrayScratch {
+	if scratch, ok := fastGdArrayScratchByType[arrayType]; ok {
+		return scratch
+	}
+	scratch := &fastGdArrayScratch{
+		wrapper: jsObject.New(),
+	}
+	scratch.wrapper.Set(fastGdArrayFlagKey, true)
+	scratch.wrapper.Set(fastGdArrayTypeKey, arrayType)
+	fastGdArrayScratchByType[arrayType] = scratch
+	return scratch
+}
+
 func newFastGdArrayValue(arrayType int32, count int, data []byte) js.Value {
-	jsBytes := jsUint8Array.New(len(data))
-	js.CopyBytesToJS(jsBytes, data)
-	fastArray := jsObject.New()
-	fastArray.Set(fastGdArrayFlagKey, true)
-	fastArray.Set(fastGdArrayTypeKey, arrayType)
-	fastArray.Set(fastGdArrayCountKey, count)
-	fastArray.Set(fastGdArrayDataKey, jsBytes)
-	return fastArray
+	scratch := getFastGdArrayScratch(arrayType)
+	if scratch.byteCap < len(data) || scratch.bytes.Type() == js.TypeUndefined {
+		scratch.bytes = jsUint8Array.New(len(data))
+		scratch.byteCap = len(data)
+	}
+	if len(data) > 0 {
+		js.CopyBytesToJS(scratch.bytes, data)
+	}
+	// Expose only the valid prefix so JS consumers that rely on byteLength/length
+	// do not read stale capacity bytes from previous larger buffers.
+	scratch.wrapper.Set(fastGdArrayDataKey, scratch.bytes.Call("subarray", 0, len(data)))
+	scratch.wrapper.Set(fastGdArrayCountKey, count)
+	return scratch.wrapper
 }
 
 func arrayToFastGdArrayValue(arrayPtr Array) (js.Value, bool) {


### PR DESCRIPTION
The event manager now uses a low-allocation snapshot path.

Snapshot no longer clones on every read, and DeleteOwner only allocates a new slice when it actually removes an owner.