### PR TITLE
refactor: streamline release workflows

### DIFF
--- a/.github/actions/lib/release_platform.sh
+++ b/.github/actions/lib/release_platform.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+normalize_platform() {
+  case "$1" in
+    darwin|macos|macOS)
+      printf 'macos\n'
+      ;;
+    linux|Linux)
+      printf 'linux\n'
+      ;;
+    windows|Windows)
+      printf 'windows\n'
+      ;;
+    *)
+      printf '%s\n' "$1" | tr '[:upper:]' '[:lower:]'
+      ;;
+  esac
+}
+
+normalize_arch() {
+  case "$1" in
+    X64|x64|amd64|x86_64)
+      printf 'x64\n'
+      ;;
+    X86|x86|386|i386|i686)
+      printf 'x86\n'
+      ;;
+    ARM64|arm64|aarch64)
+      printf 'arm64\n'
+      ;;
+    *)
+      printf '%s\n' "$1" | tr '[:upper:]' '[:lower:]'
+      ;;
+  esac
+}

--- a/.github/actions/prepare-release-goenv/action.yml
+++ b/.github/actions/prepare-release-goenv/action.yml
@@ -45,10 +45,12 @@ runs:
         INSTALLED_BIN_DIR="$GOPATH_FIRST/bin"
         INSTALLED_SPX="$INSTALLED_BIN_DIR/spx$GOEXE"
         GOENV_ROOT="$(pwd)/$GOENV_DIR"
+        GOENV_EXCLUDE="./${GOENV_DIR#./}"
         GOMODCACHE_DIR="$GOENV_ROOT/.cache/mod"
         PACKAGED_BIN_DIR="$GOENV_ROOT/go/bin"
         PACKAGED_SPX="$PACKAGED_BIN_DIR/spx$GOEXE"
-        DEST="$GOENV_DIR/.cache/mod/github.com/goplus/spx/v2@$RELEASE_VERSION"
+        DEST="$GOENV_ROOT/.cache/mod/github.com/goplus/spx/v2@$RELEASE_VERSION"
+        SMOKE_LOG_PATH="$GOENV_ROOT/prepare-release-goenv.log"
 
         if [ ! -f "$INSTALLED_SPX" ]; then
           echo "❌ Error: rebuilt spx binary not found: $INSTALLED_SPX"
@@ -57,8 +59,20 @@ runs:
 
         mkdir -p "$GOMODCACHE_DIR" "$PACKAGED_BIN_DIR"
 
-        cp "$INSTALLED_BIN_DIR"/gdspxrt* "$PACKAGED_BIN_DIR"/ || true
-        cp "$INSTALLED_BIN_DIR"/runtime.gdextension "$PACKAGED_BIN_DIR"/ || true
+        shopt -s nullglob
+        RUNTIME_BINARIES=("$INSTALLED_BIN_DIR"/gdspxrt*)
+        shopt -u nullglob
+        if [ "${#RUNTIME_BINARIES[@]}" -eq 0 ]; then
+          echo "❌ Error: runtime binaries not found in $INSTALLED_BIN_DIR"
+          exit 1
+        fi
+        if [ ! -f "$INSTALLED_BIN_DIR/runtime.gdextension" ]; then
+          echo "❌ Error: runtime.gdextension not found in $INSTALLED_BIN_DIR"
+          exit 1
+        fi
+
+        cp "${RUNTIME_BINARIES[@]}" "$PACKAGED_BIN_DIR"/
+        cp "$INSTALLED_BIN_DIR/runtime.gdextension" "$PACKAGED_BIN_DIR"/
 
         echo "Installing rebuilt spx binary: $INSTALLED_SPX -> $PACKAGED_SPX"
         cp "$INSTALLED_SPX" "$PACKAGED_SPX"
@@ -72,7 +86,7 @@ runs:
           --exclude='./.bin' \
           --exclude='./.github' \
           --exclude='./docs' \
-          --exclude='./goenv' \
+          --exclude="$GOENV_EXCLUDE" \
           --exclude='./test' \
           --exclude='./tutorial' \
           --exclude='./godot' \
@@ -81,6 +95,7 @@ runs:
             tar -xf -
           )
 
+        # Set GOMODCACHE so the following smoke run populates the bundled offline cache.
         export GOMODCACHE="$GOMODCACHE_DIR"
 
         if [ ! -f "$PACKAGED_SPX" ]; then
@@ -88,13 +103,36 @@ runs:
           exit 1
         fi
 
-        if [ "$GOEXE" = ".exe" ]; then
-          "$PACKAGED_SPX" run --goenv="$GOENV_ROOT" --path=test/CI --headless &
-          SPX_PID=$!
-          sleep 5
-          kill "$SPX_PID" || true
-        else
-          "$PACKAGED_SPX" run --goenv="$GOENV_ROOT" --path=test/CI --headless || true
+        # Run the smoke test with a bounded timeout so dependency downloads can warm GOMODCACHE.
+        rm -f "$SMOKE_LOG_PATH"
+        "$PACKAGED_SPX" run --goenv="$GOENV_ROOT" --path=test/CI --headless >"$SMOKE_LOG_PATH" 2>&1 &
+        SPX_PID=$!
+        EXIT_STATUS=""
+        TIMED_OUT=true
+        for _ in $(seq 1 30); do
+          if ! kill -0 "$SPX_PID" 2>/dev/null; then
+            wait "$SPX_PID"
+            EXIT_STATUS=$?
+            TIMED_OUT=false
+            break
+          fi
+          sleep 1
+        done
+
+        if [ "$TIMED_OUT" = true ]; then
+          echo "Smoke run exceeded 30s; stopping after warming module cache."
+          kill "$SPX_PID" 2>/dev/null || true
+          wait "$SPX_PID" 2>/dev/null || true
+        elif [ "$EXIT_STATUS" -ne 0 ]; then
+          echo "❌ Error: dependency warm-up run failed"
+          cat "$SMOKE_LOG_PATH"
+          exit 1
+        fi
+
+        if ! find "$GOMODCACHE_DIR" -type d -name '*@*' ! -path "$DEST" -print -quit | grep -q .; then
+          echo "❌ Error: dependency warm-up did not cache any additional modules"
+          cat "$SMOKE_LOG_PATH"
+          exit 1
         fi
 
         echo "Module cache collection completed"

