### PR TITLE
make install support WEB flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,7 @@ help: ## Show available commands
 	@echo ""
 	@echo "Variable notes:"
 	@echo "  MODE defaults to normal for Web-related targets."
+	@echo "  WEB=1 enables web tooling/runtime for 'make install'."
 	@echo "  GODOT_SRC defaults to ./godot and is used by:"
 	@echo "    build-dev build-editor build-desktop build-web build-android build-ios generate"
 	@echo ""
@@ -94,8 +95,15 @@ prepare-web: ## Prepare web export assets for MODE, including the host editor re
 # ============================================
 # Install & Download
 # ============================================
-install: ## Install SPX command
-	$(BUILDCTL_TOOL_CMD) install
+install: ## Install SPX command. Usage: make install [WEB=1]
+	@set --; \
+	web_enabled=0; \
+	case "$(WEB)" in \
+		""|0|false|FALSE|no|NO|off|OFF) ;; \
+		1|true|TRUE|yes|YES|on|ON) web_enabled=1; set -- "$$@" --web ;; \
+		*) echo "invalid WEB \"$(WEB)\". Expected one of: 1 true yes on 0 false no off" >&2; exit 2 ;; \
+	esac; \
+	$(BUILDCTL_TOOL_CMD) install "$$@"
 
 clean-assets: ## Remove installed SPX/Godot runtime assets from GOPATH/bin
 	$(BUILDCTL_TOOL_CMD) clean-assets

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Config
 # ============================================
 .DEFAULT_GOAL := help
-.PHONY: help buildctl list-demos prepare-host prepare-web prepare-full prepare-all build-dev install clean-assets download download-engine build-editor build-desktop build-web build-wasm build-wasm-opt build-android build-ios install-apk editor run rune run-web run-web-worker format generate clean-projects export-pack export-web stop validate-web-mode validate-download-engine
+.PHONY: help buildctl list-demos prepare-host prepare-web prepare-full prepare-all build-dev install clean-assets download download-engine build-editor build-desktop build-web build-wasm build-wasm-opt build-android build-ios install-apk editor run rune run-web run-web-worker format generate clean-projects export-pack export-web stop validate-web-mode validate-download-engine validate-install-web
 
 export GODOT_SRC
 
@@ -23,14 +23,20 @@ APK_PROJECT_DIR ?= tutorial/00-Hello
 
 PORT    ?= 8106
 MOVIE   ?= false
+WEB     ?= 0
 WEB_MODE = $(or $(strip $(MODE)),normal)
 VALID_WEB_MODES := normal worker minigame miniprogram
 VALID_ENGINE_PLATFORMS := android ios web linux windows macos
+VALID_INSTALL_WEB_TRUE_VALUES := 1 true TRUE yes YES on ON
+VALID_INSTALL_WEB_FALSE_VALUES := 0 false FALSE no NO off OFF
+VALID_INSTALL_WEB_VALUES := $(VALID_INSTALL_WEB_TRUE_VALUES) $(VALID_INSTALL_WEB_FALSE_VALUES)
 
 validate-web-mode = $(if $(filter $(WEB_MODE),$(VALID_WEB_MODES)),,$(error invalid WEB_MODE/MODE "$(WEB_MODE)". Expected one of: $(VALID_WEB_MODES)))
 validate-platform-required = $(if $(strip $(PLATFORM)),,$(error PLATFORM is required. Usage: make download-engine PLATFORM=android|ios|web [MODE=normal|worker|minigame|miniprogram]))
 validate-engine-platform = $(if $(filter $(PLATFORM),$(VALID_ENGINE_PLATFORMS)),,$(error invalid PLATFORM "$(PLATFORM)". Expected one of: $(VALID_ENGINE_PLATFORMS)))
 validate-download-engine-mode = $(if $(filter web,$(PLATFORM)),$(call validate-web-mode),$(if $(strip $(MODE)),$(error MODE is only supported when PLATFORM=web),))
+validate-install-web = $(if $(filter $(strip $(WEB)),$(VALID_INSTALL_WEB_VALUES)),,$(error invalid WEB "$(WEB)". Expected one of: $(VALID_INSTALL_WEB_TRUE_VALUES) $(VALID_INSTALL_WEB_FALSE_VALUES)))
+install-web-flag = $(if $(filter $(strip $(WEB)),$(VALID_INSTALL_WEB_TRUE_VALUES)),--web)
 
 validate-web-mode:
 	$(call validate-web-mode)
@@ -39,6 +45,9 @@ validate-download-engine:
 	$(call validate-platform-required)
 	$(call validate-engine-platform)
 	$(call validate-download-engine-mode)
+
+validate-install-web:
+	$(call validate-install-web)
 
 prepare-full prepare-web build-dev build-web export-web: validate-web-mode
 download-engine: validate-download-engine
@@ -62,7 +71,7 @@ help: ## Show available commands
 	@echo ""
 	@echo "Variable notes:"
 	@echo "  MODE defaults to normal for Web-related targets."
-	@echo "  WEB=1 enables web tooling/runtime for 'make install'."
+	@echo "  WEB defaults to 0; truthy values enable web tooling/runtime for 'make install'."
 	@echo "  GODOT_SRC defaults to ./godot and is used by:"
 	@echo "    build-dev build-editor build-desktop build-web build-android build-ios generate"
 	@echo ""
