### PR TITLE
fix: pack shared web assets for runweb

### DIFF
--- a/cmd/gox/pkg/command/export.go
+++ b/cmd/gox/pkg/command/export.go
@@ -250,7 +250,9 @@ func (pself *CmdTool) exportWebCommon(mode string) error {
 	}
 	// Append ext/*.js to engine.worker.js then remove them
 
-	pack.PackProject(pself.TargetDir, filepath.Join(pself.WebDir, "game.zip"))
+	if err := pack.PackProject(pself.TargetDir, filepath.Join(pself.WebDir, "game.zip")); err != nil {
+		return err
+	}
 	//pack.PackEngineRes(pself.ProjectFS, pself.WebDir)
 	util.CopyFile(pself.getWasmPath(), filepath.Join(pself.WebDir, "ispx.wasm"))
 	util.CopyFile(pself.getWasmPath()+".br", filepath.Join(pself.WebDir, "ispx.wasm.br"))

--- a/cmd/gox/pkg/pack/pack.go
+++ b/cmd/gox/pkg/pack/pack.go
@@ -17,12 +17,16 @@ import (
 type DirInfos struct {
 	path string
 	info os.FileInfo
+	// zipPath optionally overrides the archive entry path for assets outside baseFolder.
+	zipPath string
 }
 
-func PackProject(baseFolder string, dstZipPath string) {
+func PackProject(baseFolder string, dstZipPath string) error {
 	paths := []DirInfos{}
 	if util.IsFileExist(dstZipPath) {
-		os.Remove(dstZipPath)
+		if err := os.Remove(dstZipPath); err != nil {
+			return err
+		}
 	}
 	skipDirs := map[string]struct{}{
 		".git": {}, "project": {},
@@ -30,12 +34,18 @@ func PackProject(baseFolder string, dstZipPath string) {
 
 	file, err := os.Create(dstZipPath)
 	if err != nil {
-		panic(err)
+		return err
 	}
-	defer file.Close()
-
 	zipWriter := zip.NewWriter(file)
-	defer zipWriter.Close()
+	closeZip := func(err error) error {
+		if closeErr := zipWriter.Close(); err == nil && closeErr != nil {
+			err = closeErr
+		}
+		if closeErr := file.Close(); err == nil && closeErr != nil {
+			err = closeErr
+		}
+		return err
+	}
 
 	err = filepath.Walk(baseFolder, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
@@ -63,22 +73,35 @@ func PackProject(baseFolder string, dstZipPath string) {
 				return nil
 			}
 		}
-		paths = append(paths, DirInfos{path, info})
+		paths = append(paths, DirInfos{path: path, info: info})
 		return nil
 	})
 	if err != nil {
-		panic(err)
+		return closeZip(err)
 	}
 
-	PackZip(zipWriter, baseFolder, paths)
+	existingZipPaths := make(map[string]struct{}, len(paths))
+	for _, dirInfo := range paths {
+		existingZipPaths[zipEntryName(baseFolder, dirInfo)] = struct{}{}
+	}
+
+	extraPaths, err := collectExternalAssetPaths(baseFolder, existingZipPaths)
+	if err != nil {
+		return closeZip(err)
+	}
+	paths = append(paths, extraPaths...)
+
+	return closeZip(PackZip(zipWriter, baseFolder, paths))
 }
 
-func PackZip(zipWriter *zip.Writer, baseFolder string, paths []DirInfos) {
+func PackZip(zipWriter *zip.Writer, baseFolder string, paths []DirInfos) error {
 	baseFolder = strings.ReplaceAll(baseFolder, "\\", "/")
 	slices.SortFunc(paths, func(a, b DirInfos) int {
-		if a.path < b.path {
+		nameA := zipEntryName(baseFolder, a)
+		nameB := zipEntryName(baseFolder, b)
+		if nameA < nameB {
 			return -1
-		} else if a.path > b.path {
+		} else if nameA > nameB {
 			return 1
 		}
 		return 0
@@ -89,40 +112,58 @@ func PackZip(zipWriter *zip.Writer, baseFolder string, paths []DirInfos) {
 		info := dirInfo.info
 		header, err := zip.FileInfoHeader(info)
 		if err != nil {
-			panic(err)
+			return err
 		}
 		// Set a fixed timestamp
 		header.Modified = time.Unix(0, 0)
 
-		header.Name = strings.TrimPrefix(path, baseFolder)
-		header.Name = strings.ReplaceAll(header.Name, "\\", "/")
-		if header.Name[0] == '/' {
-			header.Name = header.Name[1:]
+		header.Name = zipEntryName(baseFolder, dirInfo)
+		if header.Name == "" {
+			continue
 		}
 		if info.IsDir() {
 			header.Name += "/"
 			_, err := zipWriter.CreateHeader(header)
 			if err != nil {
-				panic(err)
+				return err
 			}
 			continue
 		}
 
 		fileToZip, err := os.Open(path)
 		if err != nil {
-			panic(err)
+			return err
 		}
-		defer fileToZip.Close()
 
 		writer, err := zipWriter.CreateHeader(header)
 		if err != nil {
-			panic(err)
+			fileToZip.Close()
+			return err
 		}
-		_, err = io.Copy(writer, fileToZip)
-		if err != nil {
-			panic(err)
+		_, copyErr := io.Copy(writer, fileToZip)
+		closeErr := fileToZip.Close()
+		if copyErr != nil {
+			return copyErr
+		}
+		if closeErr != nil {
+			return closeErr
 		}
 	}
+	return nil
+}
+
+func zipEntryName(baseFolder string, dirInfo DirInfos) string {
+	if dirInfo.zipPath != "" {
+		return strings.TrimPrefix(normalizeZipPath(dirInfo.zipPath), "/")
+	}
+
+	baseFolder = normalizeZipPath(baseFolder)
+	name := strings.TrimPrefix(normalizeZipPath(dirInfo.path), baseFolder)
+	return strings.TrimPrefix(name, "/")
+}
+
+func normalizeZipPath(path string) string {
+	return strings.ReplaceAll(path, "\\", "/")
 }
 
 func PackEngineRes(proejct_fs embed.FS, webDir string) {
@@ -143,44 +184,56 @@ func PackDirFiles(zipName string, targetDir string, directories, files []string)
 	if err != nil {
 		return err
 	}
-	defer zipFile.Close()
-
 	zipWriter := zip.NewWriter(zipFile)
-	defer zipWriter.Close()
+	closeZip := func(err error) error {
+		if closeErr := zipWriter.Close(); err == nil && closeErr != nil {
+			err = closeErr
+		}
+		if closeErr := zipFile.Close(); err == nil && closeErr != nil {
+			err = closeErr
+		}
+		return err
+	}
+
 	paths := []DirInfos{}
 	for _, dir := range directories {
-		paths = addDirToZip(path.Join(targetDir, dir), paths)
+		paths, err = addDirToZip(path.Join(targetDir, dir), paths)
+		if err != nil {
+			return closeZip(err)
+		}
 	}
 
 	for _, file := range files {
-		paths = addFileToZip(path.Join(targetDir, file), paths)
+		paths, err = addFileToZip(path.Join(targetDir, file), paths)
+		if err != nil {
+			return closeZip(err)
+		}
 	}
 
-	PackZip(zipWriter, targetDir, paths)
-	return nil
+	return closeZip(PackZip(zipWriter, targetDir, paths))
 }
 
-func addDirToZip(dirPath string, paths []DirInfos) []DirInfos {
-	filepath.Walk(dirPath, func(path string, info os.FileInfo, err error) error {
+func addDirToZip(dirPath string, paths []DirInfos) ([]DirInfos, error) {
+	err := filepath.Walk(dirPath, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
-		paths = append(paths, DirInfos{path, info})
+		paths = append(paths, DirInfos{path: path, info: info})
 		return nil
 	})
-	return paths
+	return paths, err
 }
 
-func addFileToZip(path string, paths []DirInfos) []DirInfos {
+func addFileToZip(path string, paths []DirInfos) ([]DirInfos, error) {
 	file, err := os.Open(path)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 	defer file.Close()
 	info, err := file.Stat()
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
-	paths = append(paths, DirInfos{path, info})
-	return paths
+	paths = append(paths, DirInfos{path: path, info: info})
+	return paths, nil
 }

--- a/cmd/gox/pkg/pack/pack_test.go
+++ b/cmd/gox/pkg/pack/pack_test.go
@@ -1,0 +1,214 @@
+package pack
+
+import (
+	"archive/zip"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestPackProjectIncludesSharedExternalAssets(t *testing.T) {
+	tmpDir := t.TempDir()
+	projectDir := filepath.Join(tmpDir, "All")
+	if err := os.MkdirAll(filepath.Join(projectDir, "assets", "sprites", "SpMotion"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(tmpDir, "res"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(filepath.Join(projectDir, "assets", "index.json"), []byte(`{"map":{"width":480,"height":360}}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(projectDir, "assets", "sprites", "SpMotion", "index.json"), []byte(`{
+  "costumeSet": {
+    "faceRight": 180,
+    "path": "../../../../res/monkey.png",
+    "nx": 96
+  }
+}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, "res", "monkey.png"), []byte("png"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	zipPath := filepath.Join(tmpDir, "game.zip")
+	if err := PackProject(projectDir, zipPath); err != nil {
+		t.Fatal(err)
+	}
+
+	snapshot := readZipSnapshot(t, zipPath)
+	if snapshot.counts["res/monkey.png"] != 1 {
+		t.Fatalf("res/monkey.png count = %d, want 1", snapshot.counts["res/monkey.png"])
+	}
+	if snapshot.contents["res/monkey.png"] != "png" {
+		t.Fatalf("res/monkey.png content = %q, want %q", snapshot.contents["res/monkey.png"], "png")
+	}
+	for name := range snapshot.counts {
+		if strings.HasPrefix(name, "../") {
+			t.Fatalf("unexpected zip entry %q", name)
+		}
+	}
+}
+
+func TestPackProjectCoversExternalAssetVariants(t *testing.T) {
+	tmpDir := t.TempDir()
+	projectDir := filepath.Join(tmpDir, "Game")
+	escapeDir := filepath.Join(filepath.Dir(tmpDir), filepath.Base(tmpDir)+"-escape")
+	t.Cleanup(func() {
+		_ = os.RemoveAll(escapeDir)
+	})
+
+	writeTestFile(t, filepath.Join(projectDir, ".config"), `{"extasset":"custom_asset"}`)
+	writeTestFile(t, filepath.Join(projectDir, "assets", "index.json"), fmt.Sprintf(`{
+  "backdrops": [
+    {"path":"../../shared/bg.png"},
+    {"path":"../../../%s/ignored.png"}
+  ],
+  "bgm":"../../shared/audio/theme.mp3",
+  "tilemapPath":"../../shared/maps/map.json",
+  "map":{"width":480,"height":360}
+}`, filepath.Base(escapeDir)))
+	writeTestFile(t, filepath.Join(projectDir, "assets", "sprites", "Hero", "index.json"), `{
+  "costumes":[
+    {"path":"../../../../custom_asset/shared.png"}
+  ],
+  "costumeSet":{
+    "faceRight":180,
+    "path":"../../../../custom_asset/hero.png",
+    "nx":96
+  }
+}`)
+	writeTestFile(t, filepath.Join(projectDir, "assets", "sounds", "Bell", "index.json"), `{
+  "path":"../../../../shared/audio/ring.wav"
+}`)
+	writeTestFile(t, filepath.Join(projectDir, "extasset", "shared.png"), "local")
+
+	writeTestFile(t, filepath.Join(tmpDir, "shared", "bg.png"), "bg")
+	writeTestFile(t, filepath.Join(tmpDir, "shared", "audio", "theme.mp3"), "theme")
+	writeTestFile(t, filepath.Join(tmpDir, "shared", "audio", "ring.wav"), "ring")
+	writeTestFile(t, filepath.Join(tmpDir, "shared", "maps", "map.json"), "{}")
+	writeTestFile(t, filepath.Join(tmpDir, "custom_asset", "hero.png"), "hero")
+	writeTestFile(t, filepath.Join(tmpDir, "custom_asset", "shared.png"), "external-duplicate")
+	writeTestFile(t, filepath.Join(escapeDir, "ignored.png"), "ignored")
+
+	zipPath := filepath.Join(tmpDir, "game.zip")
+	if err := PackProject(projectDir, zipPath); err != nil {
+		t.Fatal(err)
+	}
+
+	snapshot := readZipSnapshot(t, zipPath)
+	assertZipEntryContent(t, snapshot, "shared/bg.png", "bg")
+	assertZipEntryContent(t, snapshot, "shared/audio/theme.mp3", "theme")
+	assertZipEntryContent(t, snapshot, "shared/audio/ring.wav", "ring")
+	assertZipEntryContent(t, snapshot, "shared/maps/map.json", "{}")
+	assertZipEntryContent(t, snapshot, "extasset/hero.png", "hero")
+	assertZipEntryContent(t, snapshot, "extasset/shared.png", "local")
+
+	if snapshot.counts["extasset/shared.png"] != 1 {
+		t.Fatalf("extasset/shared.png count = %d, want 1", snapshot.counts["extasset/shared.png"])
+	}
+	if _, exists := snapshot.counts[filepath.Base(escapeDir)+"/ignored.png"]; exists {
+		t.Fatalf("unexpected escaped asset %q in zip", filepath.Base(escapeDir)+"/ignored.png")
+	}
+	for name := range snapshot.counts {
+		if strings.HasPrefix(name, "../") {
+			t.Fatalf("unexpected zip entry %q", name)
+		}
+	}
+}
+
+func TestPackProjectFailsOnMissingExternalAsset(t *testing.T) {
+	tmpDir := t.TempDir()
+	projectDir := filepath.Join(tmpDir, "Game")
+
+	writeTestFile(t, filepath.Join(projectDir, "assets", "index.json"), `{
+  "backdrops":[{"path":"../../shared/missing.png"}],
+  "map":{"width":480,"height":360}
+}`)
+
+	zipPath := filepath.Join(tmpDir, "game.zip")
+	err := PackProject(projectDir, zipPath)
+	if err == nil {
+		t.Fatal("PackProject() error = nil, want missing external asset error")
+	}
+	if !strings.Contains(err.Error(), "missing.png") {
+		t.Fatalf("PackProject() error = %q, want mention of missing.png", err)
+	}
+}
+
+type zipSnapshot struct {
+	counts   map[string]int
+	contents map[string]string
+}
+
+func readZipSnapshot(t *testing.T, zipPath string) zipSnapshot {
+	t.Helper()
+
+	reader, err := zip.OpenReader(zipPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reader.Close()
+
+	snapshot := zipSnapshot{
+		counts:   make(map[string]int),
+		contents: make(map[string]string),
+	}
+	for _, file := range reader.File {
+		snapshot.counts[file.Name]++
+		if file.FileInfo().IsDir() {
+			continue
+		}
+
+		content, err := readZipFile(file)
+		if err != nil {
+			t.Fatal(err)
+		}
+		snapshot.contents[file.Name] = content
+	}
+	return snapshot
+}
+
+func readZipFile(file *zip.File) (string, error) {
+	reader, err := file.Open()
+	if err != nil {
+		return "", err
+	}
+
+	data, readErr := io.ReadAll(reader)
+	closeErr := reader.Close()
+	if readErr != nil {
+		return "", readErr
+	}
+	if closeErr != nil {
+		return "", closeErr
+	}
+	return string(data), nil
+}
+
+func assertZipEntryContent(t *testing.T, snapshot zipSnapshot, name, want string) {
+	t.Helper()
+
+	if snapshot.counts[name] != 1 {
+		t.Fatalf("%s count = %d, want 1", name, snapshot.counts[name])
+	}
+	if got := snapshot.contents[name]; got != want {
+		t.Fatalf("%s content = %q, want %q", name, got, want)
+	}
+}
+
+func writeTestFile(t *testing.T, filePath string, content string) {
+	t.Helper()
+
+	if err := os.MkdirAll(filepath.Dir(filePath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filePath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/cmd/gox/pkg/pack/project_paths.go
+++ b/cmd/gox/pkg/pack/project_paths.go
@@ -1,0 +1,306 @@
+package pack
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	spxfs "github.com/goplus/spx/v2/fs"
+	coreproject "github.com/goplus/spx/v2/internal/core/project"
+)
+
+const (
+	projectConfigName = ".config"
+	// engineExtAssetDir is the fixed zip-internal directory name used by the web runtime.
+	engineExtAssetDir = "extasset"
+	// sharedAssetEscapeDepth counts how many leading ".." segments are needed to leave <project>/assets.
+	sharedAssetEscapeDepth = 2
+)
+
+type assetProjectConfig struct {
+	// ExtAsset is the user-configured source directory name on disk.
+	// Packed entries are still rewritten into engineExtAssetDir.
+	ExtAsset string `json:"extasset"`
+}
+
+type assetPathRef struct {
+	configDir string
+	path      string
+}
+
+// collectExternalAssetPaths mirrors the runtime's shared-resource compatibility rules
+// so runweb packs files that are referenced outside assets/ but still loadable at runtime.
+func collectExternalAssetPaths(baseFolder string, existingZipPaths map[string]struct{}) ([]DirInfos, error) {
+	assetRoot := filepath.Join(baseFolder, "assets")
+	info, err := os.Stat(assetRoot)
+	if os.IsNotExist(err) || (err == nil && !info.IsDir()) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	refs, err := collectAssetPathRefs(assetRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	extAssetDir, err := readExtAssetDir(baseFolder)
+	if err != nil {
+		return nil, err
+	}
+
+	seen := make(map[string]struct{}, len(existingZipPaths))
+	for zipPath := range existingZipPaths {
+		seen[zipPath] = struct{}{}
+	}
+
+	assetRoot = cleanFilesystemPath(assetRoot)
+	compatibilityRoot := sharedAssetCompatibilityRoot(assetRoot)
+
+	var extraPaths []DirInfos
+	for _, ref := range refs {
+		normalized := normalizeConfigPath(ref.configDir, ref.path)
+		sourcePath, zipPath, ok := resolveExternalAssetPath(assetRoot, compatibilityRoot, extAssetDir, normalized)
+		if !ok {
+			continue
+		}
+		if _, exists := seen[zipPath]; exists {
+			continue
+		}
+
+		info, err := os.Stat(sourcePath)
+		if err != nil {
+			return nil, fmt.Errorf("stat external asset %s referenced by %q: %w", sourcePath, normalized, err)
+		}
+		if info.IsDir() {
+			return nil, fmt.Errorf("external asset %s referenced by %q is a directory", sourcePath, normalized)
+		}
+
+		seen[zipPath] = struct{}{}
+		extraPaths = append(extraPaths, DirInfos{path: sourcePath, info: info, zipPath: zipPath})
+	}
+
+	return extraPaths, nil
+}
+
+func collectAssetPathRefs(assetRoot string) ([]assetPathRef, error) {
+	var refs []assetPathRef
+
+	projectConfigPath := filepath.Join(assetRoot, "index.json")
+	if _, err := os.Stat(projectConfigPath); err != nil {
+		if !os.IsNotExist(err) {
+			return nil, fmt.Errorf("stat %s: %w", projectConfigPath, err)
+		}
+	} else {
+		var conf coreproject.ProjectConfig
+		if err := readJSONFile(projectConfigPath, &conf); err != nil {
+			return nil, fmt.Errorf("parse %s: %w", projectConfigPath, err)
+		}
+		for _, backdrop := range conf.Backdrops {
+			if backdrop != nil {
+				refs = appendAssetPathRef(refs, "", backdrop.Path)
+			}
+		}
+		refs = appendAssetPathRef(refs, "", conf.Bgm)
+		refs = appendAssetPathRef(refs, "", conf.TilemapPath)
+	}
+
+	spriteConfigPaths, err := filepath.Glob(filepath.Join(assetRoot, "sprites", "*", "index.json"))
+	if err != nil {
+		return nil, err
+	}
+	for _, spriteConfigPath := range spriteConfigPaths {
+		configDir, err := relConfigDir(assetRoot, filepath.Dir(spriteConfigPath))
+		if err != nil {
+			return nil, err
+		}
+
+		var conf coreproject.SpriteConfig
+		if err := readJSONFile(spriteConfigPath, &conf); err != nil {
+			return nil, fmt.Errorf("parse %s: %w", spriteConfigPath, err)
+		}
+
+		for _, costume := range conf.Costumes {
+			if costume != nil {
+				refs = appendAssetPathRef(refs, configDir, costume.Path)
+			}
+		}
+		if conf.CostumeSet != nil && conf.CostumeSet.Path != "" {
+			refs = appendAssetPathRef(refs, configDir, conf.CostumeSet.Path)
+		}
+		if conf.CostumeMPSet != nil && conf.CostumeMPSet.Path != "" {
+			refs = appendAssetPathRef(refs, configDir, conf.CostumeMPSet.Path)
+		}
+	}
+
+	soundConfigPaths, err := filepath.Glob(filepath.Join(assetRoot, "sounds", "*", "index.json"))
+	if err != nil {
+		return nil, err
+	}
+	for _, soundConfigPath := range soundConfigPaths {
+		configDir, err := relConfigDir(assetRoot, filepath.Dir(soundConfigPath))
+		if err != nil {
+			return nil, err
+		}
+
+		var conf coreproject.SoundConfig
+		if err := readJSONFile(soundConfigPath, &conf); err != nil {
+			return nil, fmt.Errorf("parse %s: %w", soundConfigPath, err)
+		}
+		refs = appendAssetPathRef(refs, configDir, conf.Path)
+	}
+
+	return refs, nil
+}
+
+func appendAssetPathRef(refs []assetPathRef, configDir, relPath string) []assetPathRef {
+	if relPath == "" {
+		return refs
+	}
+	return append(refs, assetPathRef{configDir: configDir, path: relPath})
+}
+
+// resolveExternalAssetPath keeps pack-time path handling aligned with internal/engine/path.go.
+func resolveExternalAssetPath(assetRoot, compatibilityRoot, extAssetDir, relPath string) (string, string, bool) {
+	if relPath == "" || strings.HasPrefix(relPath, "/") {
+		return "", "", false
+	}
+	if schema, _ := spxfs.SplitSchema(relPath); schema != "" {
+		return "", "", false
+	}
+
+	sourcePath := cleanFilesystemPath(filepath.Join(assetRoot, filepath.FromSlash(relPath)))
+	if zipPath := rewriteExtAssetZipPath(relPath, extAssetDir); zipPath != "" {
+		if isWithinRoot(sourcePath, compatibilityRoot) {
+			return sourcePath, zipPath, true
+		}
+		return "", "", false
+	}
+
+	if isWithinRoot(sourcePath, assetRoot) {
+		return "", "", false
+	}
+	// Preserve legacy shared resources referenced from outside <project>/assets.
+	// assets/ sits one level below the project root, so at least two ".." segments
+	// are required before the path can reach the shared parent directory.
+	if leadingParentCount(relPath) < sharedAssetEscapeDepth || !isWithinRoot(sourcePath, compatibilityRoot) {
+		return "", "", false
+	}
+
+	zipPath, err := filepath.Rel(compatibilityRoot, sourcePath)
+	if err != nil {
+		return "", "", false
+	}
+	zipPath = normalizeZipPath(zipPath)
+	if zipPath == "." || strings.HasPrefix(zipPath, "../") {
+		return "", "", false
+	}
+	return sourcePath, zipPath, true
+}
+
+// rewriteExtAssetZipPath rewrites a user-configured extasset source path to the
+// fixed engineExtAssetDir zip location expected by the web runtime.
+func rewriteExtAssetZipPath(relPath, extAssetDir string) string {
+	if extAssetDir == "" {
+		return ""
+	}
+
+	segments := strings.Split(cleanFilesystemPath(relPath), "/")
+	leadingParents := 0
+	for i, segment := range segments {
+		if segment == "" {
+			continue
+		}
+		if segment == ".." {
+			leadingParents++
+			continue
+		}
+		if segment != extAssetDir || leadingParents == 0 {
+			return ""
+		}
+
+		suffix := filepath.Join(segments[i+1:]...)
+		return normalizeZipPath(filepath.Join(engineExtAssetDir, suffix))
+	}
+
+	return ""
+}
+
+func readExtAssetDir(baseFolder string) (string, error) {
+	configPath := filepath.Join(baseFolder, projectConfigName)
+	if _, err := os.Stat(configPath); os.IsNotExist(err) {
+		return "", nil
+	} else if err != nil {
+		return "", err
+	}
+
+	var conf assetProjectConfig
+	if err := readJSONFile(configPath, &conf); err != nil {
+		return "", fmt.Errorf("parse %s: %w", configPath, err)
+	}
+	return conf.ExtAsset, nil
+}
+
+func readJSONFile(filePath string, v any) error {
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(data, v)
+}
+
+func relConfigDir(assetRoot, configDir string) (string, error) {
+	rel, err := filepath.Rel(assetRoot, configDir)
+	if err != nil {
+		return "", err
+	}
+	return normalizeZipPath(rel), nil
+}
+
+// normalizeConfigPath mirrors internal/core/project/resources.go:normalizeConfigPath
+// so build-time packing and runtime loading resolve asset references identically.
+func normalizeConfigPath(configDir, relPath string) string {
+	if relPath == "" {
+		return ""
+	}
+	if strings.HasPrefix(relPath, "/") {
+		return relPath
+	}
+	if schema, _ := spxfs.SplitSchema(relPath); schema != "" {
+		return relPath
+	}
+	return path.Clean(path.Join(configDir, relPath))
+}
+
+func cleanFilesystemPath(path string) string {
+	return normalizeZipPath(filepath.Clean(path))
+}
+
+func sharedAssetCompatibilityRoot(assetRoot string) string {
+	return cleanFilesystemPath(filepath.Join(assetRoot, "..", ".."))
+}
+
+func isWithinRoot(path, root string) bool {
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return false
+	}
+	rel = normalizeZipPath(rel)
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, "../"))
+}
+
+func leadingParentCount(relPath string) int {
+	segments := strings.Split(cleanFilesystemPath(relPath), "/")
+	count := 0
+	for _, segment := range segments {
+		if segment != ".." {
+			break
+		}
+		count++
+	}
+	return count
+}


### PR DESCRIPTION
Fix `spx runweb` asset path resolution for projects that reference shared resources outside `assets/`, such as `../../../../res/monkey.png` in `test/All`.

The web export previously only packed files physically under the project directory into `game.zip`, so shared resources like `test/res/monkey.png` were missing from the web bundle and runtime loading failed with errors like:

`Error opening file 'engine/res/monkey.png'`