### PR TITLE
chore: format buildctl api wrappers

### DIFF
--- a/internal/cmd/buildctl/dockercmd/api.go
+++ b/internal/cmd/buildctl/dockercmd/api.go
@@ -24,21 +24,28 @@ type BuildEngineConfig struct {
 	GodotSrc string
 }
 
-func Run(args []string) error { return runDocker(args) }
+func Run(args []string) error {
+	return runDocker(args)
+}
+
 func ParseDockerBuildImagesArgs(args []string) (BuildImagesConfig, error) {
 	cfg, err := parseDockerBuildImagesArgs(args)
 	return BuildImagesConfig{ProxyURL: cfg.proxyURL}, err
 }
+
 func ParseDockerBuildEngineArgs(args []string) (BuildEngineConfig, error) {
 	cfg, err := parseDockerBuildEngineArgs(args)
 	return BuildEngineConfig{GodotSrc: cfg.godotSrc}, err
 }
+
 func RunDockerBuildImages(cfg BuildImagesConfig) error {
 	return runDockerBuildImages(dockerBuildImagesConfig{proxyURL: cfg.ProxyURL})
 }
+
 func RunDockerBuildEngine(cfg BuildEngineConfig) error {
 	return runDockerBuildEngine(dockerBuildEngineConfig{godotSrc: cfg.GodotSrc})
 }
+
 func BuildPodmanSConsArgs(godotPath, platform string, sconsArgs []string, useTTY bool) []string {
 	return buildPodmanSConsArgs(godotPath, platform, sconsArgs, useTTY)
 }

