### PR TITLE
fix: repair generated local spx replace path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Config
 # ============================================
 .DEFAULT_GOAL := help
-.PHONY: help buildctl list-demos prepare-host prepare-web prepare-full prepare-all build-dev install clean-assets download download-engine build-editor build-desktop build-web build-wasm build-wasm-opt build-android build-ios install-apk editor run rune run-web run-web-worker format generate sync-goxmod export-pack export-web stop validate-web-mode validate-download-engine
+.PHONY: help buildctl list-demos prepare-host prepare-web prepare-full prepare-all build-dev install clean-assets download download-engine build-editor build-desktop build-web build-wasm build-wasm-opt build-android build-ios install-apk editor run rune run-web run-web-worker format generate sync-goxmod clean-goxmod export-pack export-web stop validate-web-mode validate-download-engine
 
 export GODOT_SRC
 
@@ -187,6 +187,12 @@ sync-goxmod: ## Sync root gox.mod to all tutorial/test projects containing .spx
 	@find tutorial test -type f -name 'main.spx' -exec dirname {} \; | sort -u | while read -r dir; do \
 		cp gox.mod "$$dir/gox.mod" || exit 1; \
 		echo "synced $$dir/gox.mod"; \
+	done
+
+clean-goxmod: ## Delete gox.mod from all tutorial/test projects
+	@find tutorial test -type f -name 'gox.mod' | sort | while read -r file; do \
+		rm -f "$$file" || exit 1; \
+		echo "removed $$file"; \
 	done
 
 export-pack: ## Export runtime pck file

--- a/cmd/spx/internal/command/env.go
+++ b/cmd/spx/internal/command/env.go
@@ -443,27 +443,48 @@ func (cmd *CmdTool) adaptGoMod() {
 			return
 		}
 
-		strContent := string(content)
-		if !strings.Contains(strContent, "replace github.com/goplus/spx/v2") {
-			relPath, err := filepath.Rel(absTargetDir, spxPath)
-			if err != nil {
-				return
-			}
-
-			replaceDir := fmt.Sprintf("\n\nreplace github.com/goplus/spx/v2 => %s\n", relPath)
-			strContent += replaceDir
-
-			os.WriteFile(rootGoModPath, []byte(strContent), 0644)
+		relPath, err := filepath.Rel(absTargetDir, spxPath)
+		if err != nil {
+			return
 		}
+
+		strContent := ensureSpxModuleReplace(string(content), filepath.ToSlash(relPath))
+		os.WriteFile(rootGoModPath, []byte(strContent), 0644)
 	}
