### PR TITLE
docs(skill): add installable spx-project skill

### DIFF
--- a/skills/spx-project/SKILL.md
+++ b/skills/spx-project/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: spx-project
+description: Write or modify user-facing spx projects with `.spx` files, events, shared state, sprite behavior, and asset configs.
+---
+
+# spx project
+
+A `.spx` file is ordinary XGo source code. Apply XGo syntax rules first. Then apply the spx-specific file roles,
+classfile behavior, project structure, event forms, and builtin-like APIs documented here.
+You can think of spx project authoring as a Scratch-style DSL built on XGo classfiles. Scratch concepts often
+transfer, but the output must still use current spx spellings and normal XGo syntax.
+
+## Use this skill when
+
+- creating or modifying `main.spx`
+- creating or modifying sprite `.spx` files
+- wiring stage events, sprite events, clone behavior, and shared state
+- using spx builtin-like APIs and their overloads
+- editing `assets/index.json` or sprite or sound config files for a spx project
+- translating Scratch-style behavior descriptions into current spx project code
+
+## Core model
+
+- `main.spx` is the stage or game script
+- every other `.spx` file is a sprite script
+- the file state is the field declaration block, which is the first top-level `var` declaration whose preceding
+  top-level declarations, if any, are only imports, `const`, or `type`
+- top-level `func` declarations without explicit receivers become methods of the current file object
+- top-level statements become the file entry body
+- the project starts automatically
+
+## Reading order
+
+Read only what the task needs:
+
+1. Read [references/scratch-compat.md](references/scratch-compat.md) first when the request is phrased in Scratch
+   blocks or other Scratch vocabulary.
+2. Read [references/project-layout.md](references/project-layout.md) first when the main question is "which file should
+   own this behavior" or "where should this state live".
+3. Read [references/xgo-syntax.md](references/xgo-syntax.md) when syntax is the uncertainty, especially lambdas,
+   command-style calls, top-level statements, or the field declaration block rule.
+4. Read [references/spx-api.md](references/spx-api.md) before writing any event or API spelling that you are not
+   already sure about.
+
+## What to do first
+
+- inspect the existing project layout and keep `assets/` or `res/` consistent with the repo
+- identify which file owns the requested behavior before writing code
+- preserve the current project's naming and calling style unless the task explicitly asks for cleanup
+- check whether the request changes `.spx` code only or also requires asset config changes
+- translate Scratch requests into current spx authoring spellings before writing code
+- read the matching reference before guessing syntax, event signatures, overloads, or uncommon APIs
+
+## Default coding workflow
+
+1. Decide which file owns the requested behavior.
+2. Decide whether the needed state belongs in `main.spx` or a sprite file.
+3. Decide whether the behavior starts from top-level entry code, `onStart`, `OnLoaded`, `onCloned`, or another event.
+4. Add or update helper functions before event handlers when the logic is reused.
+5. Register events at top level.
+6. Update asset config files only if the task truly needs config changes.
+7. Re-read the edited `.spx` file and confirm the state `var` block is still in the correct place.
+
+## Ownership rules
+
+- global score, level, game flags, scene-wide reloads, and stage-wide messages usually belong in `main.spx`
+- player movement, aiming, firing cadence, local cooldowns, and local hp usually belong in the player sprite file
+- bullet behavior usually belongs in the bullet sprite file, especially when bullets are clones
+- enemy movement, local hp, hit reactions, and death behavior usually belong in the enemy sprite file
+- HUD monitor visibility and monitor config usually involve `assets/index.json`
+- camera follow often belongs in project config, and camera movement logic often belongs in `main.spx`
+- pathfinding, physics bodies, collider setup, and trigger setup usually belong in the sprite that owns that body
+
+## Event selection rules
+
+- use top-level statements for small file-local setup only
+- use `onStart` for loops and normal lifecycle startup work
+- use `func OnLoaded()` in `main.spx` for post-load setup that should happen after sprites are initialized
+- use `onCloned` for clone-only initialization and clone-local loops
+- use `onMsg` when the sender should not depend on a concrete receiver
+- use direct sprite access when one known sprite should be called immediately
+- use `onTouchStart` for collision start reactions
+- use `touching(...)` inside a loop when you need continuous polling rather than a one-time touch start
+
+## Non-negotiable rules
+
+- use normal XGo syntax for expressions, statements, imports, control flow, composite literals, slices, maps, and
+  lambdas
+- use XGo lambdas with `=>` normally in `.spx` files
+- keep shared state in `main.spx`
+- keep per-sprite state in that sprite file
+- place the file state `var` block before all top-level helper `func` declarations
+- initialize clone-only state in `onCloned`
+- do not manually declare sprite references in `main.spx` just because `Player.spx` or `Enemy.spx` exists
+- use `onCloned` and `onTouchStart` only in sprite files
+- use direct sprite names when the project already uses that style
+- treat `func init()` and `func main()` as ordinary classfile methods, not package hooks
+- do not guess user-facing spellings or overloads
+- do not move the file state `var` block below helper functions or event registrations
+- do not put a top-level `func` before the file state `var` block unless you intentionally want later `var`
+  declarations to stop being file fields
+- do not rewrite normal project code into unusual alternate spellings
+- do not add imports for ordinary gameplay APIs that are already available directly in `.spx` project code
+
+## When to stop guessing and read the references
+
+Open the references instead of guessing when the task involves:
+
+- Scratch block wording or other Scratch-style phrasing
+- exact event callback signatures
+- `onKey`, `onMsg`, `onBackdrop`, `onCloned`, or `onTouchStart` overload choice
+- clone setup patterns
+- camera, pathfinding, tilemap, query, or physics APIs
+- monitor JSON or asset config edits
+- uncommon helpers such as `SetDebug`, `GetWidget`, `List`, or `Value`
+
+## References
+
+Read [references/scratch-compat.md](references/scratch-compat.md) when you need:
+
+- a stable Scratch to spx mental-model mapping
+- current project-side spellings for common Scratch blocks and reporters
+- translation caveats such as 1-based Scratch positions versus 0-based XGo indexing
+- a list of unsupported or not-one-to-one Scratch areas that should not be guessed
+
+Read [references/xgo-syntax.md](references/xgo-syntax.md) when you need:
+
+- XGo syntax rules inside `.spx` files
+- lambda forms with `=>`
+- command-style call syntax
+- top-level file rules and classfile-oriented source structure
+
+Read [references/project-layout.md](references/project-layout.md) when you need:
+
+- project layout and asset directory conventions
+- `main.spx` vs sprite file responsibilities
+- state placement, startup timing, cross-sprite access, and clone patterns
+- resource config patterns and stage monitor JSON
+
+Read [references/spx-api.md](references/spx-api.md) when you need:
+
+- precise event signatures and callback forms
+- exact overloads for stage or sprite APIs
+- event selection by intent
+- implementation templates for common gameplay tasks
+- helpers, constants, and uncommon project-side APIs
+
+## Output standard
+
+- write direct `.spx` project code, not abstract pseudocode
+- keep examples and explanations focused on project authorship
+- use normal project spellings such as `onStart`, `broadcastAndWait`, `setXYpos`, and `animateAndWait`
+- if the current project already uses mixed casing such as `Camera.SetZoom`, keep that local style consistent
+- use reference files instead of guessing behavior
+- when a task is ambiguous, choose the most normal project-side spelling and structure rather than inventing a lower
+  level workaround
+
+## Do and do not
+
+Do:
+
+- write `.spx` code like normal spx project code
+- follow XGo syntax rules first, then apply spx-specific file and API rules
+- keep `main.spx` focused on shared state and stage logic
+- keep sprite behavior inside sprite files
+- use top-level event registrations
+- use `onCloned` for clone setup
+- use the reference files instead of guessing overloads
+
+Do not:
+
+- rewrite normal project guidance into unusual alternate spellings
+- write explicit receiver boilerplate for normal `.spx` methods
+- move the state `var` block below top-level event code
+- add framework imports for ordinary gameplay code when direct project forms already cover the need
+- prefer alternate lower-level spellings when a direct `.spx` form already exists

--- a/skills/spx-project/agents/openai.yaml
+++ b/skills/spx-project/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "spx project"
+  short_description: "Write user-facing spx project code"
+  default_prompt: "Use $spx-project to write or modify a user-facing spx project."
+
+policy:
+  allow_implicit_invocation: true

