### PR TITLE
chore: clean up gitignore rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,23 +1,17 @@
-# Editors and local workspace
-/.vscode/
-/.idea/
+# Editors
+.vscode/
+.idea/
 *.code-workspace
 
-# OS files
+# OS
 .DS_Store
 
-# Local tool caches and generated workspace files
-/.gop/
+# Tool cache
 /.gocache/
-/_gsc/
-/_test/
-/go.work
-/go.json
-/gop.json
-/gop_autogen.go
-/xgo_autogen.go
 
-# Build outputs
+# Builds
+/go.work
+/xgo_autogen.go
 *.exe
 *.exe~
 *.dll
@@ -27,12 +21,10 @@
 *.test
 *.out
 
-# Temp directories
-.temp/
+# Root outputs
+/.temp/
 /.tmp/
-
-# Repo-local generated artifacts
 /bin/
 /.bin/
 /godot/
-.gdspx_web_server*.pid
+/.gdspx_web_server*.pid

--- a/cmd/spx/template/platform/webminigame/.gitignore
+++ b/cmd/spx/template/platform/webminigame/.gitignore
@@ -1,3 +1,3 @@
-./engine/godot.wasm.br
-*.wasm*
+*.wasm
+*.wasm.*
 .DS_Store

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,5 +1,11 @@
-/**/project
-/**/.gitignore
+# Example outputs
+project/
+.temp/
+.gdspx_web_server*.pid
+
+# Example modules
 go.mod
 go.sum
-gop.sum
+
+# Local ignores
+*/.gitignore

--- a/tutorial/.gitignore
+++ b/tutorial/.gitignore
@@ -1,4 +1,11 @@
-/**/project
-/**/.gitignore
+# Example outputs
+project/
+.temp/
+.gdspx_web_server*.pid
+
+# Example modules
 go.mod
 go.sum
+
+# Local ignores
+*/.gitignore


### PR DESCRIPTION
- simplify section comments in the root `.gitignore`
- tighten root-level ignore rules so they only match repository-root outputs such as `/.temp/` and `/.gdspx_web_server*.pid`
- remove a few currently unused root ignore entries
- add missing ignore rules for generated files in `tutorial/` and `test/` examples:
  - `project/`
  - `.temp/`
  - `.gdspx_web_server*.pid`
  - `*/.gitignore`
- normalize wasm ignore patterns in `cmd/spx/template/platform/webminigame/.gitignore` to `*.wasm` and `*.wasm.*`