+}
+
+func ensureSpxModuleReplace(content, relPath string) string {
+	const replacePrefix = "replace github.com/goplus/spx/v2 => "
+
+	wantLine := replacePrefix + relPath
+	lines := strings.Split(content, "\n")
+	for i, line := range lines {
+		trimmed := strings.TrimRight(line, "\r")
+		if !strings.HasPrefix(trimmed, replacePrefix) {
+			continue
+		}
+		if trimmed == wantLine {
+			return content
+		}
+
+		if strings.HasSuffix(line, "\r") {
+			lines[i] = wantLine + "\r"
+		} else {
+			lines[i] = wantLine
+		}
+		return strings.Join(lines, "\n")
+	}
+
+	replaceBlock := fmt.Sprintf("\n\n%s\n", wantLine)
+	return strings.TrimRight(content, "\r\n") + replaceBlock
 }
 
 // createDefaultGoMod writes the default go.mod.
 func (cmd *CmdTool) createDefaultGoMod(dir string, forceWrite bool) {
-	gopModPath, _ := filepath.Abs(path.Join(dir, "go.mod"))
-	if _, err := os.Stat(gopModPath); os.IsNotExist(err) || forceWrite {
-		gopModContent := cmd.GoModTemplate
-		os.WriteFile(gopModPath, []byte(gopModContent), 0644)
+	goModPath, _ := filepath.Abs(path.Join(dir, "go.mod"))
+	if _, err := os.Stat(goModPath); os.IsNotExist(err) || forceWrite {
+		goModContent := cmd.GoModTemplate
+		os.WriteFile(goModPath, []byte(goModContent), 0644)
 	}
 }
 

--- a/cmd/spx/internal/command/env.go
+++ b/cmd/spx/internal/command/env.go
@@ -24,6 +24,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strconv"
 	"strings"
@@ -33,6 +34,7 @@ import (
 
 var ENV_NAME = "gdspx"
 var projectNameReplacer = strings.NewReplacer("_", "", " ", "", "\"", "", "\n", "", "\r", "")
+var spxModuleReplaceLinePattern = regexp.MustCompile(`^(\s*)(replace\s+)?github\.com/goplus/spx/v2\s*=>\s*(\S+)(\s*//.*)?$`)
 
 type envVar struct {
 	key   string
@@ -429,9 +431,11 @@ func (cmd *CmdTool) setupPaths(dstRelDir string) error {
 
 // adaptGoMod patches go.mod for local development.
 func (cmd *CmdTool) adaptGoMod() {
-	rootGoModPath, _ := filepath.Abs(path.Join(cmd.TargetDir, "go.mod"))
+	rootGoModPath, _ := filepath.Abs(filepath.Join(cmd.TargetDir, "go.mod"))
 	if _, err := os.Stat(rootGoModPath); os.IsNotExist(err) {
-		cmd.createDefaultGoMod(cmd.TargetDir, false)
+		if err := cmd.createDefaultGoMod(cmd.TargetDir, false); err != nil {
+			return
+		}
 	}
 
 	absTargetDir, _ := filepath.Abs(cmd.TargetDir)
@@ -449,43 +453,77 @@ func (cmd *CmdTool) adaptGoMod() {
 		}
 
 		strContent := ensureSpxModuleReplace(string(content), filepath.ToSlash(relPath))
-		os.WriteFile(rootGoModPath, []byte(strContent), 0644)
+		if strContent == string(content) {
+			return
+		}
+		if err := os.WriteFile(rootGoModPath, []byte(strContent), 0644); err != nil {
+			return
+		}
 	}
 }
 
+// ensureSpxModuleReplace idempotently upserts the local spx replace directive,
+// repairing stale single-line or block entries while preserving newline style.
 func ensureSpxModuleReplace(content, relPath string) string {
-	const replacePrefix = "replace github.com/goplus/spx/v2 => "
+	const replaceLine = "github.com/goplus/spx/v2 => "
 
-	wantLine := replacePrefix + relPath
+	wantLine := replaceLine + relPath
 	lines := strings.Split(content, "\n")
 	for i, line := range lines {
-		trimmed := strings.TrimRight(line, "\r")
-		if !strings.HasPrefix(trimmed, replacePrefix) {
+		hasCR := strings.HasSuffix(line, "\r")
+		trimmed := strings.TrimSuffix(line, "\r")
+		match := spxModuleReplaceLinePattern.FindStringSubmatch(trimmed)
+		if match == nil {
 			continue
 		}
-		if trimmed == wantLine {
+
+		if match[3] == relPath {
 			return content
 		}
 
-		if strings.HasSuffix(line, "\r") {
-			lines[i] = wantLine + "\r"
-		} else {
-			lines[i] = wantLine
+		replacePrefix := match[1]
+		if match[2] != "" {
+			replacePrefix += "replace "
+		}
+
+		lines[i] = replacePrefix + wantLine + match[4]
+		if hasCR {
+			lines[i] += "\r"
 		}
 		return strings.Join(lines, "\n")
 	}
 
-	replaceBlock := fmt.Sprintf("\n\n%s\n", wantLine)
-	return strings.TrimRight(content, "\r\n") + replaceBlock
+	return appendSpxModuleReplace(content, "replace "+wantLine)
+}
+
+func appendSpxModuleReplace(content, replaceLine string) string {
+	lineEnding := "\n"
+	if strings.Contains(content, "\r\n") {
+		lineEnding = "\r\n"
+	}
+
+	switch {
+	case content == "":
+		return replaceLine + lineEnding
+	case strings.HasSuffix(content, lineEnding+lineEnding):
+		return content + replaceLine + lineEnding
+	case strings.HasSuffix(content, lineEnding):
+		return content + lineEnding + replaceLine + lineEnding
+	default:
+		return content + lineEnding + lineEnding + replaceLine + lineEnding
+	}
 }
 
 // createDefaultGoMod writes the default go.mod.
-func (cmd *CmdTool) createDefaultGoMod(dir string, forceWrite bool) {
-	goModPath, _ := filepath.Abs(path.Join(dir, "go.mod"))
+func (cmd *CmdTool) createDefaultGoMod(dir string, forceWrite bool) error {
+	goModPath, _ := filepath.Abs(filepath.Join(dir, "go.mod"))
 	if _, err := os.Stat(goModPath); os.IsNotExist(err) || forceWrite {
 		goModContent := cmd.GoModTemplate
-		os.WriteFile(goModPath, []byte(goModContent), 0644)
+		if err := os.WriteFile(goModPath, []byte(goModContent), 0644); err != nil {
+			return err
+		}
 	}
+	return nil
 }
 
 // findSpxRoot finds a local spx repo.

--- a/cmd/spx/internal/command/env_test.go
+++ b/cmd/spx/internal/command/env_test.go
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2021 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package command
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestAdaptGoModAddsLocalReplaceForGeneratedGoMod(t *testing.T) {
+	targetDir := setupAdaptGoModFixture(t)
+
+	cmd := CmdTool{
+		TargetDir:     targetDir,
+		GoModTemplate: "module github.com/goplus/spxdemo\n\ngo 1.25.0\n",
+	}
+	cmd.adaptGoMod()
+
+	content, err := os.ReadFile(filepath.Join(targetDir, "go.mod"))
+	if err != nil {
+		t.Fatalf("ReadFile(go.mod) returned error: %v", err)
+	}
+	if !strings.Contains(string(content), "replace github.com/goplus/spx/v2 => ../..") {
+		t.Fatalf("go.mod content = %q, want replace path ../..", string(content))
+	}
+}
+
+func TestAdaptGoModRepairsStaleLocalReplacePath(t *testing.T) {
+	targetDir := setupAdaptGoModFixture(t)
+
+	goModPath := filepath.Join(targetDir, "go.mod")
+	content := "module github.com/goplus/spxdemo\n\ngo 1.25.0\n\nreplace github.com/goplus/spx/v2 => ../../..\n"
+	if err := os.WriteFile(goModPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile(go.mod) returned error: %v", err)
+	}
+
+	cmd := CmdTool{TargetDir: targetDir}
+	cmd.adaptGoMod()
+
+	updated, err := os.ReadFile(goModPath)
+	if err != nil {
+		t.Fatalf("ReadFile(go.mod) returned error: %v", err)
+	}
+	if strings.Contains(string(updated), "../../..") {
+		t.Fatalf("go.mod content = %q, stale replace path still present", string(updated))
+	}
+	if !strings.Contains(string(updated), "replace github.com/goplus/spx/v2 => ../..") {
+		t.Fatalf("go.mod content = %q, want repaired replace path ../..", string(updated))
+	}
+}
+
+func setupAdaptGoModFixture(t *testing.T) string {
+	t.Helper()
+
+	repoRoot := t.TempDir()
+	targetDir := filepath.Join(repoRoot, "tutorial", "05-Animation")
+	if err := os.MkdirAll(targetDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s) returned error: %v", targetDir, err)
+	}
+	if err := os.WriteFile(filepath.Join(repoRoot, "gox.mod"), []byte("project main.spx Game github.com/goplus/spx/v2 math\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(gox.mod) returned error: %v", err)
+	}
+	return targetDir
+}

--- a/cmd/spx/internal/command/env_test.go
+++ b/cmd/spx/internal/command/env_test.go
@@ -63,12 +63,42 @@ func TestAdaptGoModRepairsStaleLocalReplacePath(t *testing.T) {
 	if !strings.Contains(string(updated), "replace github.com/goplus/spx/v2 => ../..") {
 		t.Fatalf("go.mod content = %q, want repaired replace path ../..", string(updated))
 	}
+	if count := strings.Count(string(updated), "replace github.com/goplus/spx/v2"); count != 1 {
+		t.Fatalf("go.mod has %d replace directives, want 1", count)
+	}
+}
+
+func TestEnsureSpxModuleReplaceRepairsIndentedReplaceBlock(t *testing.T) {
+	content := "module github.com/goplus/spxdemo\n\ngo 1.25.0\n\nreplace (\n\tgithub.com/goplus/spx/v2 => ../../..\n)\n"
+
+	updated := ensureSpxModuleReplace(content, "../..")
+
+	if strings.Contains(updated, "../../..") {
+		t.Fatalf("updated content = %q, stale replace path still present", updated)
+	}
+	if !strings.Contains(updated, "\tgithub.com/goplus/spx/v2 => ../..") {
+		t.Fatalf("updated content = %q, want repaired indented replace path ../..", updated)
+	}
+	if count := strings.Count(updated, "github.com/goplus/spx/v2 =>"); count != 1 {
+		t.Fatalf("updated content has %d replace directives, want 1", count)
+	}
+}
+
+func TestEnsureSpxModuleReplacePreservesTrailingBlankLinesAndCRLF(t *testing.T) {
+	content := "module github.com/goplus/spxdemo\r\n\r\ngo 1.25.0\r\n\r\n"
+
+	updated := ensureSpxModuleReplace(content, "../..")
+	want := content + "replace github.com/goplus/spx/v2 => ../..\r\n"
+	if updated != want {
+		t.Fatalf("updated content = %q, want %q", updated, want)
+	}
 }
 
 func setupAdaptGoModFixture(t *testing.T) string {
 	t.Helper()
 
 	repoRoot := t.TempDir()
+	// Keep the fixture two levels below the temp repo root so filepath.Rel resolves to ../...
 	targetDir := filepath.Join(repoRoot, "tutorial", "05-Animation")
 	if err := os.MkdirAll(targetDir, 0o755); err != nil {
 		t.Fatalf("MkdirAll(%s) returned error: %v", targetDir, err)

--- a/cmd/spx/internal/command/init.go
+++ b/cmd/spx/internal/command/init.go
@@ -75,7 +75,9 @@ onStart => {
 		return fmt.Errorf("failed to create main.spx: %w", err)
 	}
 
-	cmd.createDefaultGoMod(targetPath, true)
+	if err := cmd.createDefaultGoMod(targetPath, true); err != nil {
+		return fmt.Errorf("failed to create go.mod: %w", err)
+	}
 
 	fmt.Println("")
 	fmt.Println("initialized SPX project successfully")


### PR DESCRIPTION
## Summary

- update `adaptGoMod` to always normalize the local `replace github.com/goplus/spx/v2` entry
- repair stale incorrect replace paths such as `../../..` instead of leaving them unchanged
- add tests covering both initial go.mod generation and stale replace-path repair

## Root Cause

Previously `adaptGoMod` only appended the SPX local `replace` directive when it was missing.
If a generated `go.mod` already contained a stale or incorrect replace path, the command left it untouched.

That made old generated project modules keep an invalid local replacement path and fail to resolve
`github.com/goplus/spx/v2` from the expected repository root.

## Testing

- `go test ./cmd/spx/internal/command -run 'TestAdaptGoMod(AddsLocalReplaceForGeneratedGoMod|RepairsStaleLocalReplacePath)' -count=1`