--- a/.github/actions/prepare-release-goenv/action.yml
+++ b/.github/actions/prepare-release-goenv/action.yml
@@ -28,6 +28,7 @@ runs:
         RUNNER_ARCH_CONTEXT: ${{ runner.arch }}
       run: |
         set -euo pipefail
+        source ./.github/actions/lib/release_platform.sh
 
         normalize_path() {
           local raw_path="$1"
@@ -36,40 +37,6 @@ runs:
             return
           fi
           printf '%s\n' "$raw_path"
-        }
-
-        normalize_platform() {
-          case "$1" in
-            darwin|macos|macOS)
-              printf 'macos\n'
-              ;;
-            linux|Linux)
-              printf 'linux\n'
-              ;;
-            windows|Windows)
-              printf 'windows\n'
-              ;;
-            *)
-              printf '%s\n' "$1" | tr '[:upper:]' '[:lower:]'
-              ;;
-          esac
-        }
-
-        normalize_arch() {
-          case "$1" in
-            X64|x64|amd64|x86_64)
-              printf 'x64\n'
-              ;;
-            X86|x86|386|i386|i686)
-              printf 'x86\n'
-              ;;
-            ARM64|arm64|aarch64)
-              printf 'arm64\n'
-              ;;
-            *)
-              printf '%s\n' "$1" | tr '[:upper:]' '[:lower:]'
-              ;;
-          esac
         }
 
         GOEXE="$(go env GOEXE)"

--- a/.github/actions/prepare-release-goenv/action.yml
+++ b/.github/actions/prepare-release-goenv/action.yml
@@ -4,6 +4,12 @@ inputs:
   version:
     description: 'Release version without the leading v (for example, 2.0.1)'
     required: true
+  platform:
+    description: 'Platform name (darwin/windows/linux)'
+    required: true
+  package-arch:
+    description: 'Package architecture name (x86/x64/arm64)'
+    required: true
   goenv-dir:
     description: 'Portable goenv directory'
     required: false
@@ -11,11 +17,15 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Prepare release goenv contents
+    - name: Prepare release goenv
       shell: bash
       env:
         RELEASE_VERSION: v${{ inputs.version }}
+        PLATFORM: ${{ inputs.platform }}
+        PACKAGE_ARCH: ${{ inputs.package-arch }}
         GOENV_DIR: ${{ inputs.goenv-dir }}
+        RUNNER_OS_CONTEXT: ${{ runner.os }}
+        RUNNER_ARCH_CONTEXT: ${{ runner.arch }}
       run: |
         set -euo pipefail
 
@@ -26,6 +36,40 @@ runs:
             return
           fi
           printf '%s\n' "$raw_path"
+        }
+
+        normalize_platform() {
+          case "$1" in
+            darwin|macos|macOS)
+              printf 'macos\n'
+              ;;
+            linux|Linux)
+              printf 'linux\n'
+              ;;
+            windows|Windows)
+              printf 'windows\n'
+              ;;
+            *)
+              printf '%s\n' "$1" | tr '[:upper:]' '[:lower:]'
+              ;;
+          esac
+        }
+
+        normalize_arch() {
+          case "$1" in
+            X64|x64|amd64|x86_64)
+              printf 'x64\n'
+              ;;
+            X86|x86|386|i386|i686)
+              printf 'x86\n'
+              ;;
+            ARM64|arm64|aarch64)
+              printf 'arm64\n'
+              ;;
+            *)
+              printf '%s\n' "$1" | tr '[:upper:]' '[:lower:]'
+              ;;
+          esac
         }
 
         GOEXE="$(go env GOEXE)"
@@ -51,6 +95,10 @@ runs:
         PACKAGED_SPX="$PACKAGED_BIN_DIR/spx$GOEXE"
         DEST="$GOENV_ROOT/.cache/mod/github.com/goplus/spx/v2@$RELEASE_VERSION"
         SMOKE_LOG_PATH="$GOENV_ROOT/prepare-release-goenv.log"
+        TARGET_PLATFORM="$(normalize_platform "$PLATFORM")"
+        TARGET_ARCH="$(normalize_arch "$PACKAGE_ARCH")"
+        RUNNER_PLATFORM="$(normalize_platform "$RUNNER_OS_CONTEXT")"
+        RUNNER_ARCH="$(normalize_arch "$RUNNER_ARCH_CONTEXT")"
 
         if [ ! -f "$INSTALLED_SPX" ]; then
           echo "❌ Error: rebuilt spx binary not found: $INSTALLED_SPX"
@@ -78,6 +126,8 @@ runs:
         cp "$INSTALLED_SPX" "$PACKAGED_SPX"
 
         echo "Installing spx source to module cache: $RELEASE_VERSION"
+        echo "Runner platform/arch: $RUNNER_PLATFORM/$RUNNER_ARCH"
+        echo "Package target: $TARGET_PLATFORM/$TARGET_ARCH"
         rm -rf "$DEST"
         mkdir -p "$DEST"
 
@@ -101,6 +151,12 @@ runs:
         if [ ! -f "$PACKAGED_SPX" ]; then
           echo "❌ Error: packaged spx binary not found: $PACKAGED_SPX"
           exit 1
+        fi
+
+        if [ "$TARGET_PLATFORM" != "$RUNNER_PLATFORM" ] || [ "$TARGET_ARCH" != "$RUNNER_ARCH" ]; then
+          echo "Skipping dependency warm-up on non-native runner."
+          echo "Release goenv preparation completed without smoke run."
+          exit 0
         fi
 
         # Run the smoke test with a bounded timeout so dependency downloads can warm GOMODCACHE.