--- a/internal/cmd/buildctl/engine/api.go
+++ b/internal/cmd/buildctl/engine/api.go
@@ -56,55 +56,94 @@ type BuildShellConfig struct {
 
 type BuildShellPlan = engineBuildShellPlan
 
-func Run(args []string) error { return runEngine(args) }
+func Run(args []string) error {
+	return runEngine(args)
+}
+
 func ParseEngineDownloadArgs(args []string) (DownloadConfig, error) {
 	cfg, err := parseEngineDownloadArgs(args)
 	return DownloadConfig{Runtime: cfg.runtime, Platform: cfg.platform, Mode: cfg.mode}, err
 }
+
 func ParseEngineBuildArgs(args []string) (BuildConfig, error) {
 	cfg, err := parseEngineBuildArgs(args)
 	return BuildConfig{Target: cfg.target, Platform: cfg.platform, Mode: cfg.mode}, err
 }
+
 func ParseEngineExecArgs(args []string) (ExecConfig, error) {
 	cfg, err := parseEngineExecArgs(args)
 	return ExecConfig{LockDir: cfg.lockDir, Workdir: cfg.workdir, Script: cfg.script, Command: cfg.command}, err
 }
+
 func ParseEnvExportEngineBuildShellArgs(args []string) (BuildShellConfig, error) {
 	cfg, err := parseEnvExportEngineBuildShellArgs(args)
 	return BuildShellConfig{Target: cfg.target, Platform: cfg.platform, Mode: cfg.mode}, err
 }
+
 func ResolveEngineBuildShellPlan(repoRoot string, cfg BuildShellConfig) (BuildShellPlan, error) {
 	return resolveEngineBuildShellPlan(repoRoot, envExportEngineBuildShellConfig{target: cfg.Target, platform: cfg.Platform, mode: cfg.Mode})
 }
-func (plan BuildShellPlan) ShellExports() string { return engineBuildShellPlan(plan).shellExports() }
+
+func (plan BuildShellPlan) ShellExports() string {
+	return engineBuildShellPlan(plan).shellExports()
+}
+
 func DownloadEngineAssets(cfg DownloadConfig, repoRoot string) error {
 	return downloadEngineAssets(engineDownloadConfig{runtime: cfg.Runtime, platform: cfg.Platform, mode: cfg.Mode}, repoRoot)
 }
+
 func BuildEngine(cfg BuildConfig, repoRoot string) error {
 	return buildEngine(engineBuildConfig{target: cfg.Target, platform: cfg.Platform, mode: cfg.Mode}, repoRoot)
 }
+
 func ExecEngineCommand(cfg ExecConfig, repoRoot string) error {
 	return execEngineCommand(engineExecConfig{lockDir: cfg.LockDir, workdir: cfg.Workdir, script: cfg.Script, command: cfg.Command}, repoRoot)
 }
-func SConsScript(commands []string) string { return sconsScript(commands) }
+
+func SConsScript(commands []string) string {
+	return sconsScript(commands)
+}
+
 func MergeStringMaps(base map[string]string, extra map[string]string) map[string]string {
 	return mergeStringMaps(base, extra)
 }
+
 func PopulateWebTemplateCopies(srcZip, templateDir string) error {
 	return populateWebTemplateCopies(srcZip, templateDir)
 }
+
 func DetectStaleEngineBuildLock(lockDir string) (bool, string, error) {
 	return detectStaleEngineBuildLock(lockDir)
 }
-func AcquireEngineBuildLock(lockDir string) error            { return acquireEngineBuildLock(lockDir) }
-func ExtractZip(srcZip, dstDir string) error                 { return extractZip(srcZip, dstDir) }
-func FetchURLToFile(url, dst string) error                   { return fetchURLToFile(url, dst) }
-func LinkOrCopyFile(src, dst string) error                   { return linkOrCopyFile(src, dst) }
-func ShouldRefreshPreparedAssets() bool                      { return shouldRefreshPreparedAssets() }
-func WebModeReleaseTemplateName(mode string) (string, error) { return webModeReleaseTemplateName(mode) }
+
+func AcquireEngineBuildLock(lockDir string) error {
+	return acquireEngineBuildLock(lockDir)
+}
+
+func ExtractZip(srcZip, dstDir string) error {
+	return extractZip(srcZip, dstDir)
+}
+
+func FetchURLToFile(url, dst string) error {
+	return fetchURLToFile(url, dst)
+}
+
+func LinkOrCopyFile(src, dst string) error {
+	return linkOrCopyFile(src, dst)
+}
+
+func ShouldRefreshPreparedAssets() bool {
+	return shouldRefreshPreparedAssets()
+}
+
+func WebModeReleaseTemplateName(mode string) (string, error) {
+	return webModeReleaseTemplateName(mode)
+}
+
 func WebModeCachedTemplatePath(version, mode string) (string, error) {
 	return webModeCachedTemplatePath(version, mode)
 }
+
 func PrepareHostEditorAsset(repoRoot string) error {
 	env, err := EngineDownloadResolveEnv(repoRoot, "")
 	if err != nil {

--- a/internal/cmd/buildctl/runtimecmd/api.go
+++ b/internal/cmd/buildctl/runtimecmd/api.go
@@ -26,27 +26,44 @@ type BuildWasmConfig struct {
 	Opt bool
 }
 
-func Run(args []string) error { return runRuntime(args) }
+func Run(args []string) error {
+	return runRuntime(args)
+}
+
 func ParseRuntimeBuildWasmArgs(args []string) (BuildWasmConfig, error) {
 	cfg, err := parseRuntimeBuildWasmArgs(args)
 	return BuildWasmConfig{Opt: cfg.opt}, err
 }
-func ParseRuntimeCompressWasmArgs(args []string) error { return parseRuntimeCompressWasmArgs(args) }
-func ParseRuntimeExportPackArgs(args []string) error   { return parseRuntimeExportPackArgs(args) }
+
+func ParseRuntimeCompressWasmArgs(args []string) error {
+	return parseRuntimeCompressWasmArgs(args)
+}
+
+func ParseRuntimeExportPackArgs(args []string) error {
+	return parseRuntimeExportPackArgs(args)
+}
+
 func ParseRuntimeExportWebArgs(args []string) (ExportWebConfig, error) {
 	cfg, err := parseRuntimeExportWebArgs(args)
 	return ExportWebConfig{Mode: cfg.mode}, err
 }
+
 func BuildWasmRuntime(cfg BuildWasmConfig, runner shared.ScriptRunner) error {
 	return buildWasmRuntime(runtimeBuildWasmConfig{opt: cfg.Opt}, sharedScriptRunnerAdapter{inner: runner})
 }
-func CompressWasmArtifacts() error { return compressWasmArtifacts() }
+
+func CompressWasmArtifacts() error {
+	return compressWasmArtifacts()
+}
+
 func ExportPackRuntime(runner shared.ScriptRunner) error {
 	return exportPackRuntime(sharedScriptRunnerAdapter{inner: runner})
 }
+
 func ExportWebRuntime(cfg ExportWebConfig, runner shared.ScriptRunner) error {
 	return exportWebRuntime(runtimeExportWebConfig{mode: cfg.Mode}, sharedScriptRunnerAdapter{inner: runner})
 }
+
 func ExportWebTemplateRuntime(mode string, runner shared.ScriptRunner) error {
 	return exportWebTemplateRuntime(mode, sharedScriptRunnerAdapter{inner: runner})
 }

--- a/internal/cmd/buildctl/shared/api.go
+++ b/internal/cmd/buildctl/shared/api.go
@@ -58,47 +58,114 @@ func (r CommandRunner) StopWebServers() error {
 	return commandRunner{repoRoot: r.RepoRoot}.stopWebServers()
 }
 
-func FindRepoRoot() (string, error) { return findRepoRoot() }
-func FileExists(path string) bool   { return fileExists(path) }
-func DirExists(path string) bool    { return dirExists(path) }
+func FindRepoRoot() (string, error) {
+	return findRepoRoot()
+}
+
+func FileExists(path string) bool {
+	return fileExists(path)
+}
+
+func DirExists(path string) bool {
+	return dirExists(path)
+}
+
 func ResolveBuildEnvironment(repoRoot string, requestedPlatform string) (BuildEnvironment, error) {
 	return resolveBuildEnvironment(repoRoot, requestedPlatform)
 }
-func (env BuildEnvironment) ShellExports() string { return buildEnvironment(env).shellExports() }
-func ShellQuote(value string) string              { return shellQuote(value) }
+
+func (env BuildEnvironment) ShellExports() string {
+	return buildEnvironment(env).shellExports()
+}
+
+func ShellQuote(value string) string {
+	return shellQuote(value)
+}
+
 func EnsureEngineSource(repoRoot string, run func(name string, args ...string) error) error {
 	return ensureEngineSource(repoRoot, run)
 }
+
 func ResolveMacOSVulkanSDKRoot(homeDir string, envSDK string) (string, error) {
 	return resolveMacOSVulkanSDKRoot(homeDir, envSDK)
 }
-func MacOSVulkanSDKShellExports(sdkRoot string) string      { return macOSVulkanSDKShellExports(sdkRoot) }
-func ValidateSetupMode(mode string) error                   { return validateSetupMode(mode) }
-func ValidateWebMode(mode string) error                     { return validateWebMode(mode) }
-func ValidateOptionalPlatform(platform string) error        { return validateOptionalPlatform(platform) }
-func CurrentEnvMap() map[string]string                      { return currentEnvMap() }
-func EnvMapToSlice(env map[string]string) []string          { return envMapToSlice(env) }
-func PrependToPath(pathValue string, dirs ...string) string { return prependToPath(pathValue, dirs...) }
+
+func MacOSVulkanSDKShellExports(sdkRoot string) string {
+	return macOSVulkanSDKShellExports(sdkRoot)
+}
+
+func ValidateSetupMode(mode string) error {
+	return validateSetupMode(mode)
+}
+
+func ValidateWebMode(mode string) error {
+	return validateWebMode(mode)
+}
+
+func ValidateOptionalPlatform(platform string) error {
+	return validateOptionalPlatform(platform)
+}
+
+func CurrentEnvMap() map[string]string {
+	return currentEnvMap()
+}
+
+func EnvMapToSlice(env map[string]string) []string {
+	return envMapToSlice(env)
+}
+
+func PrependToPath(pathValue string, dirs ...string) string {
+	return prependToPath(pathValue, dirs...)
+}
+
 func RunCommandOutput(name string, args ...string) ([]byte, error) {
 	return runCommandOutput(name, args...)
 }
+
 func RunCommandOutputWithEnv(workdir string, env []string, name string, args ...string) ([]byte, error) {
 	return runCommandOutputWithEnv(workdir, env, name, args...)
 }
+
 func RunStreamingCommand(workdir, name string, args ...string) error {
 	return runStreamingCommand(workdir, name, args...)
 }
-func BuildctlCommandEnv() (map[string]string, error) { return buildctlCommandEnv() }
+
+func BuildctlCommandEnv() (map[string]string, error) {
+	return buildctlCommandEnv()
+}
+
 func ResolveCommandPath(name string, env map[string]string) (string, error) {
 	return resolveCommandPath(name, env)
 }
-func EnsureGoPath() (string, error)          { return ensureGoPath() }
-func DefaultRuntimeVersion() (string, error) { return defaultRuntimeVersion() }
-func CopyFile(src, dst string) error         { return copyFile(src, dst) }
-func CopyDir(src, dst string) error          { return copyDir(src, dst) }
+
+func EnsureGoPath() (string, error) {
+	return ensureGoPath()
+}
+
+func DefaultRuntimeVersion() (string, error) {
+	return defaultRuntimeVersion()
+}
+
+func CopyFile(src, dst string) error {
+	return copyFile(src, dst)
+}
+
+func CopyDir(src, dst string) error {
+	return copyDir(src, dst)
+}
+
 func WriteNamedZip(dst string, namedFiles map[string]string) error {
 	return writeNamedZip(dst, namedFiles)
 }
-func ZipDirectory(srcDir, dstZip string) error { return zipDirectory(srcDir, dstZip) }
-func ExtractZip(srcZip, dstDir string) error   { return extractZip(srcZip, dstDir) }
-func FetchURLToFile(url, dst string) error     { return fetchURLToFile(url, dst) }
+
+func ZipDirectory(srcDir, dstZip string) error {
+	return zipDirectory(srcDir, dstZip)
+}
+
+func ExtractZip(srcZip, dstDir string) error {
+	return extractZip(srcZip, dstDir)
+}
+
+func FetchURLToFile(url, dst string) error {
+	return fetchURLToFile(url, dst)
+}

--- a/internal/cmd/buildctl/tool/api.go
+++ b/internal/cmd/buildctl/tool/api.go
@@ -47,12 +47,19 @@ type EMSDKEnvironment struct {
 	RepoDir string
 }
 
-func Run(args []string) error                      { return runTool(args) }
-func ParseToolCleanAssetsArgs(args []string) error { return parseToolCleanAssetsArgs(args) }
+func Run(args []string) error {
+	return runTool(args)
+}
+
+func ParseToolCleanAssetsArgs(args []string) error {
+	return parseToolCleanAssetsArgs(args)
+}
+
 func ParseToolInstallArgs(args []string) (InstallConfig, error) {
 	cfg, err := parseToolInstallArgs(args)
 	return InstallConfig{Web: cfg.web, Opt: cfg.opt}, err
 }
+
 func ParseToolSetupNDKArgs(args []string) (SetupNDKConfig, error) {
 	cfg, err := parseToolSetupNDKArgs(args)
 	return SetupNDKConfig{
@@ -61,22 +68,30 @@ func ParseToolSetupNDKArgs(args []string) (SetupNDKConfig, error) {
 		SkipVerification: cfg.skipVerification,
 	}, err
 }
+
 func ParseToolSetupSConsArgs(args []string) (SetupSConsConfig, error) {
 	_, err := parseToolSetupSConsArgs(args)
 	return SetupSConsConfig{}, err
 }
+
 func ParseToolSetupJDKArgs(args []string) (SetupJDKConfig, error) {
 	_, err := parseToolSetupJDKArgs(args)
 	return SetupJDKConfig{}, err
 }
+
 func ParseToolSetupEMSDKArgs(args []string) (SetupEMSDKConfig, error) {
 	_, err := parseToolSetupEMSDKArgs(args)
 	return SetupEMSDKConfig{}, err
 }
+
 func InstallTools(cfg InstallConfig, runner shared.ScriptRunner) error {
 	return installTools(toolInstallConfig{web: cfg.Web, opt: cfg.Opt}, scriptRunnerAdapter{inner: runner})
 }
-func CleanInstalledAssets() error { return cleanInstalledAssets() }
+
+func CleanInstalledAssets() error {
+	return cleanInstalledAssets()
+}
+
 func SetupAndroidNDK(cfg SetupNDKConfig) error {
 	return setupAndroidNDK(toolSetupNDKConfig{
 		manualInstall:    cfg.ManualInstall,
@@ -84,27 +99,56 @@ func SetupAndroidNDK(cfg SetupNDKConfig) error {
 		skipVerification: cfg.SkipVerification,
 	})
 }
-func SetupSCons() error                                  { return setupSCons() }
-func SetupJDK() error                                    { return setupJDK() }
-func SetupEMSDK() error                                  { return setupEMSDK() }
-func ResolveJDKShellExports() (map[string]string, error) { return resolveJDKShellExports() }
+
+func SetupSCons() error {
+	return setupSCons()
+}
+
+func SetupJDK() error {
+	return setupJDK()
+}
+
+func SetupEMSDK() error {
+	return setupEMSDK()
+}
+
+func ResolveJDKShellExports() (map[string]string, error) {
+	return resolveJDKShellExports()
+}
+
 func ResolveEMSDKEnvironment() (EMSDKEnvironment, error) {
 	env, err := resolveEMSDKEnvironment()
 	return EMSDKEnvironment{RootDir: env.rootDir, RepoDir: env.repoDir}, err
 }
+
 func ResolveEMSDKVerificationEnvironment(env EMSDKEnvironment) (map[string]string, string, error) {
 	return resolveEMSDKVerificationEnvironment(emsdkEnvironment{rootDir: env.RootDir, repoDir: env.RepoDir})
 }
-func ResolveEMSDKShellExports() (map[string]string, error) { return resolveEMSDKShellExports() }
+
+func ResolveEMSDKShellExports() (map[string]string, error) {
+	return resolveEMSDKShellExports()
+}
+
 func VerifyEMSDK(env EMSDKEnvironment) error {
 	return verifyEMSDK(emsdkEnvironment{rootDir: env.RootDir, repoDir: env.RepoDir})
 }
-func EmscriptenCPPExecutableName() string                   { return emscriptenCPPExecutableName() }
-func ParseJavaMajorVersion(output string) (int, bool)       { return parseJavaMajorVersion(output) }
-func PrependToPath(pathValue string, dirs ...string) string { return prependToPath(pathValue, dirs...) }
+
+func EmscriptenCPPExecutableName() string {
+	return emscriptenCPPExecutableName()
+}
+
+func ParseJavaMajorVersion(output string) (int, bool) {
+	return parseJavaMajorVersion(output)
+}
+
+func PrependToPath(pathValue string, dirs ...string) string {
+	return prependToPath(pathValue, dirs...)
+}
+
 func SelectEMSDKExports(before, after map[string]string) map[string]string {
 	return selectEMSDKExports(before, after)
 }
+
 func UpdateNDKShellConfig(env AndroidNDKEnv) error {
 	return updateNDKShellConfig(androidNDKEnv{
 		archiveName: env.ArchiveName,

--- a/internal/cmd/buildctl/workflow/api.go
+++ b/internal/cmd/buildctl/workflow/api.go
@@ -38,43 +38,62 @@ type InstallAPKConfig struct {
 	ProjectDir string
 }
 
-func Run(args []string) error { return runWorkflow(args) }
+func Run(args []string) error {
+	return runWorkflow(args)
+}
+
 func ParseWorkflowBuildWebArgs(args []string) (BuildWebConfig, error) {
 	cfg, err := parseWorkflowBuildWebArgs(args)
 	return BuildWebConfig{Mode: cfg.mode, SkipToolInstall: cfg.skipToolInstall}, err
 }
+
 func ParseWorkflowBuildDevArgs(args []string) (BuildDevConfig, error) {
 	cfg, err := parseWorkflowBuildDevArgs(args)
 	return BuildDevConfig{WebMode: cfg.webMode}, err
 }
+
 func ParseWorkflowRunDemoArgs(args []string) (RunDemoConfig, error) {
 	cfg, err := parseWorkflowRunDemoArgs(args)
 	return RunDemoConfig{DemoIndex: cfg.demoIndex, Mode: cfg.mode, Port: cfg.port, Movie: cfg.movie}, err
 }
+
 func ParseWorkflowInstallAPKArgs(args []string) (InstallAPKConfig, error) {
 	cfg, err := parseWorkflowInstallAPKArgs(args)
 	return InstallAPKConfig{ProjectDir: cfg.projectDir}, err
 }
-func ParseWorkflowListDemosArgs(args []string) error { return parseWorkflowListDemosArgs(args) }
-func ParseWorkflowStopWebArgs(args []string) error   { return parseWorkflowStopWebArgs(args) }
+
+func ParseWorkflowListDemosArgs(args []string) error {
+	return parseWorkflowListDemosArgs(args)
+}
+
+func ParseWorkflowStopWebArgs(args []string) error {
+	return parseWorkflowStopWebArgs(args)
+}
+
 func BuildWebWorkflow(cfg BuildWebConfig, runner shared.ScriptRunner) error {
 	return buildWebWorkflow(workflowBuildWebConfig{mode: cfg.Mode, skipToolInstall: cfg.SkipToolInstall}, sharedScriptRunnerAdapter{inner: runner})
 }
+
 func BuildHostRuntimeWorkflow(runner shared.ScriptRunner) error {
 	return buildHostRuntimeWorkflow(sharedScriptRunnerAdapter{inner: runner})
 }
+
 func BuildDevWorkflow(cfg BuildDevConfig, runner shared.ScriptRunner) error {
 	return buildDevWorkflow(workflowBuildDevConfig{webMode: cfg.WebMode}, sharedScriptRunnerAdapter{inner: runner})
 }
+
 func ListDemosWorkflow(runner shared.WorkflowRunner) error {
 	return listDemosWorkflow(sharedWorkflowRunnerAdapter{inner: runner})
 }
+
 func RunDemoWorkflow(cfg RunDemoConfig, runner shared.WorkflowRunner) error {
 	return runDemoWorkflow(workflowRunDemoConfig{demoIndex: cfg.DemoIndex, mode: cfg.Mode, port: cfg.Port, movie: cfg.Movie}, sharedWorkflowRunnerAdapter{inner: runner})
 }
+
 func StopWebWorkflow(runner shared.WorkflowRunner) error {
 	return stopWebWorkflow(sharedWorkflowRunnerAdapter{inner: runner})
 }
+
 func InstallAPKWorkflow(cfg InstallAPKConfig, runner shared.WorkflowRunner) error {
 	return installAPKWorkflow(workflowInstallAPKConfig{projectDir: cfg.ProjectDir}, sharedWorkflowRunnerAdapter{inner: runner})
 }


### PR DESCRIPTION
## Summary
- normalize formatting across `internal/cmd/buildctl/*/api.go`
- expand single-line wrapper functions to multi-line bodies
- keep top-level function spacing consistent in the buildctl API surface

## Testing
- go test ./internal/cmd/buildctl/...