@@ -95,15 +104,8 @@ prepare-web: ## Prepare web export assets for MODE, including the host editor re
 # ============================================
 # Install & Download
 # ============================================
-install: ## Install SPX command. Usage: make install [WEB=1]
-	@set --; \
-	web_enabled=0; \
-	case "$(WEB)" in \
-		""|0|false|FALSE|no|NO|off|OFF) ;; \
-		1|true|TRUE|yes|YES|on|ON) web_enabled=1; set -- "$$@" --web ;; \
-		*) echo "invalid WEB \"$(WEB)\". Expected one of: 1 true yes on 0 false no off" >&2; exit 2 ;; \
-	esac; \
-	$(BUILDCTL_TOOL_CMD) install "$$@"
+install: validate-install-web ## Install SPX command. Usage: make install [WEB=1]
+	$(BUILDCTL_TOOL_CMD) install $(call install-web-flag)
 
 clean-assets: ## Remove installed SPX/Godot runtime assets from GOPATH/bin
 	$(BUILDCTL_TOOL_CMD) clean-assets

--- a/docs/zh/dev/engine/cmd_make.md
+++ b/docs/zh/dev/engine/cmd_make.md
@@ -80,7 +80,7 @@ make prepare-full MODE=worker
 | --- | --- | --- |
 | `GODOT_SRC` | `./godot` | Godot 源码目录；仅 `build-dev`、`build-editor`、`build-desktop`、`build-web`、`build-android`、`build-ios`、`generate` 使用 |
 | `MODE` | `normal` | Web 模式，可选 `normal`、`worker`、`minigame`、`miniprogram` |
-| `WEB` | `0` | `make install` 是否追加 `--web`，可选 `1/true/yes/on` 或 `0/false/no/off` |
+| `WEB` | `0` | `make install` 是否追加 `--web`，可选 `1/true/TRUE/yes/YES/on/ON` 或 `0/false/FALSE/no/NO/off/OFF` |
 | `PLATFORM` | 当前宿主平台 | `download-engine` 使用的平台名 |
 | `DEMO_INDEX` | `3` | `tutorial/*` 演示索引 |
 | `APK_PROJECT_DIR` | `tutorial/00-Hello` | `install-apk` 使用的项目目录 |

--- a/docs/zh/dev/engine/cmd_make.md
+++ b/docs/zh/dev/engine/cmd_make.md
@@ -80,6 +80,7 @@ make prepare-full MODE=worker
 | --- | --- | --- |
 | `GODOT_SRC` | `./godot` | Godot 源码目录；仅 `build-dev`、`build-editor`、`build-desktop`、`build-web`、`build-android`、`build-ios`、`generate` 使用 |
 | `MODE` | `normal` | Web 模式，可选 `normal`、`worker`、`minigame`、`miniprogram` |
+| `WEB` | `0` | `make install` 是否追加 `--web`，可选 `1/true/yes/on` 或 `0/false/no/off` |
 | `PLATFORM` | 当前宿主平台 | `download-engine` 使用的平台名 |
 | `DEMO_INDEX` | `3` | `tutorial/*` 演示索引 |
 | `APK_PROJECT_DIR` | `tutorial/00-Hello` | `install-apk` 使用的项目目录 |
@@ -107,13 +108,15 @@ make prepare-full MODE=worker
 | `make build-dev [MODE=...]` | 一次性构建带指定 Web mode runtime 的 `spx` 工具链、当前平台 editor/template、runtime pck 和 Web template |
 | `make prepare-web MODE=...` | 安装 Web 导出所需工具链，下载指定模式的 Web template/runtime，并补齐 `exporttemplateweb` 依赖的 host editor |
 | `make prepare-full [MODE=...]` | 一次性准备 host editor/runtime 资产和指定 Web mode 的导出资产 |
-| `make install` | 安装 `spx` 命令 |
+| `make install [WEB=1]` | 安装 `spx` 命令；`WEB=1` 时会透传为 `buildctl tool install --web` |
 | `make download` | 下载当前平台 runtime 所需的 editor/template/pck 资产 |
 | `make download-engine PLATFORM=... [MODE=...]` | 下载指定平台的引擎模板或 editor 资产 |
 
 示例：
 
 ```bash
+make install
+make install WEB=1
 make download-engine PLATFORM=android
 make download-engine PLATFORM=web MODE=worker
 ```


### PR DESCRIPTION
## Summary

`make install` previously always ran `buildctl tool install` without exposing a Make-level way to enable web installation, so commands like `make install -web` had no effect.

This PR adds a `WEB=1` entry point for `make install` and updates the help text and developer docs accordingly.

## Changes

- add `WEB` variable handling to the `install` target in `Makefile`
- pass `--web` to `buildctl tool install` when `WEB=1`
- update `make help` output to document the new usage
- update `docs/zh/dev/engine/cmd_make.md` with the new `make install WEB=1` examples

## Design Notes

This uses `WEB=1` instead of a `-web` style argument to stay consistent with the existing Make interface, which already uses variable-based inputs such as:

- `MODE=worker`
- `PLATFORM=web`

## Validation

- `make help`
- `make install WEB=1 BUILDCTL_BIN=$(pwd)/.bin/fakebuildctl`

## Usage

```bash
make install
make install WEB=1