--- a/.github/actions/prepare-release-goenv/action.yml
+++ b/.github/actions/prepare-release-goenv/action.yml
@@ -1,0 +1,102 @@
+name: Prepare release goenv
+description: Prepare release goenv with rebuilt binaries, release-version source, and dependent modules.
+inputs:
+  version:
+    description: 'Release version without the leading v (for example, 2.0.1)'
+    required: true
+  goenv-dir:
+    description: 'Portable goenv directory'
+    required: false
+    default: goenv
+runs:
+  using: composite
+  steps:
+    - name: Prepare release goenv contents
+      shell: bash
+      env:
+        RELEASE_VERSION: v${{ inputs.version }}
+        GOENV_DIR: ${{ inputs.goenv-dir }}
+      run: |
+        set -euo pipefail
+
+        normalize_path() {
+          local raw_path="$1"
+          if command -v cygpath >/dev/null 2>&1; then
+            cygpath -u "$raw_path" 2>/dev/null || printf '%s\n' "$raw_path"
+            return
+          fi
+          printf '%s\n' "$raw_path"
+        }
+
+        GOEXE="$(go env GOEXE)"
+        GOPATH_RAW="$(go env GOPATH | tr -d '\r')"
+        if [ -z "$GOPATH_RAW" ]; then
+          echo "❌ Error: GOPATH is empty"
+          exit 1
+        fi
+
+        GOPATH_SEP=':'
+        if [ "$GOEXE" = ".exe" ]; then
+          GOPATH_SEP=';'
+        fi
+
+        GOPATH_FIRST="${GOPATH_RAW%%${GOPATH_SEP}*}"
+        GOPATH_FIRST="$(normalize_path "$GOPATH_FIRST")"
+        INSTALLED_BIN_DIR="$GOPATH_FIRST/bin"
+        INSTALLED_SPX="$INSTALLED_BIN_DIR/spx$GOEXE"
+        GOENV_ROOT="$(pwd)/$GOENV_DIR"
+        GOMODCACHE_DIR="$GOENV_ROOT/.cache/mod"
+        PACKAGED_BIN_DIR="$GOENV_ROOT/go/bin"
+        PACKAGED_SPX="$PACKAGED_BIN_DIR/spx$GOEXE"
+        DEST="$GOENV_DIR/.cache/mod/github.com/goplus/spx/v2@$RELEASE_VERSION"
+
+        if [ ! -f "$INSTALLED_SPX" ]; then
+          echo "❌ Error: rebuilt spx binary not found: $INSTALLED_SPX"
+          exit 1
+        fi
+
+        mkdir -p "$GOMODCACHE_DIR" "$PACKAGED_BIN_DIR"
+
+        cp "$INSTALLED_BIN_DIR"/gdspxrt* "$PACKAGED_BIN_DIR"/ || true
+        cp "$INSTALLED_BIN_DIR"/runtime.gdextension "$PACKAGED_BIN_DIR"/ || true
+
+        echo "Installing rebuilt spx binary: $INSTALLED_SPX -> $PACKAGED_SPX"
+        cp "$INSTALLED_SPX" "$PACKAGED_SPX"
+
+        echo "Installing spx source to module cache: $RELEASE_VERSION"
+        rm -rf "$DEST"
+        mkdir -p "$DEST"
+
+        tar \
+          --exclude='./.git' \
+          --exclude='./.bin' \
+          --exclude='./.github' \
+          --exclude='./docs' \
+          --exclude='./goenv' \
+          --exclude='./test' \
+          --exclude='./tutorial' \
+          --exclude='./godot' \
+          -cf - . | (
+            cd "$DEST"
+            tar -xf -
+          )
+
+        export GOMODCACHE="$GOMODCACHE_DIR"
+
+        if [ ! -f "$PACKAGED_SPX" ]; then
+          echo "❌ Error: packaged spx binary not found: $PACKAGED_SPX"
+          exit 1
+        fi
+
+        if [ "$GOEXE" = ".exe" ]; then
+          "$PACKAGED_SPX" run --goenv="$GOENV_ROOT" --path=test/CI --headless &
+          SPX_PID=$!
+          sleep 5
+          kill "$SPX_PID" || true
+        else
+          "$PACKAGED_SPX" run --goenv="$GOENV_ROOT" --path=test/CI --headless || true
+        fi
+
+        echo "Module cache collection completed"
+        ls -lah "$GOMODCACHE_DIR" || true
+        du -sh "$GOMODCACHE_DIR" || true

--- a/.github/actions/verify-release/action.yml
+++ b/.github/actions/verify-release/action.yml
@@ -23,43 +23,7 @@ runs:
         RUNNER_ARCH_CONTEXT: ${{ runner.arch }}
       run: |
         set -euo pipefail
-
-        normalize_platform() {
-          case "$1" in
-            darwin)
-              printf 'macos\n'
-              ;;
-            linux)
-              printf 'linux\n'
-              ;;
-            windows)
-              printf 'windows\n'
-              ;;
-            macos)
-              printf 'macos\n'
-              ;;
-            *)
-              printf '%s\n' "$1"
-              ;;
-          esac
-        }
-
-        normalize_arch() {
-          case "$1" in
-            X64|x64|amd64|x86_64)
-              printf 'x64\n'
-              ;;
-            X86|x86|386|i386|i686)
-              printf 'x86\n'
-              ;;
-            ARM64|arm64|aarch64)
-              printf 'arm64\n'
-              ;;
-            *)
-              printf '%s\n' "$1" | tr '[:upper:]' '[:lower:]'
-              ;;
-          esac
-        }
+        source ./.github/actions/lib/release_platform.sh
 
         echo "=========================================="
         echo "🔍 Verifying release package"

--- a/.github/actions/verify-release/action.yml
+++ b/.github/actions/verify-release/action.yml
@@ -7,6 +7,9 @@ inputs:
   platform:
     description: 'Platform name (darwin/windows/linux)'
     required: true
