### PR TITLE
Track and sync demo gop.mod files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,18 +11,11 @@
 /.gocache/
 /_gsc/
 /_test/
-/gop.mod
 /go.work
 /go.json
 /gop.json
 /gop_autogen.go
 /xgo_autogen.go
-
-# Local scratch files
-/sprite.txt
-/game.txt
-/mv.sh
-/CLAUDE.md
 
 # Build outputs
 *.exe
@@ -35,7 +28,7 @@
 *.out
 
 # Temp directories
-/**/.temp/
+.temp/
 /.tmp/
 
 # Repo-local generated artifacts

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Config
 # ============================================
 .DEFAULT_GOAL := help
-.PHONY: help buildctl list-demos prepare-host prepare-web prepare-full build-dev install clean-assets download download-engine build-editor build-desktop build-web build-wasm build-wasm-opt build-android build-ios install-apk editor run rune run-web run-web-worker format generate export-pack export-web stop validate-web-mode validate-download-engine
+.PHONY: help buildctl list-demos prepare-host prepare-web prepare-full build-dev install clean-assets download download-engine build-editor build-desktop build-web build-wasm build-wasm-opt build-android build-ios install-apk editor run rune run-web run-web-worker format generate sync-gopmod export-pack export-web stop validate-web-mode validate-download-engine
 
 export GODOT_SRC
 
@@ -179,6 +179,13 @@ generate: ## Generate code
 	cd ./internal/cmd/codegen && GODOT_SRC="$(GODOT_SRC)" go run .
 	go generate ./cmd/spxrunner/runner
 	$(MAKE) format
+	$(MAKE) sync-gopmod
+
+sync-gopmod: ## Sync root gop.mod to all tutorial/test projects containing .spx
+	@find tutorial test -type f -name 'main.spx' -exec dirname {} \; | sort -u | while read -r dir; do \
+		cp gop.mod "$$dir/gop.mod" || exit 1; \
+		echo "synced $$dir/gop.mod"; \
+	done
 
 export-pack: ## Export runtime pck file
 	$(BUILDCTL_RUNTIME_CMD) export-pack

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,4 +1,5 @@
 /**/project
 /**/.gitignore
-*.mod
-*.sum
+go.mod
+go.sum
+gop.sum

--- a/test/All/gop.mod
+++ b/test/All/gop.mod
@@ -1,0 +1,7 @@
+xgo 1.6.0
+
+project main.spx Game github.com/goplus/spx/v2 math
+
+class -embed *.spx SpriteImpl
+
+runner github.com/goplus/spx/v2/cmd/spxrunner

--- a/test/Bananas/gop.mod
+++ b/test/Bananas/gop.mod
@@ -1,0 +1,7 @@
+xgo 1.6.0
+
+project main.spx Game github.com/goplus/spx/v2 math
+
+class -embed *.spx SpriteImpl
+
+runner github.com/goplus/spx/v2/cmd/spxrunner

--- a/test/Bullet/gop.mod
+++ b/test/Bullet/gop.mod
@@ -1,0 +1,7 @@
+xgo 1.6.0
+
+project main.spx Game github.com/goplus/spx/v2 math
+
+class -embed *.spx SpriteImpl
+
+runner github.com/goplus/spx/v2/cmd/spxrunner

--- a/test/CI/gop.mod
+++ b/test/CI/gop.mod
@@ -1,0 +1,7 @@
+xgo 1.6.0
+
+project main.spx Game github.com/goplus/spx/v2 math
+
+class -embed *.spx SpriteImpl
+
+runner github.com/goplus/spx/v2/cmd/spxrunner

--- a/test/Camera/gop.mod
+++ b/test/Camera/gop.mod
@@ -1,0 +1,7 @@
+xgo 1.6.0
+
+project main.spx Game github.com/goplus/spx/v2 math
+
+class -embed *.spx SpriteImpl
+
+runner github.com/goplus/spx/v2/cmd/spxrunner