--- a/skills/spx-project/references/project-layout.md
+++ b/skills/spx-project/references/project-layout.md
@@ -1,0 +1,439 @@
+# project layout for spx
+
+Use this reference when the task is about project structure, file roles, state placement, startup timing, clone
+patterns, or asset config layout in a spx project.
+
+## Contents
+
+- project tree
+- decision order
+- core coding model
+- where code should go
+- startup timing
+- `main.spx`
+- sprite files
+- shared state vs sprite state
+- cross-sprite access vs messaging
+- naming and calling style
+- adding a new sprite
+- clone patterns
+- resource config patterns
+- common task routing
+- common mistakes
+
+## Project tree
+
+Typical shape:
+
+```text
+main.spx
+Player.spx
+Enemy.spx
+assets/
+  index.json
+  sprites/
+    Player/
+      index.json
+    Enemy/
+      index.json
+  sounds/
+    Hit/
+      index.json
+```
+
+Rules:
+
+- `main.spx` is the stage or game script
+- every other `.spx` file is a sprite script
+- the filename is the sprite name
+- `assets/index.json` is the usual project config file
+- sprite config usually lives under `assets/sprites/<SpriteName>/index.json`
+- sound config usually lives under `assets/sounds/<SoundName>/index.json`
+- some existing projects use `res/` instead of `assets/`. Keep whichever root the repo already uses
+- the project starts automatically
+
+## Decision order
+
+When implementing a request, decide in this order:
+
+1. Which file owns the requested behavior.
+2. Whether the new state is shared state or per-sprite state.
+3. Whether the behavior should run from top-level entry code, `onStart`, `OnLoaded`, or another event.
+4. Whether the change requires `.spx` code only or also asset config changes.
+5. Whether direct sprite access or broadcast messaging is the simpler design.
+
+## Core coding model
+
+- `main.spx` owns shared state and stage-level logic
+- each sprite `.spx` owns that sprite's per-instance state and behavior
+- the file state must be declared in the field declaration block, which must appear before top-level helper `func`
+  declarations
+- top-level `func` declarations are methods of the current file object
+- top-level executable statements are the file's setup body
+- sprite code can directly access:
+  - shared state declared in `main.spx`
+  - stage APIs like `broadcast`, `wait`, `mouseX`, and `Camera`
+  - other sprites by name, such as `Bullet` or `Enemy`
+
+## Where code should go
+
+Put code in `main.spx` for:
+
+- score, level, round, and other shared variables
+- stage-wide input and stage-wide event coordination
+- backdrop changes, reload flow, and scene-wide messaging
+- helper functions used by more than one sprite through shared state or stage behavior
+- optional `func OnLoaded()` post-load setup
+
+Put code in a sprite file for:
+
+- local hp, speed, cooldown, facing, and animation state
+- movement, aiming, and local input handling
+- collisions, hit reactions, and local death behavior
+- clone behavior and clone-local loops
+- sprite-specific helper functions
+
+## Startup timing
+
+Use top-level statements when:
+
+- a small amount of file setup reads more clearly as entry code
+- the setup belongs to the file itself rather than an event reaction
+
+Use `onStart` when:
+
+- the behavior should start with the project or sprite lifecycle
+- the code launches a loop, repeated action, or ongoing behavior
+
+Use `func OnLoaded()` in `main.spx` when:
+
+- the project needs a post-load hook
+- the setup should happen after load rather than being part of a sprite loop
+
+Use `onCloned` when:
+
+- clone-only state must be initialized
+- the clone needs to start its own loop or behavior immediately after cloning
+
+Practical rules:
+
+- top-level statements in `main.spx` still run as part of the project entry
+- `onStart` still runs normally after startup
+- keep gameplay loops in `onStart` or `onCloned`, not in `OnLoaded`
+- use `OnLoaded` for post-load setup, not for long-running movement or collision loops
+
+## `main.spx`
+
+Use `main.spx` for:
+
+- shared variables
+- stage-level events
+- startup logic
+- scene reload logic
+- optional project-wide helper functions
+- optional `func OnLoaded()` hook for post-load setup
+
+Rules:
+
+- do not add manual `Player Player` or `Enemy Enemy` declarations just to access sprites
+- refer to sprite files by name directly when needed
+- keep `main.spx` focused on stage concerns and shared state
+- use `main.spx` when multiple sprites should react through shared state or stage messages
+
+Example:
+
+```xgo
+var (
+	score int
+)
+
+onKey KeySpace, => {
+	broadcast "fire"
+}
+
+func OnLoaded() {
+	println "loaded"
+}
+```
+
+## Sprite files
+
+Use sprite `.spx` files for:
+
+- per-sprite state
+- input handling for that sprite
+- movement and animation
+- collisions and interactions
+- clone behavior
+- helper functions specific to that sprite
+- optional local state machines such as `alive`, `cooldown`, `phase`, or `targetX`
+
+Example:
+
+```xgo
+var (
+	hp int
+)
+
+func resetHP() {
+	hp = 3
+}
+
+onStart => {
+	resetHP()
+}
+
+onTouchStart "Bullet", => {
+	hp--
+	if hp <= 0 {
+		die
+	}
+}
+```
+
+## Shared state vs sprite state
+
+Variables in `main.spx` are shared project state.
+
+Use `main.spx` state for:
+
+- score
+- level
+- shared counters
+- global flags
+- stage-wide mode switches
+
+Variables in a sprite file are that sprite's own fields.
+
+Use sprite state for:
+
+- hp
+- local cooldown
+- local movement state
+- current target
+- clone lifetime
+
+Cloned sprites copy sprite fields, so clone-only state must be reset in `onCloned`.
+
+Good clone-safe pattern:
+
+```xgo
+var (
+	life int
+)
+
+onStart => {
+	for {
+		wait 0.3
+		clone
+	}
+}
+
+onCloned => {
+	life = 3
+	show
+}
+```
+
+## Cross-sprite access vs messaging
+
+Use direct sprite access when:
+
+- the target sprite is known
+- the interaction is local and immediate
+- direct reads or method calls are clearer than message passing
+
+Example:
+
+```xgo
+Bullet.clone
+Red.SetXYpos(0, 0)
+if touching("Enemy") {
+	destroy
+}
+```
+
+Use broadcast messaging when:
+
+- multiple listeners should react
+- stage logic should coordinate multiple sprites
+- the sender should not know concrete listeners
+- the message is a gameplay event such as `"fire"`, `"hit"`, `"game-over"`, or `"next-wave"`
+
+Rule of thumb:
+
+- use direct access for one known sprite
+- use `broadcast` for one-to-many coordination
+- use `broadcastAndWait` when the sender must wait until listeners finish their work
+
+## Naming and calling style
+
+- prefer the lowercase project-code spellings already used in `.spx` files:
+  - `setXYpos`
+  - `broadcastAndWait`
+  - `animateAndWait`
+  - `changeSoundEffect`
+- exported Go-style names also exist behind the scenes, but normal `.spx` project code should prefer the lowercase
+  spellings
+- some existing repos mix lowercase spellings and Go-style spellings. Follow the current file's style unless the task
+  asks for cleanup
+- no-argument calls are often written without parentheses when used as statements:
+
+```xgo
+waitNextFrame
+show
+hide
+destroy
+clone
+```
+
+- use ordinary call syntax when you need a returned value:
+
+```xgo
+xpos()
+ypos()
+mouseX()
+mouseY()
+timer()
+answer()
+```
+
+- if the shorthand form is unclear, explicit method calls are fine:
+
+```xgo
+this.SetXYpos(10, 20)
+Camera.SetZoom(1.5)
+Enemy.SetXYpos(0, 0)
+```
+
+## Adding a new sprite
+
+When a task requires a new sprite:
+
+1. Create `<SpriteName>.spx`.
+2. Put the sprite's state in the field declaration block, before any top-level helper `func`.
+3. Add top-level event handlers and helper functions.
+4. Add or update `assets/sprites/<SpriteName>/index.json`.
+5. Keep the sprite filename and sprite config directory name aligned.
+6. Do not add manual sprite field declarations in `main.spx` just to make the new sprite visible.
+
+## Clone patterns
+
+Use clones for:
+
+- bullets
+- particles
+- repeated enemies or pickups
+- short-lived effects with mostly identical behavior
+
+Rules:
+
+- initialize clone-only state in `onCloned`
+- call `show` in `onCloned` if the clone should become visible immediately
+- do not assume clones start with clean runtime state
+- call `destroy` or `deleteThisClone` when the clone is done
+- keep emitter logic in the owner sprite and movement or lifetime logic in the cloned sprite
+
+Bullet-style pattern:
+
+```xgo
+onStart => {
+	for {
+		wait 0.1
+		Bullet.clone
+	}
+}
+```
+
+```xgo
+onCloned => {
+	setXYpos Player.xpos, Player.ypos
+	show
+	for {
+		waitNextFrame
+		step 10
+		if touching(Edge) {
+			destroy
+		}
+	}
+}
+```
+
+## Resource config patterns
+
+Project config commonly contains:
+
+- `map`
+- `backdrops`
+- `zorder`
+- optional `camera`
+
+Sprite config commonly contains:
+
+- `costumes` or `costumeSet`
+- `fAnimations`, `mAnimations`, `tAnimations`
+- `heading`
+- `size`
+- `visible`
+- `x`
+- `y`
+- `rotationStyle`
+
+Stage monitor example:
+
+```json
+{
+  "type": "monitor",
+  "target": "",
+  "val": "getVar:score",
+  "label": "score",
+  "visible": true
+}
+```
+
+Practical config rules:
+
+- add a stage monitor when shared state such as score should be visible on screen
+- add or update sprite config when a task changes costume, size, heading, visibility, or animation metadata
+- keep asset paths and directory names aligned with the project's existing layout
+- if a repo already uses a custom config shape, extend that shape consistently instead of replacing it with a new style
+
+Camera follow config example:
+
+```json
+{
+  "camera": {
+    "on": "Player"
+  }
+}
+```
+
+## Common task routing
+
+Use this table of thumb when choosing files:
+
+- add score or level counter: `main.spx` and maybe `assets/index.json`
+- add player movement or aim: player sprite file
+- add player firing cooldown: player sprite file
+- add bullet motion and lifetime: bullet sprite file
+- add enemy hp and death: enemy sprite file
+- add stage restart on game over: usually `main.spx`
+- add backdrop change on phase switch: usually `main.spx`
+- add camera follow target in config: `assets/index.json`
+- add exact collision or trigger shape: the sprite's config or sprite file, depending on the request
+
+## Common mistakes
+
+- putting shared state into one sprite file and then trying to use it as project state
+- putting clone-local initialization in `onStart` instead of `onCloned`
+- registering events inside other handlers instead of at top level
+- moving the first `var` block below top-level event code
+- adding manual sprite field declarations in `main.spx`
+- choosing `broadcast` when a direct sprite call would be simpler
+- choosing direct sprite access when the request really describes one-to-many coordination
+- putting shared score or level state inside a sprite file
+- putting per-enemy hp in `main.spx`
+- forgetting to reset clone-only state in `onCloned`
+- writing `var` blocks after top-level event statements
+- mixing `assets/` and `res/` in the same project without a task-driven reason
+- editing asset config paths without keeping filenames and sprite names aligned