+  package-arch:
+    description: 'Package architecture name (x86/x64/arm64)'
+    required: true
 runs:
   using: "composite"
   steps:
@@ -15,13 +18,54 @@ runs:
       env:
         PACKAGE_FILE: ${{ inputs.package-file }}
         PLATFORM: ${{ inputs.platform }}
+        PACKAGE_ARCH: ${{ inputs.package-arch }}
+        RUNNER_OS_CONTEXT: ${{ runner.os }}
+        RUNNER_ARCH_CONTEXT: ${{ runner.arch }}
       run: |
         set -euo pipefail
+
+        normalize_platform() {
+          case "$1" in
+            darwin)
+              printf 'macos\n'
+              ;;
+            linux)
+              printf 'linux\n'
+              ;;
+            windows)
+              printf 'windows\n'
+              ;;
+            macos)
+              printf 'macos\n'
+              ;;
+            *)
+              printf '%s\n' "$1"
+              ;;
+          esac
+        }
+
+        normalize_arch() {
+          case "$1" in
+            X64|x64|amd64|x86_64)
+              printf 'x64\n'
+              ;;
+            X86|x86|386|i386|i686)
+              printf 'x86\n'
+              ;;
+            ARM64|arm64|aarch64)
+              printf 'arm64\n'
+              ;;
+            *)
+              printf '%s\n' "$1" | tr '[:upper:]' '[:lower:]'
+              ;;
+          esac
+        }
 
         echo "=========================================="
         echo "🔍 Verifying release package"
         echo "Package: $PACKAGE_FILE"
         echo "Platform: $PLATFORM"
+        echo "Package arch: $PACKAGE_ARCH"
         echo "=========================================="
         echo ""
 
@@ -35,8 +79,14 @@ runs:
         VERIFY_TEST_ROOT_DIR="$VERIFY_ROOT_DIR/test"
         TEST_PROJECT_DIR="$VERIFY_TEST_ROOT_DIR/CI"
         VERIFY_LOG_PATH="$WORKSPACE_DIR/release-verification.log"
+        TARGET_PLATFORM="$(normalize_platform "$PLATFORM")"
+        TARGET_ARCH="$(normalize_arch "$PACKAGE_ARCH")"
+        RUNNER_PLATFORM="$(normalize_platform "$RUNNER_OS_CONTEXT")"
+        RUNNER_ARCH="$(normalize_arch "$RUNNER_ARCH_CONTEXT")"
 
         echo "📁 Workspace: $WORKSPACE_DIR"
+        echo "🖥️ Runner: $RUNNER_PLATFORM/$RUNNER_ARCH"
+        echo "📦 Package target: $TARGET_PLATFORM/$TARGET_ARCH"
 
         if ! command -v unzip >/dev/null 2>&1; then
           echo "❌ Error: unzip command is required but not available"
@@ -105,6 +155,18 @@ runs:
 
         if [ "$PLATFORM" != "windows" ]; then
           chmod +x "$SPX_BIN_PATH"
+        fi
+
+        if [ "$TARGET_PLATFORM" != "$RUNNER_PLATFORM" ] || [ "$TARGET_ARCH" != "$RUNNER_ARCH" ]; then
+          echo ""
+          echo "⏭️ Skipping smoke test on non-native runner"
+          echo "Runner platform/arch does not match package target."
+          echo "Structure verification completed successfully."
+          echo ""
+          echo "=========================================="
+          echo "✅ Release package verification PASSED"
+          echo "=========================================="
+          exit 0
         fi
 
         echo ""

--- a/.github/actions/verify-release/action.yml
+++ b/.github/actions/verify-release/action.yml
@@ -1,5 +1,5 @@
-name: Verify Release Package
-description: Verify the release package by extracting and running a test project
+name: Verify release package
+description: Verify a release package by extracting it and running a smoke test project.
 inputs:
   package-file:
     description: 'Path to the release package file'
@@ -12,86 +12,119 @@ runs:
   steps:
     - name: Verify release package
       shell: bash
+      env:
+        PACKAGE_FILE: ${{ inputs.package-file }}
+        PLATFORM: ${{ inputs.platform }}
       run: |
-        set -e
+        set -euo pipefail
 
         echo "=========================================="
-        echo "🔍 Verifying Release Package"
-        echo "Package: ${{ inputs.package-file }}"
-        echo "Platform: ${{ inputs.platform }}"
+        echo "🔍 Verifying release package"
+        echo "Package: $PACKAGE_FILE"
+        echo "Platform: $PLATFORM"
         echo "=========================================="
         echo ""
 
-        # Get current directory
-        CURRENT_DIR=$(pwd)
-        echo "📁 Current directory: $CURRENT_DIR"
-        ls -la $CURRENT_DIR
-        echo "=========================================="
-        # Check if package file exists
-        if [ ! -f "${{ inputs.package-file }}" ]; then
-          echo "❌ Error: Package file not found: ${{ inputs.package-file }}"
+        WORKSPACE_DIR=$(pwd)
+        PACKAGE_PATH="$WORKSPACE_DIR/$PACKAGE_FILE"
+        if [ -f "$PACKAGE_FILE" ]; then
+          PACKAGE_PATH="$PACKAGE_FILE"
+        fi
+
+        VERIFY_ROOT_DIR="$WORKSPACE_DIR/release-verification"
+        VERIFY_TEST_ROOT_DIR="$VERIFY_ROOT_DIR/test"
+        TEST_PROJECT_DIR="$VERIFY_TEST_ROOT_DIR/CI"
+        VERIFY_LOG_PATH="$WORKSPACE_DIR/release-verification.log"
+
+        echo "📁 Workspace: $WORKSPACE_DIR"
+
+        if ! command -v unzip >/dev/null 2>&1; then
+          echo "❌ Error: unzip command is required but not available"
           exit 1
         fi
-        echo "✓ Package file found"
 
