### PR TITLE
refactor: unify overload suffix ordering

### DIFF
--- a/game_load.go
+++ b/game_load.go
@@ -221,7 +221,7 @@ func (p *Game) loadAudioAndTilemap(proj *coreproject.ProjectConfig) {
 	p.tilemapMgr.parseTilemap()
 	p.audioState.SoundObj = p.soundMgr.AllocSound()
 	if proj.Bgm != "" {
-		p.Play__0(proj.Bgm, true)
+		p.Play__1(proj.Bgm, true)
 	}
 }
 

--- a/game_physics.go
+++ b/game_physics.go
@@ -43,17 +43,28 @@ func (p *Game) IntersectCircle(posX, posY, radius float64) []Sprite {
 // -----------------------------------------------------------------------------
 // Raycast
 // -----------------------------------------------------------------------------
-func (p *Game) Raycast__0(fromX, fromY, toX, toY float64, ignoreSprites []Sprite) (hit bool, sprite Sprite, hitX, hitY float64) {
+func (p *Game) Raycast__0(fromX, fromY, toX, toY float64) (hit bool, sprite Sprite, hitX, hitY float64) {
+	return p.Raycast__2(fromX, fromY, toX, toY, nil)
+}
+
+func (p *Game) Raycast__1(fromX, fromY, toX, toY float64, ignoreSprite Sprite) (hit bool, sprite Sprite, hitX, hitY float64) {
+	return p.Raycast__2(fromX, fromY, toX, toY, []Sprite{ignoreSprite})
+}
+
+func (p *Game) Raycast__2(fromX, fromY, toX, toY float64, ignoreSprites []Sprite) (hit bool, sprite Sprite, hitX, hitY float64) {
 	from := mathf.NewVec2(fromX, fromY)
 	to := mathf.NewVec2(toX, toY)
-	ignoreSpritesIds := make([]int64, 0)
-	for _, item := range ignoreSprites {
-		if item == nil {
-			continue
-		}
-		impl := spriteOf(item)
-		if impl != nil {
-			ignoreSpritesIds = append(ignoreSpritesIds, impl.getSpriteId())
+	var ignoreSpritesIds []int64
+	if len(ignoreSprites) > 0 {
+		ignoreSpritesIds = make([]int64, 0, len(ignoreSprites))
+		for _, item := range ignoreSprites {
+			if item == nil {
+				continue
+			}
+			impl := spriteOf(item)
+			if impl != nil {
+				ignoreSpritesIds = append(ignoreSpritesIds, impl.getSpriteId())
+			}
 		}
 	}
 	result := p.raycast(from, to, ignoreSpritesIds, -1)
@@ -71,14 +82,6 @@ func (p *Game) Raycast__0(fromX, fromY, toX, toY float64, ignoreSprites []Sprite
 		}
 	}
 	return result.Hited, target, result.PosX, result.PosY
-}
-
-func (p *Game) Raycast__1(fromX, fromY, toX, toY float64, ignoreSprite Sprite) (hit bool, sprite Sprite, hitX, hitY float64) {
-	return p.Raycast__0(fromX, fromY, toX, toY, []Sprite{ignoreSprite})
-}
-
-func (p *Game) Raycast__2(fromX, fromY, toX, toY float64) (hit bool, sprite Sprite, hitX, hitY float64) {
-	return p.Raycast__0(fromX, fromY, toX, toY, []Sprite{})
 }
 
 // -----------------------------------------------------------------------------

--- a/game_sound.go
+++ b/game_sound.go
@@ -38,14 +38,14 @@ func (p *Game) Volume() float64 {
 	})
 }
 
-func (p *Game) Play__0(name SoundName, loop bool) {
+func (p *Game) Play__0(name SoundName) {
+	p.Play__1(name, false)
+}
+
+func (p *Game) Play__1(name SoundName, loop bool) {
 	p.withGameSound(func(soundObj engine.Object) {
 		p.playSound(p.runtimeState.SyncSprite, soundObj, name, loop, 0, defaultAudioMaxDist)
 	})
-}
-
-func (p *Game) Play__1(name SoundName) {
-	p.Play__0(name, false)
 }
 
 func (p *Game) PlayAndWait(name SoundName) {

--- a/runtime_util.go
+++ b/runtime_util.go
@@ -46,12 +46,12 @@ func Iround(v float64) int {
 	return int(v - 0.5)
 }
 
-// Exit__0 exits the program with the specified exit code.
-func Exit__0(code int) {
-	engine.RequestExit(int64(code))
+// Exit__0 exits the program with exit code 0.
+func Exit__0() {
+	engine.RequestExit(0)
 }
 
-// Exit__1 exits the program with exit code 0.
-func Exit__1() {
-	engine.RequestExit(0)
+// Exit__1 exits the program with the specified exit code.
+func Exit__1(code int) {
+	engine.RequestExit(int64(code))
 }

--- a/sprite.go
+++ b/sprite.go
@@ -147,21 +147,21 @@ type Sprite interface {
 	Step__2(step float64, speed float64, animation SpriteAnimationName)
 	StepTo__0(sprite Sprite)
 	StepTo__1(sprite SpriteName)
-	StepTo__2(x, y float64)
-	StepTo__3(obj specialObj)
+	StepTo__2(obj specialObj)
+	StepTo__3(x, y float64)
 	StepTo__4(sprite Sprite, speed float64)
 	StepTo__5(sprite SpriteName, speed float64)
-	StepTo__6(x, y, speed float64)
-	StepTo__7(obj specialObj, speed float64)
+	StepTo__6(obj specialObj, speed float64)
+	StepTo__7(x, y, speed float64)
 	StepTo__8(sprite Sprite, speed float64, animation SpriteAnimationName)
 	StepTo__9(sprite SpriteName, speed float64, animation SpriteAnimationName)
-	StepTo__a(x, y, speed float64, animation SpriteAnimationName)
-	StepTo__b(obj specialObj, speed float64, animation SpriteAnimationName)
-	Glide__0(x, y float64, secs float64)
-	Glide__1(sprite Sprite, secs float64)
-	Glide__2(sprite SpriteName, secs float64)
-	Glide__3(obj specialObj, secs float64)
-	Glide__4(pos Pos, secs float64)
+	StepTo__a(obj specialObj, speed float64, animation SpriteAnimationName)
+	StepTo__b(x, y, speed float64, animation SpriteAnimationName)
+	Glide__0(sprite Sprite, secs float64)
+	Glide__1(sprite SpriteName, secs float64)
+	Glide__2(obj specialObj, secs float64)
+	Glide__3(pos Pos, secs float64)
+	Glide__4(x, y float64, secs float64)
 
 	// Heading and Rotation Methods
 	Heading() Direction
@@ -228,8 +228,8 @@ type Sprite interface {
 	DistanceTo__1(sprite SpriteName) float64
 	DistanceTo__2(obj specialObj) float64
 	DistanceTo__3(pos Pos) float64
-	Touching__0(sprite SpriteName) bool
-	Touching__1(sprite Sprite) bool
+	Touching__0(sprite Sprite) bool
+	Touching__1(sprite SpriteName) bool
 	Touching__2(obj specialObj) bool
 	TouchingColor(color Color) bool
 
@@ -245,12 +245,12 @@ type Sprite interface {
 	Quote__3(message, description string, secs float64)
 
 	// Event Methods
-	OnCloned__0(onCloned func(data any))
-	OnCloned__1(onCloned func())
-	OnTouchStart__0(sprite SpriteName, onTouchStart func(Sprite))
-	OnTouchStart__1(sprite SpriteName, onTouchStart func())
-	OnTouchStart__2(sprites []SpriteName, onTouchStart func(Sprite))
-	OnTouchStart__3(sprites []SpriteName, onTouchStart func())
+	OnCloned__0(onCloned func())
+	OnCloned__1(onCloned func(data any))
+	OnTouchStart__0(sprite SpriteName, onTouchStart func())
+	OnTouchStart__1(sprite SpriteName, onTouchStart func(Sprite))
+	OnTouchStart__2(sprites []SpriteName, onTouchStart func())
+	OnTouchStart__3(sprites []SpriteName, onTouchStart func(Sprite))
 
 	// Sound Methods
 	Volume() float64
@@ -259,8 +259,8 @@ type Sprite interface {
 	GetSoundEffect(kind SoundEffectKind) float64
 	SetSoundEffect(kind SoundEffectKind, value float64)
 	ChangeSoundEffect(kind SoundEffectKind, delta float64)
-	Play__0(name SoundName, loop bool)
-	Play__1(name SoundName)
+	Play__0(name SoundName)
+	Play__1(name SoundName, loop bool)
 	PlayAndWait(name SoundName)
 	PausePlaying(name SoundName)
 	ResumePlaying(name SoundName)

--- a/sprite_events.go
+++ b/sprite_events.go
@@ -22,13 +22,13 @@ import (
 	coreevent "github.com/goplus/spx/v2/internal/core/event"
 )
 
-func (p *SpriteImpl) OnCloned__0(onCloned func(data any)) {
-	p.spriteState.HasOnCloned = true
-	p.scriptEventRegistry.AddCloned(coreevent.NewSink(p, onCloned, coreevent.MatchOwner(p)))
+func (p *SpriteImpl) OnCloned__0(onCloned func()) {
+	p.OnCloned__1(coreevent.Ignore1[any](onCloned))
 }
 
-func (p *SpriteImpl) OnCloned__1(onCloned func()) {
-	p.OnCloned__0(coreevent.Ignore1[any](onCloned))
+func (p *SpriteImpl) OnCloned__1(onCloned func(data any)) {
+	p.spriteState.HasOnCloned = true
+	p.scriptEventRegistry.AddCloned(coreevent.NewSink(p, onCloned, coreevent.MatchOwner(p)))
 }
 
 func (p *SpriteImpl) fireTouchStart(obj *SpriteImpl) {
@@ -42,7 +42,11 @@ func (p *SpriteImpl) addTouchStartHandler(onTouchStart func(Sprite)) {
 	p.scriptEventRegistry.AddTouchStart(coreevent.NewSink(p, onTouchStart, coreevent.MatchOwner(p)))
 }
 
-func (p *SpriteImpl) OnTouchStart__0(sprite SpriteName, onTouchStart func(Sprite)) {
+func (p *SpriteImpl) OnTouchStart__0(sprite SpriteName, onTouchStart func()) {
+	p.OnTouchStart__1(sprite, coreevent.Ignore1[Sprite](onTouchStart))
+}
+
+func (p *SpriteImpl) OnTouchStart__1(sprite SpriteName, onTouchStart func(Sprite)) {
 	p.physics().addCollisionTarget(sprite)
 	p.addTouchStartHandler(func(s Sprite) {
 		impl := spriteOf(s)
@@ -52,11 +56,11 @@ func (p *SpriteImpl) OnTouchStart__0(sprite SpriteName, onTouchStart func(Sprite
 	})
 }
 
-func (p *SpriteImpl) OnTouchStart__1(sprite SpriteName, onTouchStart func()) {
-	p.OnTouchStart__0(sprite, coreevent.Ignore1[Sprite](onTouchStart))
+func (p *SpriteImpl) OnTouchStart__2(sprites []SpriteName, onTouchStart func()) {
+	p.OnTouchStart__3(sprites, coreevent.Ignore1[Sprite](onTouchStart))
 }
 
-func (p *SpriteImpl) OnTouchStart__2(sprites []SpriteName, onTouchStart func(Sprite)) {
+func (p *SpriteImpl) OnTouchStart__3(sprites []SpriteName, onTouchStart func(Sprite)) {
 	for _, sprite := range sprites {
 		p.physics().addCollisionTarget(sprite)
 	}
@@ -66,8 +70,4 @@ func (p *SpriteImpl) OnTouchStart__2(sprites []SpriteName, onTouchStart func(Spr
 			onTouchStart(s)
 		}
 	})
-}
-
-func (p *SpriteImpl) OnTouchStart__3(sprites []SpriteName, onTouchStart func()) {
-	p.OnTouchStart__2(sprites, coreevent.Ignore1[Sprite](onTouchStart))
 }

--- a/sprite_query.go
+++ b/sprite_query.go
@@ -57,11 +57,11 @@ func (p *SpriteImpl) TouchingColor(color Color) bool {
 	return p.touchingColor(toMathfColor(color))
 }
 
-func (p *SpriteImpl) Touching__0(sprite SpriteName) bool {
+func (p *SpriteImpl) Touching__0(sprite Sprite) bool {
 	return p.touching(sprite)
 }
 
-func (p *SpriteImpl) Touching__1(sprite Sprite) bool {
+func (p *SpriteImpl) Touching__1(sprite SpriteName) bool {
 	return p.touching(sprite)
 }
 

--- a/sprite_sound.go
+++ b/sprite_sound.go
@@ -31,12 +31,12 @@ const (
 // -----------------------------------------------------------------------------
 // Playback
 // -----------------------------------------------------------------------------
-func (p *SpriteImpl) Play__0(name SoundName, loop bool) {
-	p.sound().Play(name, loop)
+func (p *SpriteImpl) Play__0(name SoundName) {
+	p.Play__1(name, false)
 }
 
-func (p *SpriteImpl) Play__1(name SoundName) {
-	p.Play__0(name, false)
+func (p *SpriteImpl) Play__1(name SoundName, loop bool) {
+	p.sound().Play(name, loop)
 }
 
 func (p *SpriteImpl) PlayAndWait(name SoundName) {

--- a/sprite_transform.go
+++ b/sprite_transform.go
@@ -86,12 +86,12 @@ func (p *SpriteImpl) StepTo__1(sprite SpriteName) {
 	p.doStepTo(sprite, 1, "")
 }
 
-func (p *SpriteImpl) StepTo__2(x, y float64) {
-	p.transform().StepToPos(x, y, 1, "")
+func (p *SpriteImpl) StepTo__2(obj specialObj) {
+	p.doStepTo(obj, 1, "")
 }
 
-func (p *SpriteImpl) StepTo__3(obj specialObj) {
-	p.doStepTo(obj, 1, "")
+func (p *SpriteImpl) StepTo__3(x, y float64) {
+	p.transform().StepToPos(x, y, 1, "")
 }
 
 func (p *SpriteImpl) StepTo__4(sprite Sprite, speed float64) {
@@ -102,12 +102,12 @@ func (p *SpriteImpl) StepTo__5(sprite SpriteName, speed float64) {
 	p.doStepTo(sprite, speed, "")
 }
 
-func (p *SpriteImpl) StepTo__6(x, y, speed float64) {
-	p.transform().StepToPos(x, y, speed, "")
+func (p *SpriteImpl) StepTo__6(obj specialObj, speed float64) {
+	p.doStepTo(obj, speed, "")
 }
 
-func (p *SpriteImpl) StepTo__7(obj specialObj, speed float64) {
-	p.doStepTo(obj, speed, "")
+func (p *SpriteImpl) StepTo__7(x, y, speed float64) {
+	p.transform().StepToPos(x, y, speed, "")
 }
 
 func (p *SpriteImpl) StepTo__8(sprite Sprite, speed float64, animation SpriteAnimationName) {
@@ -118,12 +118,12 @@ func (p *SpriteImpl) StepTo__9(sprite SpriteName, speed float64, animation Sprit
 	p.doStepTo(sprite, speed, animation)
 }
 
-func (p *SpriteImpl) StepTo__a(x, y, speed float64, animation SpriteAnimationName) {
-	p.transform().StepToPos(x, y, speed, animation)
+func (p *SpriteImpl) StepTo__a(obj specialObj, speed float64, animation SpriteAnimationName) {
+	p.doStepTo(obj, speed, animation)
 }
 
-func (p *SpriteImpl) StepTo__b(obj specialObj, speed float64, animation SpriteAnimationName) {
-	p.doStepTo(obj, speed, animation)
+func (p *SpriteImpl) StepTo__b(x, y, speed float64, animation SpriteAnimationName) {
+	p.transform().StepToPos(x, y, speed, animation)
 }
 
 func (p *SpriteImpl) doGlideTo(obj any, secs float64) {
@@ -134,24 +134,24 @@ func (p *SpriteImpl) doGlideTo(obj any, secs float64) {
 	p.transform().Glide(x, y, secs)
 }
 
-func (p *SpriteImpl) Glide__0(x, y float64, secs float64) {
-	p.transform().Glide(x, y, secs)
-}
-
-func (p *SpriteImpl) Glide__1(sprite Sprite, secs float64) {
+func (p *SpriteImpl) Glide__0(sprite Sprite, secs float64) {
 	p.doGlideTo(sprite, secs)
 }
 
-func (p *SpriteImpl) Glide__2(sprite SpriteName, secs float64) {
+func (p *SpriteImpl) Glide__1(sprite SpriteName, secs float64) {
 	p.doGlideTo(sprite, secs)
 }
 
-func (p *SpriteImpl) Glide__3(obj specialObj, secs float64) {
+func (p *SpriteImpl) Glide__2(obj specialObj, secs float64) {
 	p.doGlideTo(obj, secs)
 }
 
-func (p *SpriteImpl) Glide__4(pos Pos, secs float64) {
+func (p *SpriteImpl) Glide__3(pos Pos, secs float64) {
 	p.doGlideTo(pos, secs)
+}
+
+func (p *SpriteImpl) Glide__4(x, y float64, secs float64) {
+	p.transform().Glide(x, y, secs)
 }
 
 func (p *SpriteImpl) SetXYpos(x, y float64) {


### PR DESCRIPTION
## Summary

- unify overload suffix ordering across the safe overload groups
- update interfaces and implementations for `OnCloned`, `OnTouchStart`, `Play`, `Exit`, `Raycast`, `Touching`, `StepTo`, and `Glide`
- keep `TurnTo` in its original order after verifying that current code generation depends on the existing numbering for direction-based overloads

## Validation

- `go test ./...`
- verified code generation against sample projects for:
  - `onCloned`
  - `onTouchStart`
  - `play`
  - `exit`
  - `touching`
  - `stepTo`
  - `glide`
