### PR TITLE
fix: address buildctl workflow follow-ups

### DIFF
--- a/.github/actions/deps/action.yml
+++ b/.github/actions/deps/action.yml
@@ -32,13 +32,39 @@ runs:
 
     - name: Resolve GOPATH
       id: gopath
-      run: echo "GOPATH=$(go env GOPATH)" >> $GITHUB_OUTPUT
+      run: echo "GOPATH=$(go env GOPATH)" >> "$GITHUB_OUTPUT"
       shell: bash
 
     - name: Resolve runtime version
       id: runtime-version
-      run: echo "version=$(go run ./.github/scripts/runtime_version.go)" >> $GITHUB_OUTPUT
+      run: echo "version=$(go run ./.github/scripts/runtime_version.go)" >> "$GITHUB_OUTPUT"
       shell: bash
+
+    - name: Resolve download cache keys
+      id: cache-keys
+      shell: bash
+      env:
+        CACHE_VERSION: ${{ inputs.cache-version }}
+        SETUP_MODE: ${{ inputs.setup-mode }}
+        WEB_MODE: ${{ inputs.web-mode }}
+        RUNNER_OS_NAME: ${{ runner.os }}
+      run: |
+        set -euo pipefail
+
+        scope="$SETUP_MODE"
+        if [ "$SETUP_MODE" != "runtime" ]; then
+          scope="$SETUP_MODE-$WEB_MODE"
+        fi
+
+        echo "scope=$scope" >> "$GITHUB_OUTPUT"
+        {
+          echo "restore_keys<<EOF"
+          echo "spx-download-${CACHE_VERSION}-${RUNNER_OS_NAME}-${scope}-"
+          if [ "$SETUP_MODE" != "runtime" ]; then
+            echo "spx-download-${CACHE_VERSION}-${RUNNER_OS_NAME}-${SETUP_MODE}-"
+          fi
+          echo "EOF"
+        } >> "$GITHUB_OUTPUT"
 
     - name: Restore downloaded engine assets
       id: cache-downloads
@@ -51,10 +77,8 @@ runs:
           ~/.local/share/godot/export_templates
           ~/Library/Application Support/Godot/export_templates
           ~/AppData/Roaming/Godot/export_templates
-        key: spx-download-${{ inputs.cache-version }}-${{ runner.os }}-${{ inputs.setup-mode }}-${{ inputs.setup-mode != 'runtime' && inputs.web-mode || 'runtime' }}-${{ steps.runtime-version.outputs.version }}
-        restore-keys: |
-          spx-download-${{ inputs.cache-version }}-${{ runner.os }}-${{ inputs.setup-mode }}-${{ inputs.setup-mode != 'runtime' && inputs.web-mode || 'runtime' }}-
-          spx-download-${{ inputs.cache-version }}-${{ runner.os }}-${{ inputs.setup-mode }}-
+        key: spx-download-${{ inputs.cache-version }}-${{ runner.os }}-${{ steps.cache-keys.outputs.scope }}-${{ steps.runtime-version.outputs.version }}
+        restore-keys: ${{ steps.cache-keys.outputs.restore_keys }}
 
     - name: Validate downloaded engine assets
       id: cache-download-verify

--- a/.github/actions/deps/action.yml
+++ b/.github/actions/deps/action.yml
@@ -20,7 +20,7 @@ inputs:
   cache-version:
     description: 'Manual cache version for download cache invalidation'
     required: false
-    default: 'v3'
+    default: 'v4'
 runs:
   using: "composite"
   steps:

--- a/.github/actions/setup-buildctl/action.yml
+++ b/.github/actions/setup-buildctl/action.yml
@@ -9,7 +9,6 @@ runs:
         set -euo pipefail
 
         if [ -n "${BUILDCTL:-}" ] && [ -x "$BUILDCTL" ]; then
-          echo "BUILDCTL=$BUILDCTL" >> "$GITHUB_ENV"
           exit 0
         fi
 

--- a/.github/actions/setup-buildctl/action.yml
+++ b/.github/actions/setup-buildctl/action.yml
@@ -8,6 +8,11 @@ runs:
       run: |
         set -euo pipefail
 
