### PR TITLE
runtime: run MainEntry and sprite Main in an explicit bootstrap phase

### DIFF
--- a/game.go
+++ b/game.go
@@ -96,10 +96,12 @@ type Game struct {
 
 	events chan event
 
-	scriptEvents scriptEventRegistry
-	gamer        Gamer
-
-	pendingAfterAwake []func()
+	scriptEvents     scriptEventRegistry
+	gamer            Gamer
+	bootstrapMu      sync.Mutex
+	bootstrapGen     uint64
+	bootstrapStarted bool
+	pendingBootstrap []func()
 
 	sprCollisionInfos       map[string]*spriteCollisionInfo
 	isCollisionByPixel      bool
@@ -237,7 +239,7 @@ func (p *Game) getSpriteProtoByName(name string, g reflect.Value) Sprite {
 }
 
 func (p *Game) reset() {
-	p.lifecycleState.IsRunned = false
+	p.lifecycleState.IsRunned.Store(false)
 
 	p.releaseGameAudio()
 	p.EraseAll()
@@ -247,20 +249,20 @@ func (p *Game) reset() {
 
 	p.debugState.DebugPanel = nil
 	p.dialogState.AskPanel = nil
-	p.lifecycleState.IsLoaded = false
+	p.resetBootstrapState()
+	p.lifecycleState.StartDispatched.Store(false)
+	p.Stop(AllOtherScripts)
 
 	p.lifecycleState.StartFlag = sync.Once{}
 	p.lifecycleState.RunOnce = sync.Once{}
 	p.lifecycleState.OncePathFinder = sync.Once{}
 	p.sprs = make(map[string]Sprite)
-	p.pendingAfterAwake = nil
 
 	p.resetImageSizeCache()
 	p.resetEventQueueStats()
 	close(p.events)
 
 	itime.OnReload()
-	p.Stop(AllOtherScripts)
 }
 
 func (p *Game) initGame(sprites []Sprite) *Game {

--- a/game_build.go
+++ b/game_build.go
@@ -39,17 +39,19 @@ type gameBuilder struct {
 
 	game       *Game
 	gamerValue reflect.Value
+	generation uint64
 	err        error
 }
 
 // -----------------------------------------------------------------------------
 // Builder
 // -----------------------------------------------------------------------------
-func newGameBuilder(game Gamer, resource any, gameConf ...*Config) *gameBuilder {
+func newGameBuilder(game Gamer, resource any, generation uint64, gameConf ...*Config) *gameBuilder {
 	return &gameBuilder{
-		gamer:    game,
-		resource: resource,
-		gameConf: gameConf,
+		gamer:      game,
+		resource:   resource,
+		gameConf:   gameConf,
+		generation: generation,
 	}
 }
 
@@ -123,7 +125,7 @@ func (b *gameBuilder) finalizeLoad() *gameBuilder {
 	if b.err != nil {
 		return b
 	}
-	if err := b.game.endLoad(b.gamerValue, &b.proj); err != nil {
+	if err := b.game.endLoad(b.gamerValue, &b.proj, b.generation); err != nil {
 		b.err = err
 		return b
 	}

--- a/game_load.go
+++ b/game_load.go
@@ -44,19 +44,14 @@ func (p *Game) loadSprite(sprite Sprite, name string, gamer reflect.Value) error
 	return bindSpriteOwner(vSpr, gamer)
 }
 
-func (p *Game) loadIndex(g reflect.Value, proj *coreproject.ProjectConfig) (err error) {
+func (p *Game) loadIndex(g reflect.Value, proj *coreproject.ProjectConfig, generation uint64) (err error) {
 	p.setupDisplayConfig(proj)
 	p.setupWorldAndWindow(proj)
 	p.setupPlatformAndCamera(proj)
 
 	inits := p.loadAndInitSprites(g, proj)
-	p.runSpriteCallbacks(inits, proj, g)
-	p.deferAfterAwake(func() {
-		p.setupCollisionLayers(inits)
-	})
+	p.runSpriteCallbacks(inits, proj, g, generation)
 	p.loadAudioAndTilemap(proj)
-
-	p.lifecycleState.IsLoaded = true
 	return
 }
 
@@ -188,7 +183,7 @@ func (p *Game) loadAndInitSprites(g reflect.Value, proj *coreproject.ProjectConf
 	return inits
 }
 
-func (p *Game) runSpriteCallbacks(inits []Sprite, proj *coreproject.ProjectConfig, g reflect.Value) {
+func (p *Game) runSpriteCallbacks(inits []Sprite, proj *coreproject.ProjectConfig, g reflect.Value, generation uint64) {
 	var onLoaded func()
 	if loader, ok := g.Addr().Interface().(interface{ OnLoaded() }); ok {
 		onLoaded = loader.OnLoaded
@@ -199,18 +194,28 @@ func (p *Game) runSpriteCallbacks(inits []Sprite, proj *coreproject.ProjectConfi
 	}
 	coreproject.RunSpriteInitializers(coreproject.SpriteInitConfig[Sprite]{
 		Items: inits,
-		Setup: func(ini Sprite) {
+		BeforeMain: func(ini Sprite) {
 			spr := spriteOf(ini)
 			if spr != nil {
 				spr.onAwake(func() {
-					runMain(ini.Main)
 					spr.awake()
 				})
 			}
 		},
-		CameraTarget: cameraTarget,
-		FollowCamera: p.Camera.Follow__1,
-		OnLoaded:     onLoaded,
+		RunMain: func(ini Sprite) {
+			p.deferBootstrapFor(generation, func() {
+				runMain(ini.Main)
+			})
+		},
+	})
+	p.deferBootstrapFor(generation, func() {
+		p.setupCollisionLayers(inits)
+		if cameraTarget != "" {
+			p.Camera.Follow__1(cameraTarget)
+		}
+		if onLoaded != nil {
+			onLoaded()
+		}
 	})
 }
 
@@ -225,9 +230,9 @@ func (p *Game) loadAudioAndTilemap(proj *coreproject.ProjectConfig) {
 	}
 }
 
-func (p *Game) endLoad(g reflect.Value, proj *coreproject.ProjectConfig) (err error) {
+func (p *Game) endLoad(g reflect.Value, proj *coreproject.ProjectConfig, generation uint64) (err error) {
 	spxlog.Debug("==> EndLoad")
-	return p.loadIndex(g, proj)
+	return p.loadIndex(g, proj, generation)
 }
 
 func (p *Game) addSpecialShape(g reflect.Value, v coreproject.StageShape, inits []Sprite) ([]Sprite, error) {

--- a/game_run.go
+++ b/game_run.go
@@ -55,6 +55,7 @@ func XGot_Game_Reload(game Gamer, index any) (err error) {
 	v := reflect.ValueOf(game).Elem()
 	g := instance(v)
 	g.reset()
+	generation := g.currentBootstrapGeneration()
 	engine.ClearAllSprites()
 
 	g.events = make(chan event, eventBufferSize)
@@ -78,9 +79,14 @@ func XGot_Game_Reload(game Gamer, index any) (err error) {
 		return
 	}
 	gco.OnRestart()
-	err = g.loadIndex(v, &proj)
-	gco.OnInited()
+	err = g.loadIndex(v, &proj, generation)
+	if err != nil {
+		return
+	}
 	g.initEventLoop()
+	gco.OnInited()
+	g.lifecycleState.IsRunned.Store(true)
+	g.startBootstrapPhaseFor(generation)
 	return
 }
 

--- a/internal/core/project/load.go
+++ b/internal/core/project/load.go
@@ -22,11 +22,9 @@ import (
 )
 
 type SpriteInitConfig[T any] struct {
-	Items        []T
-	Setup        func(T)
-	CameraTarget string
-	FollowCamera func(string)
-	OnLoaded     func()
+	Items      []T
+	BeforeMain func(T)
+	RunMain    func(T)
 }
 
 func WalkZOrder(
@@ -54,16 +52,12 @@ func WalkZOrder(
 
 func RunSpriteInitializers[T any](cfg SpriteInitConfig[T]) {
 	for _, item := range cfg.Items {
-		if cfg.Setup != nil {
-			cfg.Setup(item)
+		if cfg.BeforeMain != nil {
+			cfg.BeforeMain(item)
 		}
-	}
-
-	if cfg.CameraTarget != "" && cfg.FollowCamera != nil {
-		cfg.FollowCamera(cfg.CameraTarget)
-	}
-	if cfg.OnLoaded != nil {
-		cfg.OnLoaded()
+		if cfg.RunMain != nil {
+			cfg.RunMain(item)
+		}
 	}
 }
 

--- a/internal/core/project/project_test.go
+++ b/internal/core/project/project_test.go
@@ -476,18 +476,14 @@ func TestRunSpriteInitializers(t *testing.T) {
 	var got []string
 	RunSpriteInitializers(SpriteInitConfig[string]{
 		Items: []string{"a", "b"},
-		Setup: func(item string) {
-			got = append(got, "setup:"+item)
+		BeforeMain: func(item string) {
+			got = append(got, "before:"+item)
 		},
-		CameraTarget: "hero",
-		FollowCamera: func(target string) {
-			got = append(got, "follow:"+target)
-		},
-		OnLoaded: func() {
-			got = append(got, "loaded")
+		RunMain: func(item string) {
+			got = append(got, "main:"+item)
 		},
 	})
-	want := []string{"setup:a", "setup:b", "follow:hero", "loaded"}
+	want := []string{"before:a", "main:a", "before:b", "main:b"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("RunSpriteInitializers got %v, want %v", got, want)
 	}

--- a/internal/core/state/game.go
+++ b/internal/core/state/game.go
@@ -18,6 +18,7 @@ package state
 
 import (
 	"sync"
+	"sync/atomic"
 	"time"
 
 	coreevent "github.com/goplus/spx/v2/internal/core/event"
@@ -26,11 +27,12 @@ import (
 )
 
 type GameLifecycleState struct {
-	StartFlag      sync.Once
-	RunOnce        sync.Once
-	OncePathFinder sync.Once
-	IsLoaded       bool
-	IsRunned       bool
+	StartFlag       sync.Once
+	RunOnce         sync.Once
+	OncePathFinder  sync.Once
+	BootstrapDone   atomic.Bool
+	StartDispatched atomic.Bool
+	IsRunned        atomic.Bool
 }
 
 type GameDisplayState struct {

--- a/runtime_bootstrap_test.go
+++ b/runtime_bootstrap_test.go
@@ -1,0 +1,95 @@
+package spx
+
+import "testing"
+
+func TestGameRunBootstrapTasksDrainsNestedCallbacks(t *testing.T) {
+	var g Game
+	var got []string
+
+	g.deferBootstrap(func() {
+		got = append(got, "first")
+		g.deferBootstrap(func() {
+			got = append(got, "nested")
+		})
+	})
+	g.deferBootstrap(func() {
+		got = append(got, "second")
+	})
+
+	g.runBootstrapTasks()
+
+	want := []string{"first", "second", "nested"}
+	if len(got) != len(want) {
+		t.Fatalf("runBootstrapTasks got %v, want %v", got, want)
+	}
+	for i, item := range want {
+		if got[i] != item {
+			t.Fatalf("runBootstrapTasks got %v, want %v", got, want)
+		}
+	}
+}
+
+func TestGameBootstrapCanOrderGameStartBeforeSpriteStart(t *testing.T) {
+	var g Game
+	g.scriptEventBindings.init(&g.scriptEvents, &g)
+
+	var sprite SpriteImpl
+	sprite.scriptEventBindings.init(&g.scriptEvents, &sprite)
+
+	g.deferBootstrap(func() {
+		g.OnStart(func() {})
+	})
+	g.deferBootstrap(func() {
+		sprite.OnStart(func() {})
+	})
+
+	g.runBootstrapTasks()
+
+	got := g.scriptEvents.SnapshotStart()
+	if len(got) != 2 {
+		t.Fatalf("SnapshotStart len = %d, want 2", len(got))
+	}
+	if _, ok := got[0].Owner.(*Game); !ok {
+		t.Fatalf("first start owner = %T, want *Game", got[0].Owner)
+	}
+	if _, ok := got[1].Owner.(*SpriteImpl); !ok {
+		t.Fatalf("second start owner = %T, want *SpriteImpl", got[1].Owner)
+	}
+}
+
+func TestGameRunBootstrapTasksStopsDrainingAfterReset(t *testing.T) {
+	var g Game
+	generation := g.currentBootstrapGeneration()
+	var got []string
+
+	if !g.deferBootstrapFor(generation, func() {
+		got = append(got, "first")
+		g.resetBootstrapState()
+		g.deferBootstrapFor(g.currentBootstrapGeneration(), func() {
+			got = append(got, "new")
+		})
+	}) {
+		t.Fatal("deferBootstrapFor rejected current generation")
+	}
+	if !g.deferBootstrapFor(generation, func() {
+		got = append(got, "stale")
+	}) {
+		t.Fatal("deferBootstrapFor rejected current generation")
+	}
+
+	g.runBootstrapTasksFor(generation)
+	if len(got) != 1 || got[0] != "first" {
+		t.Fatalf("old generation drained stale tasks: got %v, want [first]", got)
+	}
+
+	g.runBootstrapTasks()
+	want := []string{"first", "new"}
+	if len(got) != len(want) {
+		t.Fatalf("current generation tasks got %v, want %v", got, want)
+	}
+	for i, item := range want {
+		if got[i] != item {
+			t.Fatalf("current generation tasks got %v, want %v", got, want)
+		}
+	}
+}

--- a/runtime_engine.go
+++ b/runtime_engine.go
@@ -19,6 +19,8 @@ package spx
 import (
 	"time"
 
+	"github.com/goplus/spx/v2/internal/coroutine"
+
 	"github.com/goplus/spbase/mathf"
 	coreruntime "github.com/goplus/spx/v2/internal/core/runtime"
 	"github.com/goplus/spx/v2/internal/engine"
@@ -31,23 +33,24 @@ import (
 func (p *Game) OnEngineStart() {
 	p.lifecycleState.RunOnce.Do(func() {
 		cachedBounds = make(map[string]mathf.Rect2)
-		onStart := func() {
+		generation := p.currentBootstrapGeneration()
+		go func() {
 			defer engine.CheckPanic()
-			gamer := p.gamer
-			if me, ok := gamer.(interface{ MainEntry() }); ok {
-				p.onAwake(func() {
+			if me, ok := p.gamer.(interface{ MainEntry() }); ok {
+				p.deferBootstrapFor(generation, func() {
 					runMain(me.MainEntry)
 				})
 			}
-			if !p.lifecycleState.IsRunned {
-				builder := newGameBuilder(gamer, "assets")
+			if !p.lifecycleState.IsRunned.Load() {
+				builder := newGameBuilder(p.gamer, "assets", generation)
 				if err := builder.buildAndRun(); err != nil {
 					engine.Panic(err)
 				}
 			}
 			engine.OnGameStarted()
-		}
-		go onStart()
+			p.lifecycleState.IsRunned.Store(true)
+			p.startBootstrapPhaseFor(generation)
+		}()
 	})
 }
 
@@ -59,25 +62,25 @@ func (p *Game) OnEngineReset() {
 }
 
 func (p *Game) OnEngineUpdate(delta float64) {
-	if !p.lifecycleState.IsRunned {
+	if !p.lifecycleState.IsRunned.Load() {
 		return
 	}
-	p.dispatchStartEventIfNeeded()
+	if p.lifecycleState.BootstrapDone.Load() {
+		p.dispatchStartEventIfNeeded()
+	}
 	p.updateSpriteProxies()
 	p.pullPhysicsPositions()
 }
 
 func (p *Game) OnEngineRender(delta float64) {
-	if !p.lifecycleState.IsRunned {
+	if !p.lifecycleState.StartDispatched.Load() {
 		return
 	}
 	p.processPhysicsTriggers()
 }
 
-func (p *Game) OnEnginePause(isPaused bool) {
-	if !p.lifecycleState.IsRunned {
-		return
-	}
+func (p *Game) OnEnginePause(bool) {
+	// Pause lifecycle hooks are intentionally handled by engine-level managers.
 }
 
 // -----------------------------------------------------------------------------
@@ -90,10 +93,117 @@ func (p *Game) runLoop(cfg *Config) (err error) {
 	}
 	p.initEventLoop()
 	p.engine().PlatformMgr.SetWindowTitle(cfg.Title)
-	p.lifecycleState.IsRunned = true
 	return nil
 }
 
 func runMain(call func()) {
 	coreruntime.RunMain(call, time.Now(), setSchedInMain, setMainSchedTime)
+}
+
+func (p *Game) deferBootstrap(call func()) {
+	p.deferBootstrapFor(p.currentBootstrapGeneration(), call)
+}
+
+func (p *Game) deferBootstrapFor(generation uint64, call func()) bool {
+	if call == nil {
+		return false
+	}
+	p.bootstrapMu.Lock()
+	defer p.bootstrapMu.Unlock()
+	if generation != p.bootstrapGen {
+		return false
+	}
+	p.pendingBootstrap = append(p.pendingBootstrap, call)
+	return true
+}
+
+func (p *Game) currentBootstrapGeneration() uint64 {
+	p.bootstrapMu.Lock()
+	defer p.bootstrapMu.Unlock()
+	return p.bootstrapGen
+}
+
+func (p *Game) resetBootstrapState() {
+	p.bootstrapMu.Lock()
+	p.bootstrapGen++
+	p.bootstrapStarted = false
+	p.pendingBootstrap = nil
+	p.bootstrapMu.Unlock()
+	p.lifecycleState.BootstrapDone.Store(false)
+}
+
+func (p *Game) runBootstrapTasks() {
+	p.runBootstrapTasksFor(p.currentBootstrapGeneration())
+}
+
+func (p *Game) runBootstrapTasksFor(generation uint64) {
+	for {
+		tasks, ok := p.takeBootstrapTasksFor(generation)
+		if !ok || len(tasks) == 0 {
+			return
+		}
+		// Re-check after each pass so tasks queued by tasks are also consumed.
+		for _, task := range tasks {
+			if !p.isBootstrapGenerationCurrent(generation) {
+				return
+			}
+			task()
+		}
+	}
+}
+
+func (p *Game) takeBootstrapTasksFor(generation uint64) ([]func(), bool) {
+	p.bootstrapMu.Lock()
+	defer p.bootstrapMu.Unlock()
+	if generation != p.bootstrapGen {
+		return nil, false
+	}
+	if len(p.pendingBootstrap) == 0 {
+		return nil, true
+	}
+	tasks := p.pendingBootstrap
+	p.pendingBootstrap = nil
+	return tasks, true
+}
+
+func (p *Game) isBootstrapGenerationCurrent(generation uint64) bool {
+	p.bootstrapMu.Lock()
+	defer p.bootstrapMu.Unlock()
+	return generation == p.bootstrapGen
+}
+
+func (p *Game) claimBootstrapPhaseFor(generation uint64) (hasTasks, ok bool) {
+	p.bootstrapMu.Lock()
+	defer p.bootstrapMu.Unlock()
+	if generation != p.bootstrapGen || p.bootstrapStarted {
+		return false, false
+	}
+	p.bootstrapStarted = true
+	return len(p.pendingBootstrap) > 0, true
+}
+
+func (p *Game) startBootstrapPhaseFor(generation uint64) {
+	engine.WaitMainThread(func() {
+		hasTasks, ok := p.claimBootstrapPhaseFor(generation)
+		if !ok {
+			return
+		}
+		if !hasTasks {
+			p.lifecycleState.BootstrapDone.Store(true)
+			return
+		}
+
+		p.lifecycleState.BootstrapDone.Store(false)
+		gco.CreateAndStart(false, p, func(coroutine.Thread) int {
+			p.runBootstrapTasksFor(generation)
+			if p.isBootstrapGenerationCurrent(generation) {
+				p.lifecycleState.BootstrapDone.Store(true)
+			}
+			return 0
+		})
+	})
+}
+
+func (p *Game) startBootstrapPhase() {
+	p.startBootstrapPhaseFor(p.currentBootstrapGeneration())
 }

--- a/runtime_events.go
+++ b/runtime_events.go
@@ -304,8 +304,8 @@ func (p *Game) handleEvent(ev event) {
 		p.scriptEvents.doWhenKeyPressed(e.Key)
 	case *eventStart:
 		p.scriptEvents.doWhenAwake(nil)
-		p.runAfterAwake()
 		p.scriptEvents.doWhenStart()
+		p.lifecycleState.StartDispatched.Store(true)
 	case *eventTimer:
 		p.scriptEvents.doWhenTimer(e.Time)
 	}
@@ -330,21 +330,6 @@ func (p *scriptEventRegistry) doWhenStart() {
 		})()
 		ev.Handler.(func())()
 	})
-}
-
-func (p *Game) deferAfterAwake(call func()) {
-	if call == nil {
-		return
-	}
-	p.pendingAfterAwake = append(p.pendingAfterAwake, call)
-}
-
-func (p *Game) runAfterAwake() {
-	hooks := p.pendingAfterAwake
-	p.pendingAfterAwake = nil
-	for _, hook := range hooks {
-		hook()
-	}
 }
 
 func (p *scriptEventRegistry) doWhenAwake(this threadObj) {

--- a/runtime_events_test.go
+++ b/runtime_events_test.go
@@ -5,22 +5,22 @@ import (
 	"testing"
 )
 
-func TestGameRunAfterAwakeExecutesQueuedHooksOnce(t *testing.T) {
+func TestGameRunBootstrapTasksExecutesQueuedHooksOnce(t *testing.T) {
 	var g Game
 
 	var got []string
-	g.deferAfterAwake(func() {
+	g.deferBootstrap(func() {
 		got = append(got, "first")
 	})
-	g.deferAfterAwake(func() {
+	g.deferBootstrap(func() {
 		got = append(got, "second")
 	})
 
-	g.runAfterAwake()
-	g.runAfterAwake()
+	g.runBootstrapTasks()
+	g.runBootstrapTasks()
 
 	want := []string{"first", "second"}
 	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("runAfterAwake got %v, want %v", got, want)
+		t.Fatalf("runBootstrapTasks got %v, want %v", got, want)
 	}
 }

--- a/runtime_sync.go
+++ b/runtime_sync.go
@@ -41,12 +41,11 @@ func (p *SpriteImpl) resetRuntimeProxy(applyCostume bool) {
 	})
 }
 
-// dispatchStartEventIfNeeded fires the start event once after the game begins running.
-func (p *Game) dispatchStartEventIfNeeded() error {
+// dispatchStartEventIfNeeded fires the start event once after bootstrap completes.
+func (p *Game) dispatchStartEventIfNeeded() {
 	coreruntime.SyncOnce(&p.lifecycleState.StartFlag, func() {
 		p.fireEvent(&eventStart{})
 	})
-	return nil
 }
 
 // updateSpriteProxies activates pending shapes, batches dirty sprite proxy changes,
@@ -73,7 +72,7 @@ func (p *Game) flushSyncBuffer() {
 }
 
 // pullPhysicsPositions retrieves sprite positions from the physics engine in batch.
-func (p *Game) pullPhysicsPositions() error {
+func (p *Game) pullPhysicsPositions() {
 	coreruntime.SyncBatchPositions(
 		p.getTempShapes(),
 		func(item Shape) bool {
@@ -88,7 +87,6 @@ func (p *Game) pullPhysicsPositions() error {
 			item.(*SpriteImpl).applyPhysicsPosition(x, y)
 		},
 	)
-	return nil
 }
 
 // processPhysicsTriggers consumes trigger events and fires collision callbacks.
@@ -153,8 +151,6 @@ func (p *baseObj) applyAtlasUVRemap() {
 	val := mathf.NewVec4(uvRemap.Position.X, uvRemap.Position.Y, uvRemap.Size.X, uvRemap.Size.Y)
 	p.setMaterialParamsVec4("atlas_uv_rect2", val, true)
 }
-
-// Sprite proxy lifecycle hooks.
 
 // ensureProxyInitialized initializes the sprite's engine proxy if it hasn't been created yet.
 func (sprite *SpriteImpl) ensureProxyInitialized() {


### PR DESCRIPTION
## Summary

This PR changes the startup implementation for `MainEntry` / sprite `Main`.

Instead of moving `Game.MainEntry` directly into `Awake`, startup work now runs in an explicit bootstrap phase before the first `Awake` / `Start`.

Fixes #1472

## Why

The previous direction tied `MainEntry` to `Awake`, but that made startup ordering fragile.

Some sprite registrations are established from `Main()`, while bootstrap setup such as collision-layer initialization still needs to observe those registrations before startup finishes. In practice, that could make ordering observable and cause startup-time behavior such as `OnTouchStart` to be missed or processed too early.

## Implementation

Startup ordering is now:

`bootstrap (Game.MainEntry -> sprite Main -> collision/camera/OnLoaded finalizer) -> Awake -> Start`

Concretely, this PR:

- queues `Game.MainEntry` into a dedicated bootstrap phase
- queues each sprite `Main` into the same bootstrap phase, serially
- keeps sprite `awake()` in the real `Awake` lifecycle
- moves collision setup, camera follow, and `OnLoaded` into a bootstrap finalizer
- starts `Start` only after bootstrap completes
- allows physics trigger processing only after `Start` has actually been dispatched
- removes the previous `afterAwake` path

## Notes

This keeps the important guarantee from the proposal:

- startup work that registers `OnStart` completes before the first `Start`
- bootstrap work that depends on `Main()` registrations runs after those registrations are established, but still before `Awake` / `Start`

It also avoids a few issues from the previous approach:

- no special-cased game `OnStart` prepend path
- no need to overload `Awake` with `MainEntry`
- no concurrent `runMain` execution from sprite awake dispatch

## Tests

- add bootstrap ordering coverage
- add bootstrap queue draining coverage
- `go test ./...`