--- a/skills/spx-project/references/scratch-compat.md
+++ b/skills/spx-project/references/scratch-compat.md
@@ -1,0 +1,357 @@
+# Scratch compatibility for spx project authoring
+
+Use this reference when a request is phrased in Scratch blocks or other Scratch terms.
+
+This file is a translation aid. It helps map Scratch concepts to current `.spx` project code. It does not replace
+`xgo-syntax.md`, `project-layout.md`, or `spx-api.md`.
+
+You can think of spx project authoring as a Scratch-style DSL layer on top of XGo classfiles:
+
+- Scratch contributes the stage, sprite, message, clone, costume, backdrop, and monitor mental model
+- spx contributes the exact project-side APIs and enums
+- XGo classfiles contribute the actual source form, top-level rules, and type system
+
+## How to use this reference
+
+1. Translate the Scratch concept to the nearest current spx authoring shape here.
+2. Use `project-layout.md` to decide which `.spx` file owns the behavior.
+3. Use `spx-api.md` to confirm the exact event signature, overload, enum, or helper spelling.
+4. Use `xgo-syntax.md` to write the final code in valid `.spx` form.
+
+## Non-negotiable translation rules
+
+- Write current `.spx` spellings such as `onStart`, `onMsg`, `setXYpos`, `broadcastAndWait`, and `touchingColor`.
+- Do not emit raw Scratch block labels or `Type::Method` style names in handwritten project code.
+- Treat Scratch scripts as top-level event registrations plus helper `func` declarations in the owning `.spx` file.
+- Treat Scratch custom blocks as normal top-level helper `func` declarations in the owning file.
+- Treat Scratch control blocks as ordinary XGo control flow or spx loop helpers, not as a separate block DSL.
+- Keep the field declaration block rules from `xgo-syntax.md`. Shared or per-sprite state still belongs in the first
+  qualifying top-level `var` declaration.
+- Use real XGo types when the intended type is clear. Do not keep everything as dynamically typed Scratch-style data.
+- Prefer current project-side spellings over older alternate names.
+- Older names such as `lookLike:`, `startScene`, and `whenSceneStarts` should be mentally translated to current
+  authoring spellings such as `setCostume`, `setBackdrop`, and `onBackdrop`.
+
+## Mental model
+
+- Scratch stage maps to `main.spx`
+- each Scratch sprite maps to one non-`main.spx` file
+- stage-wide variables and stage-wide coordination usually belong in `main.spx`
+- sprite-local variables and behavior usually belong in that sprite file
+- broadcast-based coordination still maps well to stage-plus-sprites project structure
+- Scratch monitors still often involve `assets/index.json`, plus `showVar(name)` and `hideVar(name)` when visibility is
+  changed at runtime
+- a Scratch script stack usually becomes one top-level event registration plus helper functions in the owning file
+
+## Event mapping
+
+- `when green flag clicked` maps to top-level `onStart => { ... }`
+- `when this sprite clicked` maps to `onClick => { ... }`
+- `when [key] key pressed` maps to `onKey KeySpace, => { ... }` or another `Key...` constant
+- `when I receive [message]` maps to `onMsg "message", => { ... }`
+- `when backdrop switches to [name]` maps to `onBackdrop "name", => { ... }`
+- `when I start as a clone` maps to `onCloned => { ... }`
+- `when [sensor] > [value]` has no normal direct spx event. Model it with polling, timers, or another existing API
+  instead of inventing a fake event.
+
+Event rules:
+
+- register event handlers at top level
+- use `onCloned` only in sprite files
+- use a helper `func` when several handlers share the same logic
+- if a Scratch task suggests one event family but the current repo needs another, prefer the current spx API over the
+  literal Scratch phrasing
+
+## Broadcasts and control flow
+
+- `broadcast [msg]` maps to `broadcast "msg"`
+- `broadcast [msg] and wait` maps to `broadcastAndWait "msg"`
+- `wait (secs)` maps to `wait secs`
+- `wait until <condition>` maps to `waitUntil(condition)` or a normal polling loop
+- `forever` usually maps to a normal `for { ... }` loop started from `onStart` or `onCloned`
+- `repeat (n)` maps to `repeat(n, func())` or a normal `for` loop
+- `repeat until <condition>` maps to `repeatUntil(condition, func())` or a normal loop
+- `if` and `if else` map to normal XGo `if` and `if else`
+- `stop [all]` maps to `stop(All)`
+- `stop [this script]` maps to `stop(ThisScript)`
+- `stop [other scripts in sprite]` maps to `stop(OtherScriptsInSprite)`
+- `run without screen refresh` or `warp` has no normal handwritten `.spx` equivalent
+
+Control-flow rules:
+
+- for simple gameplay loops, normal XGo `for` is usually clearer than forcing everything through loop helpers
+- for small Scratch-style rewrites, `repeat`, `repeatUntil`, `waitUntil`, and `forever` can preserve the intent well
+- `broadcastAndWait` is the direct equivalent when the sender must block until listeners finish
+
+## Motion and targeting
+
+- `move (10) steps` usually maps to `step 10`
+- clockwise and counterclockwise turn blocks usually map to `turn angle` with the appropriate sign
+- `point in direction (90)` maps to `setHeading 90`
+- `point towards [sprite or mouse-pointer]` maps to `turnTo "Sprite"` or `turnTo Mouse`
+- `go to x: (x) y: (y)` maps to `setXYpos x, y`
+- `change x by` and `change y by` map to `changeXpos dx` and `changeYpos dy`
+- `set x to` and `set y to` map to `setXpos x` and `setYpos y`
+- `go to [mouse-pointer]` maps to `stepTo Mouse`
+- `go to [random position]` usually becomes explicit random coordinates such as
+  `setXYpos rand(minX, maxX), rand(minY, maxY)` in authored project code
+- `glide (secs) to x: (x) y: (y)` maps to `glide x, y, secs`
+- `glide (secs) to [mouse-pointer]` maps to `glide Mouse, secs`
+- `if on edge, bounce` maps to `bounceOffEdge`
+- `set rotation style [left-right]` maps to `setRotationStyle(LeftRight)`
+- `set rotation style [don't rotate]` maps to `setRotationStyle(None)`
+- `set rotation style [all around]` maps to `setRotationStyle(Normal)`
+
+Targeting and motion notes:
+
+- in current project code, common special targets include `Mouse`, `Edge`, and `Random` where the API family supports
+  them
+- `step` is the normal project-side spelling that most directly matches the common Scratch "move steps" intent
+- `turnTo` means face a target or direction immediately. `setHeading` is the direct setter for heading
+- keep the local project's calling style. If the repo uses command-style calls such as `setXYpos x, y`, follow that
+
+## Looks, costume, backdrop, layer, and size
+
+- `show` maps to `show`
+- `hide` maps to `hide`
+- `say [msg]` maps to `say msg`
+- `say [msg] for (2) seconds` maps to `say msg, 2`
+- `think [msg]` maps to `think msg`
+- `think [msg] for (2) seconds` maps to `think msg, 2`
+- `switch costume to [name]` maps to `setCostume "name"`
+- `next costume` maps to `setCostume Next`
+- `previous costume` maps to `setCostume Prev`
+- costume reporters map to `costumeIndex()` and `costumeName()`
+- `switch backdrop to [name]` maps to `setBackdrop "name"`
+- `switch backdrop to [name] and wait` maps to `setBackdropAndWait "name"`
+- `next backdrop` maps to `setBackdrop Next`
+- `previous backdrop` maps to `setBackdrop Prev`
+- backdrop reporters map to `backdropIndex()` and `backdropName()`
+- `go to front layer` maps to `setLayer(Front)`
+- `go to back layer` maps to `setLayer(Back)`
+- `go forward (n) layers` maps to `setLayer(Forward, n)`
+- `go backward (n) layers` maps to `setLayer(Backward, n)`
+- `change [graphic effect] by` maps to `changeGraphicEffect(kind, delta)`
+- `set [graphic effect] to` maps to `setGraphicEffect(kind, value)`
+- `clear graphic effects` maps to `clearGraphicEffects()`
+- `change size by` maps to `changeSize delta`
+- `set size to (100)%` maps to `setSize 100`
+- `size` maps to `size()`
+
+Looks and size notes:
+
+- in handwritten current `.spx` authoring, size uses the same percentage-like values that current spx project code
+  already uses. Do not rewrite `100` to `1` in normal project code
+- use current effect enums such as `ColorEffect`, `BrightnessEffect`, `GhostEffect`, `FishEyeEffect`, `WhirlEffect`,
+  `PixelateEffect`, and `MosaicEffect`
+- `hide all sprites` and `say nothing` do not have normal one-to-one project-side APIs. Re-express the behavior with
+  current spx features instead of inventing a helper
+
+## Sound, ask, and answer
+
+- `start sound [name]` maps to `play "name"`
+- `play sound [name] until done` maps to `playAndWait "name"`
+- `stop all sounds` maps to `stopAllSounds()`
+- `volume` maps to `volume()`
+- `set volume to` maps to `setVolume value`
+- `change volume by` maps to `changeVolume delta`
+- `set [sound effect] to` maps to `setSoundEffect(kind, value)`
+- `change [sound effect] by` maps to `changeSoundEffect(kind, delta)`
+- `clear sound effects` maps to `clearSoundEffects()`
+- `ask [question] and wait` maps to `ask "question"`
+- `answer` maps to `answer`
+
+Sound notes:
+
+- current sound-effect enums are `SoundPanEffect` and `SoundPitchEffect`
+- do not assume Scratch music-extension blocks such as tempo, drum, or instrument exist in normal project authoring
+- use sprite sound APIs when the sound belongs to that sprite, and stage sound APIs when the sound is project-wide
+
+## Sensing, input, and property reporters
+
+- `mouse x` and `mouse y` map to `mouseX()` and `mouseY()`
+- `mouse down?` maps to `mousePressed()`
+- `key [space] pressed?` maps to `keyPressed(KeySpace)`
+- a dynamic key name string maps to `keyPressed(KeyFromString(name))`
+- `touching [sprite or edge or mouse-pointer]?` maps to `touching("Sprite")`, `touching(Edge)`, or `touching(Mouse)`
+- `touching color [color]?` maps to `touchingColor(color)`
+- `distance to [sprite or mouse-pointer]` maps to `distanceTo("Sprite")` or `distanceTo(Mouse)`
+- `timer` maps to `timer()`
+- `reset timer` maps to `resetTimer()`
+- `username` maps to `username()`
+- reporters such as `x position`, `y position`, `direction`, `costume #`, `costume name`, `backdrop #`, and
+  `backdrop name` usually map to current spx getters such as `xpos()`, `ypos()`, `heading()`, `costumeIndex()`,
+  `costumeName()`, `backdropIndex()`, and `backdropName()`
+
+Reporter and sensing rules:
+
+- if the target sprite is known, prefer direct access in the local project style, for example `Player.xpos()` or the
+  equivalent shorthand already used by the repo
+- if a Scratch task is phrased as "of [target]" property access, translate the property name to current spx spellings
+  before writing code
+- use `onKey` when the task is event-driven and `keyPressed(...)` when the task is polling inside a loop
+
+Sensing notes:
+
+- current `touching` behavior follows Scratch-like alpha-aware overlap semantics
+- for color-based sensing, use a real `Color` value. `HSB` and `HSBA` use Scratch-like `0..100` ranges
+- when a Scratch block gives a color number or color picker value, translate it to a `Color` before calling
+  `touchingColor`, pen APIs, or other color-based helpers
+
+## Operators, text, and math
+
+- arithmetic operators such as `+`, `-`, `*`, `/`, `>`, `<`, `=`, `and`, `or`, and `not` usually map directly to
+  normal XGo operators
+- `pick random (from) to (to)` maps to `rand(from, to)`
+- `round (value)` maps to `iround(value)`
+- `join [a] [b]` usually maps to `a + b`
+- `length of [text]` maps to `len(text)`
+- `letter (n) of [text]` usually maps to `text[n-1]`
+- `(a) mod (b)` maps to `mod(a, b)`
+
+Operator notes:
+
+- Scratch positions are 1-based. XGo indexing is 0-based. Subtract `1` when translating letter or list-position blocks
+- most Scratch operator blocks become ordinary expressions, not API calls
+- if a task depends on Scratch-specific math semantics rather than simple arithmetic, prefer explicit code over assumed
+  implicit conversions
+- if a task depends on degree-based Scratch trig behavior, spell that conversion out explicitly in `.spx` code
+
+## Colors, pen, and effects
+
+- Scratch-style color thinking usually maps best to `HSB(h, s, b)` or `HSBA(h, s, b, a)` in project code
+- `set pen color to [color]` maps to `setPenColor(color)`
+- `set pen [hue|saturation|brightness|transparency] to` maps to `setPenColor(kind, value)`
+- `change pen [hue|saturation|brightness|transparency] by` maps to `changePenColor(kind, delta)`
+- `set pen size to` maps to `setPenSize size`
+- `change pen size by` maps to `changePenSize delta`
+- `pen down` maps to `penDown`
+- `pen up` maps to `penUp`
+- `stamp` maps to `stamp`
+
+Pen notes:
+
+- current pen component enums are `PenHue`, `PenSaturation`, `PenBrightness`, and `PenTransparency`
+- prefer the current pen API documented by the repo over older spellings such as `setPenHue` or `changePenShade`
+- if the task is about a named graphical effect rather than pen state, use `setGraphicEffect` or
+  `changeGraphicEffect`, not pen APIs
+
+## Variables, lists, monitors, and indexing
+
+- `set [var] to` usually maps to normal assignment in the owning `.spx` file
+- `change [var] by` usually maps to `+=`
+- Scratch stage variables usually become shared state in `main.spx`
+- Scratch sprite-only variables usually become sprite-local state in that sprite file
+- `show variable [name]` and `hide variable [name]` map to `showVar(name)` and `hideVar(name)`
+- Scratch list state usually maps to a `List`
+- `add [x] to [list]` maps to `myList.Append(x)`
+- `delete (n) of [list]` maps to `myList.Delete(n-1)`
+- `delete all of [list]` maps to `myList.Delete(All)` or `myList.Clear()`
+- `insert [x] at (n) of [list]` maps to `myList.Insert(n-1, x)`
+- `replace item (n) of [list] with [x]` maps to `myList.Set(n-1, x)`
+- `item (n) of [list]` maps to `myList.At(n-1)`
+- `length of [list]` maps to `myList.Len()`
+- `[list] contains [x]?` maps to `myList.Contains(x)`
+
+Data and indexing notes:
+
+- Scratch positions are 1-based. XGo indexing and current list APIs are 0-based. Translate positions carefully
+- `List.At(i)` returns `Value`, not an untyped Scratch cell. Convert or compare it intentionally
+- persistent monitor configuration still usually belongs in `assets/index.json`
+- use current XGo types for scalar state instead of emulating Scratch's implicit dynamic conversions everywhere
+
+## Custom blocks and helpers
+
+- Scratch custom block definitions usually map to top-level helper `func` declarations in the owning `.spx` file
+- Scratch custom block calls map to ordinary function calls
+- if several Scratch hats or scripts share the same steps, pull that logic into a helper `func`
+- do not add explicit receivers for normal `.spx` helper functions
+
+## Unsupported or not-one-to-one areas
+
+Treat these as redesign points, not as an invitation to guess a fake matching API:
+
+- `when [sensor] > [value]`
+- `color [a] is touching [b]`
+- drag mode blocks
+- most video sensing blocks
+- many music-extension blocks such as tempo, drum, and instrument
+- `hide all sprites`
+- `say nothing`
+- generic property reporters when the target is not known and no current documented spx helper covers the need
+- any Scratch extension block that is not already represented in the current spx docs
+
+When you hit one of these:
+
+- restate the behavior in terms of current spx APIs
+- use normal XGo code when that is the clearest rewrite
+- consult current repo docs or tests instead of assuming a one-to-one translation exists
+
+## Translation examples
+
+Scratch intent:
+
+- when green flag clicked
+- forever
+- move 5 steps
+- if on edge, bounce
+
+Normal `.spx` shape:
+
+```xgo
+onStart => {
+	for {
+		step 5
+		bounceOffEdge
+		waitNextFrame
+	}
+}
+```
+
+Scratch intent:
+
+- when I receive `fire`
+- create clone of `Bullet`
+- when I start as a clone, move from the player and destroy at the edge
+
+Normal `.spx` shape:
+
+```xgo
+onMsg "fire", => {
+	Bullet.clone
+}
+
+onCloned => {
+	setXYpos Player.xpos(), Player.ypos()
+	show
+	for {
+		step 12
+		if touching(Edge) {
+			destroy
+		}
+		waitNextFrame
+	}
+}
+```
+
+Scratch intent:
+
+- if key `(costume name)` pressed
+
+Normal `.spx` shape:
+
+```xgo
+if keyPressed(KeyFromString(costumeName())) {
+	say "pressed"
+}
+```
+
+Scratch intent:
+
+- set item 2 of `scores` to 50
+
+Normal `.spx` shape:
+
+```xgo
+scores.Set(2-1, 50)
+```

