### PR TITLE
Ci: streamline buildctl workflows

### DIFF
--- a/.github/actions/deps/action.yml
+++ b/.github/actions/deps/action.yml
@@ -1,93 +1,78 @@
-name: Setup go/xgo & engine
-description: Setup go/xgo & engine.
+name: Set up Go, XGo, and engine assets
+description: Set up the toolchain, restore downloaded engine assets, and prepare local build artifacts.
 inputs:
   go-version:
-    description: 'Go version to setup'
+    description: 'Go version to install'
     required: false
     default: '1.25.8'
   xgo-version:
-    description: 'XGo version to setup'
+    description: 'XGo version to install'
     required: false
     default: '1.6.6'
   setup-mode:
-    description: 'Engine setup mode: runtime, web, or full'
+    description: 'Asset preparation mode: runtime, web, or full'
     required: false
     default: 'runtime'
   web-mode:
-    description: 'Web template mode when setup-mode is web/full'
+    description: 'Web runtime mode to prepare when setup-mode is web or full'
     required: false
     default: 'normal'
   cache-version:
-    description: 'Cache version for manual invalidation'
+    description: 'Manual cache version for download cache invalidation'
     required: false
     default: 'v3'
 runs:
   using: "composite"
   steps:
-    - name: Set up Go/XGo
+    - name: Set up Go and XGo
       uses: goplus/setup-xgo@v1
       with:
         go-version: ${{ inputs.go-version }}
         xgo-version: ${{ inputs.xgo-version }}
 
-    - name: Get GOPATH
+    - name: Resolve GOPATH
       id: gopath
       run: echo "GOPATH=$(go env GOPATH)" >> $GITHUB_OUTPUT
       shell: bash
 
-    - name: Cache Godot engine files
-      id: cache-godot
+    - name: Resolve runtime version
+      id: runtime-version
+      run: echo "version=$(go run ./.github/scripts/runtime_version.go)" >> $GITHUB_OUTPUT
+      shell: bash
+
+    - name: Restore downloaded engine assets
+      id: cache-downloads
       uses: actions/cache@v4
       with:
         path: |
-          ${{ steps.gopath.outputs.GOPATH }}/bin/spx*
           ${{ steps.gopath.outputs.GOPATH }}/bin/gdspx[0-9]*
-          ${{ steps.gopath.outputs.GOPATH }}/bin/gdspx-*
-          ${{ steps.gopath.outputs.GOPATH }}/bin/gdspxrt*
-          ${{ steps.gopath.outputs.GOPATH }}/bin/ispx
-          ${{ steps.gopath.outputs.GOPATH }}/bin/ispx.wasm
-          ${{ steps.gopath.outputs.GOPATH }}/bin/runtime.gdextension
+          ${{ steps.gopath.outputs.GOPATH }}/bin/gdspxrt[0-9]*
+          !${{ steps.gopath.outputs.GOPATH }}/bin/gdspxrt[0-9]*_web*
           ~/.local/share/godot/export_templates
           ~/Library/Application Support/Godot/export_templates
           ~/AppData/Roaming/Godot/export_templates
-        key: spx-godot-${{ inputs.cache-version }}-${{ runner.os }}-${{ inputs.setup-mode }}-${{ inputs.setup-mode != 'runtime' && inputs.web-mode || 'runtime' }}-${{ hashFiles('Makefile', 'go.mod', 'go.sum', 'cmd/gox/go.mod', 'cmd/gox/go.sum', 'cmd/gox/**/*.go', 'cmd/gox/**/*.sh', 'cmd/ispx/**/*.go', 'cmd/ispx/**/*.sh', 'cmd/ispx/web/**', 'cmd/ispxnative/**/*.go', 'cmd/ispxnative/**/*.sh', 'cmd/gox/template/**', 'internal/cmd/buildctl/**/*.go', 'internal/releasemeta/**/*.go', 'internal/tools/**/*.sh', 'internal/gdengine/binding/web/**/*.go', 'pkg/ispx/**/*.go', '.github/actions/deps/action.yml', '.github/scripts/runtime_version.go') }}
+        key: spx-download-${{ inputs.cache-version }}-${{ runner.os }}-${{ inputs.setup-mode }}-${{ inputs.setup-mode != 'runtime' && inputs.web-mode || 'runtime' }}-${{ steps.runtime-version.outputs.version }}
         restore-keys: |
-          spx-godot-${{ inputs.cache-version }}-${{ runner.os }}-${{ inputs.setup-mode }}-${{ inputs.setup-mode != 'runtime' && inputs.web-mode || 'runtime' }}-
-          spx-godot-${{ inputs.cache-version }}-${{ runner.os }}-${{ inputs.setup-mode }}-
+          spx-download-${{ inputs.cache-version }}-${{ runner.os }}-${{ inputs.setup-mode }}-${{ inputs.setup-mode != 'runtime' && inputs.web-mode || 'runtime' }}-
+          spx-download-${{ inputs.cache-version }}-${{ runner.os }}-${{ inputs.setup-mode }}-
 
