### PR TITLE
fix: stop stale runweb servers across projects

### DIFF
--- a/cmd/gox/pkg/command/run.go
+++ b/cmd/gox/pkg/command/run.go
@@ -1,7 +1,10 @@
 package command
 
 import (
+	"encoding/json"
+	"errors"
 	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"path"
@@ -17,6 +20,21 @@ import (
 type projConf struct {
 	Robots []string `json:"robots"`
 }
+
+const defaultWebServerPort = 8005
+
+type webServerPIDRecord struct {
+	PID          int    `json:"pid"`
+	LocalPIDPath string `json:"localPidPath,omitempty"`
+}
+
+var (
+	isPortAvailableFn    = isPortAvailable
+	findListeningPIDsFn  = findListeningPIDs
+	processCommandLineFn = processCommandLine
+	killPIDFn            = killPID
+	waitForPortFreeFn    = waitForPortFree
+)
 
 func (pself *CmdTool) Run(arg string) (err error) {
 	return util.RunCommandInDir(pself.ProjectDir, pself.CmdPath, arg)
@@ -74,8 +92,82 @@ func (pself *CmdTool) webServerPIDPath() string {
 	return pidPath
 }
 
+func (pself *CmdTool) webServerPort() int {
+	if pself.ServerPort != 0 {
+		return pself.ServerPort
+	}
+	return defaultWebServerPort
+}
+
+func (pself *CmdTool) globalWebServerPIDPath() string {
+	return filepath.Join(os.TempDir(), fmt.Sprintf("gdspx_web_server_%d.pid", pself.webServerPort()))
+}
+
+func (pself *CmdTool) webServerPIDPaths() []string {
+	paths := []string{pself.webServerPIDPath()}
+	globalPIDPath := pself.globalWebServerPIDPath()
+	if globalPIDPath != paths[0] {
+		paths = append(paths, globalPIDPath)
+	}
+	return paths
+}
+
+func (pself *CmdTool) writeWebServerPIDFiles(pid int) error {
+	localPIDPath := pself.webServerPIDPath()
+	pidBytes := []byte(strconv.Itoa(pid))
+	if err := os.WriteFile(localPIDPath, pidBytes, 0644); err != nil {
+		return fmt.Errorf("failed to record web server pid: %w", err)
+	}
+
+	recordBytes, err := json.Marshal(webServerPIDRecord{
+		PID:          pid,
+		LocalPIDPath: localPIDPath,
+	})
+	if err != nil {
+		_ = os.Remove(localPIDPath)
+		return fmt.Errorf("failed to marshal web server pid record: %w", err)
+	}
+	if err := os.WriteFile(pself.globalWebServerPIDPath(), recordBytes, 0644); err != nil {
+		_ = os.Remove(localPIDPath)
+		return fmt.Errorf("failed to record global web server pid: %w", err)
+	}
+	return nil
+}
+
+func (pself *CmdTool) cleanupWebServerPIDFiles(paths map[string]struct{}) {
+	for _, pidPath := range pself.webServerPIDPaths() {
+		paths[pidPath] = struct{}{}
+	}
+	for pidPath := range paths {
+		if pidPath == "" {
+			continue
+		}
+		_ = os.Remove(pidPath)
+	}
+}
+
+func (pself *CmdTool) readWebServerPIDRecord(pidPath string) (webServerPIDRecord, error) {
+	pidBytes, err := os.ReadFile(pidPath)
+	if err != nil {
+		return webServerPIDRecord{}, err
+	}
+
+	if pidPath == pself.globalWebServerPIDPath() {
+		var record webServerPIDRecord
+		if err := json.Unmarshal(pidBytes, &record); err == nil && record.PID > 0 {
+			return record, nil
+		}
+	}
+
+	pid, err := strconv.Atoi(strings.TrimSpace(string(pidBytes)))
+	if err != nil {
+		return webServerPIDRecord{}, err
+	}
+	return webServerPIDRecord{PID: pid}, nil
+}
+
 func (pself *CmdTool) runWebServer() error {
-	port := pself.ServerPort
+	port := pself.webServerPort()
 	if err := pself.StopWeb(); err != nil {
 		return err
 	}
@@ -100,9 +192,9 @@ func (pself *CmdTool) runWebServer() error {
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("error starting server: %v", err)
 	}
-	if err := os.WriteFile(pself.webServerPIDPath(), []byte(strconv.Itoa(cmd.Process.Pid)), 0644); err != nil {
+	if err := pself.writeWebServerPIDFiles(cmd.Process.Pid); err != nil {
 		_ = cmd.Process.Kill()
-		return fmt.Errorf("failed to record web server pid: %w", err)
+		return err
 	}
 
 	done := make(chan error, 1)
@@ -112,7 +204,7 @@ func (pself *CmdTool) runWebServer() error {
 
 	select {
 	case err := <-done:
-		_ = os.Remove(pself.webServerPIDPath())
+		pself.cleanupWebServerPIDFiles(map[string]struct{}{})
 		if err != nil {
 			return fmt.Errorf("web server exited early: %w", err)
 		}
@@ -126,26 +218,191 @@ func (pself *CmdTool) runWebServer() error {
 }
 
 func (pself *CmdTool) StopWeb() (err error) {
-	pidBytes, readErr := os.ReadFile(pself.webServerPIDPath())
-	if os.IsNotExist(readErr) {
+	stopped := make(map[int]struct{})
+	cleanupPaths := make(map[string]struct{})
+	for _, pidPath := range pself.webServerPIDPaths() {
+		cleanupPaths[pidPath] = struct{}{}
+
+		record, readErr := pself.readWebServerPIDRecord(pidPath)
+		if os.IsNotExist(readErr) {
+			continue
+		}
+		if readErr != nil {
+			continue
+		}
+		if record.LocalPIDPath != "" {
+			cleanupPaths[record.LocalPIDPath] = struct{}{}
+		}
+		if record.PID <= 0 {
+			continue
+		}
+		if _, ok := stopped[record.PID]; ok {
+			continue
+		}
+		stoppedServer, stopErr := stopRecordedWebServerPID(record.PID)
+		if stopErr != nil {
+			pself.cleanupWebServerPIDFiles(cleanupPaths)
+			return stopErr
+		}
+		if stoppedServer {
+			stopped[record.PID] = struct{}{}
+		}
+	}
+
+	defer pself.cleanupWebServerPIDFiles(cleanupPaths)
+	return pself.stopWebServerOnPort(stopped)
+}
+
+func stopRecordedWebServerPID(pid int) (bool, error) {
+	if pid <= 0 {
+		return false, nil
+	}
+
+	cmdline, err := processCommandLineFn(pid)
+	if err != nil && runtime.GOOS != "windows" {
+		return false, nil
+	}
+	if cmdline != "" && !isGdspxWebServerCommand(cmdline) {
+		return false, nil
+	}
+
+	if err := killPIDFn(pid); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func (pself *CmdTool) stopWebServerOnPort(stopped map[int]struct{}) error {
+	port := pself.webServerPort()
+	if port <= 0 {
 		return nil
 	}
-	if readErr != nil {
-		return fmt.Errorf("failed to read web server pid: %w", readErr)
-	}
 
-	pid, convErr := strconv.Atoi(strings.TrimSpace(string(pidBytes)))
-	if convErr != nil {
-		_ = os.Remove(pself.webServerPIDPath())
+	if len(stopped) > 0 {
+		if err := waitForPortFreeFn(port, 1500*time.Millisecond); err == nil {
+			return nil
+		}
+	}
+	if isPortAvailableFn(port) {
 		return nil
 	}
 
-	process, findErr := os.FindProcess(pid)
-	if findErr == nil {
-		_ = process.Kill()
+	listeningPIDs, err := findListeningPIDsFn(port)
+	if err == nil {
+		for _, pid := range listeningPIDs {
+			if _, ok := stopped[pid]; ok {
+				continue
+			}
+			cmdline, cmdErr := processCommandLineFn(pid)
+			if cmdErr != nil || !isGdspxWebServerCommand(cmdline) {
+				continue
+			}
+			if killErr := killPIDFn(pid); killErr != nil {
+				return killErr
+			}
+			stopped[pid] = struct{}{}
+		}
+		if len(stopped) > 0 {
+			if err := waitForPortFreeFn(port, 2*time.Second); err == nil {
+				return nil
+			}
+		}
 	}
 
-	_ = os.Remove(pself.webServerPIDPath())
+	if isPortAvailableFn(port) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("port %d is already in use and the existing gdspx web server could not be identified: %w", port, err)
+	}
+	return fmt.Errorf("port %d is already in use by another process", port)
+}
+
+func isGdspxWebServerCommand(cmdline string) bool {
+	return strings.Contains(cmdline, "gdspx_web_server.py")
+}
+
+func isPortAvailable(port int) bool {
+	ln, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	if err != nil {
+		return false
+	}
+	_ = ln.Close()
+	return true
+}
+
+func waitForPortFree(port int, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if isPortAvailableFn(port) {
+			return nil
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if isPortAvailableFn(port) {
+		return nil
+	}
+	return fmt.Errorf("timed out waiting for port %d to become available", port)
+}
+
+func findListeningPIDs(port int) ([]int, error) {
+	switch runtime.GOOS {
+	case "windows":
+		return nil, errors.New("listing listening pids is not supported on windows")
+	default:
+		return findListeningPIDsUnix(port)
+	}
+}
+
+func findListeningPIDsUnix(port int) ([]int, error) {
+	cmd := exec.Command("lsof", "-nP", fmt.Sprintf("-iTCP:%d", port), "-sTCP:LISTEN", "-t")
+	output, err := cmd.Output()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	var pids []int
+	for _, field := range strings.Fields(string(output)) {
+		pid, convErr := strconv.Atoi(strings.TrimSpace(field))
+		if convErr != nil {
+			continue
+		}
+		pids = append(pids, pid)
+	}
+	return pids, nil
+}
+
+func processCommandLine(pid int) (string, error) {
+	switch runtime.GOOS {
+	case "windows":
+		cmd := exec.Command("powershell", "-NoProfile", "-Command", fmt.Sprintf("(Get-CimInstance Win32_Process -Filter \"ProcessId = %d\").CommandLine", pid))
+		output, err := cmd.Output()
+		if err != nil {
+			return "", err
+		}
+		return strings.TrimSpace(string(output)), nil
+	default:
+		cmd := exec.Command("ps", "-p", strconv.Itoa(pid), "-o", "command=")
+		output, err := cmd.Output()
+		if err != nil {
+			return "", err
+		}
+		return strings.TrimSpace(string(output)), nil
+	}
+}
+
+func killPID(pid int) error {
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return err
+	}
+	if err := process.Kill(); err != nil && !errors.Is(err, os.ErrProcessDone) {
+		return err
+	}
 	return nil
 }
 

--- a/cmd/gox/pkg/command/run_test.go
+++ b/cmd/gox/pkg/command/run_test.go
@@ -2,10 +2,12 @@ package command
 
 import (
 	"errors"
+	"net"
 	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
+	"time"
 )
 
 func TestRunWebCommandRunsExportBeforeServer(t *testing.T) {
@@ -75,7 +77,7 @@ func TestIsRuntimeModeCommand(t *testing.T) {
 
 func TestStopWebIgnoresInvalidPIDFile(t *testing.T) {
 	targetDir := t.TempDir()
-	cmd := CmdTool{TargetDir: targetDir}
+	cmd := CmdTool{TargetDir: targetDir, ServerPort: freeTCPPort(t)}
 	pidFile := filepath.Join(targetDir, ".gdspx_web_server.pid")
 	if err := os.WriteFile(pidFile, []byte("invalid"), 0644); err != nil {
 		t.Fatalf("write pid file: %v", err)
@@ -87,4 +89,132 @@ func TestStopWebIgnoresInvalidPIDFile(t *testing.T) {
 	if _, err := os.Stat(pidFile); !os.IsNotExist(err) {
 		t.Fatalf("pid file should be removed, stat err = %v", err)
 	}
+}
+
+func TestStopWebStopsProcessFromGlobalPIDFile(t *testing.T) {
+	port := freeTCPPort(t)
+	targetDirA := t.TempDir()
+	targetDirB := t.TempDir()
+	cmd := CmdTool{TargetDir: targetDirB, ServerPort: port}
+	localPIDPath := filepath.Join(targetDirA, ".gdspx_web_server.pid")
+	recordBytes := []byte(`{"pid":31337,"localPidPath":"` + localPIDPath + `"}`)
+	if err := os.WriteFile(localPIDPath, []byte("31337"), 0644); err != nil {
+		t.Fatalf("write local pid file: %v", err)
+	}
+	if err := os.WriteFile(cmd.globalWebServerPIDPath(), recordBytes, 0644); err != nil {
+		t.Fatalf("write global pid file: %v", err)
+	}
+
+	origProcessCommandLine := processCommandLineFn
+	origKillPID := killPIDFn
+	t.Cleanup(func() {
+		processCommandLineFn = origProcessCommandLine
+		killPIDFn = origKillPID
+	})
+
+	processCommandLineFn = func(pid int) (string, error) {
+		if pid != 31337 {
+			t.Fatalf("unexpected pid lookup: %d", pid)
+		}
+		return "/usr/bin/python3 /tmp/gdspx_web_server.py -p 8005", nil
+	}
+	killed := false
+	killPIDFn = func(pid int) error {
+		if pid != 31337 {
+			t.Fatalf("unexpected pid kill: %d", pid)
+		}
+		killed = true
+		return nil
+	}
+
+	if err := cmd.StopWeb(); err != nil {
+		t.Fatalf("StopWeb returned error: %v", err)
+	}
+	if !killed {
+		t.Fatal("expected StopWeb to kill the process recorded in the global pid file")
+	}
+	if _, err := os.Stat(localPIDPath); !os.IsNotExist(err) {
+		t.Fatalf("local pid file should be removed, stat err = %v", err)
+	}
+	if _, err := os.Stat(cmd.globalWebServerPIDPath()); !os.IsNotExist(err) {
+		t.Fatalf("global pid file should be removed, stat err = %v", err)
+	}
+}
+
+func TestStopWebKillsGdspxServerByPortWhenPIDFilesMissing(t *testing.T) {
+	origIsPortAvailable := isPortAvailableFn
+	origFindListeningPIDs := findListeningPIDsFn
+	origProcessCommandLine := processCommandLineFn
+	origKillPID := killPIDFn
+	origWaitForPortFree := waitForPortFreeFn
+	t.Cleanup(func() {
+		isPortAvailableFn = origIsPortAvailable
+		findListeningPIDsFn = origFindListeningPIDs
+		processCommandLineFn = origProcessCommandLine
+		killPIDFn = origKillPID
+		waitForPortFreeFn = origWaitForPortFree
+	})
+
+	isPortAvailableFn = func(port int) bool { return false }
+	findListeningPIDsFn = func(port int) ([]int, error) { return []int{4242}, nil }
+	processCommandLineFn = func(pid int) (string, error) {
+		return "/usr/bin/python3 /tmp/gdspx_web_server.py -p 8005", nil
+	}
+	var killed []int
+	killPIDFn = func(pid int) error {
+		killed = append(killed, pid)
+		return nil
+	}
+	waitForPortFreeFn = func(port int, timeout time.Duration) error { return nil }
+
+	cmd := CmdTool{TargetDir: t.TempDir(), ServerPort: freeTCPPort(t)}
+	if err := cmd.StopWeb(); err != nil {
+		t.Fatalf("StopWeb returned error: %v", err)
+	}
+	if !reflect.DeepEqual(killed, []int{4242}) {
+		t.Fatalf("killed pids = %v, want [4242]", killed)
+	}
+}
+
+func TestStopWebDoesNotKillNonGdspxProcessOnPort(t *testing.T) {
+	origIsPortAvailable := isPortAvailableFn
+	origFindListeningPIDs := findListeningPIDsFn
+	origProcessCommandLine := processCommandLineFn
+	origKillPID := killPIDFn
+	t.Cleanup(func() {
+		isPortAvailableFn = origIsPortAvailable
+		findListeningPIDsFn = origFindListeningPIDs
+		processCommandLineFn = origProcessCommandLine
+		killPIDFn = origKillPID
+	})
+
+	isPortAvailableFn = func(port int) bool { return false }
+	findListeningPIDsFn = func(port int) ([]int, error) { return []int{5252}, nil }
+	processCommandLineFn = func(pid int) (string, error) {
+		return "/usr/bin/python3 /tmp/other_server.py -p 8005", nil
+	}
+	killed := false
+	killPIDFn = func(pid int) error {
+		killed = true
+		return nil
+	}
+
+	cmd := CmdTool{TargetDir: t.TempDir(), ServerPort: freeTCPPort(t)}
+	if err := cmd.StopWeb(); err == nil {
+		t.Fatal("StopWeb should fail when the port is occupied by a non-gdspx process")
+	}
+	if killed {
+		t.Fatal("StopWeb should not kill a non-gdspx process")
+	}
+}
+
+func freeTCPPort(t *testing.T) int {
+	t.Helper()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen on ephemeral port: %v", err)
+	}
+	defer ln.Close()
+	return ln.Addr().(*net.TCPAddr).Port
 }


### PR DESCRIPTION
Fix `spx runweb` failing with `OSError: [Errno 48] Address already in use` when switching between different projects on the same web port.

Before this change, `runweb` only stopped the web server recorded in the current project's `.gdspx_web_server.pid`.
If project A started a server first and project B later ran `spx runweb` on the same port, B could not stop A's server because A's pid file lived in a different project directory.