--- a/skills/spx-project/references/spx-api.md
+++ b/skills/spx-project/references/spx-api.md
@@ -1,0 +1,1142 @@
+# spx APIs and events
+
+Use this reference when the task needs exact event signatures, API overloads,
+helpers, constants, or uncommon project-side APIs.
+
+## Contents
+
+- how to use this reference
+- event and lifecycle selection guide
+- event reference
+- shared stage APIs
+- sprite API reference
+- API selection by intent
+- common implementation templates
+- `List`, `Value`, colors, helpers
+- constants and enums
+- extra imports
+- known caveats
+
+## How to use this reference
+
+Use this file in three passes:
+
+1. Pick the owner file with `project-layout.md`.
+2. Pick the right event or API family here.
+3. Only then write the code.
+
+If you are not sure which overload exists, read the exact signature list below before writing code.
+
+## Event and lifecycle selection guide
+
+Choose startup timing like this:
+
+- use top-level statements for tiny file-local setup
+- use `onStart` for normal startup behavior and loops
+- use `func OnLoaded()` in `main.spx` for post-load setup
+- use `onCloned` for clone-local initialization and clone-local loops
+
+Choose input events like this:
+
+- use `onKey` when a specific key or key set should trigger behavior
+- use `onAnyKey` when the pressed key value itself is the payload
+- use `onClick` when click reaction is enough
+- use `onSwipe` for swipe-direction input
+
+Choose communication style like this:
+
+- use direct sprite calls when one known sprite should act immediately
+- use `broadcast` when multiple listeners may react
+- use `broadcastAndWait` when the sender must continue only after listeners finish
+- use `onMsg(func(msg MsgName, data any))` when you need the message name and payload
+- use `onMsg "name", => { ... }` when only one message name matters and no payload is needed
+
+Choose collision or sensing style like this:
+
+- use `onTouchStart` for touch-start reactions
+- use `touching(...)` inside a loop for continuous polling
+- use `distanceTo(...)` for proximity decisions
+- use `intersectRect`, `intersectCircle`, or `raycast` for scene queries from stage logic
+
+Choose timing like this:
+
+- use `wait` inside loops for repeated behavior
+- use `waitNextFrame` for frame-by-frame logic
+- use `onTimer` for one-shot delayed behavior
+- use `resetTimer()` when later `onTimer` timing should be relative to a new time base
+
+## Event reference
+
+Register events at top level. These are ordinary XGo calls whose callback is usually written as a lambda.
+
+Events available in both `main.spx` and sprite files:
+
+```xgo
+onStart => { ... }
+onClick => { ... }
+onKey KeySpace, => { ... }
+onKey [KeyA, KeyD], => { ... }
+onMsg "fire", => { ... }
+onBackdrop "level2", => { ... }
+onSwipe Left, => { ... }
+onTimer 0.5, => { ... }
+```
+
+Sprite-only events:
+
+```xgo
+onCloned => { ... }
+onTouchStart "Bullet", => { ... }
+onTouchStart ["Enemy", "Boss"], => { ... }
+```
+
+For short one-off handlers, inline lambdas are idiomatic. Use a named function when the callback is reused, takes
+parameters you want to spell out clearly, or becomes long:
+
+```xgo
+func handleAnyKey(key Key) {
+	println key
+}
+
+onAnyKey handleAnyKey
+```
+
+```xgo
+func handleMsg(msg MsgName, data any) {
+	println msg, data
+}
+
+onMsg handleMsg
+```
+
+```xgo
+func handleBackdrop(name BackdropName) {
+	println name
+}
+
+onBackdrop handleBackdrop
+```
+
+```xgo
+func handleClone(data any) {
+	println data
+}
+
+onCloned handleClone
+clone {"hp": 3}
+```
+
+```xgo
+func handleTouch(other Sprite) {
+	other.Destroy()
+}
+
+onTouchStart "Enemy", handleTouch
+```
+
+Event signatures:
+
+```xgo
+onStart(func())
+onClick(func())
+onAnyKey(func(key Key))
+onKey(key, func())
+onKey([]Key, func())
+onKey([]Key, func(key Key))
+onMsg(msg, func())
+onMsg(func(msg MsgName, data any))
+onBackdrop(name, func())
+onBackdrop(func(name BackdropName))
+onSwipe(direction, func())
+onTimer(seconds, func())
+onCloned(func())
+onCloned(func(data any))
+onTouchStart(spriteName, func())
+onTouchStart(spriteName, func(other Sprite))
+onTouchStart([]SpriteName, func())
+onTouchStart([]SpriteName, func(other Sprite))
+```
+
+Rules:
+
+- register events at top level
+- use only the shared event set in `main.spx`
+- use `onCloned` and `onTouchStart` only in sprite files
+- do not register `onStart` late from inside other callbacks
+- multiple handlers for the same event are allowed
+- use `onCloned` for clone initialization
+- if you need the pressed key value, use `onAnyKey` or `onKey` with a key list callback that accepts `key Key`
+- if you need message payload data, use the catch-all `onMsg(func(msg MsgName, data any))` form
+- if you need the touched sprite object, use the `func(other Sprite)` form of `onTouchStart`
+- `onTimer 0.5, ...` is a one-shot event at 0.5 seconds since the current timer base
+- `resetTimer()` resets that base time
+
+Event selection notes:
+
+- `onStart => { ... }` is the normal place for startup loops
+- `onClick => { ... }` works well for simple interactive sprites
+- `onKey KeySpace, => { ... }` is the direct choice for one known key
+- `onKey [KeyA, KeyD], key => { ... }` is the direct choice when several keys share one handler and the key value
+  matters
+- `onBackdrop "boss", => { ... }` reacts to one named backdrop
+- `onBackdrop(func(name BackdropName))` is the catch-all form when the backdrop name matters
+- `onCloned(data => { ... })` is the most explicit clone setup when clone payload data matters
+
+Useful patterns:
+
+```xgo
+onMsg func(msg MsgName, data any) {
+	if msg == "damage" {
+		hp -= data.(int)
+	}
+}
+```
+
+```xgo
+onKey [KeyLeft, KeyRight], key => {
+	if key == KeyLeft {
+		changeXpos -5
+	} else {
+		changeXpos 5
+	}
+}
+```
+
+## Shared stage APIs
+
+These APIs are stage-owned, but normal sprite project code can also call them directly.
+
+### Reload, messaging, stop
+
+```xgo
+reload(index)
+
+broadcast(msg)
+broadcast(msg, data)
+
+broadcastAndWait(msg)
+broadcastAndWait(msg, data)
+
+stop(kind)
+
+exit()
+exit(code)
+```
+
+Notes:
+
+- `reload(index)` is commonly used with another index file such as `"ch-2.json"`
+- `broadcast(msg, data)` pairs with `onMsg func(msg MsgName, data any)`
+- `stop(kind)` uses stop-kind constants like `AllStop`, `ThisSprite`, `ThisScript`
+- use `broadcastAndWait` when listeners must finish before the current code continues
+
+### Stage input, time, dialog, variables
+
+```xgo
+keyPressed(key) bool
+mousePressed() bool
+mouseX() float64
+mouseY() float64
+
+wait(seconds)
+waitNextFrame
+timer() float64
+resetTimer()
+
+ask(msg)
+answer() string
+
+showVar(name)
+hideVar(name)
+```
+
+Notes:
+
+- `ask(msg)` on stage opens the ask UI without a sprite bubble
+- `answer()` returns the latest answer string
+- `showVar(name)` and `hideVar(name)` target stage monitors by property name
+
+### Backdrop and stage visuals
+
+```xgo
+backdropName() string
+backdropIndex() int
+
+setBackdrop(name)
+setBackdrop(indexFloat)
+setBackdrop(indexInt)
+setBackdrop(Prev)
+setBackdrop(Next)
+
+setBackdropAndWait(name)
+setBackdropAndWait(indexFloat)
+setBackdropAndWait(indexInt)
+setBackdropAndWait(Prev)
+setBackdropAndWait(Next)
+
+setGraphicEffect(kind, value)
+changeGraphicEffect(kind, delta)
+clearGraphicEffects()
+
+setWindowSize(width, height)
+eraseAll()
+```
+
+Backdrop selection rules:
+
+- use `setBackdrop(name)` when the target backdrop is known by name
+- use `setBackdrop(Next)` or `setBackdrop(Prev)` for simple cycling
+- use `setBackdropAndWait(...)` when later code must wait for the switch to complete
+
+### Stage sound
+
+```xgo
+play(sound)
+play(sound, loop)
+playAndWait(sound)
+pausePlaying(sound)
+resumePlaying(sound)
+stopPlaying(sound)
+
+volume() float64
+setVolume(value)
+changeVolume(delta)
+
+getSoundEffect(kind) float64
+setSoundEffect(kind, value)
+changeSoundEffect(kind, delta)
+clearSoundEffects()
+
+stopAllSounds()
+loudness() float64
+username() string
+```
+
+Notes:
+
+- `loudness()` currently returns `0`
+- `username()` currently returns `""`
+
+### Camera
+
+```xgo
+Camera.ViewportRect() (x, y, w, h)
+Camera.SetZoom(scale)
+Camera.Zoom() float64
+Camera.Xpos() float64
+Camera.Ypos() float64
+Camera.SetXYpos(x, y)
+Camera.ChangeXYpos(dx, dy)
+Camera.Follow(sprite)
+Camera.Follow(spriteName)
+```
+
+Camera selection rules:
+
+- use `Camera.Follow(sprite)` or `Camera.Follow(spriteName)` when one target should drive the camera
+- use `Camera.SetXYpos(x, y)` when the camera should jump to a fixed position
+- use `Camera.ChangeXYpos(dx, dy)` when input or scripted motion nudges the camera
+- use `Camera.SetZoom(scale)` when the task explicitly changes zoom level
+
+### Pathfinding, physics query, debug draw
+
+```xgo
+setupPathFinder()
+setupPathFinder(xGridSize, yGridSize, xCellSize, yCellSize, withJump, withDebug)
+
+findPath(xFrom, yFrom, xTo, yTo) []float64
+findPath(xFrom, yFrom, xTo, yTo, withDebug) []float64
+findPath(xFrom, yFrom, xTo, yTo, withDebug, withJump) []float64
+
+intersectRect(x, y, width, height) []Sprite
+intersectCircle(x, y, radius) []Sprite
+
+raycast(fromX, fromY, toX, toY) (hit bool, sprite Sprite, hitX float64, hitY float64)
+raycast(fromX, fromY, toX, toY, ignoreSprite) (hit bool, sprite Sprite, hitX float64, hitY float64)
+raycast(fromX, fromY, toX, toY, ignoreSprites) (hit bool, sprite Sprite, hitX float64, hitY float64)
+
+debugDrawRect(x, y, width, height, color)
+debugDrawCircle(x, y, radius, color)
+debugDrawLine(fromX, fromY, toX, toY, color)
+debugDrawLines([]float64{x1, y1, x2, y2, ...}, color)
+```
+
+Notes:
+
+- `findPath` returns a flattened point array like `[x1, y1, x2, y2, ...]`
+- `debugDrawLines` also uses a flattened point array
+- use `findPath` when the stage or a controller sprite needs waypoint data
+- use `raycast` for line-of-sight style checks
+- use `intersectRect` or `intersectCircle` for area queries
+
+### Tilemap
+
+```xgo
+placeTiles([]float64{x1, y1, x2, y2, ...}, texturePath)
+placeTiles([]float64{x1, y1, x2, y2, ...}, texturePath, layerIndex)
+
+placeTile(x, y, texturePath)
+
+eraseTile(x, y)
+eraseTile(x, y, layerIndex)
+
+getTile(x, y) string
+getTile(x, y, layerIndex) string
+
+loadTilemap(mapDir)
+unloadTilemap()
+tilemapName() string
+```
+
+Tilemap rules:
+
+- use `placeTile` or `placeTiles` when the task edits map tiles at runtime
+- use `loadTilemap(mapDir)` when the task explicitly swaps map content
+- use `getTile` to inspect current tile state
+
+## Sprite API reference
+
+### Core lifecycle
+
+```xgo
+name() string
+isCloned() bool
+
+clone
+clone(data)
+
+deleteThisClone
+destroy
+die
+
+deltaTime() float64
+timeSinceLevelLoad() float64
+```
+
+Notes:
+
+- `deleteThisClone` only affects clones
+- `die` plays the `"die"` animation first if the sprite has one, then destroys the sprite
+- `clone(data)` pairs with `onCloned func(data any)`
+- `timeSinceLevelLoad()` is often useful for spawn patterns or delayed behavior without adding new counters
+
+### Visibility, costume, layer, size
+
+```xgo
+show
+hide
+visible() bool
+
+showVar(name)
+hideVar(name)
+
+size() float64
+setSize(size)
+changeSize(delta)
+
+costumeName() SpriteCostumeName
+costumeIndex() int
+
+setCostume(name)
+setCostume(indexFloat)
+setCostume(indexInt)
+setCostume(Prev)
+setCostume(Next)
+
+setLayer(Front)
+setLayer(Back)
+setLayer(Forward, delta)
+setLayer(Backward, delta)
+
+setGraphicEffect(kind, value)
+changeGraphicEffect(kind, delta)
+clearGraphicEffects()
+```
+
+Notes:
+
+- in sprite files, `showVar(name)` and `hideVar(name)` first target that sprite's own monitor, then fall back to
+  the stage monitor with the same name
+- use `show` or `hide` for sprite visibility
+- use `setLayer(Front)` or `setLayer(Back)` for coarse ordering
+- use `setLayer(Forward, delta)` or `setLayer(Backward, delta)` for relative layer movement
+
+### Motion and transform
+
+```xgo
+xpos() float64
+ypos() float64
+heading() Direction
+
+setXYpos(x, y)
+changeXYpos(dx, dy)
+setXpos(x)
+changeXpos(dx)
+setYpos(y)
+changeYpos(dy)
+
+move(stepFloat)
+move(stepInt)
+
+step(step)
+step(step, speed)
+step(step, speed, animation)
+
+stepTo(sprite)
+stepTo(spriteName)
+stepTo(Mouse)
+stepTo(x, y)
+stepTo(sprite, speed)
+stepTo(spriteName, speed)
+stepTo(Mouse, speed)
+stepTo(x, y, speed)
+stepTo(sprite, speed, animation)
+stepTo(spriteName, speed, animation)
+stepTo(Mouse, speed, animation)
+stepTo(x, y, speed, animation)
+
+glide(sprite, secs)
+glide(spriteName, secs)
+glide(Mouse, secs)
+glide(Random, secs)
+glide(x, y, secs)
+
+setHeading(dir)
+changeHeading(dir)
+
+turn(dir)
+turn(dir, speed)
+turn(dir, speed, animation)
+
+turnTo(sprite)
+turnTo(spriteName)
+turnTo(dir)
+turnTo(Mouse)
+turnTo(sprite, speed)
+turnTo(spriteName, speed)
+turnTo(dir, speed)
+turnTo(Mouse, speed)
+turnTo(sprite, speed, animation)
+turnTo(spriteName, speed, animation)
+turnTo(dir, speed, animation)
+turnTo(Mouse, speed, animation)
+
+setRotationStyle(Normal)
+setRotationStyle(LeftRight)
+setRotationStyle(None)
+
+bounceOffEdge()
+```
+
+Notes:
+
+- `move` is a direct move along the current heading
+- `step` is the more flexible movement helper with optional speed and animation
+- for `stepTo` and `turnTo`, the special target used in project code is normally `Mouse`
+- `glide(Random, secs)` is the practical use of the `Pos` overload
+
+Motion selection rules:
+
+- use `move` for simple heading-based motion
+- use `step` for repeated movement that may later gain speed or animation arguments
+- use `stepTo` to move toward a target position or target object
+- use `glide` for time-based interpolation to a destination
+- use `turn` to rotate relative to the current heading
+- use `turnTo` to face a target direction, sprite, or mouse position
+- use `bounceOffEdge()` when the sprite should reflect from stage edges
+
+Typical choices:
+
+```xgo
+step 8
+step 8, 0.2, "walk"
+turnTo Mouse
+glide 100, 50, 0.4
+```
+
+### Animation
+
+```xgo
+animate(name)
+animate(name, loop)
+animateAndWait(name)
+stopAnimation(name)
+```
+
+Animation rules:
+
+- use `animate(name)` for fire-and-forget animation
+- use `animate(name, true)` for looping animation
+- use `animateAndWait(name)` when later code should wait for the animation to finish
+- use `stopAnimation(name)` to end one named animation explicitly
+
+### Sensing
+
+```xgo
+touching(sprite) bool
+touching(spriteName) bool
+touching(Mouse) bool
+touching(Edge) bool
+touching(EdgeTop) bool
+touching(EdgeBottom) bool
+touching(EdgeLeft) bool
+touching(EdgeRight) bool
+
+touchingColor(color) bool
+
+distanceTo(sprite) float64
+distanceTo(spriteName) float64
+distanceTo(Mouse) float64
+distanceTo(Random) float64
+```
+
+Sensing rules:
+
+- use `touching(spriteName)` for direct collision-style checks in loops
+- use `touching(Mouse)` for pointer overlap
+- use `touching(Edge...)` for stage boundary checks
+- use `touchingColor(color)` when the task is color-based rather than sprite-based
+- use `distanceTo(...)` when the task is proximity-based rather than overlap-based
+
+### Dialog
+
+```xgo
+say(msg)
+say(msg, secs)
+
+think(msg)
+think(msg, secs)
+
+ask(msg)
+
+quote(message)
+quote(message, secs)
+quote(message, description)
+quote(message, description, secs)
+```
+
+Notes:
+
+- sprite `ask(msg)` shows the sprite bubble and the ask UI
+- `quote("")` clears the quote bubble
+- use `say` for speech bubbles
+- use `think` for thought bubbles
+- use `quote` for quote-style presentation when the task explicitly wants that UI
+
+### Pen
+
+```xgo
+penDown
+penUp
+stamp
+
+setPenColor(color)
+setPenColor(kind, value)
+changePenColor(kind, delta)
+
+setPenSize(size)
+changePenSize(delta)
+```
+
+Pen rules:
+
+- use `penDown` before moving if the sprite should draw
+- use `stamp` to stamp the current sprite image
+- use `setPenColor(color)` when a concrete color value is already known
+- use `setPenColor(kind, value)` or `changePenColor(kind, delta)` when adjusting hue, saturation, brightness, or
+  transparency components
+
+### Sprite sound
+
+```xgo
+play(sound)
+play(sound, loop)
+playAndWait(sound)
+pausePlaying(sound)
+resumePlaying(sound)
+stopPlaying(sound)
+
+volume() float64
+setVolume(value)
+changeVolume(delta)
+
+getSoundEffect(kind) float64
+setSoundEffect(kind, value)
+changeSoundEffect(kind, delta)
+```
+
+Sound rules:
+
+- use sprite sound APIs when the sound belongs to that sprite's behavior
+- use stage sound APIs when the sound is project-wide or not owned by a specific sprite
+
+### Sprite physics
+
+```xgo
+setPhysicsMode(mode)
+physicsMode() PhysicsMode
+
+velocity() (velocityX, velocityY)
+setVelocity(velocityX, velocityY)
+
+gravity() float64
+setGravity(gravity)
+
+addImpulse(impulseX, impulseY)
+isOnFloor() bool
+
+setColliderShape(isTrigger, colliderType, params) error
+colliderShape(isTrigger) (ColliderShapeType, []float64)
+
+setColliderPivot(isTrigger, offsetX, offsetY)
+colliderPivot(isTrigger) (offsetX, offsetY)
+
+setCollisionLayer(layer)
+setCollisionMask(mask)
+setCollisionEnabled(enabled)
+collisionLayer() int64
+collisionMask() int64
+collisionEnabled() bool
+
+setTriggerEnabled(enabled)
+setTriggerLayer(layer)
+setTriggerMask(mask)
+triggerLayer() int64
+triggerMask() int64
+triggerEnabled() bool
+```
+
+Physics notes:
+
+- `isTrigger == false` means the normal collision body
+- `isTrigger == true` means the trigger shape
+- collider parameters:
+  - `RectCollider`: `[]float64{width, height}`
+  - `CircleCollider`: `[]float64{radius}`
+  - `CapsuleCollider`: `[]float64{radius, height}`
+  - `PolygonCollider`: `[]float64{x1, y1, x2, y2, ...}`
+- polygon vertices should be provided in counterclockwise order
+- common examples:
+
+```xgo
+setColliderShape false, RectCollider, []float64{32, 48}
+setColliderShape true, CircleCollider, []float64{16}
+setColliderShape false, PolygonCollider, []float64{0, -16, -16, 16, 16, 16}
+```
+
+Physics selection rules:
+
+- use `setPhysicsMode(DynamicPhysics)` for physically simulated bodies
+- use `setPhysicsMode(KinematicPhysics)` for script-driven motion with collision support
+- use `setPhysicsMode(StaticPhysics)` for non-moving colliders
+- use `setColliderShape(false, ...)` for the solid collision body
+- use `setColliderShape(true, ...)` for a trigger shape
+- use collision layer and mask APIs when selective collision routing matters
+- use trigger layer and mask APIs when selective trigger routing matters
+- use `isOnFloor()` for platforming-style grounded checks
+
+Common physics setup:
+
+```xgo
+onStart => {
+	setPhysicsMode KinematicPhysics
+	setColliderShape false, RectCollider, []float64{32, 48}
+}
+```
+
+```xgo
+onStart => {
+	setPhysicsMode DynamicPhysics
+	setColliderShape false, CircleCollider, []float64{16}
+	setTriggerEnabled true
+	setColliderShape true, CircleCollider, []float64{32}
+}
+```
+
+## API selection by intent
+
+### Movement and facing
+
+- use `changeXpos`, `changeYpos`, or `changeXYpos` for direct axis updates
+- use `move` when heading already determines motion
+- use `step` for common scripted movement
+- use `stepTo` when movement should chase a target
+- use `glide` for timed movement
+- use `turnTo` when facing matters more than immediate movement
+
+### Communication and coordination
+
+- use direct sprite calls for one known target
+- use `broadcast` for one-to-many event fanout
+- use `broadcastAndWait` for synchronized multi-listener flows
+- use shared state in `main.spx` for project-wide counters and flags
+
+### Sensing and hit detection
+
+- use `onTouchStart` for hit-on-contact events
+- use `touching(...)` for continuous overlap polling
+- use `distanceTo(...)` for chase or flee thresholds
+- use `raycast(...)` for line-of-sight or straight-shot checks
+- use `intersectRect` or `intersectCircle` for area scans
+
+### Scene and stage control
+
+- use `setBackdrop` or `setBackdropAndWait` for backdrop transitions
+- use `reload(index)` for scene reload or chapter switch tasks
+- use `showVar` or `hideVar` for monitor visibility
+- use `ask` and `answer` for simple input prompts
+
+### Camera
+
+- use `Camera.Follow(...)` for tracking a sprite
+- use `Camera.SetXYpos(...)` for fixed camera jumps
+- use `Camera.ChangeXYpos(...)` for input-driven pans
+- use `Camera.SetZoom(...)` for zoom changes
+
+### Physics and pathfinding
+
+- use physics mode and collider APIs when the task explicitly involves bodies, grounded checks, or triggers
+- use `findPath(...)` when the task asks for route computation
+- use `setupPathFinder(...)` before `findPath(...)` when the project has not already done so
+
+## Common implementation templates
+
+### Player fires bullet clones
+
+Emitter sprite:
+
+```xgo
+var cooldown float64
+
+onStart => {
+	for {
+		waitNextFrame
+		if cooldown > 0 {
+			cooldown -= deltaTime()
+		}
+	}
+}
+
+onKey KeySpace, => {
+	if cooldown <= 0 {
+		Bullet.clone
+		cooldown = 0.15
+	}
+}
+```
+
+Bullet sprite:
+
+```xgo
+onCloned => {
+	setXYpos Player.xpos(), Player.ypos()
+	turnTo Player.heading()
+	show
+	for {
+		waitNextFrame
+		step 12
+		if touching(Edge) {
+			destroy
+		}
+	}
+}
+```
+
+### Enemy hp and bullet hit
+
+```xgo
+var hp int
+
+onCloned => {
+	hp = 3
+	show
+}
+
+onTouchStart "Bullet", => {
+	hp--
+	if hp <= 0 {
+		die
+	}
+}
+```
+
+### Broadcast with payload data
+
+Sender:
+
+```xgo
+broadcast "damage", 2
+```
+
+Receiver:
+
+```xgo
+onMsg func(msg MsgName, data any) {
+	if msg == "damage" {
+		hp -= data.(int)
+	}
+}
+```
+
+### Repeating timed behavior
+
+Use a loop plus `wait`:
+
+```xgo
+onStart => {
+	for {
+		wait 0.5
+		clone
+	}
+}
+```
+
+Use `onTimer` only for one-shot delay:
+
+```xgo
+onTimer 2.0, => {
+	broadcast "phase-2"
+}
+```
+
+### Reload stage or switch chapter
+
+```xgo
+func gameOver() {
+	reload "game-over.json"
+}
+```
+
+```xgo
+onMsg "restart", => {
+	reload "index.json"
+}
+```
+
+### Camera follow
+
+```xgo
+func OnLoaded() {
+	Camera.Follow "Player"
+	Camera.SetZoom(1.2)
+}
+```
+
+### Simple kinematic collider
+
+```xgo
+onStart => {
+	setPhysicsMode KinematicPhysics
+	setColliderShape false, RectCollider, []float64{32, 48}
+}
+```
+
+### Trigger area around a sprite
+
+```xgo
+onStart => {
+	setPhysicsMode KinematicPhysics
+	setColliderShape false, RectCollider, []float64{32, 48}
+	setColliderShape true, CircleCollider, []float64{80}
+	setTriggerEnabled true
+}
+```
+
+## `List`, `Value`, colors, helpers
+
+### `Value`
+
+```xgo
+v := NewValue(123)
+
+v.Equal(other) bool
+v.String() string
+v.Int() int
+v.Float() float64
+v.Set(value)
+```
+
+### `List`
+
+```xgo
+l := NewList(1, 2, 3)
+
+l.Init(values...)
+l.InitFrom(&other)
+l.Len() int
+l.String() string
+l.Contains(value) bool
+l.Append(value)
+l.Set(index, value)
+l.Insert(index, value)
+l.Delete(index)
+l.At(index) Value
+l.IndexOf(value) Pos
+l.Clear()
+```
+
+Index helpers:
+
+- `Invalid`
+- `Last`
+- `All`
+- `Random`
+
+Notes:
+
+- `l.Delete(All)` clears the whole list
+- `l.At(i)` returns `Value`
+- `Last` and `Random` are especially useful with list APIs
+
+### Colors and numeric helpers
+
+```xgo
+HSB(h, s, b) Color
+HSBA(h, s, b, a) Color
+
+rand(intFrom, intTo) float64
+rand(floatFrom, floatTo) float64
+
+iround(v) int
+KeyFromString(name) Key
+```
+
+Notes:
+
+- integer `rand` is inclusive on both ends
+- `HSB` and `HSBA` use Scratch-like `0..100` ranges
+
+### Loop helpers
+
+```xgo
+repeat(loopCount, func())
+repeatUntil(condition, func())
+waitUntil(condition)
+forever(func())
+```
+
+Advanced scheduler helpers:
+
+```xgo
+Sched()
+SchedNow()
+```
+
+`Sched` and `SchedNow` are advanced helpers. Normal project code usually does not need them.
+
+## Constants and enums
+
+### Keys
+
+- `Key0` through `Key9`
+- `KeyA` through `KeyZ`
+- arrows and common controls such as `KeyUp`, `KeyDown`, `KeyLeft`, `KeyRight`, `KeySpace`, `KeyEnter`,
+  `KeyEscape`, `KeyShift`, `KeyControl`, `KeyAlt`
+- function keys such as `KeyF1` through `KeyF12`
+- `KeyAny`
+- `KeyMax`
+
+### Stage and sprite targeting
+
+- `Mouse`
+- `Edge`
+- `EdgeTop`
+- `EdgeBottom`
+- `EdgeLeft`
+- `EdgeRight`
+- `Up`
+- `Down`
+- `Left`
+- `Right`
+
+### Costume and layer helpers
+
+- `Prev`
+- `Next`
+- `Front`
+- `Back`
+- `Forward`
+- `Backward`
+
+### Stop kinds
+
+- `AllStop`
+- `AllOtherScripts`
+- `AllSprites`
+- `ThisSprite`
+- `ThisScript`
+- `OtherScriptsInSprite`
+
+### Graphics
+
+- `Normal`
+- `LeftRight`
+- `None`
+
+- `ColorEffect`
+- `FishEyeEffect`
+- `WhirlEffect`
+- `PixelateEffect`
+- `MosaicEffect`
+- `BrightnessEffect`
+- `GhostEffect`
+
+### Pen and sound enums
+
+- `PenHue`
+- `PenSaturation`
+- `PenBrightness`
+- `PenTransparency`
+
+- `SoundPanEffect`
+- `SoundPitchEffect`
+
+### Physics enums
+
+- `NoPhysics`
+- `KinematicPhysics`
+- `DynamicPhysics`
+- `StaticPhysics`
+
+- `RectCollider`
+- `CircleCollider`
+- `CapsuleCollider`
+- `PolygonCollider`
+
+## Extra imports
+
+Most gameplay code should use normal `.spx` project code directly and needs no framework import.
+
+Only add imports when you need normal Go packages like:
+
+- `fmt`
+- `math`
+- `strings`
+
+If a task explicitly needs advanced coroutine control, it can import `github.com/goplus/spx/v2/pkg/spx` for helpers
+such as:
+
+- `Go`
+- `Execute`
+- `ExecuteNative`
+- `Wait`
+- `WaitNextFrame`
+- `IsInCoroutine`
+- `IsAbortThreadError`
+
+Do not import the main spx framework package just to access normal gameplay APIs. Those are already available in normal
+`.spx` project code.
+
+## Known caveats
+
+- `SetDebug` and debug flags such as `DbgFlagLoad`, `DbgFlagInstr`, `DbgFlagEvent`, `DbgFlagPerf`, and `DbgFlagAll`
+  exist for runtime debugging. Use them only when a task explicitly needs debug instrumentation.
+- `GetWidget` and `Widget` exist for UI/widget lookup, but the current repository does not provide a stable project-side
+  example of their normal `.spx` spelling. If a task explicitly needs widgets, inspect that project's existing code
+  first instead of guessing the calling pattern.
+- `loudness()` currently returns `0`.
+- `username()` currently returns `""`.
+- `onStart` should be registered at top level. Late registration is ignored.
+- `onTimer` is one-shot, not a repeating timer.
+- sprite `showVar(name)` and `hideVar(name)` first target the sprite monitor, then fall back to the stage monitor.
+- keep using normal project events and helpers. Do not switch to engine lifecycle callbacks for ordinary project tasks.