-    - name: Validate cached engine files
-      id: cache-verify
-      if: steps.cache-godot.outputs.cache-hit == 'true'
+    - name: Validate downloaded engine assets
+      id: cache-download-verify
+      if: steps.cache-downloads.outputs.cache-hit == 'true'
       shell: bash
       env:
         GOPATH_DIR: ${{ steps.gopath.outputs.GOPATH }}
         SETUP_MODE: ${{ inputs.setup-mode }}
-        WEB_MODE: ${{ inputs.web-mode }}
+        RUNTIME_VERSION: ${{ steps.runtime-version.outputs.version }}
       run: |
         set -euo pipefail
 
-        version="$(go run ./.github/scripts/runtime_version.go)"
         missing=0
         bin_suffix=""
-        lib_suffix=""
-        goos="$(go env GOOS)"
-        goarch="$(go env GOARCH)"
 
         if [ "${RUNNER_OS}" = "Windows" ]; then
           bin_suffix=".exe"
         fi
-
-        case "$goos" in
-          windows)
-            lib_suffix=".dll"
-            ;;
-          darwin)
-            lib_suffix=".dylib"
-            ;;
-          *)
-            lib_suffix=".so"
-            ;;
-        esac
 
         require_path() {
           if [ ! -e "$1" ]; then
@@ -96,33 +81,32 @@ runs:
           fi
         }
 
-        require_path "$GOPATH_DIR/bin/spx${bin_suffix}"
+        require_path "$GOPATH_DIR/bin/gdspx${RUNTIME_VERSION}${bin_suffix}"
 
         if [ "$SETUP_MODE" = "runtime" ] || [ "$SETUP_MODE" = "full" ]; then
-          require_path "$GOPATH_DIR/bin/gdspx${version}${bin_suffix}"
-          require_path "$GOPATH_DIR/bin/gdspx-${goos}-${goarch}${lib_suffix}"
-          require_path "$GOPATH_DIR/bin/gdspxrt${version}${bin_suffix}"
-          require_path "$GOPATH_DIR/bin/gdspxrt${version}.pck"
-          require_path "$GOPATH_DIR/bin/runtime.gdextension"
-        fi
-
-        if [ "$SETUP_MODE" = "web" ] || [ "$SETUP_MODE" = "full" ]; then
-          require_path "$GOPATH_DIR/bin/gdspx${version}${bin_suffix}"
-          require_path "$GOPATH_DIR/bin/ispx"
-          require_path "$GOPATH_DIR/bin/ispx.wasm"
-          require_path "$GOPATH_DIR/bin/gdspxrt${version}_web${WEB_MODE}"
+          require_path "$GOPATH_DIR/bin/gdspxrt${RUNTIME_VERSION}${bin_suffix}"
+          require_path "$GOPATH_DIR/bin/gdspxrt${RUNTIME_VERSION}.pck"
         fi
 
         echo "repair=$missing" >> "$GITHUB_OUTPUT"
 
-    - name: Setup engine assets
-      if: steps.cache-godot.outputs.cache-hit != 'true' || steps.cache-verify.outputs.repair == '1'
+    - name: Build local buildctl
+      uses: ./.github/actions/setup-buildctl
+
+    - name: Prepare engine assets
       shell: bash
       env:
         SETUP_MODE: ${{ inputs.setup-mode }}
         WEB_MODE: ${{ inputs.web-mode }}
+        DOWNLOAD_CACHE_HIT: ${{ steps.cache-downloads.outputs.cache-hit }}
+        DOWNLOAD_CACHE_REPAIR: ${{ steps.cache-download-verify.outputs.repair }}
       run: |
         set -euo pipefail
-        mkdir -p ./.bin
-        go build -o "./.bin/buildctl$(go env GOEXE)" ./internal/cmd/buildctl
-        "./.bin/buildctl$(go env GOEXE)" prepare --setup-mode "$SETUP_MODE" --web-mode "$WEB_MODE"
+
+        force_refresh=1
+        if [ "${DOWNLOAD_CACHE_HIT}" = "true" ] && [ "${DOWNLOAD_CACHE_REPAIR:-0}" != "1" ]; then
+          force_refresh=0
+        fi
+
+        export SPX_PREPARE_FORCE_REFRESH="$force_refresh"
+        "$BUILDCTL" prepare --setup-mode "$SETUP_MODE" --web-mode "$WEB_MODE"

--- a/.github/actions/replace-version/action.yml
+++ b/.github/actions/replace-version/action.yml
@@ -1,13 +1,16 @@
-name: Replace Version
-description: Replace version in go.mod.template with the release version
+name: Update template version
+description: Update cmd/gox/template/go.mod.template for a release build and reinstall spx.
 inputs:
   version:
-    description: 'Version to replace (e.g., v2.0.1)'
+    description: 'Release version without the leading v (for example, 2.0.1)'
     required: true
 runs:
   using: "composite"
   steps:
-    - name: Replace version in go.mod.template
+    - name: Build local buildctl
+      uses: ./.github/actions/setup-buildctl
+
+    - name: Update go.mod.template version
       shell: bash
       run: |
         VERSION="v${{ inputs.version }}"
@@ -42,4 +45,4 @@ runs:
         echo ""
         echo "✅ Successfully updated $FILE with version $VERSION"
         echo "reinstall spx"
-        make install
+        "$BUILDCTL" tool install

