### PR TITLE
fix issues in thread handling

### DIFF
--- a/internal/coroutine/thread.go
+++ b/internal/coroutine/thread.go
@@ -38,6 +38,10 @@ type threadImpl struct {
 // Thread represents a coroutine id.
 type Thread = *threadImpl
 
+type threadNamer interface {
+	Name() string
+}
+
 // -------------------------------------------------------------------------------------
 // Thread Methods
 // -------------------------------------------------------------------------------------
@@ -72,8 +76,9 @@ func (p *threadImpl) Stopped() bool {
 }
 
 func (p Thread) IsSchedTimeout(ms float64) bool {
-	if p.schedFrame < time.Frame() {
-		p.schedFrame = time.Frame()
+	frame := time.Frame()
+	if p.schedFrame < frame {
+		p.schedFrame = frame
 		p.schedTimestamp = stime.Now()
 	}
 	timeout := stime.Since(p.schedTimestamp) > stime.Duration(ms)*stime.Millisecond
@@ -132,37 +137,45 @@ func (p *Coroutines) AbortAll() {
 func (p *Coroutines) AbortAllAndWait(timeout stime.Duration) bool {
 	p.AbortAll()
 
-	done := make(chan struct{})
-	go func() {
-		p.wg.Wait()
-		close(done)
-	}()
-
 	if timeout <= 0 {
-		<-done
+		p.wg.Wait()
 		return true
 	}
 
-	select {
-	case <-done:
-		return true
-	case <-stime.After(timeout):
-		return false
+	deadline := stime.Now().Add(timeout)
+	for {
+		p.mutex.Lock()
+		done := len(p.allThreads) == 0
+		p.mutex.Unlock()
+		if done {
+			return true
+		}
+
+		remaining := stime.Until(deadline)
+		if remaining <= 0 {
+			return false
+		}
+		if remaining > 10*stime.Millisecond {
+			remaining = 10 * stime.Millisecond
+		}
+		stime.Sleep(remaining)
 	}
 }
 
 func (p *Coroutines) StopIf(filter func(th Thread) bool) {
-	threads := func() []Thread {
-		p.mutex.Lock()
-		defer p.mutex.Unlock()
-		list := make([]Thread, 0, len(p.suspended))
-		for th := range p.suspended {
-			if filter(th) {
-				list = append(list, th)
-			}
+	p.mutex.Lock()
+	allThreads := make([]Thread, 0, len(p.allThreads))
+	for th := range p.allThreads {
+		allThreads = append(allThreads, th)
+	}
+	p.mutex.Unlock()
+
+	threads := allThreads[:0]
+	for _, th := range allThreads {
+		if filter(th) {
+			threads = append(threads, th)
 		}
-		return list
-	}()
+	}
 
 	// Stop each thread with proper signaling
 	for _, th := range threads {
@@ -197,23 +210,16 @@ func resolveThreadName(obj ThreadObj) string {
 		return str
 	}
 
+	if named, ok := obj.(threadNamer); ok {
+		return named.Name()
+	}
+
 	t := reflect.TypeOf(obj)
 	if t.Kind() != reflect.Pointer || t.Elem().Name() == "" {
 		return ""
 	}
 
-	name := "*" + t.Elem().Name()
-	v := reflect.ValueOf(obj)
-	nameMethod := v.MethodByName("Name")
-	if !nameMethod.IsValid() {
-		return name
-	}
-
-	results := nameMethod.Call(nil)
-	if len(results) > 0 {
-		name = results[0].String()
-	}
-	return name
+	return "*" + t.Elem().Name()
 }
 
 func (p *Coroutines) newThread(obj ThreadObj) Thread {

--- a/internal/coroutine/thread_test.go
+++ b/internal/coroutine/thread_test.go
@@ -1,0 +1,143 @@
+package coroutine
+
+import (
+	"runtime"
+	"testing"
+	"time"
+)
+
+type namedThreadObj struct{}
+
+func (*namedThreadObj) Name() string {
+	return "named-thread"
+}
+
+type invalidNamedThreadObj struct{}
+
+func (*invalidNamedThreadObj) Name(_ string) string {
+	return "invalid"
+}
+
+func canReenterCoroutineMutex(co *Coroutines) bool {
+	if !co.mutex.TryLock() {
+		return false
+	}
+	co.mutex.Unlock()
+	return true
+}
+
+func TestResolveThreadNameUsesNameMethodWithoutReflectionCall(t *testing.T) {
+	if got := resolveThreadName(&namedThreadObj{}); got != "named-thread" {
+		t.Fatalf("expected name from interface method, got %q", got)
+	}
+}
+
+func TestResolveThreadNameFallsBackForInvalidNameSignature(t *testing.T) {
+	if got := resolveThreadName(&invalidNamedThreadObj{}); got != "*invalidNamedThreadObj" {
+		t.Fatalf("expected fallback type name, got %q", got)
+	}
+}
+
+func TestStopIfStopsActiveThread(t *testing.T) {
+	co := New(nil)
+	started := make(chan Thread, 1)
+	done := make(chan struct{})
+
+	co.CreateAndStart(true, "worker", func(me Thread) int {
+		started <- me
+		for {
+			select {
+			case <-me.Context().Done():
+				close(done)
+				return 0
+			default:
+				runtime.Gosched()
+			}
+		}
+	})
+
+	var th Thread
+	timer := time.NewTimer(time.Second)
+	defer timer.Stop()
+	select {
+	case th = <-started:
+	case <-timer.C:
+		t.Fatal("coroutine did not start")
+	}
+
+	co.mutex.Lock()
+	_, suspended := co.suspended[th]
+	co.mutex.Unlock()
+	if suspended {
+		t.Fatal("test precondition failed: spinning thread should not be in suspended map")
+	}
+
+	co.StopIf(func(candidate Thread) bool {
+		return candidate == th
+	})
+
+	timer = time.NewTimer(time.Second)
+	defer timer.Stop()
+	select {
+	case <-done:
+	case <-timer.C:
+		t.Fatal("active coroutine did not stop after StopIf")
+	}
+}
+
+func TestStopIfEvaluatesFilterWithoutHoldingMutex(t *testing.T) {
+	co := New(nil)
+	started := make(chan Thread, 1)
+	done := make(chan struct{})
+
+	co.CreateAndStart(true, "worker", func(me Thread) int {
+		started <- me
+		for {
+			select {
+			case <-me.Context().Done():
+				close(done)
+				return 0
+			default:
+				runtime.Gosched()
+			}
+		}
+	})
+
+	timer := time.NewTimer(time.Second)
+	defer timer.Stop()
+	var th Thread
+	select {
+	case th = <-started:
+	case <-timer.C:
+		t.Fatal("coroutine did not start")
+	}
+
+	var reacquired bool
+	stopDone := make(chan struct{})
+	go func() {
+		co.StopIf(func(candidate Thread) bool {
+			reacquired = canReenterCoroutineMutex(co)
+			return candidate == th
+		})
+		close(stopDone)
+	}()
+
+	timer = time.NewTimer(time.Second)
+	defer timer.Stop()
+	select {
+	case <-stopDone:
+	case <-timer.C:
+		t.Fatal("StopIf deadlocked when filter re-entered the coroutine mutex")
+	}
+	if !reacquired {
+		t.Fatal("StopIf evaluated filter while holding the coroutine mutex")
+	}
+
+	timer = time.NewTimer(time.Second)
+	defer timer.Stop()
+	select {
+	case <-done:
+	case <-timer.C:
+		t.Fatal("active coroutine did not stop after StopIf")
+	}
+}


### PR DESCRIPTION
 - make StopIf stop matching active threads instead of only suspended ones
 - avoid timer leaks in AbortAllAndWait
 - simplify resolveThreadName to avoid reflective Name() calls and invalid method-signature panics
 - read time.Frame() once in IsSchedTimeout