+        if [ -n "${BUILDCTL:-}" ] && [ -x "$BUILDCTL" ]; then
+          echo "BUILDCTL=$BUILDCTL" >> "$GITHUB_ENV"
+          exit 0
+        fi
+
         buildctl_path="$(pwd)/.bin/buildctl$(go env GOEXE)"
 
         mkdir -p ./.bin

--- a/.github/workflows/build_android.yml
+++ b/.github/workflows/build_android.yml
@@ -42,7 +42,7 @@ jobs:
       uses: ./.github/actions/deps
 
     - name: Export ANDROID_NDK_ROOT
-      run: echo "ANDROID_NDK_ROOT=${{ steps.setup-ndk.outputs.ndk-path }}" >> $GITHUB_ENV
+      run: echo "ANDROID_NDK_ROOT=${{ steps.setup-ndk.outputs.ndk-path }}" >> "$GITHUB_ENV"
 
     - name: Verify and fix Android NDK installation
       run: |

--- a/.github/workflows/build_android.yml
+++ b/.github/workflows/build_android.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Export ANDROID_NDK_ROOT
       run: echo "ANDROID_NDK_ROOT=${{ steps.setup-ndk.outputs.ndk-path }}" >> $GITHUB_ENV
 
-    - name: Verify Android NDK
+    - name: Verify and fix Android NDK installation
       run: |
         echo "ANDROID_NDK_ROOT: $ANDROID_NDK_ROOT"
         echo "Checking for clang binary:"

