### PR TITLE
fix: auto-install web runtime before runweb

### DIFF
--- a/cmd/spx/internal/command/env.go
+++ b/cmd/spx/internal/command/env.go
@@ -438,8 +438,8 @@ func (cmd *CmdTool) adaptGoMod() {
 		}
 	}
 
-	absTargetDir, _ := filepath.Abs(cmd.TargetDir)
-	spxPath := cmd.findSpxRoot(absTargetDir)
+	absTargetDir := cmd.TargetAbsDir
+	spxPath := cmd.findSpxRoot()
 
 	if spxPath != "" {
 		content, err := os.ReadFile(rootGoModPath)
@@ -527,15 +527,22 @@ func (cmd *CmdTool) createDefaultGoMod(dir string, forceWrite bool) error {
 }
 
 // findSpxRoot finds a local spx repo.
-func (cmd *CmdTool) findSpxRoot(startDir string) string {
-	currentDir := filepath.Dir(startDir)
+func (cmd *CmdTool) findSpxRoot() string {
+	startDir := cmd.TargetAbsDir
+	if startDir == "" && cmd.TargetDir != "" {
+		absTargetDir, err := filepath.Abs(cmd.TargetDir)
+		if err != nil {
+			return ""
+		}
+		startDir = absTargetDir
+	}
+	if startDir == "" {
+		return ""
+	}
+	currentDir := filepath.Clean(startDir)
 	for {
-		goxModPath := path.Join(currentDir, "gox.mod")
-		if _, err := os.Stat(goxModPath); err == nil {
-			content, err := os.ReadFile(goxModPath)
-			if err == nil && strings.Contains(string(content), "github.com/goplus/spx/v2") {
-				return currentDir
-			}
+		if isLocalSpxRepoRoot(currentDir) {
+			return currentDir
 		}
 
 		parent := filepath.Dir(currentDir)
@@ -545,6 +552,30 @@ func (cmd *CmdTool) findSpxRoot(startDir string) string {
 		currentDir = parent
 	}
 	return ""
+}
+
+func isLocalSpxRepoRoot(dir string) bool {
+	goModPath := filepath.Join(dir, "go.mod")
+	content, err := os.ReadFile(goModPath)
+	if err != nil {
+		return false
+	}
+	if !hasGoModuleDeclaration(string(content), "github.com/goplus/spx/v2") {
+		return false
+	}
+	return util.IsFileExist(filepath.Join(dir, "cmd", "spx", "install.sh"))
+}
+
+func hasGoModuleDeclaration(content, modulePath string) bool {
+	moduleDecl := "module " + modulePath
+	for _, line := range strings.Split(content, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "//") {
+			continue
+		}
+		return line == moduleDecl
+	}
+	return false
 }
 
 func resolveAppPath(gobinDir, tag, version string, customGoEnv bool) (string, string, error) {

--- a/cmd/spx/internal/command/env_test.go
+++ b/cmd/spx/internal/command/env_test.go
@@ -28,6 +28,7 @@ func TestAdaptGoModAddsLocalReplaceForGeneratedGoMod(t *testing.T) {
 
 	cmd := CmdTool{
 		TargetDir:     targetDir,
+		TargetAbsDir:  targetDir,
 		GoModTemplate: "module github.com/goplus/spxdemo\n\ngo 1.25.0\n",
 	}
 	cmd.adaptGoMod()
@@ -50,7 +51,7 @@ func TestAdaptGoModRepairsStaleLocalReplacePath(t *testing.T) {
 		t.Fatalf("WriteFile(go.mod) returned error: %v", err)
 	}
 
-	cmd := CmdTool{TargetDir: targetDir}
+	cmd := CmdTool{TargetDir: targetDir, TargetAbsDir: targetDir}
 	cmd.adaptGoMod()
 
 	updated, err := os.ReadFile(goModPath)
@@ -103,8 +104,6 @@ func setupAdaptGoModFixture(t *testing.T) string {
 	if err := os.MkdirAll(targetDir, 0o755); err != nil {
 		t.Fatalf("MkdirAll(%s) returned error: %v", targetDir, err)
 	}
-	if err := os.WriteFile(filepath.Join(repoRoot, "gox.mod"), []byte("project main.spx Game github.com/goplus/spx/v2 math\n"), 0o644); err != nil {
-		t.Fatalf("WriteFile(gox.mod) returned error: %v", err)
-	}
+	writeLocalSpxRepoMarker(t, repoRoot)
 	return targetDir
 }

--- a/cmd/spx/internal/command/run.go
+++ b/cmd/spx/internal/command/run.go
@@ -51,11 +51,15 @@ func (cmd *CmdTool) RunPackMode(pargs ...string) error {
 }
 
 func (cmd *CmdTool) RunWeb() error {
-	return runWebCommand(cmd.ExportWeb, cmd.runWebServer)
+	return runWebCommandWithSetup(func() error {
+		return cmd.installRepoWebRuntime(webNormalMode)
+	}, cmd.ExportWeb, cmd.runWebServer)
 }
 
 func (cmd *CmdTool) RunWebWorker() error {
-	return runWebCommand(cmd.ExportWebWorker, cmd.runWebServer)
+	return runWebCommandWithSetup(func() error {
+		return cmd.installRepoWebRuntime(webWorkerMode)
+	}, cmd.ExportWebWorker, cmd.runWebServer)
 }
 
 func (cmd *CmdTool) StopWeb() (err error) {
@@ -163,10 +167,48 @@ func (cmd *CmdTool) buildRuntimeArgs(inputArgs []string, tempDir, extPath string
 
 // runWebCommand exports before serving.
 func runWebCommand(exportFn func() error, serverFn func() error) error {
+	return runWebCommandWithSetup(nil, exportFn, serverFn)
+}
+
+func runWebCommandWithSetup(setupFn func() error, exportFn func() error, serverFn func() error) error {
+	if setupFn != nil {
+		if err := setupFn(); err != nil {
+			return err
+		}
+	}
 	if err := exportFn(); err != nil {
 		return err
 	}
 	return serverFn()
+}
+
+func (cmd *CmdTool) installRepoWebRuntime(mode string) error {
+	if cmd.hasInstalledWebRuntimeAssets(mode) {
+		return nil
+	}
+	spxRoot := cmd.findSpxRoot()
+	if spxRoot == "" {
+		return nil
+	}
+	scriptPath := filepath.Join(spxRoot, "cmd", "spx", "install.sh")
+	if !util.IsFileExist(scriptPath) {
+		return nil
+	}
+	return util.ExecCommand(util.CommandOptions{}, "bash", scriptPath, "--web")
+}
+
+func (cmd *CmdTool) hasInstalledWebRuntimeAssets(mode string) bool {
+	requiredPaths := []string{
+		filepath.Join(cmd.GoBinPath, "ispx"),
+		filepath.Join(cmd.GoBinPath, "ispx.wasm"),
+		filepath.Join(cmd.GoBinPath, "gdspxrt"+cmd.Version+"_web"+mode),
+	}
+	for _, requiredPath := range requiredPaths {
+		if !util.IsFileExist(requiredPath) {
+			return false
+		}
+	}
+	return true
 }
 
 func (cmd *CmdTool) webServerPIDPath() string {

--- a/cmd/spx/internal/command/run_test.go
+++ b/cmd/spx/internal/command/run_test.go
@@ -48,6 +48,62 @@ func TestRunWebCommandRunsExportBeforeServer(t *testing.T) {
 	}
 }
 
+func TestRunWebCommandRunsSetupBeforeExportAndServer(t *testing.T) {
+	var calls []string
+
+	err := runWebCommandWithSetup(
+		func() error {
+			calls = append(calls, "setup")
+			return nil
+		},
+		func() error {
+			calls = append(calls, "export")
+			return nil
+		},
+		func() error {
+			calls = append(calls, "serve")
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("runWebCommandWithSetup returned error: %v", err)
+	}
+
+	want := []string{"setup", "export", "serve"}
+	if !reflect.DeepEqual(calls, want) {
+		t.Fatalf("unexpected call order: got %v, want %v", calls, want)
+	}
+}
+
+func TestRunWebCommandStopsOnSetupError(t *testing.T) {
+	wantErr := errors.New("setup failed")
+	exportCalled := false
+	serverCalled := false
+
+	err := runWebCommandWithSetup(
+		func() error {
+			return wantErr
+		},
+		func() error {
+			exportCalled = true
+			return nil
+		},
+		func() error {
+			serverCalled = true
+			return nil
+		},
+	)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("runWebCommandWithSetup error = %v, want %v", err, wantErr)
+	}
+	if exportCalled {
+		t.Fatal("export should not start when setup fails")
+	}
+	if serverCalled {
+		t.Fatal("server should not start when setup fails")
+	}
+}
+
 func TestRunWebCommandStopsOnExportError(t *testing.T) {
 	wantErr := errors.New("export failed")
 	serverCalled := false
@@ -66,6 +122,100 @@ func TestRunWebCommandStopsOnExportError(t *testing.T) {
 	}
 	if serverCalled {
 		t.Fatal("server should not start when export fails")
+	}
+}
+
+func writeLocalSpxRepoMarker(t *testing.T, root string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(root, "cmd", "spx"), 0755); err != nil {
+		t.Fatalf("mkdir cmd/spx: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "go.mod"), []byte("module github.com/goplus/spx/v2\n"), 0644); err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "cmd", "spx", "install.sh"), []byte("#!/bin/bash\n"), 0755); err != nil {
+		t.Fatalf("write install.sh: %v", err)
+	}
+}
+
+func TestFindSpxRootFindsCurrentDir(t *testing.T) {
+	root := t.TempDir()
+	writeLocalSpxRepoMarker(t, root)
+
+	cmd := CmdTool{}
+	cmd.TargetAbsDir = root
+	got := cmd.findSpxRoot()
+	if got != root {
+		t.Fatalf("findSpxRoot = %s, want %s", got, root)
+	}
+}
+
+func TestFindSpxRootFindsParentDir(t *testing.T) {
+	root := t.TempDir()
+	startDir := filepath.Join(root, "tutorial", "00-Hello")
+	if err := os.MkdirAll(startDir, 0755); err != nil {
+		t.Fatalf("mkdir start dir: %v", err)
+	}
+	writeLocalSpxRepoMarker(t, root)
+
+	cmd := CmdTool{}
+	cmd.TargetAbsDir = startDir
+	got := cmd.findSpxRoot()
+	if got != root {
+		t.Fatalf("findSpxRoot = %s, want %s", got, root)
+	}
+}
+
+func TestFindSpxRootReturnsEmptyWhenMissing(t *testing.T) {
+	root := t.TempDir()
+
+	cmd := CmdTool{}
+	cmd.TargetAbsDir = root
+	got := cmd.findSpxRoot()
+	if got != "" {
+		t.Fatalf("findSpxRoot = %s, want empty", got)
+	}
+}
+
+func TestFindSpxRootIgnoresProjectsThatOnlyReferenceSpx(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "cmd", "spx"), 0755); err != nil {
+		t.Fatalf("mkdir cmd/spx: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "go.mod"), []byte("module example.com/demo\n"), 0644); err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "gox.mod"), []byte("project main.spx Game github.com/goplus/spx/v2 math\n"), 0644); err != nil {
+		t.Fatalf("write gox.mod: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "cmd", "spx", "install.sh"), []byte("#!/bin/bash\n"), 0755); err != nil {
+		t.Fatalf("write install.sh: %v", err)
+	}
+
+	cmd := CmdTool{TargetAbsDir: root}
+	if got := cmd.findSpxRoot(); got != "" {
+		t.Fatalf("findSpxRoot = %s, want empty", got)
+	}
+}
+
+func TestHasInstalledWebRuntimeAssetsIsModeSpecific(t *testing.T) {
+	goBinPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(goBinPath, "ispx"), 0755); err != nil {
+		t.Fatalf("mkdir ispx: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(goBinPath, "ispx.wasm"), []byte("wasm"), 0644); err != nil {
+		t.Fatalf("write ispx.wasm: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(goBinPath, "gdspxrt2.0.0_webnormal"), 0755); err != nil {
+		t.Fatalf("mkdir webnormal template dir: %v", err)
+	}
+
+	cmd := CmdTool{GoBinPath: goBinPath, Version: "2.0.0"}
+	if !cmd.hasInstalledWebRuntimeAssets(webNormalMode) {
+		t.Fatal("hasInstalledWebRuntimeAssets(normal) = false, want true")
+	}
+	if cmd.hasInstalledWebRuntimeAssets(webWorkerMode) {
+		t.Fatal("hasInstalledWebRuntimeAssets(worker) = true, want false")
 	}
 }
 


### PR DESCRIPTION
## Summary

This change makes `spx runweb` automatically install web runtime assets before exporting and starting the local web server.

## Changes

- run `cmd/spx/install.sh --web` before `spx runweb`
- reuse `CmdTool.TargetAbsDir` when locating the local spx repo
- simplify `findSpxRoot` to use `CmdTool.TargetAbsDir` directly
- add tests for setup ordering and local repo root detection

## Testing

- go test ./cmd/spx/internal/command
