### PR TITLE
fix(platform): return android platform type on android

### DIFF
--- a/internal/engine/platform/define_android.go
+++ b/internal/engine/platform/define_android.go
@@ -4,5 +4,5 @@
 package platform
 
 func GetPlatformType() int {
-	return PlatformTypeIos
+	return PlatformTypeAndroid
 }


### PR DESCRIPTION
## Summary

- fix Android platform detection to return `PlatformTypeAndroid`
- correct the Android-specific implementation in `internal/engine/platform/define_android.go`

## Testing

- verified cross-compilation with `GOOS=android GOARCH=arm64 go test -c ./internal/engine/platform`