-        # Create test directory
-        rm -rf rlcheck
-        mkdir -p rlcheck
-        echo "✓ Created test directory: rlcheck"
+        if [ ! -f "$PACKAGE_PATH" ]; then
+          echo "❌ Error: package file not found: $PACKAGE_PATH"
+          exit 1
+        fi
+        echo "✓ Package file found: $PACKAGE_PATH"
 
-        # Extract package
+        rm -rf "$VERIFY_ROOT_DIR"
+        mkdir -p "$VERIFY_ROOT_DIR"
+        echo "✓ Created verification directory: $VERIFY_ROOT_DIR"
+
         echo ""
         echo "📦 Extracting package..."
-        cd rlcheck
-        unzip -q "$CURRENT_DIR/${{ inputs.package-file }}"
-        cd "$CURRENT_DIR"
+        unzip -q "$PACKAGE_PATH" -d "$VERIFY_ROOT_DIR"
         echo "✓ Package extracted"
 
-        # Verify extracted structure
-        echo ""
-        echo "📂 Extracted structure:"
-        ls -la rlcheck/
-        echo ""
-        echo "📂 Go bin directory:"
-        ls -la rlcheck/go/bin/ || echo "Warning: go/bin directory not found"
-        echo ""
-        echo "📂 Go toolchain directory:"
-        ls -la rlcheck/gotoolchain/ || echo "Warning: gotoolchain directory not found"
-
-        # Create test subdirectory and copy test project
-        echo ""
-        echo "📋 Preparing test project..."
-        mkdir -p rlcheck/test
-        cp -r test/CI rlcheck/test/
-        echo "✓ Test project copied"
-
-        # Verify spx executable exists
-        SPX_BIN="rlcheck/go/bin/spx"
-        if [ "${{ inputs.platform }}" = "windows" ]; then
-          SPX_BIN="rlcheck/go/bin/spx.exe"
-        fi
-
-        if [ ! -f "$SPX_BIN" ]; then
-          echo "❌ Error: spx executable not found: $SPX_BIN"
+        if [ ! -d "$VERIFY_ROOT_DIR/go/bin" ]; then
+          echo "❌ Error: go/bin directory not found in extracted package"
           exit 1
         fi
-        echo "✓ SPX executable found: $SPX_BIN"
 
-        # Make spx executable (for Unix-like systems)
-        if [ "${{ inputs.platform }}" != "windows" ]; then
-          chmod +x "$SPX_BIN"
+        if [ ! -d "$VERIFY_ROOT_DIR/gotoolchain/go" ]; then
+          echo "❌ Error: portable Go toolchain not found in extracted package"
+          exit 1
         fi
 
-        # Run test
         echo ""
-        echo "🚀 Running test project..."
-        echo "Command: $SPX_BIN run --ixgogen --goenv=$CURRENT_DIR/rlcheck --path=$CURRENT_DIR/rlcheck/test/CI"
+        echo "📂 Extracted top-level contents:"
+        ls -la "$VERIFY_ROOT_DIR"
+        echo ""
+        echo "📂 Go bin directory:"
+        ls -la "$VERIFY_ROOT_DIR/go/bin"
+        echo ""
+        echo "📂 Go toolchain directory:"
+        ls -la "$VERIFY_ROOT_DIR/gotoolchain"
+
+        echo ""
+        echo "📋 Preparing test project..."
+        mkdir -p "$VERIFY_TEST_ROOT_DIR"
+        cp -R test/CI "$VERIFY_TEST_ROOT_DIR/"
+        echo "✓ Test project copied"
+
+        case "$PLATFORM" in
+          windows)
+            SPX_BIN_PATH="$VERIFY_ROOT_DIR/go/bin/spx.exe"
+            ;;
+          darwin|linux)
+            SPX_BIN_PATH="$VERIFY_ROOT_DIR/go/bin/spx"
+            ;;
+          *)
+            echo "❌ Error: unsupported platform: $PLATFORM"
+            exit 1
+            ;;
+        esac
+
+        if [ ! -f "$SPX_BIN_PATH" ]; then
+          echo "❌ Error: spx executable not found: $SPX_BIN_PATH"
+          exit 1
+        fi
+        echo "✓ SPX executable found: $SPX_BIN_PATH"
+
+        if [ "$PLATFORM" != "windows" ]; then
+          chmod +x "$SPX_BIN_PATH"
+        fi
+
+        echo ""
+        echo "🚀 Running smoke test..."
+        echo "Command: $SPX_BIN_PATH run --ixgogen --goenv=$VERIFY_ROOT_DIR --path=$TEST_PROJECT_DIR --headless"
         echo ""
 
-        cd rlcheck
-        # Skip the check since the real version hasn't been released yet.
-        # "$CURRENT_DIR/$SPX_BIN" run --ixgogen --goenv="$CURRENT_DIR/rlcheck" --path="$CURRENT_DIR/rlcheck/test/CI" 
-        cd "$CURRENT_DIR"
+        rm -f "$VERIFY_LOG_PATH"
+        if ! "$SPX_BIN_PATH" run --ixgogen --goenv="$VERIFY_ROOT_DIR" --path="$TEST_PROJECT_DIR" --headless 2>&1 | tee "$VERIFY_LOG_PATH"; then
+          echo "❌ Error: smoke test command failed"
+          exit 1
+        fi
+
+        if ! grep -q "===>SpxCIRunSucc" "$VERIFY_LOG_PATH"; then
+          echo "❌ Error: smoke test success marker not found"
+          echo "Smoke test log:"
+          cat "$VERIFY_LOG_PATH"
+          exit 1
+        fi
+        echo "✓ Smoke test success marker found"
 
         echo ""
         echo "=========================================="

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,11 +35,13 @@ jobs:
 
       - name: Resolve release version
         id: set-version
+        env:
+          RELEASE_TAG_INPUT: ${{ github.event.inputs.release_tag }}
         run: |
           if [ "${{ github.event_name }}" == "release" ]; then
             VERSION="${{ github.event.release.tag_name }}"
           else
