### PR TITLE
refactor: deduplicate game sound playback

### DIFF
--- a/component_animation.go
+++ b/component_animation.go
@@ -268,7 +268,7 @@ func (a *animationComponent) playDefaultAnim() {
 func (a *animationComponent) playAnimAudio(ani *coreproject.AniConfig, info *animState) {
 	if ani.OnStart != nil && ani.OnStart.Play != "" {
 		info.AudioName = ani.OnStart.Play
-		info.AudioId = a.sprite.playAudio(info.AudioName, false)
+		a.sprite.playAudio(info.AudioName, false)
 	}
 }
 

--- a/component_sound.go
+++ b/component_sound.go
@@ -130,9 +130,9 @@ func (s *soundComponent) ChangeSoundEffect(kind SoundEffectKind, delta float64) 
 // Internal Audio Management
 // ============================================================================
 
-func (s *soundComponent) playAudio(name SoundName, loop bool) soundId {
+func (s *soundComponent) playAudio(name SoundName, loop bool) {
 	s.checkSoundObj()
-	return s.sprite.g.playSound(s.sprite.runtimeState.SyncSprite, s.soundObj, name, loop, s.sprite.g.audioState.AudioAttenuation, s.sprite.g.audioState.AudioMaxDistance)
+	s.sprite.g.playSound(s.sprite.runtimeState.SyncSprite, s.soundObj, name, loop, s.sprite.g.audioState.AudioAttenuation, s.sprite.g.audioState.AudioMaxDistance)
 }
 
 func (s *soundComponent) checkSoundObj() {

--- a/game_sound.go
+++ b/game_sound.go
@@ -143,19 +143,15 @@ func (p *Game) loadSound(name SoundName) (media sound, err error) {
 	return
 }
 
-func (p *Game) playSound(sprite *engine.Sprite, audioId engine.Object, name SoundName, isLoop bool, attenuation, maxDistance float64) soundId {
-	m, err := p.loadSound(name)
-	if err != nil {
-		return invalidSoundId
-	}
-	ownerID := engine.Object(0)
-	if sprite != nil {
-		ownerID = sprite.Id
-	}
-	return p.soundMgr.Play(audioId, m.Path, isLoop, false, ownerID, attenuation, maxDistance)
+func (p *Game) playSound(sprite *engine.Sprite, audioId engine.Object, name SoundName, isLoop bool, attenuation, maxDistance float64) {
+	p.playSoundInternal(sprite, audioId, name, isLoop, false, attenuation, maxDistance)
 }
 
 func (p *Game) playSoundAndWait(sprite *engine.Sprite, audioId engine.Object, name SoundName, attenuation, maxDistance float64) {
+	p.playSoundInternal(sprite, audioId, name, false, true, attenuation, maxDistance)
+}
+
+func (p *Game) playSoundInternal(sprite *engine.Sprite, audioId engine.Object, name SoundName, isLoop, wait bool, attenuation, maxDistance float64) {
 	m, err := p.loadSound(name)
 	if err != nil {
 		return
@@ -164,7 +160,7 @@ func (p *Game) playSoundAndWait(sprite *engine.Sprite, audioId engine.Object, na
 	if sprite != nil {
 		ownerID = sprite.Id
 	}
-	p.soundMgr.Play(audioId, m.Path, false, true, ownerID, attenuation, maxDistance)
+	p.soundMgr.Play(audioId, m.Path, isLoop, wait, ownerID, attenuation, maxDistance)
 }
 
 func (p *Game) withSound(name SoundName, action func(m sound)) {

--- a/sprite_animation.go
+++ b/sprite_animation.go
@@ -89,7 +89,6 @@ type animState struct {
 	IsCanceled bool
 	Speed      float64
 	AudioName  string
-	AudioId    soundId
 }
 
 // -----------------------------------------------------------------------------

--- a/sprite_sound.go
+++ b/sprite_sound.go
@@ -88,8 +88,8 @@ func (p *SpriteImpl) ChangeSoundEffect(kind SoundEffectKind, delta float64) {
 // -----------------------------------------------------------------------------
 // Internals
 // -----------------------------------------------------------------------------
-func (p *SpriteImpl) playAudio(name SoundName, loop bool) soundId {
-	return p.sound().playAudio(name, loop)
+func (p *SpriteImpl) playAudio(name SoundName, loop bool) {
+	p.sound().playAudio(name, loop)
 }
 
 func (p *SpriteImpl) flushPendingAudios(buffer []string) []string {


### PR DESCRIPTION
This PR removes duplicated playback logic in game_sound.go.

playSound and playSoundAndWait previously repeated the same steps for:

loading the sound config
resolving the owner sprite ID
calling soundMgr.Play
The shared logic is now moved into a new internal helper, playSoundInternal, while keeping the existing external behavior unchanged.