--- a/.github/actions/setup-buildctl/action.yml
+++ b/.github/actions/setup-buildctl/action.yml
@@ -1,0 +1,15 @@
+name: Set up buildctl
+description: Build the local buildctl binary and export BUILDCTL for later CI steps.
+runs:
+  using: composite
+  steps:
+    - name: Build local buildctl
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        buildctl_path="$(pwd)/.bin/buildctl$(go env GOEXE)"
+
+        mkdir -p ./.bin
+        go build -o "$buildctl_path" ./internal/cmd/buildctl
+        echo "BUILDCTL=$buildctl_path" >> "$GITHUB_ENV"

--- a/.github/workflows/build_android.yml
+++ b/.github/workflows/build_android.yml
@@ -1,4 +1,4 @@
-name: Android
+name: Build Android APK
 
 on:
   workflow_call:
@@ -10,16 +10,17 @@ concurrency:
 jobs:
 
   build:
+    name: Build Android APK
     runs-on: ubuntu-latest
     timeout-minutes: 60
 
     steps:
-    - name: Checkout
+    - name: Check out code
       uses: actions/checkout@v6
       with:
         submodules: recursive
 
-    - name: Get dependencies
+    - name: Install Linux dependencies
       run: sudo apt-get update && sudo apt-get install gcc libgl1-mesa-dev libegl1-mesa-dev libgles2-mesa-dev libx11-dev xorg-dev libasound2-dev libopenal-dev
       if: ${{ runner.os == 'Linux' }}
 
@@ -37,13 +38,13 @@ jobs:
         add-to-path: true
         local-cache: true
 
-    - name: Setup go/xgo & engine
+    - name: Set up toolchain and engine assets
       uses: ./.github/actions/deps
 
-    - name: Set Android NDK environment variable
+    - name: Export ANDROID_NDK_ROOT
       run: echo "ANDROID_NDK_ROOT=${{ steps.setup-ndk.outputs.ndk-path }}" >> $GITHUB_ENV
 
-    - name: Verify and fix NDK installation
+    - name: Verify Android NDK
       run: |
         echo "ANDROID_NDK_ROOT: $ANDROID_NDK_ROOT"
         echo "Checking for clang binary:"
@@ -80,18 +81,18 @@ jobs:
         ls -la "$ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/linux-x86_64/bin/clang" || echo "❌ clang still not found"
         ls -la "$ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android21-clang" || echo "❌ wrapper not found"
 
-    - name: Download Android engine templates
+    - name: Download Android export templates
       run: |
         echo "Downloading Android engine templates..."
-        make download-engine PLATFORM=android
+        "$BUILDCTL" engine download --platform android
         echo "Listing downloaded templates:"
         ls -la ~/.local/share/godot/export_templates/
 
-    - name: Run test demo
+    - name: Build sample APK
       shell: bash
       run: cd tutorial/00-Hello && spx exportapk 2>&1 | tee build_apk.txt || true
 
-    - name: Check build result
+    - name: Verify APK output
       shell: bash
       run: |
         echo "Checking if APK was built successfully..."

--- a/.github/workflows/build_ios.yml
+++ b/.github/workflows/build_ios.yml
@@ -1,4 +1,4 @@
-name: iOS
+name: Build iOS IPA
 
 on:
   workflow_call:
@@ -9,19 +9,20 @@ concurrency:
 
 jobs:
   build:
+    name: Build iOS IPA
     runs-on: macos-latest
     timeout-minutes: 60
 
     steps:
-    - name: Checkout
+    - name: Check out code
       uses: actions/checkout@v6
       with:
         submodules: recursive
 
-    - name: Setup go/xgo & engine
+    - name: Set up toolchain and engine assets
       uses: ./.github/actions/deps
 
-    - name: Setup Vulkan SDK
+    - name: Set up Vulkan SDK
       run: |
         echo "Installing Vulkan SDK for MoltenVK support..."
         # Install jq if not available
@@ -57,14 +58,14 @@ jobs:
         rm -f /tmp/vulkan-sdk.json /tmp/vulkan-sdk.zip
         rm -rf /tmp/vulkansdk-macOS-$VULKAN_VERSION.app
 
-    - name: Download iOS engine templates
+    - name: Download iOS export templates
       run: |
         echo "Downloading iOS engine templates..."
-        make download-engine PLATFORM=ios
+        "$BUILDCTL" engine download --platform ios
         echo "Listing downloaded templates:"
         ls -la ~/Library/Application\ Support/Godot/export_templates/
 
-    - name: Configure export preset for CI
+    - name: Configure iOS export preset
       shell: bash
       run: |
         echo "Configuring iOS export preset for CI (export Xcode project only)..."
@@ -79,9 +80,12 @@ jobs:
 
     - name: Export Xcode project
       shell: bash
-      run: make install && cd tutorial/00-Hello && spx exportios 2>&1 | tee build_ios.txt || true
+      run: |
+        "$BUILDCTL" tool install
+        cd tutorial/00-Hello
+        spx exportios 2>&1 | tee build_ios.txt || true
 
-    - name: Copy MoltenVK framework to Xcode project
+    - name: Copy MoltenVK framework
       shell: bash
       run: |
         echo "Copying MoltenVK.xcframework to Xcode project..."
