### PR TITLE
fix: clamp negative sprite size before physics update

### DIFF
--- a/component_transform.go
+++ b/component_transform.go
@@ -209,6 +209,10 @@ func (t *transformComponent) SetSize(size float64) {
 	if isDebugInstrEnabled() {
 		spxlog.Debug("SetSize: sprite=%s, size=%v", t.sprite.name, size)
 	}
+	if size < 0 {
+		spxlog.Warn("SetSize: sprite=%s, size=%v is negative, clamping to 0", t.sprite.name, size)
+		size = 0
+	}
 
 	t.sprite.runtimeState.Scale = size
 	t.sprite.runtimeState.IsCostumeDirty = true


### PR DESCRIPTION
## Summary
- clamp negative values passed to `SetSize` to `0`
- emit a warning log when a negative size is received
- prevent negative `RectangleShape2D` sizes when physics shapes are rescaled

## Testing
- go test .