-            VERSION="${{ github.event.inputs.release_tag }}"
+            VERSION="$RELEASE_TAG_INPUT"
           fi
           VERSION="${VERSION#v}"  # Remove 'v' prefix (if present)
           echo "VERSION=$VERSION"
@@ -47,13 +49,15 @@ jobs:
 
       - name: Resolve target platforms
         id: set-platforms
+        env:
+          PLATFORMS_INPUT: ${{ github.event.inputs.platforms }}
         run: |
           set -euo pipefail
 
           if [ "${{ github.event_name }}" = "release" ]; then
             RAW_PLATFORMS="all"
           else
-            RAW_PLATFORMS="${{ github.event.inputs.platforms }}"
+            RAW_PLATFORMS="$PLATFORMS_INPUT"
           fi
 
           PLATFORMS=$(printf '%s' "$RAW_PLATFORMS" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,9 +10,9 @@ on:
         required: true
         default: 'v2.0.1'
       platforms:
-        description: 'Platforms to build (comma-separated, for example: web,all)'
+        description: 'Platforms to build (comma-separated: all,web,macos,windows,linux)'
         required: true
-        default: 'web'
+        default: 'all'
 concurrency:
   group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-release
   cancel-in-progress: true
@@ -23,7 +23,10 @@ jobs:
     runs-on: ubuntu-22.04
     outputs:
       version: ${{ steps.set-version.outputs.version }}
-      platforms: ${{ steps.set-platforms.outputs.platforms }}
+      run_web: ${{ steps.set-platforms.outputs.run_web }}
+      run_macos: ${{ steps.set-platforms.outputs.run_macos }}
+      run_windows: ${{ steps.set-platforms.outputs.run_windows }}
+      run_linux: ${{ steps.set-platforms.outputs.run_linux }}
     steps:
       - name: Check out code
         uses: actions/checkout@v6
@@ -45,18 +48,64 @@ jobs:
       - name: Resolve target platforms
         id: set-platforms
         run: |
-          if [ "${{ github.event_name }}" == "release" ]; then
-            PLATFORMS="all"
+          set -euo pipefail
+
+          if [ "${{ github.event_name }}" = "release" ]; then
+            RAW_PLATFORMS="all"
           else
-            PLATFORMS="${{ github.event.inputs.platforms }}"
+            RAW_PLATFORMS="${{ github.event.inputs.platforms }}"
           fi
 
-          if [ "$PLATFORMS" == "all" ]; then
-            PLATFORMS="web"
+          PLATFORMS=$(printf '%s' "$RAW_PLATFORMS" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')
+          if [ -z "$PLATFORMS" ]; then
+            PLATFORMS="all"
+          fi
+
+          case ",$PLATFORMS," in
+            *,all,*)
+              PLATFORMS="web,macos,windows,linux"
+              ;;
+          esac
+
+          IFS=',' read -r -a PLATFORM_ITEMS <<< "$PLATFORMS"
+          RUN_WEB=false
+          RUN_MACOS=false
+          RUN_WINDOWS=false
+          RUN_LINUX=false
+
+          for PLATFORM in "${PLATFORM_ITEMS[@]}"; do
+            case "$PLATFORM" in
+              web)
+                RUN_WEB=true
+                ;;
+              macos)
+                RUN_MACOS=true
+                ;;
+              windows)
+                RUN_WINDOWS=true
+                ;;
+              linux)
+                RUN_LINUX=true
+                ;;
+              "")
+                ;;
+              *)
+                echo "Unsupported platform: $PLATFORM"
+                exit 1
+                ;;
+            esac
+          done
+
+          if [ "$RUN_WEB" = false ] && [ "$RUN_MACOS" = false ] && [ "$RUN_WINDOWS" = false ] && [ "$RUN_LINUX" = false ]; then
+            echo "No valid platforms resolved from: $RAW_PLATFORMS"
+            exit 1
           fi
 
           echo "PLATFORMS=$PLATFORMS"
-          echo "platforms=$PLATFORMS" >> $GITHUB_OUTPUT
+          echo "run_web=$RUN_WEB" >> $GITHUB_OUTPUT
+          echo "run_macos=$RUN_MACOS" >> $GITHUB_OUTPUT
+          echo "run_windows=$RUN_WINDOWS" >> $GITHUB_OUTPUT
+          echo "run_linux=$RUN_LINUX" >> $GITHUB_OUTPUT
 
   static-checks:
     name: Static checks
@@ -66,6 +115,7 @@ jobs:
   web-build:
     name: Release web bundle
     needs: [setup, static-checks]
+    if: needs.setup.outputs.run_web == 'true'
     uses: ./.github/workflows/release_web.yml
     with:
       version: ${{ needs.setup.outputs.version }}
@@ -73,6 +123,7 @@ jobs:
   macos-build:
     name: Release macOS package
     needs: [setup, static-checks]
+    if: needs.setup.outputs.run_macos == 'true'
     uses: ./.github/workflows/release_macos.yml
     with:
       version: ${{ needs.setup.outputs.version }}
@@ -80,6 +131,7 @@ jobs:
   windows-build:
     name: Release Windows package
     needs: [setup, static-checks]
+    if: needs.setup.outputs.run_windows == 'true'
     uses: ./.github/workflows/release_windows.yml
     with:
       version: ${{ needs.setup.outputs.version }}
@@ -87,6 +139,7 @@ jobs:
   linux-build:
     name: Release Linux package
     needs: [setup, static-checks]
+    if: needs.setup.outputs.run_linux == 'true'
     uses: ./.github/workflows/release_linux.yml
     with:
       version: ${{ needs.setup.outputs.version }}

--- a/.github/workflows/release_linux.yml
+++ b/.github/workflows/release_linux.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up toolchain and engine assets
         uses: ./.github/actions/deps
 
-      - name: Download Go toolchain
+      - name: Download go toolchain
         run: |
           mkdir -p goenv/gotoolchain
           cd goenv/gotoolchain