--- a/internal/cmd/buildctl/build_env.go
+++ b/internal/cmd/buildctl/build_env.go
@@ -25,7 +25,10 @@ type buildEnvironment struct {
 }
 
 func resolveBuildEnvironment(repoRoot string, requestedPlatform string) (buildEnvironment, error) {
-	version := defaultRuntimeVersion()
+	version, err := defaultRuntimeVersion()
+	if err != nil {
+		return buildEnvironment{}, err
+	}
 	goPath, err := ensureGoPath()
 	if err != nil {
 		return buildEnvironment{}, err

--- a/internal/cmd/buildctl/engine_build_shell_test.go
+++ b/internal/cmd/buildctl/engine_build_shell_test.go
@@ -22,7 +22,7 @@ func TestResolveEngineBuildShellPlanWebWorker(t *testing.T) {
 	t.Setenv("GOPATH", filepath.Join(repoRoot, "gopath"))
 	t.Setenv("HOME", repoRoot)
 	t.Setenv("APPDATA", filepath.Join(repoRoot, "AppData"))
-	version := defaultRuntimeVersion()
+	version := mustDefaultRuntimeVersion(t)
 
 	plan, err := resolveEngineBuildShellPlan(repoRoot, envExportEngineBuildShellConfig{
 		target:   "template",
@@ -128,7 +128,7 @@ func TestResolveEngineBuildShellPlanEditorUsesHostArtifactNames(t *testing.T) {
 	t.Setenv("GOPATH", filepath.Join(repoRoot, "gopath"))
 	t.Setenv("HOME", repoRoot)
 	t.Setenv("APPDATA", filepath.Join(repoRoot, "AppData"))
-	version := defaultRuntimeVersion()
+	version := mustDefaultRuntimeVersion(t)
 
 	plan, err := resolveEngineBuildShellPlan(repoRoot, envExportEngineBuildShellConfig{target: "editor"})
 	if err != nil {

--- a/internal/cmd/buildctl/engine_download_test.go
+++ b/internal/cmd/buildctl/engine_download_test.go
@@ -167,9 +167,6 @@ func TestLinkOrCopyFileReplacesExistingHardLinkWithoutTruncatingSource(t *testin
 func TestShouldRefreshPreparedAssetsDefaultsToGitHubActions(t *testing.T) {
 	t.Setenv("GITHUB_ACTIONS", "true")
 	previous, ok := os.LookupEnv("SPX_PREPARE_FORCE_REFRESH")
-	if err := os.Unsetenv("SPX_PREPARE_FORCE_REFRESH"); err != nil {
-		t.Fatalf("Unsetenv returned error: %v", err)
-	}
 	t.Cleanup(func() {
 		if !ok {
 			_ = os.Unsetenv("SPX_PREPARE_FORCE_REFRESH")
@@ -177,6 +174,9 @@ func TestShouldRefreshPreparedAssetsDefaultsToGitHubActions(t *testing.T) {
 		}
 		_ = os.Setenv("SPX_PREPARE_FORCE_REFRESH", previous)
 	})
+	if err := os.Unsetenv("SPX_PREPARE_FORCE_REFRESH"); err != nil {
+		t.Fatalf("Unsetenv returned error: %v", err)
+	}
 
 	if !shouldRefreshPreparedAssets() {
 		t.Fatal("expected GitHub Actions runs to refresh prepared assets by default")

--- a/internal/cmd/buildctl/engine_download_test.go
+++ b/internal/cmd/buildctl/engine_download_test.go
@@ -166,9 +166,17 @@ func TestLinkOrCopyFileReplacesExistingHardLinkWithoutTruncatingSource(t *testin
 
 func TestShouldRefreshPreparedAssetsDefaultsToGitHubActions(t *testing.T) {
 	t.Setenv("GITHUB_ACTIONS", "true")
+	previous, ok := os.LookupEnv("SPX_PREPARE_FORCE_REFRESH")
 	if err := os.Unsetenv("SPX_PREPARE_FORCE_REFRESH"); err != nil {
 		t.Fatalf("Unsetenv returned error: %v", err)
 	}
+	t.Cleanup(func() {
+		if !ok {
+			_ = os.Unsetenv("SPX_PREPARE_FORCE_REFRESH")
+			return
+		}
+		_ = os.Setenv("SPX_PREPARE_FORCE_REFRESH", previous)
+	})
 
 	if !shouldRefreshPreparedAssets() {
 		t.Fatal("expected GitHub Actions runs to refresh prepared assets by default")

--- a/internal/cmd/buildctl/engine_test.go
+++ b/internal/cmd/buildctl/engine_test.go
@@ -50,7 +50,7 @@ func TestParseEngineBuildArgsWebDefaultMode(t *testing.T) {
 func TestDownloadEngineAssetsRuntime(t *testing.T) {
 	runner := newRuntimeFixtureRunner(t)
 	installFakeEngineDownload(t, runner.repoRoot, "linux", "x86_64")
-	version := defaultRuntimeVersion()
+	version := mustDefaultRuntimeVersion(t)
 
 	if err := downloadEngineAssets(engineDownloadConfig{runtime: true}, runner.repoRoot); err != nil {
 		t.Fatalf("downloadEngineAssets returned error: %v", err)
@@ -75,7 +75,7 @@ func TestDownloadEngineAssetsRuntimeRefreshesPackLocally(t *testing.T) {
 	runner := newRuntimeFixtureRunner(t)
 	installFakeEngineDownload(t, runner.repoRoot, "linux", "x86_64")
 	t.Setenv("GITHUB_ACTIONS", "")
-	version := defaultRuntimeVersion()
+	version := mustDefaultRuntimeVersion(t)
 
 	gopathBin := filepath.Join(os.Getenv("GOPATH"), "bin")
 	editorPath := filepath.Join(gopathBin, "gdspx"+version)
@@ -136,7 +136,7 @@ func TestDownloadEngineAssetsRuntimeRefreshesPackLocally(t *testing.T) {
 func TestDownloadEngineAssetsWeb(t *testing.T) {
 	runner := newRuntimeFixtureRunner(t)
 	installFakeEngineDownload(t, runner.repoRoot, "linux", "x86_64")
-	version := defaultRuntimeVersion()
+	version := mustDefaultRuntimeVersion(t)
 
 	if err := downloadEngineAssets(engineDownloadConfig{platform: "web", mode: "worker"}, runner.repoRoot); err != nil {
 		t.Fatalf("downloadEngineAssets returned error: %v", err)
@@ -155,7 +155,7 @@ func TestDownloadEngineAssetsRuntimeOverwritesStaleDesktopBinariesInGitHubAction
 	runner := newRuntimeFixtureRunner(t)
 	installFakeEngineDownload(t, runner.repoRoot, "linux", "x86_64")
 	t.Setenv("GITHUB_ACTIONS", "true")
-	version := defaultRuntimeVersion()
+	version := mustDefaultRuntimeVersion(t)
 
 	gopathBin := filepath.Join(os.Getenv("GOPATH"), "bin")
 	editorPath := filepath.Join(gopathBin, "gdspx"+version)
@@ -212,7 +212,7 @@ func TestDownloadEngineAssetsWebSkipsExistingCachedTemplateLocally(t *testing.T)
 	runner := newRuntimeFixtureRunner(t)
 	installFakeEngineDownload(t, runner.repoRoot, "linux", "x86_64")
 	t.Setenv("GITHUB_ACTIONS", "")
-	version := defaultRuntimeVersion()
+	version := mustDefaultRuntimeVersion(t)
 
 	gopathBin := filepath.Join(os.Getenv("GOPATH"), "bin")
 	cachedZip := filepath.Join(gopathBin, "gdspx"+version+"_webworker.zip")
@@ -256,7 +256,7 @@ func installFakeEngineDownload(t *testing.T, repoRoot, defaultPlatform, arch str
 		if platform == "" {
 			platform = defaultPlatform
 		}
-		version := defaultRuntimeVersion()
+		version := mustDefaultRuntimeVersion(t)
 		return engineDownloadEnv{
 			repoRoot:    repoRootArg,
 			version:     version,

--- a/internal/cmd/buildctl/env_cmd_test.go
+++ b/internal/cmd/buildctl/env_cmd_test.go
@@ -40,7 +40,7 @@ func TestResolveBuildEnvironmentUsesGodotSrcOverride(t *testing.T) {
 }
 
 func TestBuildEnvironmentShellExports(t *testing.T) {
-	version := defaultRuntimeVersion()
+	version := mustDefaultRuntimeVersion(t)
 	env := buildEnvironment{
 		ProjectDir:    "/repo",
 		EngineDir:     "/repo/godot src",

--- a/internal/cmd/buildctl/prepare_test.go
+++ b/internal/cmd/buildctl/prepare_test.go
@@ -144,7 +144,7 @@ func TestPrepareAssetsRuntime(t *testing.T) {
 	runner := newRuntimeFixtureRunner(t)
 	installFakeEngineDownload(t, runner.repoRoot, "linux", "x86_64")
 	cfg := prepareConfig{setupMode: "runtime", webMode: "normal"}
-	version := defaultRuntimeVersion()
+	version := mustDefaultRuntimeVersion(t)
 
 	if err := prepareAssets(cfg, runner); err != nil {
 		t.Fatalf("prepareAssets returned error: %v", err)
@@ -166,7 +166,7 @@ func TestPrepareAssetsWeb(t *testing.T) {
 	runner := newRuntimeFixtureRunner(t)
 	installFakeEngineDownload(t, runner.repoRoot, "linux", "x86_64")
 	cfg := prepareConfig{setupMode: "web", webMode: "worker"}
-	version := defaultRuntimeVersion()
+	version := mustDefaultRuntimeVersion(t)
 
 	if err := prepareAssets(cfg, runner); err != nil {
 		t.Fatalf("prepareAssets returned error: %v", err)

--- a/internal/cmd/buildctl/runtime_assets.go
+++ b/internal/cmd/buildctl/runtime_assets.go
@@ -124,7 +124,10 @@ func exportWebTemplateRuntime(mode string, runner scriptRunner) error {
 }
 
 func prepareRuntimeWorkspace(repoRoot string, includeRuntimeExtension bool) (runtimeWorkspace, func(), error) {
-	version := defaultRuntimeVersion()
+	version, err := defaultRuntimeVersion()
+	if err != nil {
+		return runtimeWorkspace{}, nil, err
+	}
 	goPath, err := ensureGoPath()
 	if err != nil {
 		return runtimeWorkspace{}, nil, err
@@ -190,12 +193,12 @@ func ensureGoPath() (string, error) {
 	return goPath, nil
 }
 
-func defaultRuntimeVersion() string {
+func defaultRuntimeVersion() (string, error) {
 	version := releasemeta.DefaultReleaseMeta().Runtime.Version
 	if version == "" {
-		panic("releasemeta: Runtime.Version is empty")
+		return "", fmt.Errorf("releasemeta: Runtime.Version is empty")
 	}
-	return version
+	return version, nil
 }
 
 func webModeOutputZip(mode string) (string, error) {

--- a/internal/cmd/buildctl/runtime_cmd_test.go
+++ b/internal/cmd/buildctl/runtime_cmd_test.go
@@ -43,7 +43,7 @@ func TestRuntimeBuildWasmOptSequence(t *testing.T) {
 	runner := newRuntimeFixtureRunner(t)
 	installFakeBrotli(t, runner.repoRoot)
 	gopathBin := filepath.Join(os.Getenv("GOPATH"), "bin")
-	version := defaultRuntimeVersion()
+	version := mustDefaultRuntimeVersion(t)
 	mustWriteFile(t, filepath.Join(gopathBin, "ispx.wasm"), []byte("wasm"))
 	mustWriteFile(t, filepath.Join(gopathBin, "gdspxrt"+version+"_webnormal", "engine.wasm"), []byte("engine"))
 
@@ -99,7 +99,7 @@ func TestRuntimeExportWebSequence(t *testing.T) {
 
 func TestRuntimeExportPackSequence(t *testing.T) {
 	runner := newRuntimeFixtureRunner(t)
-	version := defaultRuntimeVersion()
+	version := mustDefaultRuntimeVersion(t)
 
 	if err := exportPackRuntime(runner); err != nil {
 		t.Fatalf("exportPackRuntime returned error: %v", err)
@@ -121,7 +121,7 @@ func TestCompressWasmArtifactsLegacyWebDirFallback(t *testing.T) {
 	gopath := filepath.Join(root, "gopath")
 	t.Setenv("GOPATH", gopath)
 	installFakeBrotli(t, root)
-	version := defaultRuntimeVersion()
+	version := mustDefaultRuntimeVersion(t)
 
 	gopathBin := filepath.Join(gopath, "bin")
 	mustWriteFile(t, filepath.Join(gopathBin, "ispx.wasm"), []byte("wasm"))

--- a/internal/cmd/buildctl/runtime_compress.go
+++ b/internal/cmd/buildctl/runtime_compress.go
@@ -10,7 +10,10 @@ import (
 )
 
 func compressWasmArtifacts() error {
-	version := defaultRuntimeVersion()
+	version, err := defaultRuntimeVersion()
+	if err != nil {
+		return err
+	}
 	goPath, err := ensureGoPath()
 	if err != nil {
 		return err

--- a/internal/cmd/buildctl/test_helpers_test.go
+++ b/internal/cmd/buildctl/test_helpers_test.go
@@ -1,0 +1,13 @@
+package main
+
+import "testing"
+
+func mustDefaultRuntimeVersion(t *testing.T) string {
+	t.Helper()
+
+	version, err := defaultRuntimeVersion()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return version
+}

--- a/internal/cmd/buildctl/tool_cleanup_test.go
+++ b/internal/cmd/buildctl/tool_cleanup_test.go
@@ -10,7 +10,7 @@ func TestCleanInstalledAssetsRemovesKnownArtifactsOnly(t *testing.T) {
 	root := t.TempDir()
 	gopath := filepath.Join(root, "gopath")
 	t.Setenv("GOPATH", gopath)
-	version := defaultRuntimeVersion()
+	version := mustDefaultRuntimeVersion(t)
 
 	binDir := filepath.Join(gopath, "bin")
 	if err := os.MkdirAll(binDir, 0o755); err != nil {


### PR DESCRIPTION
- return errors instead of panicking when default runtime metadata is missing

- reuse existing BUILDCTL builds and quote GITHUB_OUTPUT writes in CI actions

- fix download cache key generation and keep test environment changes isolated