--- a/test/CameraTouching/gop.mod
+++ b/test/CameraTouching/gop.mod
@@ -1,0 +1,7 @@
+xgo 1.6.0
+
+project main.spx Game github.com/goplus/spx/v2 math
+
+class -embed *.spx SpriteImpl
+
+runner github.com/goplus/spx/v2/cmd/spxrunner

--- a/test/Dinosaur/gop.mod
+++ b/test/Dinosaur/gop.mod
@@ -1,0 +1,7 @@
+xgo 1.6.0
+
+project main.spx Game github.com/goplus/spx/v2 math
+
+class -embed *.spx SpriteImpl
+
+runner github.com/goplus/spx/v2/cmd/spxrunner

--- a/test/Hello/gop.mod
+++ b/test/Hello/gop.mod
@@ -1,0 +1,7 @@
+xgo 1.6.0
+
+project main.spx Game github.com/goplus/spx/v2 math
+
+class -embed *.spx SpriteImpl
+
+runner github.com/goplus/spx/v2/cmd/spxrunner

--- a/test/Measure/gop.mod
+++ b/test/Measure/gop.mod
@@ -1,0 +1,7 @@
+xgo 1.6.0
+
+project main.spx Game github.com/goplus/spx/v2 math
+
+class -embed *.spx SpriteImpl
+
+runner github.com/goplus/spx/v2/cmd/spxrunner

--- a/test/MiniMapCamera/gop.mod
+++ b/test/MiniMapCamera/gop.mod
@@ -1,0 +1,7 @@
+xgo 1.6.0
+
+project main.spx Game github.com/goplus/spx/v2 math
+
+class -embed *.spx SpriteImpl
+
+runner github.com/goplus/spx/v2/cmd/spxrunner

--- a/test/MonkeyAndCrocodile/gop.mod
+++ b/test/MonkeyAndCrocodile/gop.mod
@@ -1,0 +1,7 @@
+xgo 1.6.0
+
+project main.spx Game github.com/goplus/spx/v2 math
+
+class -embed *.spx SpriteImpl
+
+runner github.com/goplus/spx/v2/cmd/spxrunner

--- a/test/Reloadable/gop.mod
+++ b/test/Reloadable/gop.mod
@@ -1,0 +1,7 @@
+xgo 1.6.0
+
+project main.spx Game github.com/goplus/spx/v2 math
+
+class -embed *.spx SpriteImpl
+
+runner github.com/goplus/spx/v2/cmd/spxrunner

--- a/test/StageMonitor/gop.mod
+++ b/test/StageMonitor/gop.mod
@@ -1,0 +1,7 @@
+xgo 1.6.0
+
+project main.spx Game github.com/goplus/spx/v2 math
+
+class -embed *.spx SpriteImpl
+
+runner github.com/goplus/spx/v2/cmd/spxrunner

--- a/test/Think/gop.mod
+++ b/test/Think/gop.mod
@@ -1,0 +1,7 @@
+xgo 1.6.0
+
+project main.spx Game github.com/goplus/spx/v2 math
+
+class -embed *.spx SpriteImpl
+
+runner github.com/goplus/spx/v2/cmd/spxrunner

--- a/test/TurnHeading/gop.mod
+++ b/test/TurnHeading/gop.mod
@@ -1,0 +1,7 @@
+xgo 1.6.0
+
+project main.spx Game github.com/goplus/spx/v2 math
+
+class -embed *.spx SpriteImpl
+
+runner github.com/goplus/spx/v2/cmd/spxrunner

--- a/test/TurnToMouse/gop.mod
+++ b/test/TurnToMouse/gop.mod
@@ -1,0 +1,7 @@
+xgo 1.6.0
+
+project main.spx Game github.com/goplus/spx/v2 math
+
+class -embed *.spx SpriteImpl
+
+runner github.com/goplus/spx/v2/cmd/spxrunner

--- a/test/TurnTogether/gop.mod
+++ b/test/TurnTogether/gop.mod
@@ -1,0 +1,7 @@
+xgo 1.6.0
+
+project main.spx Game github.com/goplus/spx/v2 math
+
+class -embed *.spx SpriteImpl
+
+runner github.com/goplus/spx/v2/cmd/spxrunner