@@ -110,7 +114,7 @@ jobs:
           exit 1
         fi
 
-    - name: Build IPA from Xcode project without code signing
+    - name: Build unsigned IPA
       shell: bash
       run: |
         echo "Building IPA from Xcode project..."
@@ -160,7 +164,7 @@ jobs:
         echo "✅ IPA created successfully"
         ls -lh Game.ipa
 
-    - name: Check build result
+    - name: Verify IPA output
       shell: bash
       run: |
         echo "Checking if IPA was built successfully..."

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -1,4 +1,4 @@
-name: Linux
+name: Build Linux
 
 on:
   workflow_call:
@@ -9,16 +9,18 @@ concurrency:
 
 jobs:
   build:
+    name: Build Linux
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - name: Check out code
+      uses: actions/checkout@v6
 
-    - name: Get dependencies
+    - name: Install Linux dependencies
       run: sudo apt-get update && sudo apt-get install gcc libgl1-mesa-dev libegl1-mesa-dev libgles2-mesa-dev libx11-dev xorg-dev libasound2-dev libopenal-dev
       if: ${{ runner.os == 'Linux' }}
 
-    - name: Setup go/xgo & engine
+    - name: Set up toolchain and engine assets
       uses: ./.github/actions/deps
 
-    - name: Test
+    - name: Run project test
       uses: ./.github/actions/project-test

--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -1,4 +1,4 @@
-name: MacOS
+name: Build macOS
 
 on:
   workflow_call:
@@ -10,13 +10,13 @@ concurrency:
 jobs:
   build:
     runs-on: "macos-latest"
-    name: macos
+    name: Build macOS
     steps:
-    - uses: actions/checkout@v6
+    - name: Check out code
+      uses: actions/checkout@v6
 
-    - name: Setup go/xgo & engine
+    - name: Set up toolchain and engine assets
       uses: ./.github/actions/deps
 
-    - name: Test
+    - name: Run project test
       uses: ./.github/actions/project-test
-

--- a/.github/workflows/build_web.yml
+++ b/.github/workflows/build_web.yml
@@ -1,4 +1,4 @@
-name: Web
+name: Build Web Bundle
 
 on:
   workflow_call:
@@ -10,7 +10,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
-    name: web-export (${{ matrix.mode }})
+    name: Build web bundle (${{ matrix.mode }})
     strategy:
       fail-fast: false
       matrix:
@@ -24,9 +24,10 @@ jobs:
           - mode: miniprogram
             zip_file: spx_web_miniprogram.zip
     steps:
-      - uses: actions/checkout@v6
+      - name: Check out code
+        uses: actions/checkout@v6
 
-      - name: Get dependencies
+      - name: Install Linux dependencies
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
@@ -42,7 +43,7 @@ jobs:
             binaryen \
             brotli
 
-      - name: Setup go/xgo & engine
+      - name: Set up toolchain and engine assets
         uses: ./.github/actions/deps
         with:
           setup-mode: web
@@ -52,13 +53,9 @@ jobs:
         env:
           MATRIX_MODE: ${{ matrix.mode }}
         run: |
-          if [ "$MATRIX_MODE" != "normal" ]; then
-            make export-web MODE="$MATRIX_MODE"
-          else
-            make export-web
-          fi
+          "$BUILDCTL" runtime export-web --mode "$MATRIX_MODE"
 
-      - name: Verify web bundle
+      - name: Verify bundle artifact
         run: |
           if [ ! -f "${{ matrix.zip_file }}" ]; then
             echo "${{ matrix.zip_file }} not found"

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -1,4 +1,4 @@
-name: Windows
+name: Build Windows
 
 on:
   workflow_call:
@@ -10,9 +10,11 @@ concurrency:
 jobs:
 
   build:
+    name: Build Windows
     runs-on: "windows-latest"
     steps:
-    - uses: actions/checkout@v6
+    - name: Check out code
+      uses: actions/checkout@v6
 
     - name: Set up MSYS2
       uses: msys2/setup-msys2@v2
@@ -22,9 +24,8 @@ jobs:
           base-devel
           mingw-w64-x86_64-toolchain
 
-    - name: Setup go/xgo & engine
+    - name: Set up toolchain and engine assets
       uses: ./.github/actions/deps
 
-    - name: Test
+    - name: Run project test
       uses: ./.github/actions/project-test
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: 🚀 Release Build
+name: Release
 
 on:
   release:
@@ -6,11 +6,11 @@ on:
   workflow_dispatch:
     inputs:
       release_tag:
-        description: 'Release version (e.g. v2.0.1)'
+        description: 'Release tag (for example, v2.0.1)'
         required: true
         default: 'v2.0.1'
       platforms:
-        description: 'Platforms to build (comma-separated: web,all)'
+        description: 'Platforms to build (comma-separated, for example: web,all)'
         required: true
         default: 'web'
 concurrency:
@@ -19,18 +19,18 @@ concurrency:
 
 jobs:
   setup:
-    name: 📋 Prepare Build Environment
+    name: Prepare release inputs
     runs-on: ubuntu-22.04
     outputs:
       version: ${{ steps.set-version.outputs.version }}
       platforms: ${{ steps.set-platforms.outputs.platforms }}
     steps:
-      - name: Checkout
+      - name: Check out code
         uses: actions/checkout@v6
         with:
           submodules: recursive
 
-      - name: Set Version Number
+      - name: Resolve release version
         id: set-version
         run: |
           if [ "${{ github.event_name }}" == "release" ]; then
@@ -42,7 +42,7 @@ jobs:
           echo "VERSION=$VERSION"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
-      - name: Set Build Platforms
+      - name: Resolve target platforms
         id: set-platforms
         run: |
           if [ "${{ github.event_name }}" == "release" ]; then
@@ -59,33 +59,33 @@ jobs:
           echo "platforms=$PLATFORMS" >> $GITHUB_OUTPUT
 
   static-checks:
-    name: 📊 Static checks
+    name: Static checks
     needs: setup
     uses: ./.github/workflows/static_checks.yml
 
   web-build:
-    name: 🌐 Web Release
+    name: Release web bundle
     needs: [setup, static-checks]
     uses: ./.github/workflows/release_web.yml
     with:
       version: ${{ needs.setup.outputs.version }}
 
   macos-build:
-    name: 🍎 macOS Release
+    name: Release macOS package
     needs: [setup, static-checks]
     uses: ./.github/workflows/release_macos.yml
     with:
       version: ${{ needs.setup.outputs.version }}
 
   windows-build:
-    name: 🏁 Windows Release
+    name: Release Windows package
     needs: [setup, static-checks]
     uses: ./.github/workflows/release_windows.yml
     with:
       version: ${{ needs.setup.outputs.version }}
 
   linux-build:
-    name: 🐧 Linux Release
+    name: Release Linux package
     needs: [setup, static-checks]
     uses: ./.github/workflows/release_linux.yml
     with:

--- a/.github/workflows/release_linux.yml
+++ b/.github/workflows/release_linux.yml
@@ -1,10 +1,10 @@
-name: 🐧 Release Linux Build
+name: Release Linux Package
 
 on:
   workflow_call:
     inputs:
       version:
-        description: 'Release version (e.g., v2.0.1)'
+        description: 'Release version without the leading v (for example, 2.0.1)'
         required: true
         type: string
 
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   linux-goenv:
-    name: 🐧 Linux Goenv Package
+    name: Package Linux goenv (${{ matrix.arch_name }})
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -26,15 +26,16 @@ jobs:
           - arch: arm64
             arch_name: arm64
     steps:
-      - uses: actions/checkout@v6
+      - name: Check out code
+        uses: actions/checkout@v6
       
-      - name: Get dependencies
+      - name: Install Linux dependencies
         run: sudo apt-get update && sudo apt-get install gcc libgl1-mesa-dev libegl1-mesa-dev libgles2-mesa-dev libx11-dev xorg-dev libasound2-dev libopenal-dev zip
 
-      - name: Setup go/xgo & engine
+      - name: Set up toolchain and engine assets
         uses: ./.github/actions/deps
 
-      - name: Download and extract Go toolchain
+      - name: Download Go toolchain
         run: |
           mkdir -p goenv/gotoolchain
           cd goenv/gotoolchain
@@ -43,7 +44,7 @@ jobs:
           rm go1.25.8.linux-${{ matrix.arch }}.tar.gz
           cd ../..
 
-      - name: Collect Go module cache
+      - name: Collect module cache
         run: |
           # Set up mod cache directory (no build cache needed)
           mkdir -p goenv/.cache/mod
@@ -78,12 +79,12 @@ jobs:
           ls -lah goenv/.cache/mod || true
           du -sh goenv/.cache/mod || true
 
-      - name: Replace version
+      - name: Update template version
         uses: ./.github/actions/replace-version
         with:
           version: ${{ inputs.version }}
 
-      - name: Update spx binary with versioned build
+      - name: Refresh versioned spx binary
         run: |
           # After replace-version rebuilds spx with the new version,
           # update the binary in goenv to match
@@ -103,7 +104,7 @@ jobs:
           zip -r ../spx-linux-${{ matrix.arch_name }}.zip .
           cd ..
 
-      - name: Upload artifact
+      - name: Upload release artifact
         uses: actions/upload-artifact@v7
         with:
           name: spx-linux-${{ matrix.arch_name }}
@@ -116,7 +117,7 @@ jobs:
           package-file: spx-linux-${{ matrix.arch_name }}.zip
           platform: linux
 
-      - name: Publish to GitHub Release
+      - name: Publish release asset
         if: github.event_name == 'release'
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/release_macos.yml
+++ b/.github/workflows/release_macos.yml
@@ -1,10 +1,10 @@
-name: 🍎 Release macOS Build
+name: Release macOS Package
 
 on:
   workflow_call:
     inputs:
       version:
-        description: 'Release version (e.g., v2.0.1)'
+        description: 'Release version without the leading v (for example, 2.0.1)'
         required: true
         type: string
 
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   macos-goenv:
-    name: 🍎 macOS Goenv Package
+    name: Package macOS goenv (${{ matrix.arch_name }})
     runs-on: macos-latest
     strategy:
       matrix:
@@ -24,12 +24,13 @@ jobs:
           - arch: arm64
             arch_name: arm64
     steps:
-      - uses: actions/checkout@v6
+      - name: Check out code
+        uses: actions/checkout@v6
 
-      - name: Setup go/xgo & engine
+      - name: Set up toolchain and engine assets
         uses: ./.github/actions/deps
 
-      - name: Download and extract Go toolchain
+      - name: Download Go toolchain
         run: |
           mkdir -p goenv/gotoolchain
           cd goenv/gotoolchain
@@ -38,7 +39,7 @@ jobs:
           rm go1.25.8.darwin-${{ matrix.arch }}.tar.gz
           cd ../..
 
-      - name: Collect Go module cache
+      - name: Collect module cache
         run: |
           # Set up mod cache directory (no build cache needed)
           mkdir -p goenv/.cache/mod
@@ -73,12 +74,12 @@ jobs:
           ls -lah goenv/.cache/mod || true
           du -sh goenv/.cache/mod || true
 
-      - name: Replace version
+      - name: Update template version
         uses: ./.github/actions/replace-version
         with:
           version: ${{ inputs.version }}
 
-      - name: Update spx binary with versioned build
+      - name: Refresh versioned spx binary
         run: |
           # After replace-version rebuilds spx with the new version,
           # update the binary in goenv to match
@@ -98,7 +99,7 @@ jobs:
           zip -r ../spx-darwin-${{ matrix.arch_name }}.zip .
           cd ..
 
-      - name: Upload artifact
+      - name: Upload release artifact
         uses: actions/upload-artifact@v7
         with:
           name: spx-darwin-${{ matrix.arch_name }}
@@ -111,7 +112,7 @@ jobs:
           package-file: spx-darwin-${{ matrix.arch_name }}.zip
           platform: darwin
 
-      - name: Publish to GitHub Release
+      - name: Publish release asset
         if: github.event_name == 'release'
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/release_web.yml
+++ b/.github/workflows/release_web.yml
@@ -1,10 +1,10 @@
-name: 🌐 Release Web Build
+name: Release Web Bundle
 
 on:
   workflow_call:
     inputs:
       version:
-        description: 'Release version (e.g., v2.0.1)'
+        description: 'Release version without the leading v (for example, 2.0.1)'
         required: true
         type: string
 
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   web-build:
-    name: 🌐 Web Release (${{ matrix.mode }})
+    name: Release web bundle (${{ matrix.mode }})
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -36,40 +36,37 @@ jobs:
             artifact_name: web-miniprogram-release
             display_name: Web Miniprogram Release
     steps:
-      - uses: actions/checkout@v6
+      - name: Check out code
+        uses: actions/checkout@v6
 
-      - name: Get dependencies
+      - name: Install Linux dependencies
         run: sudo apt-get update && sudo apt-get install gcc libgl1-mesa-dev libegl1-mesa-dev libgles2-mesa-dev libx11-dev xorg-dev libasound2-dev libopenal-dev binaryen brotli
         if: ${{ runner.os == 'Linux' }}
 
-      - name: Setup go/xgo & engine
+      - name: Set up toolchain and engine assets
         uses: ./.github/actions/deps
         with:
           setup-mode: web
           web-mode: ${{ matrix.mode }}
 
-      - name: Build release pack
+      - name: Build release bundle
         env:
           MATRIX_MODE: ${{ matrix.mode }}
         run: |
-          if [ "$MATRIX_MODE" != "normal" ]; then
-            make export-web MODE="$MATRIX_MODE"
-          else
-            make export-web
-          fi
+          "$BUILDCTL" runtime export-web --mode "$MATRIX_MODE"
           if [ ! -f "${{ matrix.zip_file }}" ]; then
             echo "${{ matrix.zip_file }} not found"
             exit 1
           fi
 
-      - name: Upload Web Build Results
+      - name: Upload release artifact
         uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact_name }}
           path: ${{ matrix.zip_file }}
           retention-days: 14
 
-      - name: Publish to GitHub Release
+      - name: Publish release asset
         if: github.event_name == 'release'
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/release_windows.yml
+++ b/.github/workflows/release_windows.yml
@@ -1,10 +1,10 @@
-name: 🏁 Release Windows Build
+name: Release Windows Package
 
 on:
   workflow_call:
     inputs:
       version:
-        description: 'Release version (e.g., v2.0.1)'
+        description: 'Release version without the leading v (for example, 2.0.1)'
         required: true
         type: string
 
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   windows-goenv:
-    name: 🏁 Windows Goenv Package
+    name: Package Windows goenv (${{ matrix.arch_name }})
     runs-on: windows-latest
     strategy:
       matrix:
@@ -24,7 +24,8 @@ jobs:
           - arch: amd64
             arch_name: x64
     steps:
-      - uses: actions/checkout@v6
+      - name: Check out code
+        uses: actions/checkout@v6
 
       - name: Set up MSYS2
         uses: msys2/setup-msys2@v2
@@ -35,14 +36,13 @@ jobs:
             mingw-w64-x86_64-toolchain
             zip
             unzip
-            make
             bash
             rsync
 
-      - name: Setup go/xgo & engine
+      - name: Set up toolchain and engine assets
         uses: ./.github/actions/deps
 
