### PR TITLE
Make project camera follow overridable during bootstrap

### DIFF
--- a/game_load.go
+++ b/game_load.go
@@ -192,6 +192,11 @@ func (p *Game) runSpriteCallbacks(inits []Sprite, proj *coreproject.ProjectConfi
 	if proj.Camera != nil {
 		cameraTarget = proj.Camera.On
 	}
+	// Apply the project camera target as an initial default so bootstrap hooks
+	// such as MainEntry/Main/OnLoaded can still override it later.
+	if cameraTarget != "" {
+		p.Camera.Follow__1(cameraTarget)
+	}
 	coreproject.RunSpriteInitializers(coreproject.SpriteInitConfig[Sprite]{
 		Items: inits,
 		BeforeMain: func(ini Sprite) {
@@ -210,9 +215,6 @@ func (p *Game) runSpriteCallbacks(inits []Sprite, proj *coreproject.ProjectConfi
 	})
 	p.deferBootstrapFor(generation, func() {
 		p.setupCollisionLayers(inits)
-		if cameraTarget != "" {
-			p.Camera.Follow__1(cameraTarget)
-		}
 		if onLoaded != nil {
 			onLoaded()
 		}

--- a/game_load_test.go
+++ b/game_load_test.go
@@ -1,0 +1,61 @@
+package spx
+
+import (
+	"reflect"
+	"testing"
+
+	coreproject "github.com/goplus/spx/v2/internal/core/project"
+)
+
+type cameraFollowOverrideGame struct {
+	Game
+}
+
+type cameraFollowOverrideSprite struct {
+	SpriteImpl
+	followTarget SpriteName
+}
+
+func (s *cameraFollowOverrideSprite) Main() {
+	if s.followTarget != "" {
+		s.g.Camera.Follow__1(s.followTarget)
+	}
+}
+
+func newCameraFollowOverrideSprite(g *Game, name string, followTarget SpriteName) *cameraFollowOverrideSprite {
+	sprite := &cameraFollowOverrideSprite{followTarget: followTarget}
+	sprite.g = g
+	sprite.name = name
+	sprite.sprite = sprite
+	sprite.scriptEventBindings.init(&g.scriptEvents, &sprite.SpriteImpl)
+	return sprite
+}
+
+func TestRunSpriteCallbacksKeepsManualCameraFollowLast(t *testing.T) {
+	game := &cameraFollowOverrideGame{}
+	game.initShapeMgr()
+	game.camera = &cameraImpl{g: &game.Game}
+	game.Camera = game.camera
+
+	spriteA := newCameraFollowOverrideSprite(&game.Game, "SpriteA", "")
+	spriteB := newCameraFollowOverrideSprite(&game.Game, "SpriteB", "SpriteB")
+	game.addShape(spriteOf(spriteA))
+	game.addShape(spriteOf(spriteB))
+
+	generation := game.currentBootstrapGeneration()
+	game.runSpriteCallbacks(
+		[]Sprite{spriteA, spriteB},
+		&coreproject.ProjectConfig{Camera: &coreproject.CameraConfig{On: "SpriteA"}},
+		reflect.ValueOf(game).Elem(),
+		generation,
+	)
+	game.runBootstrapTasksFor(generation)
+
+	followTarget, ok := game.camera.followTarget.(*SpriteImpl)
+	if !ok {
+		t.Fatalf("camera follow target type = %T, want *SpriteImpl", game.camera.followTarget)
+	}
+	if followTarget != spriteOf(spriteB) {
+		t.Fatalf("camera follow target = %q, want %q", followTarget.name, spriteOf(spriteB).name)
+	}
+}


### PR DESCRIPTION
## Summary

This changes the project-level `camera.on` behavior from a final bootstrap override to an initial default.

Before this change, `runSpriteCallbacks` applied the project camera target after all sprite `Main` functions had run, which meant a manual `Camera.follow(...)` inside `MainEntry` or sprite `Main` could be overwritten during bootstrap finalization.

With this change:
- project `camera.on` is applied first as the default follow target
- `MainEntry`, sprite `Main`, and `OnLoaded` can still override it later
- a regression test is added to verify that a manual camera follow set during bootstrap remains the final result

## Why

This makes bootstrap behavior match user expectation: hand-written camera follow logic should win if it runs later than the project default.

## Testing

- `go test ./... -run TestRunSpriteCallbacksKeepsManualCameraFollowLast -count=1`
