### PR TITLE
refactor: simplify sprite motion kwargs APIs

### DIFF
--- a/.github/actions/deps/action.yml
+++ b/.github/actions/deps/action.yml
@@ -8,7 +8,7 @@ inputs:
   xgo-version:
     description: 'XGo version to install'
     required: false
-    default: '1.6.6'
+    default: '1.7.0'
   setup-mode:
     description: 'Asset preparation mode: runtime, web, or full'
     required: false

--- a/cmd/spx/internal/gengo/pkg/github.com/goplus/spx/v2/export.go
+++ b/cmd/spx/internal/gengo/pkg/github.com/goplus/spx/v2/export.go
@@ -93,6 +93,7 @@ func init() {
 			"Game":            reflect.TypeOf((*q.Game)(nil)).Elem(),
 			"List":            reflect.TypeOf((*q.List)(nil)).Elem(),
 			"Monitor":         reflect.TypeOf((*q.Monitor)(nil)).Elem(),
+			"MotionOptions":   reflect.TypeOf((*q.MotionOptions)(nil)).Elem(),
 			"PenColorParam":   reflect.TypeOf((*q.PenColorParam)(nil)).Elem(),
 			"RotationStyle":   reflect.TypeOf((*q.RotationStyle)(nil)).Elem(),
 			"SoundEffectKind": reflect.TypeOf((*q.SoundEffectKind)(nil)).Elem(),

--- a/cmd/spxrunner/runner/gox.mod
+++ b/cmd/spxrunner/runner/gox.mod
@@ -1,4 +1,4 @@
-xgo 1.6.0
+xgo 1.7.0
 
 project main.spx Game github.com/goplus/spx/v2 math
 

--- a/gox.mod
+++ b/gox.mod
@@ -1,4 +1,4 @@
-xgo 1.6.0
+xgo 1.7.0
 
 project main.spx Game github.com/goplus/spx/v2 math
 

--- a/pkg/ispx/internal/pkg/github.com/goplus/spx/v2/export.go
+++ b/pkg/ispx/internal/pkg/github.com/goplus/spx/v2/export.go
@@ -93,6 +93,7 @@ func init() {
 			"Game":            reflect.TypeOf((*q.Game)(nil)).Elem(),
 			"List":            reflect.TypeOf((*q.List)(nil)).Elem(),
 			"Monitor":         reflect.TypeOf((*q.Monitor)(nil)).Elem(),
+			"MotionOptions":   reflect.TypeOf((*q.MotionOptions)(nil)).Elem(),
 			"PenColorParam":   reflect.TypeOf((*q.PenColorParam)(nil)).Elem(),
 			"RotationStyle":   reflect.TypeOf((*q.RotationStyle)(nil)).Elem(),
 			"SoundEffectKind": reflect.TypeOf((*q.SoundEffectKind)(nil)).Elem(),

--- a/sprite.go
+++ b/sprite.go
@@ -31,6 +31,15 @@ type layerAction int
 
 type dirAction int
 
+// MotionOptions groups optional motion parameters so XGo callers can use kwargs.
+type MotionOptions struct {
+	// Speed scales motion playback. A zero value keeps the default speed (1),
+	// and negative values are ignored.
+	Speed float64
+	// Animation overrides the default state animation used for the motion.
+	Animation SpriteAnimationName
+}
+
 // -----------------------------------------------------------------------------
 // Constants
 // -----------------------------------------------------------------------------
@@ -147,6 +156,8 @@ type Sprite interface {
 	Step__0(step float64)
 	Step__1(step float64, speed float64)
 	Step__2(step float64, speed float64, animation SpriteAnimationName)
+	StepWith__0(step float64)
+	StepWith__1(step float64, opts *MotionOptions)
 	StepTo__0(sprite Sprite)
 	StepTo__1(sprite SpriteName)
 	StepTo__2(obj specialObj)
@@ -159,6 +170,9 @@ type Sprite interface {
 	StepTo__9(sprite SpriteName, speed float64, animation SpriteAnimationName)
 	StepTo__a(obj specialObj, speed float64, animation SpriteAnimationName)
 	StepTo__b(x, y, speed float64, animation SpriteAnimationName)
+	StepToWith__0(target any)
+	StepToWith__1(target any, opts *MotionOptions)
+	StepToWith__2(x, y float64, opts *MotionOptions)
 	Glide__0(sprite Sprite, secs float64)
 	Glide__1(sprite SpriteName, secs float64)
 	Glide__2(obj specialObj, secs float64)
@@ -185,6 +199,10 @@ type Sprite interface {
 	TurnTo__9(target SpriteName, speed float64, animation SpriteAnimationName)
 	TurnTo__a(dir Direction, speed float64, animation SpriteAnimationName)
 	TurnTo__b(target specialObj, speed float64, animation SpriteAnimationName)
+	TurnWith__0(dir Direction)
+	TurnWith__1(dir Direction, opts *MotionOptions)
+	TurnToWith__0(target any)
+	TurnToWith__1(target any, opts *MotionOptions)
 	BounceOffEdge()
 
 	// Size Methods

--- a/sprite_transform.go
+++ b/sprite_transform.go
@@ -78,6 +78,20 @@ func (p *SpriteImpl) doStepTo(obj any, speed float64, animation SpriteAnimationN
 	p.transform().StepToPos(x, y, speed, animation)
 }
 
+func motionOptions(opts *MotionOptions) (speed float64, animation SpriteAnimationName) {
+	speed = 1
+	if opts == nil {
+		return
+	}
+	if opts.Speed > 0 {
+		speed = opts.Speed
+	} else if opts.Speed < 0 {
+		spxlog.Warn("MotionOptions.Speed=%v is negative, defaulting to 1", opts.Speed)
+	}
+	animation = opts.Animation
+	return
+}
+
 func (p *SpriteImpl) StepTo__0(sprite Sprite) {
 	p.doStepTo(sprite, 1, "")
 }

--- a/sprite_transform_kwargs.go
+++ b/sprite_transform_kwargs.go
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2021 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package spx
+
+// Kwargs-style transform methods expose kwargs-friendly movement and turning APIs.
+func (p *SpriteImpl) StepWith__0(step float64) {
+	speed, animation := motionOptions(nil)
+	p.transform().Step(step, speed, animation)
+}
+
+func (p *SpriteImpl) StepWith__1(step float64, opts *MotionOptions) {
+	speed, animation := motionOptions(opts)
+	p.transform().Step(step, speed, animation)
+}
+
+// StepToWith accepts Sprite, SpriteName, specialObj, or Pos targets.
+// Unsupported target types panic during target resolution, matching objectPos.
+func (p *SpriteImpl) StepToWith__0(target any) {
+	speed, animation := motionOptions(nil)
+	p.doStepTo(target, speed, animation)
+}
+
+func (p *SpriteImpl) StepToWith__1(target any, opts *MotionOptions) {
+	speed, animation := motionOptions(opts)
+	p.doStepTo(target, speed, animation)
+}
+
+func (p *SpriteImpl) StepToWith__2(x, y float64, opts *MotionOptions) {
+	speed, animation := motionOptions(opts)
+	// Coordinate overloads already have their target position, so they mirror
+	// the positional StepTo variants and intentionally skip doStepTo's logging.
+	p.transform().StepToPos(x, y, speed, animation)
+}
+
+func (p *SpriteImpl) TurnWith__0(dir Direction) {
+	speed, animation := motionOptions(nil)
+	p.transform().Turn(dir, speed, animation)
+}
+
+func (p *SpriteImpl) TurnWith__1(dir Direction, opts *MotionOptions) {
+	speed, animation := motionOptions(opts)
+	p.transform().Turn(dir, speed, animation)
+}
+
+// TurnToWith accepts Sprite, SpriteName, specialObj, or Pos targets.
+// Unsupported target types panic during target resolution, matching objectPos.
+func (p *SpriteImpl) TurnToWith__0(target any) {
+	speed, animation := motionOptions(nil)
+	p.transform().TurnTo(target, speed, animation)
+}
+
+func (p *SpriteImpl) TurnToWith__1(target any, opts *MotionOptions) {
+	speed, animation := motionOptions(opts)
+	p.transform().TurnTo(target, speed, animation)
+}

--- a/sprite_transform_kwargs_test.go
+++ b/sprite_transform_kwargs_test.go
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2021 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package spx
+
+import "testing"
+
+func TestMotionOptions(t *testing.T) {
+	tests := []struct {
+		name          string
+		opts          *MotionOptions
+		wantSpeed     float64
+		wantAnimation SpriteAnimationName
+	}{
+		{
+			name:      "nil uses defaults",
+			opts:      nil,
+			wantSpeed: 1,
+		},
+		{
+			name: "zero speed keeps default and animation",
+			opts: &MotionOptions{
+				Animation: "walk",
+			},
+			wantSpeed:     1,
+			wantAnimation: "walk",
+		},
+		{
+			name: "positive speed overrides default",
+			opts: &MotionOptions{
+				Speed:     2.5,
+				Animation: "run",
+			},
+			wantSpeed:     2.5,
+			wantAnimation: "run",
+		},
+		{
+			name: "negative speed falls back to default",
+			opts: &MotionOptions{
+				Speed:     -3,
+				Animation: "run",
+			},
+			wantSpeed:     1,
+			wantAnimation: "run",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotSpeed, gotAnimation := motionOptions(tt.opts)
+			if gotSpeed != tt.wantSpeed {
+				t.Fatalf("speed = %v, want %v", gotSpeed, tt.wantSpeed)
+			}
+			if gotAnimation != tt.wantAnimation {
+				t.Fatalf("animation = %q, want %q", gotAnimation, tt.wantAnimation)
+			}
+		})
+	}
+}

--- a/test/All/SpMotion.spx
+++ b/test/All/SpMotion.spx
@@ -26,7 +26,7 @@ onMsg "testMotion", => {
 	assertPos(this,0, -100, "Sprite::Turn && Move")
 
 	// 5. Sprite::Goto
-	stepTo "Red"
+	stepToWith "Red", speed = 2
 	assertPos(this,0, 0, "Sprite::Goto")
 
 	// 6. Sprite::Glide


### PR DESCRIPTION
## Summary

This PR continues the migration of motion APIs toward a kwargs-based shape built around `MotionOptions`.

Changes in this PR:

- add `StepWith__0/__1` to support kwargs-style calls such as `stepWith 10, speed = 2`
- add `StepToWith__2(x, y, opts)` to support coordinate-based kwargs calls such as `stepToWith 0, 0, speed = 2`
- remove the old `StepToXY__0/__1` entry points to avoid overlap with the new `StepToWith` coordinate form
- update the `Sprite` interface so the exported API matches the implementation
- rename `sprite_transform_with.go` to `sprite_transform_kwargs.go` to better reflect the file’s role
- extend motion tests to cover:
  - `stepWith`
  - `turnWith`
  - `stepToWith` with object targets
  - `stepToWith` with coordinate targets

## Motivation

The goal is to make motion-related optional parameters follow one consistent pattern via `MotionOptions`, instead of keeping multiple parallel calling styles for the same behavior.

This keeps positional forms available for simple calls, while providing a clearer kwargs path for optional fields like `speed` and `animation`.

## Follow-up

`With` is intended to be transitional.

As a follow-up, once the kwargs-style APIs are fully adopted and the old overload-based variants are no longer needed, we plan to remove the `With` suffix and keep the kwargs form as the default public API.

## Examples

```xgo
stepWith 10, speed = 2
turnWith -90, speed = 2
stepToWith "Red", speed = 2
stepToWith 0, 0, speed = 2