-      - name: Download and extract Go toolchain
+      - name: Download Go toolchain
         shell: msys2 {0}
         run: |
           mkdir -p goenv/gotoolchain
@@ -52,7 +52,7 @@ jobs:
           rm go1.25.8.windows-${{ matrix.arch }}.zip
           cd ../..
 
-      - name: Get GOPATH and short SHA
+      - name: Resolve GOPATH and short SHA
         id: env-vars
         shell: pwsh
         run: |
@@ -63,7 +63,7 @@ jobs:
           $shortSha = "${{ github.sha }}".Substring(0, 7)
           echo "short_sha=$shortSha" >> $env:GITHUB_OUTPUT
 
-      - name: Collect Go module cache
+      - name: Collect module cache
         shell: msys2 {0}
         run: |
           # Set up mod cache directory (no build cache needed)
@@ -110,12 +110,12 @@ jobs:
           ls -lah goenv/.cache/mod || true
           du -sh goenv/.cache/mod || true
 
-      - name: Replace version
+      - name: Update template version
         uses: ./.github/actions/replace-version
         with:
           version: ${{ inputs.version }}
 
-      - name: Update spx binary with versioned build
+      - name: Refresh versioned spx binary
         shell: msys2 {0}
         run: |
           # After replace-version rebuilds spx with the new version,
@@ -138,7 +138,7 @@ jobs:
           zip -r ../spx-windows-${{ matrix.arch_name }}.zip .
           cd ..
 
-      - name: Upload artifact
+      - name: Upload release artifact
         uses: actions/upload-artifact@v7
         with:
           name: spx-windows-${{ matrix.arch_name }}
@@ -151,7 +151,7 @@ jobs:
           package-file: spx-windows-${{ matrix.arch_name }}.zip
           platform: windows
 
-      - name: Publish to GitHub Release
+      - name: Publish release asset
         if: github.event_name == 'release'
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -7,41 +7,41 @@ concurrency:
 
 jobs:
   static-checks:
-    name: 📊 Static checks
+    name: Static checks
     uses: ./.github/workflows/static_checks.yml
 
   go-builds:
-    name: 🧪 Go builds
+    name: Go builds
     uses: ./.github/workflows/go_builds.yml
 
   android-build:
     needs: static-checks
-    name: 🤖 Android
+    name: Build Android APK
     uses: ./.github/workflows/build_android.yml
 
   ios-build:
     needs: static-checks
-    name: 🍏 iOS
+    name: Build iOS IPA
     uses: ./.github/workflows/build_ios.yml
 
   web-build:
     needs: static-checks
-    name: 🌐 Web
+    name: Build web bundle
     uses: ./.github/workflows/build_web.yml
 
   linux-build:
     needs: static-checks
-    name: 🐧 Linux
+    name: Build Linux
     uses: ./.github/workflows/build_linux.yml
 
   macos-build:
     needs: static-checks
-    name: 🍎 macOS
+    name: Build macOS
     uses: ./.github/workflows/build_macos.yml
 
   windows-build:
     needs: static-checks
-    name: 🏁 Windows
+    name: Build Windows
     uses: ./.github/workflows/build_windows.yml
 
   ci-gate:
@@ -55,7 +55,7 @@ jobs:
       - linux-build
       - macos-build
       - windows-build
-    name: ✅ CI Gate
+    name: CI gate
     runs-on: ubuntu-latest
     steps:
       - name: Verify all required jobs passed

--- a/.github/workflows/web_runtime_artifact.yml
+++ b/.github/workflows/web_runtime_artifact.yml
@@ -1,4 +1,4 @@
-name: 🧪 Web Runtime Artifact
+name: Publish Web Runtime Artifact
 
 on:
   push:
@@ -17,9 +17,10 @@ concurrency:
 
 jobs:
   build:
+    name: Publish web runtime artifact
     runs-on: ubuntu-latest
     steps:
-      - name: Validate manual target
+      - name: Validate dispatch target
         if: github.event_name == 'workflow_dispatch'
         env:
           TARGET: ${{ inputs.target }}
@@ -38,14 +39,14 @@ jobs:
             exit 1
           fi
 
-      - name: Checkout
+      - name: Check out code
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: true
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.target || github.sha }}
 
-      - name: Get dependencies
+      - name: Install Linux dependencies
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
@@ -61,23 +62,24 @@ jobs:
             binaryen \
             brotli
 
-      - name: Setup go/xgo & engine
+      - name: Set up toolchain and engine assets
         uses: ./.github/actions/deps
         with:
           setup-mode: web
           web-mode: normal
 
-      - name: Setup ORAS
+      - name: Set up ORAS
         uses: oras-project/setup-oras@v1
 
-      - name: Compute pseudo version
+      - name: Compute pseudo-version
         run: |
           SPX_VERSION="$(go run ./.github/scripts/pseudo_version.go HEAD)"
           echo "SPX_VERSION=${SPX_VERSION}"
           echo "SPX_VERSION=${SPX_VERSION}" >> "${GITHUB_ENV}"
 
       - name: Build web bundle
