### PR TITLE
ci: skip interpreted project test on windows

### DIFF
--- a/.github/actions/project-test/action.yml
+++ b/.github/actions/project-test/action.yml
@@ -25,11 +25,13 @@ runs:
         fi
 
     - name: Run test demo in interpreted mode
+      if: runner.os != 'Windows'
       shell: bash
       run: |
         spx runi -path="test/CI" -headless=true 2>&1 | tee cilog_interpreted_mode.txt
 
     - name: Check test result in interpreted mode
+      if: runner.os != 'Windows'
       shell: bash
       run: |
         if grep -q "===>SpxCIRunSucc" cilog_interpreted_mode.txt; then


### PR DESCRIPTION
## Summary

Skip interpreted mode project tests on Windows in the composite CI action.

## Changes

- add `if: runner.os != 'Windows'` to the interpreted mode test step
- add `if: runner.os != 'Windows'` to the interpreted mode result check step
- keep the regular project test unchanged on Windows

## Reason

`spx runi` is unstable or fails on Windows runners, which causes unnecessary CI failures.
This change removes the Windows-specific failure path while preserving Linux and macOS coverage for interpreted mode.

## Testing

- verified the GitHub Action YAML diff
- confirmed the change is isolated to `.github/actions/project-test/action.yml`