--- a/.github/workflows/release_linux.yml
+++ b/.github/workflows/release_linux.yml
@@ -44,51 +44,15 @@ jobs:
           rm go1.25.8.linux-${{ matrix.arch }}.tar.gz
           cd ../..
 
-      - name: Collect module cache
-        run: |
-          # Set up mod cache directory (no build cache needed)
-          mkdir -p goenv/.cache/mod
-
-          # IMPORTANT: Copy binaries BEFORE running spx to collect dependencies
-          # Without these, spx run will fail and won't download dependencies
-          mkdir -p goenv/go/bin
-          cp $HOME/go/bin/gdspxrt* goenv/go/bin/ || true
-          cp $HOME/go/bin/runtime.gdextension goenv/go/bin/ || true
-          cp $HOME/go/bin/spx goenv/go/bin/
-
-          # Set environment to use our mod cache location
-          export GOMODCACHE=$(pwd)/goenv/.cache/mod
-
-          # Add current spx source to mod cache so users can use offline
-          SPX_VERSION="v2.0.0-$(git rev-parse --short HEAD)"
-          DEST="$GOMODCACHE/github.com/goplus/spx/v2@$SPX_VERSION"
-
-          echo "Installing spx source to mod cache: $SPX_VERSION"
-          mkdir -p "$DEST"
-          rsync -av --exclude='.git' --exclude='goenv' \
-            --exclude='test' --exclude='tutorial' --exclude='demo-game' \
-            --exclude='spx_demos' --exclude='cmd/demo' \
-            . "$DEST/"
-
-          # Run test/CI demo to collect other dependencies
-          cd test/CI
-          $HOME/go/bin/spx run --goenv=../../goenv  --path=. --headless || true
-          cd ../..
-
-          echo "Module cache collection completed"
-          ls -lah goenv/.cache/mod || true
-          du -sh goenv/.cache/mod || true
-
       - name: Update template version
         uses: ./.github/actions/replace-version
         with:
           version: ${{ inputs.version }}
 
-      - name: Refresh versioned spx binary
-        run: |
-          # After replace-version rebuilds spx with the new version,
-          # update the binary in goenv to match
-          cp $HOME/go/bin/spx goenv/go/bin/spx
+      - name: Sync release goenv contents
+        uses: ./.github/actions/prepare-release-goenv
+        with:
+          version: ${{ inputs.version }}
 
       - name: Package goenv
         run: |

--- a/.github/workflows/release_linux.yml
+++ b/.github/workflows/release_linux.yml
@@ -80,6 +80,7 @@ jobs:
         with:
           package-file: spx-linux-${{ matrix.arch_name }}.zip
           platform: linux
+          package-arch: ${{ matrix.arch_name }}
 
       - name: Publish release asset
         if: github.event_name == 'release'

--- a/.github/workflows/release_linux.yml
+++ b/.github/workflows/release_linux.yml
@@ -49,10 +49,12 @@ jobs:
         with:
           version: ${{ inputs.version }}
 
-      - name: Sync release goenv contents
+      - name: Prepare release goenv
         uses: ./.github/actions/prepare-release-goenv
         with:
           version: ${{ inputs.version }}
+          platform: linux
+          package-arch: ${{ matrix.arch_name }}
 
       - name: Package goenv
         run: |

--- a/.github/workflows/release_macos.yml
+++ b/.github/workflows/release_macos.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up toolchain and engine assets
         uses: ./.github/actions/deps
 
-      - name: Download Go toolchain
+      - name: Download go toolchain
         run: |
           mkdir -p goenv/gotoolchain
           cd goenv/gotoolchain

--- a/.github/workflows/release_macos.yml
+++ b/.github/workflows/release_macos.yml
@@ -44,10 +44,12 @@ jobs:
         with:
           version: ${{ inputs.version }}
 
-      - name: Sync release goenv contents
+      - name: Prepare release goenv
         uses: ./.github/actions/prepare-release-goenv
         with:
           version: ${{ inputs.version }}
+          platform: darwin
+          package-arch: ${{ matrix.arch_name }}
 
       - name: Package goenv
         run: |

--- a/.github/workflows/release_macos.yml
+++ b/.github/workflows/release_macos.yml
@@ -75,6 +75,7 @@ jobs:
         with:
           package-file: spx-darwin-${{ matrix.arch_name }}.zip
           platform: darwin
+          package-arch: ${{ matrix.arch_name }}
 
       - name: Publish release asset
         if: github.event_name == 'release'

--- a/.github/workflows/release_macos.yml
+++ b/.github/workflows/release_macos.yml
@@ -39,51 +39,15 @@ jobs:
           rm go1.25.8.darwin-${{ matrix.arch }}.tar.gz
           cd ../..
 
-      - name: Collect module cache
-        run: |
-          # Set up mod cache directory (no build cache needed)
-          mkdir -p goenv/.cache/mod
-
-          # IMPORTANT: Copy binaries BEFORE running spx to collect dependencies
-          # Without these, spx run will fail and won't download dependencies
-          mkdir -p goenv/go/bin
-          cp $HOME/go/bin/gdspxrt* goenv/go/bin/ || true
-          cp $HOME/go/bin/runtime.gdextension goenv/go/bin/ || true
-          cp $HOME/go/bin/spx goenv/go/bin/
-
-          # Set environment to use our mod cache location
-          export GOMODCACHE=$(pwd)/goenv/.cache/mod
-
-          # Add current spx source to mod cache so users can use offline
-          SPX_VERSION="v2.0.0-$(git rev-parse --short HEAD)"
-          DEST="$GOMODCACHE/github.com/goplus/spx/v2@$SPX_VERSION"
-
-          echo "Installing spx source to mod cache: $SPX_VERSION"
-          mkdir -p "$DEST"
-          rsync -av --exclude='.git' --exclude='goenv' \
-            --exclude='test' --exclude='tutorial' --exclude='demo-game' \
-            --exclude='spx_demos' --exclude='cmd/demo' \
-            . "$DEST/"
-
-          # Run test/CI demo to collect other dependencies
-          cd test/CI
-          $HOME/go/bin/spx run --goenv=../../goenv --path=. --headless || true
-          cd ../..
-
-          echo "Module cache collection completed"
-          ls -lah goenv/.cache/mod || true
-          du -sh goenv/.cache/mod || true
-
       - name: Update template version
         uses: ./.github/actions/replace-version
         with:
           version: ${{ inputs.version }}
 
