### PR TITLE
refactor event bucket dispatch helpers

### DIFF
--- a/internal/core/event/dispatch.go
+++ b/internal/core/event/dispatch.go
@@ -7,6 +7,34 @@ type DispatchHooks struct {
 	Wait  func(func())
 }
 
+func (m *Manager) DispatchBucketAsync(bucket Bucket, start bool, data any, hooks DispatchHooks, do func(*Sink)) {
+	if m == nil {
+		return
+	}
+	DispatchAsync(m.Snapshot(bucket), start, data, hooks, do)
+}
+
+func (m *Manager) DispatchBucketSync(bucket Bucket, data any, hooks DispatchHooks, do func(*Sink)) {
+	if m == nil {
+		return
+	}
+	DispatchSync(m.Snapshot(bucket), data, hooks, do)
+}
+
+func (m *Manager) DispatchBucket(bucket Bucket, wait bool, data any, hooks DispatchHooks, do func(*Sink)) {
+	if m == nil {
+		return
+	}
+	Dispatch(m.Snapshot(bucket), wait, data, hooks, do)
+}
+
+func (m *Manager) DispatchStartOnce(start bool, data any, hooks DispatchHooks, do func(*Sink)) {
+	if m == nil {
+		return
+	}
+	DispatchAsync(m.SnapshotStartOnce(), start, data, hooks, do)
+}
+
 func DispatchAsync(sinks []Sink, start bool, data any, hooks DispatchHooks, do func(*Sink)) {
 	for _, sink := range sinks {
 		sink := sink

--- a/internal/core/event/dispatch.go
+++ b/internal/core/event/dispatch.go
@@ -7,6 +7,8 @@ type DispatchHooks struct {
 	Wait  func(func())
 }
 
+// DispatchBucketAsync snapshots the requested bucket and dispatches matching sinks asynchronously.
+// A nil Manager is treated as a no-op.
 func (m *Manager) DispatchBucketAsync(bucket Bucket, start bool, data any, hooks DispatchHooks, do func(*Sink)) {
 	if m == nil {
 		return
@@ -14,6 +16,8 @@ func (m *Manager) DispatchBucketAsync(bucket Bucket, start bool, data any, hooks
 	DispatchAsync(m.Snapshot(bucket), start, data, hooks, do)
 }
 
+// DispatchBucketSync snapshots the requested bucket and dispatches matching sinks synchronously.
+// A nil Manager is treated as a no-op.
 func (m *Manager) DispatchBucketSync(bucket Bucket, data any, hooks DispatchHooks, do func(*Sink)) {
 	if m == nil {
 		return
@@ -21,6 +25,9 @@ func (m *Manager) DispatchBucketSync(bucket Bucket, data any, hooks DispatchHook
 	DispatchSync(m.Snapshot(bucket), data, hooks, do)
 }
 
+// DispatchBucket snapshots the requested bucket and dispatches matching sinks.
+// When wait is true it waits for synchronous completion; otherwise it dispatches asynchronously.
+// A nil Manager is treated as a no-op.
 func (m *Manager) DispatchBucket(bucket Bucket, wait bool, data any, hooks DispatchHooks, do func(*Sink)) {
 	if m == nil {
 		return
@@ -28,6 +35,9 @@ func (m *Manager) DispatchBucket(bucket Bucket, wait bool, data any, hooks Dispa
 	Dispatch(m.Snapshot(bucket), wait, data, hooks, do)
 }
 
+// DispatchStartOnce dispatches BucketStart sinks at most once per Manager lifetime.
+// The start flag controls async spawn semantics independently from the once-only guarantee.
+// A nil Manager is treated as a no-op.
 func (m *Manager) DispatchStartOnce(start bool, data any, hooks DispatchHooks, do func(*Sink)) {
 	if m == nil {
 		return

--- a/internal/core/event/dispatch.go
+++ b/internal/core/event/dispatch.go
@@ -36,13 +36,13 @@ func (m *Manager) DispatchBucket(bucket Bucket, wait bool, data any, hooks Dispa
 }
 
 // DispatchStartOnce dispatches BucketStart sinks at most once per Manager lifetime.
-// The start flag controls async spawn semantics independently from the once-only guarantee.
+// After the first call, subsequent calls are no-ops.
 // A nil Manager is treated as a no-op.
-func (m *Manager) DispatchStartOnce(start bool, data any, hooks DispatchHooks, do func(*Sink)) {
+func (m *Manager) DispatchStartOnce(data any, hooks DispatchHooks, do func(*Sink)) {
 	if m == nil {
 		return
 	}
-	DispatchAsync(m.SnapshotStartOnce(), start, data, hooks, do)
+	DispatchAsync(m.SnapshotStartOnce(), false, data, hooks, do)
 }
 
 func DispatchAsync(sinks []Sink, start bool, data any, hooks DispatchHooks, do func(*Sink)) {

--- a/internal/core/event/dispatch_test.go
+++ b/internal/core/event/dispatch_test.go
@@ -192,16 +192,16 @@ func TestManagerDispatchStartOnce(t *testing.T) {
 	hooks := DispatchHooks{
 		Spawn: func(start bool, owner any, call func()) {
 			if start {
-				t.Fatal("DispatchStartOnce should not require start=true in this test")
+				t.Fatal("DispatchStartOnce should always dispatch with start=false")
 			}
 			call()
 		},
 	}
 
-	mgr.DispatchStartOnce(false, nil, hooks, func(sink *Sink) {
+	mgr.DispatchStartOnce(nil, hooks, func(sink *Sink) {
 		calls = append(calls, sink.Handler.(string))
 	})
-	mgr.DispatchStartOnce(false, nil, hooks, func(sink *Sink) {
+	mgr.DispatchStartOnce(nil, hooks, func(sink *Sink) {
 		calls = append(calls, sink.Handler.(string))
 	})
 

--- a/internal/core/event/dispatch_test.go
+++ b/internal/core/event/dispatch_test.go
@@ -109,3 +109,100 @@ func TestDispatchFallbackHooks(t *testing.T) {
 		t.Fatalf("calls = %+v, want [A]", calls)
 	}
 }
+
+func TestManagerDispatchBucketAsync(t *testing.T) {
+	var (
+		starts []bool
+		owners []string
+		calls  []string
+	)
+
+	var mgr Manager
+	mgr.Add(BucketClick, Sink{Owner: "a", Handler: "A"})
+	mgr.Add(BucketClick, Sink{
+		Owner:   "b",
+		Handler: "B",
+		Cond: func(data any) bool {
+			return data == "ok"
+		},
+	})
+
+	mgr.DispatchBucketAsync(BucketClick, true, "ok", DispatchHooks{
+		Spawn: func(start bool, owner any, call func()) {
+			starts = append(starts, start)
+			owners = append(owners, owner.(string))
+			call()
+		},
+	}, func(sink *Sink) {
+		calls = append(calls, sink.Handler.(string))
+	})
+
+	if len(starts) != 2 || !starts[0] || !starts[1] {
+		t.Fatalf("starts = %+v, want [true true]", starts)
+	}
+	if want := []string{"a", "b"}; len(owners) != len(want) || owners[0] != want[0] || owners[1] != want[1] {
+		t.Fatalf("owners = %+v, want %+v", owners, want)
+	}
+	if want := []string{"A", "B"}; len(calls) != len(want) || calls[0] != want[0] || calls[1] != want[1] {
+		t.Fatalf("calls = %+v, want %+v", calls, want)
+	}
+}
+
+func TestManagerDispatchBucketSync(t *testing.T) {
+	waited := false
+	var calls []string
+
+	var mgr Manager
+	mgr.Add(BucketTimer, Sink{Owner: "timer", Handler: "A"})
+
+	mgr.DispatchBucketSync(BucketTimer, 1.0, DispatchHooks{
+		Spawn: func(start bool, owner any, call func()) {
+			if start {
+				t.Fatal("DispatchBucketSync should not mark start=true")
+			}
+			call()
+		},
+		Wait: func(wait func()) {
+			waited = true
+			wait()
+		},
+	}, func(sink *Sink) {
+		calls = append(calls, sink.Handler.(string))
+	})
+
+	if !waited {
+		t.Fatal("expected wait hook to be called")
+	}
+	if len(calls) != 1 || calls[0] != "A" {
+		t.Fatalf("calls = %+v, want [A]", calls)
+	}
+}
+
+func TestManagerDispatchStartOnce(t *testing.T) {
+	var calls []string
+
+	var mgr Manager
+	if !mgr.TryAddStart(Sink{Owner: "game", Handler: "start"}) {
+		t.Fatal("expected start sink to be added")
+	}
+
+	hooks := DispatchHooks{
+		Spawn: func(start bool, owner any, call func()) {
+			if start {
+				t.Fatal("DispatchStartOnce should not require start=true in this test")
+			}
+			call()
+		},
+	}
+
+	mgr.DispatchStartOnce(false, nil, hooks, func(sink *Sink) {
+		calls = append(calls, sink.Handler.(string))
+	})
+	mgr.DispatchStartOnce(false, nil, hooks, func(sink *Sink) {
+		calls = append(calls, sink.Handler.(string))
+	})
+
+	if len(calls) != 1 || calls[0] != "start" {
+		t.Fatalf("calls = %+v, want [start]", calls)
+	}
+}

--- a/internal/core/event/dispatch_test.go
+++ b/internal/core/event/dispatch_test.go
@@ -1,6 +1,9 @@
 package event
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 func TestDispatchAsync(t *testing.T) {
 	var (
@@ -46,10 +49,10 @@ func TestDispatchAsync(t *testing.T) {
 	if len(starts) != 2 || !starts[0] || !starts[1] {
 		t.Fatalf("starts = %+v, want [true true]", starts)
 	}
-	if want := []string{"a", "b"}; len(owners) != len(want) || owners[0] != want[0] || owners[1] != want[1] {
+	if want := []string{"a", "b"}; !reflect.DeepEqual(owners, want) {
 		t.Fatalf("owners = %+v, want %+v", owners, want)
 	}
-	if want := []string{"A", "B"}; len(calls) != len(want) || calls[0] != want[0] || calls[1] != want[1] {
+	if want := []string{"A", "B"}; !reflect.DeepEqual(calls, want) {
 		t.Fatalf("calls = %+v, want %+v", calls, want)
 	}
 }
@@ -89,7 +92,7 @@ func TestDispatchSync(t *testing.T) {
 	if !waited {
 		t.Fatal("expected wait hook to be called")
 	}
-	if want := []string{"A", "B"}; len(calls) != len(want) || calls[0] != want[0] || calls[1] != want[1] {
+	if want := []string{"A", "B"}; !reflect.DeepEqual(calls, want) {
 		t.Fatalf("calls = %+v, want %+v", calls, want)
 	}
 }
@@ -140,10 +143,10 @@ func TestManagerDispatchBucketAsync(t *testing.T) {
 	if len(starts) != 2 || !starts[0] || !starts[1] {
 		t.Fatalf("starts = %+v, want [true true]", starts)
 	}
-	if want := []string{"a", "b"}; len(owners) != len(want) || owners[0] != want[0] || owners[1] != want[1] {
+	if want := []string{"a", "b"}; !reflect.DeepEqual(owners, want) {
 		t.Fatalf("owners = %+v, want %+v", owners, want)
 	}
-	if want := []string{"A", "B"}; len(calls) != len(want) || calls[0] != want[0] || calls[1] != want[1] {
+	if want := []string{"A", "B"}; !reflect.DeepEqual(calls, want) {
 		t.Fatalf("calls = %+v, want %+v", calls, want)
 	}
 }
@@ -173,8 +176,8 @@ func TestManagerDispatchBucketSync(t *testing.T) {
 	if !waited {
 		t.Fatal("expected wait hook to be called")
 	}
-	if len(calls) != 1 || calls[0] != "A" {
-		t.Fatalf("calls = %+v, want [A]", calls)
+	if want := []string{"A"}; !reflect.DeepEqual(calls, want) {
+		t.Fatalf("calls = %+v, want %+v", calls, want)
 	}
 }
 
@@ -202,7 +205,75 @@ func TestManagerDispatchStartOnce(t *testing.T) {
 		calls = append(calls, sink.Handler.(string))
 	})
 
-	if len(calls) != 1 || calls[0] != "start" {
-		t.Fatalf("calls = %+v, want [start]", calls)
+	if want := []string{"start"}; !reflect.DeepEqual(calls, want) {
+		t.Fatalf("calls = %+v, want %+v", calls, want)
 	}
+}
+
+func TestManagerDispatchBucket(t *testing.T) {
+	t.Run("async", func(t *testing.T) {
+		waited := false
+		var calls []string
+
+		var mgr Manager
+		mgr.Add(BucketIReceive, Sink{
+			Owner:   "msg",
+			Handler: "A",
+			Cond: func(data any) bool {
+				return data == "ok"
+			},
+		})
+
+		mgr.DispatchBucket(BucketIReceive, false, "ok", DispatchHooks{
+			Spawn: func(start bool, owner any, call func()) {
+				if start {
+					t.Fatal("DispatchBucket async path should not force start=true")
+				}
+				call()
+			},
+			Wait: func(wait func()) {
+				waited = true
+				wait()
+			},
+		}, func(sink *Sink) {
+			calls = append(calls, sink.Handler.(string))
+		})
+
+		if waited {
+			t.Fatal("wait hook should not be called for async DispatchBucket")
+		}
+		if want := []string{"A"}; !reflect.DeepEqual(calls, want) {
+			t.Fatalf("calls = %+v, want %+v", calls, want)
+		}
+	})
+
+	t.Run("sync", func(t *testing.T) {
+		waited := false
+		var calls []string
+
+		var mgr Manager
+		mgr.Add(BucketBackdropChanged, Sink{Owner: "backdrop", Handler: "B"})
+
+		mgr.DispatchBucket(BucketBackdropChanged, true, "stage", DispatchHooks{
+			Spawn: func(start bool, owner any, call func()) {
+				if start {
+					t.Fatal("DispatchBucket sync path should not force start=true")
+				}
+				call()
+			},
+			Wait: func(wait func()) {
+				waited = true
+				wait()
+			},
+		}, func(sink *Sink) {
+			calls = append(calls, sink.Handler.(string))
+		})
+
+		if !waited {
+			t.Fatal("expected wait hook to be called for sync DispatchBucket")
+		}
+		if want := []string{"B"}; !reflect.DeepEqual(calls, want) {
+			t.Fatalf("calls = %+v, want %+v", calls, want)
+		}
+	})
 }

--- a/internal/core/event/manager.go
+++ b/internal/core/event/manager.go
@@ -29,6 +29,9 @@ const (
 	bucketCount
 )
 
+// Manager groups event sinks by Bucket and tracks the one-time BucketStart lifecycle.
+// DispatchBucketAsync, DispatchBucketSync, DispatchBucket, and DispatchStartOnce
+// treat a nil receiver as a no-op.
 type Manager struct {
 	mu      sync.RWMutex
 	buckets [bucketCount][]Sink

--- a/runtime_events.go
+++ b/runtime_events.go
@@ -77,8 +77,8 @@ func (p *scriptEventRegistry) dispatch(bucket coreevent.Bucket, wait bool, data 
 	p.DispatchBucket(bucket, wait, data, scriptEventDispatchHooks, do)
 }
 
-func (p *scriptEventRegistry) dispatchStartOnce(start bool, data any, do func(*eventSink)) {
-	p.DispatchStartOnce(start, data, scriptEventDispatchHooks, do)
+func (p *scriptEventRegistry) dispatchStartOnce(data any, do func(*eventSink)) {
+	p.DispatchStartOnce(data, scriptEventDispatchHooks, do)
 }
 
 func (p *scriptEventBindings) doDeleteClone() {
@@ -323,7 +323,7 @@ func (p *Game) fireEvent(ev event) {
 // Event Dispatch
 // -----------------------------------------------------------------------------
 func (p *scriptEventRegistry) doWhenStart() {
-	p.dispatchStartOnce(false, nil, func(ev *eventSink) {
+	p.dispatchStartOnce(nil, func(ev *eventSink) {
 		coreevent.If0(isDebugEventEnabled, func() {
 			spxlog.Debug("==> onStart: %s", nameOf(ev.Owner))
 		})()

--- a/runtime_events.go
+++ b/runtime_events.go
@@ -55,6 +55,22 @@ func (p *scriptEventBindings) initFrom(src *scriptEventBindings, this threadObj)
 	p.pthis = this
 }
 
+func (p *scriptEventRegistry) dispatchAsync(bucket coreevent.Bucket, start bool, data any, do func(*eventSink)) {
+	p.DispatchBucketAsync(bucket, start, data, eventDispatchHooks(), do)
+}
+
+func (p *scriptEventRegistry) dispatchSync(bucket coreevent.Bucket, data any, do func(*eventSink)) {
+	p.DispatchBucketSync(bucket, data, eventDispatchHooks(), do)
+}
+
+func (p *scriptEventRegistry) dispatch(bucket coreevent.Bucket, wait bool, data any, do func(*eventSink)) {
+	p.DispatchBucket(bucket, wait, data, eventDispatchHooks(), do)
+}
+
+func (p *scriptEventRegistry) dispatchStartOnce(start bool, data any, do func(*eventSink)) {
+	p.DispatchStartOnce(start, data, eventDispatchHooks(), do)
+}
+
 func (p *scriptEventBindings) doDeleteClone() {
 	p.scriptEventRegistry.DeleteOwner(p.pthis)
 }
@@ -297,11 +313,7 @@ func (p *Game) fireEvent(ev event) {
 // Event Dispatch
 // -----------------------------------------------------------------------------
 func (p *scriptEventRegistry) doWhenStart() {
-	sinks := p.SnapshotStartOnce()
-	if len(sinks) == 0 {
-		return
-	}
-	coreevent.DispatchAsync(sinks, false, nil, eventDispatchHooks(), func(ev *eventSink) {
+	p.dispatchStartOnce(false, nil, func(ev *eventSink) {
 		coreevent.If0(isDebugEventEnabled, func() {
 			spxlog.Debug("==> onStart: %s", nameOf(ev.Owner))
 		})()
@@ -310,8 +322,7 @@ func (p *scriptEventRegistry) doWhenStart() {
 }
 
 func (p *scriptEventRegistry) doWhenAwake(this threadObj) {
-	sinks := p.SnapshotAwake()
-	coreevent.DispatchSync(sinks, this, eventDispatchHooks(), func(ev *eventSink) {
+	p.dispatchSync(coreevent.BucketAwake, this, func(ev *eventSink) {
 		coreevent.If0(isDebugEventEnabled, func() {
 			spxlog.Debug("==> onAwake: %s", nameOf(ev.Owner))
 		})()
@@ -320,22 +331,19 @@ func (p *scriptEventRegistry) doWhenAwake(this threadObj) {
 }
 
 func (p *scriptEventRegistry) doWhenTimer(time float64) {
-	sinks := p.SnapshotTimer()
-	coreevent.DispatchAsync(sinks, false, time, eventDispatchHooks(), func(ev *eventSink) {
+	p.dispatchAsync(coreevent.BucketTimer, false, time, func(ev *eventSink) {
 		ev.Handler.(func(float64))(time)
 	})
 }
 
 func (p *scriptEventRegistry) doWhenKeyPressed(key Key) {
-	sinks := p.SnapshotKeyPressed()
-	coreevent.DispatchAsync(sinks, false, key, eventDispatchHooks(), func(ev *eventSink) {
+	p.dispatchAsync(coreevent.BucketKeyPressed, false, key, func(ev *eventSink) {
 		ev.Handler.(func(Key))(key)
 	})
 }
 
 func (p *scriptEventRegistry) doWhenSwipe(direction Direction, this threadObj) {
-	sinks := p.SnapshotSwipe()
-	coreevent.DispatchAsync(sinks, false, direction, eventDispatchHooks(), func(ev *eventSink) {
+	p.dispatchAsync(coreevent.BucketSwipe, false, direction, func(ev *eventSink) {
 		if ev.Owner == this {
 			ev.Handler.(func(Direction))(direction)
 		}
@@ -343,8 +351,7 @@ func (p *scriptEventRegistry) doWhenSwipe(direction Direction, this threadObj) {
 }
 
 func (p *scriptEventRegistry) doWhenClick(this threadObj) {
-	sinks := p.SnapshotClick()
-	coreevent.DispatchAsync(sinks, false, this, eventDispatchHooks(), func(ev *eventSink) {
+	p.dispatchAsync(coreevent.BucketClick, false, this, func(ev *eventSink) {
 		coreevent.If0(isDebugEventEnabled, func() {
 			spxlog.Debug("==> onClick: %s", nameOf(this))
 		})()
@@ -353,8 +360,7 @@ func (p *scriptEventRegistry) doWhenClick(this threadObj) {
 }
 
 func (p *scriptEventRegistry) doWhenTouchStart(this threadObj, obj *SpriteImpl) {
-	sinks := p.SnapshotTouchStart()
-	coreevent.DispatchAsync(sinks, false, this, eventDispatchHooks(), func(ev *eventSink) {
+	p.dispatchAsync(coreevent.BucketTouchStart, false, this, func(ev *eventSink) {
 		coreevent.If0(isDebugEventEnabled, func() {
 			spxlog.Debug("===> onTouchStart: %s, %s", nameOf(this), obj.name)
 		})()
@@ -363,8 +369,7 @@ func (p *scriptEventRegistry) doWhenTouchStart(this threadObj, obj *SpriteImpl) 
 }
 
 func (p *scriptEventRegistry) doWhenTouching(this threadObj, obj *SpriteImpl) {
-	sinks := p.SnapshotTouching()
-	coreevent.DispatchAsync(sinks, false, this, eventDispatchHooks(), func(ev *eventSink) {
+	p.dispatchAsync(coreevent.BucketTouching, false, this, func(ev *eventSink) {
 		coreevent.If0(isDebugEventEnabled, func() {
 			spxlog.Debug("==> onTouching: %s, %s", nameOf(this), obj.name)
 		})()
@@ -373,8 +378,7 @@ func (p *scriptEventRegistry) doWhenTouching(this threadObj, obj *SpriteImpl) {
 }
 
 func (p *scriptEventRegistry) doWhenTouchEnd(this threadObj, obj *SpriteImpl) {
-	sinks := p.SnapshotTouchEnd()
-	coreevent.DispatchAsync(sinks, false, this, eventDispatchHooks(), func(ev *eventSink) {
+	p.dispatchAsync(coreevent.BucketTouchEnd, false, this, func(ev *eventSink) {
 		coreevent.If0(isDebugEventEnabled, func() {
 			spxlog.Debug("===> onTouchEnd: %s, %s", nameOf(this), obj.name)
 		})()
@@ -383,8 +387,7 @@ func (p *scriptEventRegistry) doWhenTouchEnd(this threadObj, obj *SpriteImpl) {
 }
 
 func (p *scriptEventRegistry) doWhenCloned(this threadObj, data any) {
-	sinks := p.SnapshotCloned()
-	coreevent.DispatchAsync(sinks, true, this, eventDispatchHooks(), func(ev *eventSink) {
+	p.dispatchAsync(coreevent.BucketCloned, true, this, func(ev *eventSink) {
 		coreevent.If0(isDebugEventEnabled, func() {
 			spxlog.Debug("==> onCloned: %s", nameOf(this))
 		})()
@@ -393,15 +396,13 @@ func (p *scriptEventRegistry) doWhenCloned(this threadObj, data any) {
 }
 
 func (p *scriptEventRegistry) doWhenIReceive(msg string, data any, wait bool) {
-	sinks := p.SnapshotIReceive()
-	coreevent.Dispatch(sinks, wait, msg, eventDispatchHooks(), func(ev *eventSink) {
+	p.dispatch(coreevent.BucketIReceive, wait, msg, func(ev *eventSink) {
 		ev.Handler.(func(string, any))(msg, data)
 	})
 }
 
 func (p *scriptEventRegistry) doWhenBackdropChanged(name BackdropName, wait bool) {
-	sinks := p.SnapshotBackdropChanged()
-	coreevent.Dispatch(sinks, wait, name, eventDispatchHooks(), func(ev *eventSink) {
+	p.dispatch(coreevent.BucketBackdropChanged, wait, name, func(ev *eventSink) {
 		ev.Handler.(func(BackdropName))(name)
 	})
 }

--- a/runtime_events.go
+++ b/runtime_events.go
@@ -31,6 +31,16 @@ const (
 	clickTimerStage  = 0
 )
 
+var scriptEventDispatchHooks = coreevent.DispatchHooks{
+	Spawn: func(start bool, owner any, call func()) {
+		gco.CreateAndStart(start, owner, func(coroutine.Thread) int {
+			call()
+			return 0
+		})
+	},
+	Wait: engine.WaitToDo,
+}
+
 // -----------------------------------------------------------------------------
 // Event Bindings
 // -----------------------------------------------------------------------------
@@ -56,19 +66,19 @@ func (p *scriptEventBindings) initFrom(src *scriptEventBindings, this threadObj)
 }
 
 func (p *scriptEventRegistry) dispatchAsync(bucket coreevent.Bucket, start bool, data any, do func(*eventSink)) {
-	p.DispatchBucketAsync(bucket, start, data, eventDispatchHooks(), do)
+	p.DispatchBucketAsync(bucket, start, data, scriptEventDispatchHooks, do)
 }
 
 func (p *scriptEventRegistry) dispatchSync(bucket coreevent.Bucket, data any, do func(*eventSink)) {
-	p.DispatchBucketSync(bucket, data, eventDispatchHooks(), do)
+	p.DispatchBucketSync(bucket, data, scriptEventDispatchHooks, do)
 }
 
 func (p *scriptEventRegistry) dispatch(bucket coreevent.Bucket, wait bool, data any, do func(*eventSink)) {
-	p.DispatchBucket(bucket, wait, data, eventDispatchHooks(), do)
+	p.DispatchBucket(bucket, wait, data, scriptEventDispatchHooks, do)
 }
 
 func (p *scriptEventRegistry) dispatchStartOnce(start bool, data any, do func(*eventSink)) {
-	p.DispatchStartOnce(start, data, eventDispatchHooks(), do)
+	p.DispatchStartOnce(start, data, scriptEventDispatchHooks, do)
 }
 
 func (p *scriptEventBindings) doDeleteClone() {
@@ -405,16 +415,4 @@ func (p *scriptEventRegistry) doWhenBackdropChanged(name BackdropName, wait bool
 	p.dispatch(coreevent.BucketBackdropChanged, wait, name, func(ev *eventSink) {
 		ev.Handler.(func(BackdropName))(name)
 	})
-}
-
-func eventDispatchHooks() coreevent.DispatchHooks {
-	return coreevent.DispatchHooks{
-		Spawn: func(start bool, owner any, call func()) {
-			gco.CreateAndStart(start, owner, func(coroutine.Thread) int {
-				call()
-				return 0
-			})
-		},
-		Wait: engine.WaitToDo,
-	}
 }


### PR DESCRIPTION
This PR reduces duplication in the runtime event layer by moving the repeated SnapshotX + DispatchAsync/Sync pattern into internal/core/event.