--- a/skills/spx-project/references/xgo-syntax.md
+++ b/skills/spx-project/references/xgo-syntax.md
@@ -1,0 +1,316 @@
+# xgo syntax for spx
+
+Use this reference when the task is about XGo syntax inside `.spx` files, especially lambdas, command-style calls,
+top-level file rules, and classfile-oriented source structure.
+
+## Contents
+
+- mental model
+- top-level source structure
+- import placement
+- field declaration block
+- top-level functions
+- top-level statements and entry body
+- XGo lambdas and closures
+- command-style calls
+- practical guidance
+
+## Mental model
+
+- a `.spx` file is still an ordinary XGo source file
+- syntax questions should be answered with XGo rules, not by inventing spx-only syntax
+- classfile behavior changes how top-level declarations and top-level statements are interpreted, but it does not
+  replace the underlying XGo language
+
+## Top-level source structure
+
+Treat a `.spx` file as:
+
+```text
+[package]
+imports
+declarations
+top-level statements
+```
+
+Practical consequences:
+
+- `import` declarations must stay before all non-import declarations and top-level statements
+- the first top-level statement starts the file entry body
+- after the first top-level statement, the rest of the file is parsed like ordinary function-body statements
+- do not place later `var`, `const`, or `type` declarations after top-level statements unless you intentionally want
+  them to be local declarations inside the entry body
+
+## Import placement
+
+Keep imports in normal XGo position:
+
+- `package`, if present
+- all `import` declarations
+- top-level declarations such as the file state block and helper functions
+- top-level executable statements
+
+Good:
+
+```xgo
+import "math"
+
+var speed float64
+
+func resetSpeed() {
+	speed = 3
+}
+
+onStart => {
+	speed = math.Max(speed, 3)
+}
+```
+
+Bad:
+
+```xgo
+onStart => {
+	wait 1
+}
+
+import "math"
+```
+
+## Field declaration block
+
+For normal project authoring, the file state is the field declaration block.
+
+The field declaration block is not defined as "whatever top-level `var` appears first in the file".
+
+It is the first top-level `var` declaration that satisfies all of these conditions:
+
+- it appears in the file declaration list, before top-level statements begin
+- every preceding top-level declaration, if any, is only an `import`, `const`, or `type` declaration
+- it is the first top-level `var` declaration that satisfies those conditions
+
+Practical consequences:
+
+- put the file state `var` block before helper functions and before event registrations
+- do not put a top-level `func` before the file state `var` block
+- in `main.spx`, that field declaration block becomes shared project state
+- in a sprite file, that field declaration block becomes per-sprite state
+- any other top-level `var` declaration is not part of the file state
+- avoid additional top-level `var` declarations before top-level statements unless you really need package-level values
+
+Good:
+
+```xgo
+var (
+	score int
+	level int
+)
+
+func resetGame() {
+	score = 0
+	level = 1
+}
+
+onStart => {
+	resetGame()
+}
+```
+
+This is valid because the `var` declaration appears before any top-level `func`.
+
+Bad:
+
+```xgo
+onStart => {
+	score = 0
+}
+
+var (
+	score int
+)
+```
+
+Bad:
+
+```xgo
+func resetGame() {
+	score = 0
+}
+
+var (
+	score int
+)
+```
+
+In that pattern, the `var` declaration is no longer the field declaration block because a top-level `func` appears
+before it. That `var` follows ordinary variable-declaration rules instead of becoming class fields.
+
+Risky:
+
+```xgo
+var (
+	score int
+)
+
+var (
+	globalDebug bool
+)
+```
+
+That second top-level `var` is no longer part of the file state block. In normal project code, avoid patterns that make
+state ownership ambiguous.
+
+## Top-level functions
+
+Top-level `func` declarations without explicit receivers are methods of the current file object.
+
+Practical consequences:
+
+- helper functions in `main.spx` can directly use shared state
+- helper functions in a sprite file can directly use that sprite's state and methods
+- helper functions should usually be declared after the file state `var` block, because putting `func` first changes how
+  a later `var` declaration is classified
+- `func init()` inside `.spx` is not a package initialization hook
+- `func main()` inside `.spx` is not a package entrypoint
+- explicit receiver methods are possible in XGo, but they are not the normal style for spx project code
+
+Use plain top-level functions:
+
+```xgo
+func resetHP() {
+	hp = 3
+}
+```
+
+Do not introduce receiver boilerplate unless a task explicitly needs it.
+
+## Top-level statements and entry body
+
+Top-level statements become the file entry body.
+
+Practical consequences:
+
+- top-level statements are real executable code
+- in `main.spx`, they run as part of the project entry
+- in sprite files, they run as part of that sprite's file entry
+- prefer helper functions plus event handlers for most gameplay logic
+- use top-level statements for small setup code only when that form is clearer than `onStart`
+
+Good small setup:
+
+```xgo
+hide
+
+onCloned => {
+	show
+}
+```
+
+Less clear for ongoing behavior:
+
+```xgo
+for {
+	wait 0.1
+	step 10
+}
+```
+
+Prefer `onStart` or `onCloned` for loops like that.
+
+## XGo lambdas and closures
+
+XGo function literals use `=>`. They are ordinary lambdas with type inference and closure capture.
+
+Common forms:
+
+```xgo
+=> doSomething()
+x => x * 2
+(x, y) => x + y
+x => {
+	return x * factor
+}
+```
+
+Rules:
+
+- parameter types are inferred from context
+- return types are inferred from context
+- lambda parameters do not use explicit type annotations
+- lambdas capture surrounding variables like ordinary closures
+
+Closure example:
+
+```xgo
+var speed float64
+
+func startMover(multiplier float64) {
+	onStart => {
+		speed = 2 * multiplier
+	}
+}
+```
+
+In `.spx` files, event handlers are commonly written as lambdas:
+
+```xgo
+onStart => {
+	resetScore()
+}
+
+onMsg "fire", => {
+	clone
+}
+
+onTimer 0.5, => {
+	broadcast "tick"
+}
+```
+
+Use a named function instead of an inline lambda when:
+
+- the handler is reused
+- the callback takes parameters and you want the signature to be explicit
+- the body is long enough that inline form hurts readability
+
+## Command-style calls
+
+XGo supports command-style calls without parentheses. spx project code uses this style heavily.
+
+Common examples:
+
+```xgo
+wait 1
+broadcast "fire"
+setXYpos mouseX, mouseY
+turnTo Mouse
+```
+
+Prefer explicit call syntax when:
+
+- you need a return value
+- the expression appears inside a larger expression
+- the shorthand form is unclear
+
+Examples:
+
+```xgo
+x := mouseX()
+y := mouseY()
+if touching(Mouse) {
+	destroy
+}
+Camera.SetZoom(1.5)
+```
+
+## Practical guidance
+
+- keep imports first
+- place the file state block before helper functions and before event registrations
+- keep long callbacks in named helper functions
+- do not invent new syntactic sugar
+- if a user request is fundamentally about language syntax, answer it with XGo rules first and only then apply
+  spx-specific file semantics
+- remember that event registration forms like `onStart => { ... }` are still ordinary XGo calls plus a lambda
+- prefer the simplest ordinary XGo form that matches the current project style
+- do not summarize the field declaration rule as merely "the first `var` block". The declarations before that `var`
+  matter


### PR DESCRIPTION
Add a distributable `skills/spx-project` skill for authoring user-facing spx projects.

Split the guidance across `SKILL.md` and focused references for Scratch compatibility, XGo syntax, project layout, and spx APIs so the skill stays navigable while still covering event forms, ownership rules, and common code patterns.

Add a dedicated `scratch-compat.md` reference that translates Scratch-style requests into current project-side `.spx` spellings while keeping the guidance centered on normal authoring rather than converter internals or runtime method inventories.

Include `agents/openai.yaml` so the skill can be discovered and invoked through the standard Codex skill metadata.
