### PR TITLE
chore(deps): bump xgo to 1.7.0

### DIFF
--- a/.github/actions/deps/action.yml
+++ b/.github/actions/deps/action.yml
@@ -8,7 +8,7 @@ inputs:
   xgo-version:
     description: 'XGo version to install'
     required: false
-    default: '1.6.6'
+    default: '1.7.0'
   setup-mode:
     description: 'Asset preparation mode: runtime, web, or full'
     required: false

--- a/cmd/spxrunner/runner/gox.mod
+++ b/cmd/spxrunner/runner/gox.mod
@@ -1,4 +1,4 @@
-xgo 1.6.0
+xgo 1.7.0
 
 project main.spx Game github.com/goplus/spx/v2 math
 

--- a/gox.mod
+++ b/gox.mod
@@ -1,4 +1,4 @@
-xgo 1.6.0
+xgo 1.7.0
 
 project main.spx Game github.com/goplus/spx/v2 math
 


### PR DESCRIPTION
## Summary

This PR upgrades XGo to `1.7.0` and aligns the related templates and CI defaults with the version already used in the repository.

## Changes

- bump root `gox.mod` from `xgo 1.6.0` to `xgo 1.7.0`
- bump `cmd/spxrunner/runner/gox.mod` from `xgo 1.6.0` to `xgo 1.7.0`
- update `.github/actions/deps/action.yml` default `xgo-version` from `1.6.6` to `1.7.0`

## Why

`go.mod` already depends on `github.com/goplus/xgo v1.7.0`, so this change keeps:
- repository config
- generated project template config
- CI/dependency setup

on the same XGo version to avoid version skew.

## Verification

- `go test ./...`