-        run: make export-web
+        run: |
+          "$BUILDCTL" runtime export-web --mode normal
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v4
@@ -86,7 +88,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
-      - name: Publish `spx_web.zip` to GitHub Container Registry
+      - name: Publish web bundle to GitHub Container Registry
         run: |
           REVISION="$(git rev-parse HEAD)"
           oras push \

--- a/cmd/spxrunner/runner/embed.go
+++ b/cmd/spxrunner/runner/embed.go
@@ -40,7 +40,7 @@ var GopModTemplate string
 //go:embed go.mod.template
 var GoModTemplate string
 
-// RuntimeVersion returns the default SPX runtime version.
+// RuntimeVersion returns the latest known SPX runtime version.
 func RuntimeVersion() string {
 	return releasemeta.DefaultReleaseMeta().Runtime.Version
 }

--- a/internal/cmd/buildctl/engine_download.go
+++ b/internal/cmd/buildctl/engine_download.go
@@ -293,13 +293,28 @@ func shouldDownloadPreparedAsset(path string) bool {
 }
 
 func shouldRefreshPreparedAssets() bool {
+	if value, ok := envFlagValue("SPX_PREPARE_FORCE_REFRESH"); ok {
+		return flagValueEnabled(value)
+	}
 	// GitHub Actions may restore a fallback cache entry via restore-keys before
 	// prepare runs, so CI refreshes assets while local prepares reuse GOPATH/bin.
-	return envFlagEnabled("GITHUB_ACTIONS") || envFlagEnabled("SPX_PREPARE_FORCE_REFRESH")
+	return envFlagEnabled("GITHUB_ACTIONS")
 }
 
 func envFlagEnabled(name string) bool {
-	value := strings.TrimSpace(os.Getenv(name))
+	value, _ := envFlagValue(name)
+	return flagValueEnabled(value)
+}
+
+func envFlagValue(name string) (string, bool) {
+	value, ok := os.LookupEnv(name)
+	if !ok {
+		return "", false
+	}
+	return strings.TrimSpace(value), true
+}
+
+func flagValueEnabled(value string) bool {
 	switch strings.ToLower(value) {
 	case "", "0", "false", "no", "off":
 		return false

--- a/internal/cmd/buildctl/engine_download_test.go
+++ b/internal/cmd/buildctl/engine_download_test.go
@@ -163,3 +163,32 @@ func TestLinkOrCopyFileReplacesExistingHardLinkWithoutTruncatingSource(t *testin
 		t.Fatalf("destination content = %q, want copied content preserved", string(dstContent))
 	}
 }
+
+func TestShouldRefreshPreparedAssetsDefaultsToGitHubActions(t *testing.T) {
+	t.Setenv("GITHUB_ACTIONS", "true")
+	if err := os.Unsetenv("SPX_PREPARE_FORCE_REFRESH"); err != nil {
+		t.Fatalf("Unsetenv returned error: %v", err)
+	}
+
+	if !shouldRefreshPreparedAssets() {
+		t.Fatal("expected GitHub Actions runs to refresh prepared assets by default")
+	}
+}
+
+func TestShouldRefreshPreparedAssetsAllowsExplicitDisableInCI(t *testing.T) {
+	t.Setenv("GITHUB_ACTIONS", "true")
+	t.Setenv("SPX_PREPARE_FORCE_REFRESH", "0")
+
+	if shouldRefreshPreparedAssets() {
+		t.Fatal("expected SPX_PREPARE_FORCE_REFRESH=0 to disable forced refresh in CI")
+	}
+}
+
+func TestShouldRefreshPreparedAssetsAllowsExplicitEnableLocally(t *testing.T) {
+	t.Setenv("GITHUB_ACTIONS", "")
+	t.Setenv("SPX_PREPARE_FORCE_REFRESH", "1")
+
+	if !shouldRefreshPreparedAssets() {
+		t.Fatal("expected SPX_PREPARE_FORCE_REFRESH=1 to force refresh locally")
+	}
+}

--- a/internal/cmd/buildctl/runtime_assets.go
+++ b/internal/cmd/buildctl/runtime_assets.go
@@ -191,7 +191,11 @@ func ensureGoPath() (string, error) {
 }
 
 func defaultRuntimeVersion() string {
-	return releasemeta.DefaultReleaseMeta().Runtime.Version
+	version := releasemeta.DefaultReleaseMeta().Runtime.Version
+	if version == "" {
+		panic("releasemeta: Runtime.Version is empty")
+	}
+	return version
 }
 
 func webModeOutputZip(mode string) (string, error) {


### PR DESCRIPTION
This PR streamlines our GitHub Actions setup around `buildctl` and makes the CI workflows easier to follow.

It also keeps the small runtime metadata follow-up fixes from the previous review in the same commit.

## Changes

- cache only downloaded engine assets in `.github/actions/deps`
- always rebuild repo-generated artifacts instead of caching them
- allow `SPX_PREPARE_FORCE_REFRESH` to explicitly disable forced refresh in CI
- add a shared `.github/actions/setup-buildctl` composite action
- export a shared `BUILDCTL` environment variable instead of repeating `./.bin/buildctl$(go env GOEXE)` across workflows
- update CI workflows to call `buildctl` directly instead of the old `make` wrappers
