### PR TITLE
runtime: restore startup ordering with an explicit post-awake phase

### DIFF
--- a/game.go
+++ b/game.go
@@ -99,6 +99,8 @@ type Game struct {
 	scriptEvents scriptEventRegistry
 	gamer        Gamer
 
+	pendingAfterAwake []func()
+
 	sprCollisionInfos       map[string]*spriteCollisionInfo
 	isCollisionByPixel      bool
 	isAutoSetCollisionLayer bool
@@ -251,6 +253,7 @@ func (p *Game) reset() {
 	p.lifecycleState.RunOnce = sync.Once{}
 	p.lifecycleState.OncePathFinder = sync.Once{}
 	p.sprs = make(map[string]Sprite)
+	p.pendingAfterAwake = nil
 
 	p.resetImageSizeCache()
 	p.resetEventQueueStats()

--- a/game_load.go
+++ b/game_load.go
@@ -51,7 +51,9 @@ func (p *Game) loadIndex(g reflect.Value, proj *coreproject.ProjectConfig) (err 
 
 	inits := p.loadAndInitSprites(g, proj)
 	p.runSpriteCallbacks(inits, proj, g)
-	p.setupCollisionLayers(inits)
+	p.deferAfterAwake(func() {
+		p.setupCollisionLayers(inits)
+	})
 	p.loadAudioAndTilemap(proj)
 
 	p.lifecycleState.IsLoaded = true
@@ -197,16 +199,14 @@ func (p *Game) runSpriteCallbacks(inits []Sprite, proj *coreproject.ProjectConfi
 	}
 	coreproject.RunSpriteInitializers(coreproject.SpriteInitConfig[Sprite]{
 		Items: inits,
-		BeforeMain: func(ini Sprite) {
+		Setup: func(ini Sprite) {
 			spr := spriteOf(ini)
 			if spr != nil {
 				spr.onAwake(func() {
+					runMain(ini.Main)
 					spr.awake()
 				})
 			}
-		},
-		RunMain: func(ini Sprite) {
-			runMain(ini.Main)
 		},
 		CameraTarget: cameraTarget,
 		FollowCamera: p.Camera.Follow__1,

--- a/internal/core/event/manager.go
+++ b/internal/core/event/manager.go
@@ -62,13 +62,6 @@ func appendSinkCopy(sinks []Sink, sink Sink) []Sink {
 	return out
 }
 
-func prependSinkCopy(sinks []Sink, sink Sink) []Sink {
-	out := make([]Sink, len(sinks)+1)
-	out[0] = sink
-	copy(out[1:], sinks)
-	return out
-}
-
 func readOnlySnapshot(sinks []Sink) []Sink {
 	if len(sinks) == 0 {
 		return sinks
@@ -141,16 +134,6 @@ func (m *Manager) TryAddStart(sink Sink) bool {
 		return false
 	}
 	m.buckets[BucketStart] = appendSinkCopy(m.buckets[BucketStart], sink)
-	return true
-}
-
-func (m *Manager) TryAddStartPrepend(sink Sink) bool {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	if m.startFired {
-		return false
-	}
-	m.buckets[BucketStart] = prependSinkCopy(m.buckets[BucketStart], sink)
 	return true
 }
 

--- a/internal/core/event/manager_test.go
+++ b/internal/core/event/manager_test.go
@@ -144,21 +144,3 @@ func TestManagerStartLifecycle(t *testing.T) {
 		t.Fatal("expected reset to reopen start registration")
 	}
 }
-
-func TestManagerTryAddStartPrepend(t *testing.T) {
-	var mgr Manager
-	if !mgr.TryAddStart(Sink{Owner: "sprite", Handler: func() {}}) {
-		t.Fatal("expected sprite start sink to be registered")
-	}
-	if !mgr.TryAddStartPrepend(Sink{Owner: "game", Handler: func() {}}) {
-		t.Fatal("expected game start sink to be prepended")
-	}
-
-	got := mgr.SnapshotStart()
-	if len(got) != 2 {
-		t.Fatalf("SnapshotStart len = %d, want 2", len(got))
-	}
-	if got[0].Owner != "game" || got[1].Owner != "sprite" {
-		t.Fatalf("SnapshotStart order = [%v %v], want [game sprite]", got[0].Owner, got[1].Owner)
-	}
-}

--- a/internal/core/project/load.go
+++ b/internal/core/project/load.go
@@ -23,8 +23,7 @@ import (
 
 type SpriteInitConfig[T any] struct {
 	Items        []T
-	BeforeMain   func(T)
-	RunMain      func(T)
+	Setup        func(T)
 	CameraTarget string
 	FollowCamera func(string)
 	OnLoaded     func()
@@ -55,11 +54,8 @@ func WalkZOrder(
 
 func RunSpriteInitializers[T any](cfg SpriteInitConfig[T]) {
 	for _, item := range cfg.Items {
-		if cfg.BeforeMain != nil {
-			cfg.BeforeMain(item)
-		}
-		if cfg.RunMain != nil {
-			cfg.RunMain(item)
+		if cfg.Setup != nil {
+			cfg.Setup(item)
 		}
 	}
 

--- a/internal/core/project/project_test.go
+++ b/internal/core/project/project_test.go
@@ -476,11 +476,8 @@ func TestRunSpriteInitializers(t *testing.T) {
 	var got []string
 	RunSpriteInitializers(SpriteInitConfig[string]{
 		Items: []string{"a", "b"},
-		BeforeMain: func(item string) {
-			got = append(got, "before:"+item)
-		},
-		RunMain: func(item string) {
-			got = append(got, "main:"+item)
+		Setup: func(item string) {
+			got = append(got, "setup:"+item)
 		},
 		CameraTarget: "hero",
 		FollowCamera: func(target string) {
@@ -490,7 +487,7 @@ func TestRunSpriteInitializers(t *testing.T) {
 			got = append(got, "loaded")
 		},
 	})
-	want := []string{"before:a", "main:a", "before:b", "main:b", "follow:hero", "loaded"}
+	want := []string{"setup:a", "setup:b", "follow:hero", "loaded"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("RunSpriteInitializers got %v, want %v", got, want)
 	}

--- a/runtime_events.go
+++ b/runtime_events.go
@@ -96,13 +96,7 @@ func (p *scriptEventBindings) onAwake(onAwake func()) {
 
 func (p *scriptEventBindings) OnStart(onStart func()) {
 	sink := coreevent.NewSink(p.pthis, onStart)
-	var added bool
-	if _, ok := sink.Owner.(*Game); ok {
-		added = p.scriptEventRegistry.TryAddStartPrepend(sink)
-	} else {
-		added = p.scriptEventRegistry.TryAddStart(sink)
-	}
-	if added {
+	if p.scriptEventRegistry.TryAddStart(sink) {
 		return
 	}
 	if sprite, ok := sink.Owner.(*SpriteImpl); ok && sprite.spriteState.Cloned {
@@ -310,6 +304,7 @@ func (p *Game) handleEvent(ev event) {
 		p.scriptEvents.doWhenKeyPressed(e.Key)
 	case *eventStart:
 		p.scriptEvents.doWhenAwake(nil)
+		p.runAfterAwake()
 		p.scriptEvents.doWhenStart()
 	case *eventTimer:
 		p.scriptEvents.doWhenTimer(e.Time)
@@ -335,6 +330,21 @@ func (p *scriptEventRegistry) doWhenStart() {
 		})()
 		ev.Handler.(func())()
 	})
+}
+
+func (p *Game) deferAfterAwake(call func()) {
+	if call == nil {
+		return
+	}
+	p.pendingAfterAwake = append(p.pendingAfterAwake, call)
+}
+
+func (p *Game) runAfterAwake() {
+	hooks := p.pendingAfterAwake
+	p.pendingAfterAwake = nil
+	for _, hook := range hooks {
+		hook()
+	}
 }
 
 func (p *scriptEventRegistry) doWhenAwake(this threadObj) {

--- a/runtime_events_test.go
+++ b/runtime_events_test.go
@@ -1,0 +1,26 @@
+package spx
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestGameRunAfterAwakeExecutesQueuedHooksOnce(t *testing.T) {
+	var g Game
+
+	var got []string
+	g.deferAfterAwake(func() {
+		got = append(got, "first")
+	})
+	g.deferAfterAwake(func() {
+		got = append(got, "second")
+	})
+
+	g.runAfterAwake()
+	g.runAfterAwake()
+
+	want := []string{"first", "second"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("runAfterAwake got %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

This PR restores startup ordering after reverting the `#1463` lifecycle change.

Instead of relying on special-cased `OnStart` insertion order, it introduces an explicit post-awake step so bootstrap work that depends on `Main()` registrations still runs before the first `Start`.

## Implementation

This change does the following:

- keep sprite initialization as a single `Setup` callback instead of split `BeforeMain` / `RunMain`
- keep sprite `Main()` attached to sprite `onAwake`
- add an explicit `afterAwake` queue on `Game`
- run that queue during startup in the order:

  `Awake -> afterAwake -> Start`

- defer collision-layer setup to `afterAwake`, so registrations established in sprite `Main()` are visible before startup finishes
- remove the game-specific `OnStart` prepend path and go back to normal start registration

## Why

The previous startup flow could make bootstrap ordering observable.

A concrete issue was that some sprite event/collision registrations happen in `Main()`, while collision-layer setup was still performed too early during load. That could cause startup-time sprite events such as `OnTouchStart` to be missed.

This PR fixes that by making post-`Awake`, pre-`Start` work explicit, rather than depending on special casing in `OnStart`.

## Revert context

This PR is based on reverting `#1463`, then restoring the needed startup behavior with a smaller and more explicit lifecycle step.

## Tests

- add coverage for queued `afterAwake` hooks
- `go test ./...`