--- a/test/_Quote/gop.mod
+++ b/test/_Quote/gop.mod
@@ -1,0 +1,7 @@
+xgo 1.6.0
+
+project main.spx Game github.com/goplus/spx/v2 math
+
+class -embed *.spx SpriteImpl
+
+runner github.com/goplus/spx/v2/cmd/spxrunner

--- a/tutorial/.gitignore
+++ b/tutorial/.gitignore
@@ -1,4 +1,4 @@
 /**/project
 /**/.gitignore
-*.mod
-*.sum
+go.mod
+go.sum

--- a/tutorial/00-Blank/gop.mod
+++ b/tutorial/00-Blank/gop.mod
@@ -1,0 +1,7 @@
+xgo 1.6.0
+
+project main.spx Game github.com/goplus/spx/v2 math
+
+class -embed *.spx SpriteImpl
+
+runner github.com/goplus/spx/v2/cmd/spxrunner

--- a/tutorial/00-Hello/gop.mod
+++ b/tutorial/00-Hello/gop.mod
@@ -1,0 +1,7 @@
+xgo 1.6.0
+
+project main.spx Game github.com/goplus/spx/v2 math
+
+class -embed *.spx SpriteImpl
+
+runner github.com/goplus/spx/v2/cmd/spxrunner

--- a/tutorial/01-Weather/gop.mod
+++ b/tutorial/01-Weather/gop.mod
@@ -1,0 +1,7 @@
+xgo 1.6.0
+
+project main.spx Game github.com/goplus/spx/v2 math
+
+class -embed *.spx SpriteImpl
+
+runner github.com/goplus/spx/v2/cmd/spxrunner

--- a/tutorial/01-WeatherPlay/gop.mod
+++ b/tutorial/01-WeatherPlay/gop.mod
@@ -1,0 +1,7 @@
+xgo 1.6.0
+
+project main.spx Game github.com/goplus/spx/v2 math
+
+class -embed *.spx SpriteImpl
+
+runner github.com/goplus/spx/v2/cmd/spxrunner

--- a/tutorial/02-Dragon/gop.mod
+++ b/tutorial/02-Dragon/gop.mod
@@ -1,0 +1,7 @@
+xgo 1.6.0
+
+project main.spx Game github.com/goplus/spx/v2 math
+
+class -embed *.spx SpriteImpl
+
+runner github.com/goplus/spx/v2/cmd/spxrunner

--- a/tutorial/03-Clone/gop.mod
+++ b/tutorial/03-Clone/gop.mod
@@ -1,0 +1,7 @@
+xgo 1.6.0
+
+project main.spx Game github.com/goplus/spx/v2 math
+
+class -embed *.spx SpriteImpl
+
+runner github.com/goplus/spx/v2/cmd/spxrunner

--- a/tutorial/04-Bullet/gop.mod
+++ b/tutorial/04-Bullet/gop.mod
@@ -1,0 +1,7 @@
+xgo 1.6.0
+
+project main.spx Game github.com/goplus/spx/v2 math
+
+class -embed *.spx SpriteImpl
+
+runner github.com/goplus/spx/v2/cmd/spxrunner

--- a/tutorial/05-Animation/gop.mod
+++ b/tutorial/05-Animation/gop.mod
@@ -1,0 +1,7 @@
+xgo 1.6.0
+
+project main.spx Game github.com/goplus/spx/v2 math
+
+class -embed *.spx SpriteImpl
+
+runner github.com/goplus/spx/v2/cmd/spxrunner


### PR DESCRIPTION
This PR starts tracking `gop.mod` in SPX demo and test projects, and adds an explicit sync command to keep them aligned with the root template.

## Changes

- add `gop.mod` to all tutorial/test project directories that contain `.spx` sources
- normalize existing demo `gop.mod` files to the current root template
- stop ignoring `gop.mod` in repo, tutorial, and test `.gitignore` files
- add `make sync-gopmod` to copy the root `gop.mod` into all demo/test projects