-      - name: Refresh versioned spx binary
-        run: |
-          # After replace-version rebuilds spx with the new version,
-          # update the binary in goenv to match
-          cp $HOME/go/bin/spx goenv/go/bin/spx
+      - name: Sync release goenv contents
+        uses: ./.github/actions/prepare-release-goenv
+        with:
+          version: ${{ inputs.version }}
 
       - name: Package goenv
         run: |

--- a/.github/workflows/release_windows.yml
+++ b/.github/workflows/release_windows.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Set up toolchain and engine assets
         uses: ./.github/actions/deps
 
-      - name: Download Go toolchain
+      - name: Download go toolchain
         shell: msys2 {0}
         run: |
           mkdir -p goenv/gotoolchain

--- a/.github/workflows/release_windows.yml
+++ b/.github/workflows/release_windows.yml
@@ -56,10 +56,12 @@ jobs:
         with:
           version: ${{ inputs.version }}
 
-      - name: Sync release goenv contents
+      - name: Prepare release goenv
         uses: ./.github/actions/prepare-release-goenv
         with:
           version: ${{ inputs.version }}
+          platform: windows
+          package-arch: ${{ matrix.arch_name }}
 
       - name: Package goenv
         shell: msys2 {0}

--- a/.github/workflows/release_windows.yml
+++ b/.github/workflows/release_windows.yml
@@ -37,7 +37,6 @@ jobs:
             zip
             unzip
             bash
-            rsync
 
       - name: Set up toolchain and engine assets
         uses: ./.github/actions/deps
@@ -52,76 +51,15 @@ jobs:
           rm go1.25.8.windows-${{ matrix.arch }}.zip
           cd ../..
 
-      - name: Resolve GOPATH and short SHA
-        id: env-vars
-        shell: pwsh
-        run: |
-          $gopath = go env GOPATH
-          echo "gopath=$gopath" >> $env:GITHUB_OUTPUT
-
-          # Get short SHA (first 7 characters)
-          $shortSha = "${{ github.sha }}".Substring(0, 7)
-          echo "short_sha=$shortSha" >> $env:GITHUB_OUTPUT
-
-      - name: Collect module cache
-        shell: msys2 {0}
-        run: |
-          # Set up mod cache directory (no build cache needed)
-          mkdir -p goenv/.cache/mod
-
-          # Get GOPATH in Unix format
-          GOPATH_UNIX=$(cygpath "${{ steps.env-vars.outputs.gopath }}")
-
-          # IMPORTANT: Copy binaries BEFORE running spx to collect dependencies
-          # Without these, spx run will fail and won't download dependencies
-          mkdir -p goenv/go/bin
-          cp "$GOPATH_UNIX"/bin/gdspxrt* goenv/go/bin/ || true
-          cp "$GOPATH_UNIX"/bin/runtime.gdextension goenv/go/bin/ || true
-          cp "$GOPATH_UNIX"/bin/spx.exe goenv/go/bin/
-
-          # Set environment to use our mod cache location
-          export GOMODCACHE=$(pwd)/goenv/.cache/mod
-
-          # Add current spx source to mod cache so users can use offline
-          SPX_VERSION="v2.0.0-${{ steps.env-vars.outputs.short_sha }}"
-          DEST="$GOMODCACHE/github.com/goplus/spx/v2@$SPX_VERSION"
-
-          echo "Installing spx source to mod cache: $SPX_VERSION"
-          mkdir -p "$DEST"
-          rsync -av --exclude='.git' --exclude='goenv' \
-            --exclude='test' --exclude='tutorial' --exclude='demo-game' \
-            --exclude='spx_demos' --exclude='cmd/demo' \
-            . "$DEST/"
-
-          # Run test/CI demo to collect other dependencies
-          cd test/CI
-          "$GOPATH_UNIX"/bin/spx.exe run --goenv=../../goenv --path=. --headless &
-          SPX_PID=$!
-
-          # Wait a few seconds for initialization
-          sleep 5
-
-          # Kill the process
-          kill $SPX_PID || true
-
-          cd ../..
-
-          echo "Module cache collection completed"
-          ls -lah goenv/.cache/mod || true
-          du -sh goenv/.cache/mod || true
-
       - name: Update template version
         uses: ./.github/actions/replace-version
         with:
           version: ${{ inputs.version }}
 
-      - name: Refresh versioned spx binary
-        shell: msys2 {0}
-        run: |
-          # After replace-version rebuilds spx with the new version,
-          # update the binary in goenv to match
-          GOPATH_UNIX=$(cygpath "${{ steps.env-vars.outputs.gopath }}")
-          cp "$GOPATH_UNIX"/bin/spx.exe goenv/go/bin/spx.exe
+      - name: Sync release goenv contents
+        uses: ./.github/actions/prepare-release-goenv
+        with:
+          version: ${{ inputs.version }}
 
       - name: Package goenv
         shell: msys2 {0}

--- a/.github/workflows/release_windows.yml
+++ b/.github/workflows/release_windows.yml
@@ -88,6 +88,7 @@ jobs:
         with:
           package-file: spx-windows-${{ matrix.arch_name }}.zip
           platform: windows
+          package-arch: ${{ matrix.arch_name }}
 
       - name: Publish release asset
         if: github.event_name == 'release'


### PR DESCRIPTION
## Changes

- add `prepare-release-goenv` composite action to centralize release goenv preparation
- simplify `verify-release` naming and smoke-test paths
- make `release.yml` platform selection actually work for `workflow_dispatch`
- default release builds to all platforms
- remove unused platform output and dead release logic
- reduce duplicated release setup logic across linux, macOS, and windows workflows