### PR TITLE
fix: stage sprite initialization before Main and refresh auto collision layers

### DIFF
--- a/component_physics.go
+++ b/component_physics.go
@@ -214,7 +214,13 @@ func (p *physicsComponent) getCollisionTargets() map[string]bool {
 }
 
 func (p *physicsComponent) addCollisionTarget(target string) {
+	if p.collisionTargets[target] {
+		return
+	}
 	p.collisionTargets[target] = true
+	if p.sprite != nil && p.sprite.g != nil {
+		p.sprite.g.refreshCollisionLayers()
+	}
 }
 
 // SetColliderShape sets the collider shape type and parameters.

--- a/game_load.go
+++ b/game_load.go
@@ -48,10 +48,10 @@ func (p *Game) loadIndex(g reflect.Value, proj *coreproject.ProjectConfig, gener
 	p.setupDisplayConfig(proj)
 	p.setupWorldAndWindow(proj)
 	p.setupPlatformAndCamera(proj)
+	p.setupAudioAndTilemap(proj)
 
 	inits := p.loadAndInitSprites(g, proj)
 	p.runSpriteCallbacks(inits, proj, g, generation)
-	p.loadAudioAndTilemap(proj)
 	return
 }
 
@@ -199,6 +199,11 @@ func (p *Game) runSpriteCallbacks(inits []Sprite, proj *coreproject.ProjectConfi
 	}
 	coreproject.RunSpriteInitializers(coreproject.SpriteInitConfig[Sprite]{
 		Items: inits,
+		Setup: func(items []Sprite) {
+			p.deferBootstrapFor(generation, func() {
+				p.setupCollisionLayers(items)
+			})
+		},
 		BeforeMain: func(ini Sprite) {
 			spr := spriteOf(ini)
 			if spr != nil {
@@ -212,19 +217,20 @@ func (p *Game) runSpriteCallbacks(inits []Sprite, proj *coreproject.ProjectConfi
 				runMain(ini.Main)
 			})
 		},
-	})
-	p.deferBootstrapFor(generation, func() {
-		p.setupCollisionLayers(inits)
-		if onLoaded != nil {
-			onLoaded()
-		}
+		OnLoaded: func() {
+			p.deferBootstrapFor(generation, func() {
+				if onLoaded != nil {
+					onLoaded()
+				}
+			})
+		},
 	})
 }
 
 // -----------------------------------------------------------------------------
 // Stage Items
 // -----------------------------------------------------------------------------
-func (p *Game) loadAudioAndTilemap(proj *coreproject.ProjectConfig) {
+func (p *Game) setupAudioAndTilemap(proj *coreproject.ProjectConfig) {
 	p.tilemapMgr.parseTilemap()
 	p.audioState.SoundObj = p.soundMgr.AllocSound()
 	if proj.Bgm != "" {

--- a/game_load_test.go
+++ b/game_load_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	coreproject "github.com/goplus/spx/v2/internal/core/project"
+	"github.com/goplus/spx/v2/internal/engine/platform"
 )
 
 type cameraFollowOverrideGame struct {
@@ -16,9 +17,24 @@ type cameraFollowOverrideSprite struct {
 	followTarget SpriteName
 }
 
+type collisionLayerOrderGame struct {
+	Game
+}
+
+type collisionLayerOrderSprite struct {
+	SpriteImpl
+	onMain func()
+}
+
 func (s *cameraFollowOverrideSprite) Main() {
 	if s.followTarget != "" {
 		s.g.Camera.Follow__1(s.followTarget)
+	}
+}
+
+func (s *collisionLayerOrderSprite) Main() {
+	if s.onMain != nil {
+		s.onMain()
 	}
 }
 
@@ -28,6 +44,16 @@ func newCameraFollowOverrideSprite(g *Game, name string, followTarget SpriteName
 	sprite.name = name
 	sprite.sprite = sprite
 	sprite.scriptEventBindings.init(&g.scriptEvents, &sprite.SpriteImpl)
+	return sprite
+}
+
+func newCollisionLayerOrderSprite(g *Game, name string, onMain func()) *collisionLayerOrderSprite {
+	sprite := &collisionLayerOrderSprite{onMain: onMain}
+	sprite.g = g
+	sprite.name = name
+	sprite.sprite = sprite
+	sprite.scriptEventBindings.init(&g.scriptEvents, &sprite.SpriteImpl)
+	sprite.components.initComponents(&sprite.SpriteImpl, &coreproject.SpriteConfig{})
 	return sprite
 }
 
@@ -57,5 +83,81 @@ func TestRunSpriteCallbacksKeepsManualCameraFollowLast(t *testing.T) {
 	}
 	if followTarget != spriteOf(spriteB) {
 		t.Fatalf("camera follow target = %q, want %q", followTarget.name, spriteOf(spriteB).name)
+	}
+}
+
+func TestRunSpriteCallbacksSetsCollisionLayersBeforeRunMain(t *testing.T) {
+	game := &collisionLayerOrderGame{}
+	game.isAutoSetCollisionLayer = true
+	game.sprCollisionInfos = map[string]*spriteCollisionInfo{
+		"SpriteA": {Index: 0, Layer: 1 << 0},
+		"SpriteB": {Index: 1, Layer: 1 << 1},
+	}
+
+	var spriteA *collisionLayerOrderSprite
+	spriteA = newCollisionLayerOrderSprite(&game.Game, "SpriteA", func() {
+		delete(spriteA.physics().collisionTargets, "SpriteB")
+	})
+	spriteB := newCollisionLayerOrderSprite(&game.Game, "SpriteB", nil)
+
+	spriteA.physics().addCollisionTarget("SpriteB")
+	spriteB.physics().addCollisionTarget("SpriteA")
+
+	generation := game.currentBootstrapGeneration()
+	platform.RunOnMainThread(func() {
+		game.runSpriteCallbacks(
+			[]Sprite{spriteA, spriteB},
+			&coreproject.ProjectConfig{},
+			reflect.ValueOf(game).Elem(),
+			generation,
+		)
+	})
+	platform.RunOnMainThread(func() {
+		game.runBootstrapTasksFor(generation)
+	})
+
+	if got := game.sprCollisionInfos["SpriteA"].Mask; got != game.sprCollisionInfos["SpriteB"].Layer {
+		t.Fatalf("SpriteA collision mask = %d, want %d", got, game.sprCollisionInfos["SpriteB"].Layer)
+	}
+	if got := game.sprCollisionInfos["SpriteB"].Mask; got != game.sprCollisionInfos["SpriteA"].Layer {
+		t.Fatalf("SpriteB collision mask = %d, want %d", got, game.sprCollisionInfos["SpriteA"].Layer)
+	}
+}
+
+func TestRunSpriteCallbacksRefreshesCollisionLayersRegisteredInMain(t *testing.T) {
+	game := &collisionLayerOrderGame{}
+	game.initShapeMgr()
+	game.isAutoSetCollisionLayer = true
+	game.sprCollisionInfos = map[string]*spriteCollisionInfo{
+		"SpriteA": {Index: 0, Layer: 1 << 0},
+		"SpriteB": {Index: 1, Layer: 1 << 1},
+	}
+
+	var spriteA *collisionLayerOrderSprite
+	spriteA = newCollisionLayerOrderSprite(&game.Game, "SpriteA", func() {
+		spriteA.OnTouchStart__0("SpriteB", func() {})
+	})
+	spriteB := newCollisionLayerOrderSprite(&game.Game, "SpriteB", nil)
+	game.addShape(spriteOf(spriteA))
+	game.addShape(spriteOf(spriteB))
+
+	generation := game.currentBootstrapGeneration()
+	platform.RunOnMainThread(func() {
+		game.runSpriteCallbacks(
+			[]Sprite{spriteA, spriteB},
+			&coreproject.ProjectConfig{},
+			reflect.ValueOf(game).Elem(),
+			generation,
+		)
+	})
+	platform.RunOnMainThread(func() {
+		game.runBootstrapTasksFor(generation)
+	})
+
+	if got := game.sprCollisionInfos["SpriteA"].Mask; got != game.sprCollisionInfos["SpriteB"].Layer {
+		t.Fatalf("SpriteA collision mask = %d, want %d", got, game.sprCollisionInfos["SpriteB"].Layer)
+	}
+	if got := game.sprCollisionInfos["SpriteB"].Mask; got != 0 {
+		t.Fatalf("SpriteB collision mask = %d, want 0", got)
 	}
 }

--- a/game_physics.go
+++ b/game_physics.go
@@ -178,27 +178,15 @@ func (p *Game) setupCollisionLayers(inits []Sprite) {
 		return
 	}
 
-	spriteData := p.buildSpriteCollisionData(inits)
-	maskMap := make([]int64, maxCollisionLayerIdx)
+	p.applyCollisionLayers(p.buildSpriteCollisionData(inits))
+}
 
-	for _, data := range spriteData {
-		data.info.Mask = 0
-		for target := range data.sprite.physics().getCollisionTargets() {
-			targetInfo := p.getSpriteCollisionInfo(target)
-			maskMap[data.modIdx] |= targetInfo.Layer
-		}
+func (p *Game) refreshCollisionLayers() {
+	if !p.isAutoSetCollisionLayer {
+		return
 	}
 
-	for _, data := range spriteData {
-		data.info.Mask = maskMap[data.modIdx]
-		spxlog.Debug("init sprite collision info: name=%s, layer=%d, mask=%d", data.sprite.name, data.info.Layer, data.info.Mask)
-	}
-
-	engine.WaitMainThread(func() {
-		for _, data := range spriteData {
-			data.sprite.applyPhysicsProxyConfig()
-		}
-	})
+	p.applyCollisionLayers(p.buildActiveSpriteCollisionData())
 }
 
 // -----------------------------------------------------------------------------
@@ -220,6 +208,9 @@ func (p *Game) buildSpriteCollisionData(inits []Sprite) []*spriteCollisionData {
 	spriteData := make([]*spriteCollisionData, 0, len(inits))
 	for _, ini := range inits {
 		spr := spriteOf(ini)
+		if spr == nil {
+			continue
+		}
 		info := p.getSpriteCollisionInfo(spr.name)
 		spriteData = append(spriteData, &spriteCollisionData{
 			sprite: spr,
@@ -228,6 +219,51 @@ func (p *Game) buildSpriteCollisionData(inits []Sprite) []*spriteCollisionData {
 		})
 	}
 	return spriteData
+}
+
+func (p *Game) buildActiveSpriteCollisionData() []*spriteCollisionData {
+	shapes := p.getTempShapes()
+	spriteData := make([]*spriteCollisionData, 0, len(shapes))
+	for _, item := range shapes {
+		spr, ok := item.(*SpriteImpl)
+		if !ok {
+			continue
+		}
+		info := p.getSpriteCollisionInfo(spr.name)
+		spriteData = append(spriteData, &spriteCollisionData{
+			sprite: spr,
+			info:   info,
+			modIdx: getCollisionLayerIndex(info),
+		})
+	}
+	return spriteData
+}
+
+func (p *Game) applyCollisionLayers(spriteData []*spriteCollisionData) {
+	if len(spriteData) == 0 {
+		return
+	}
+
+	maskMap := make([]int64, maxCollisionLayerIdx)
+
+	for _, data := range spriteData {
+		data.info.Mask = 0
+		for target := range data.sprite.physics().getCollisionTargets() {
+			targetInfo := p.getSpriteCollisionInfo(target)
+			maskMap[data.modIdx] |= targetInfo.Layer
+		}
+	}
+
+	for _, data := range spriteData {
+		data.info.Mask = maskMap[data.modIdx]
+		spxlog.Debug("init sprite collision info: name=%s, layer=%d, mask=%d", data.sprite.name, data.info.Layer, data.info.Mask)
+	}
+
+	engine.WaitMainThread(func() {
+		for _, data := range spriteData {
+			data.sprite.applyPhysicsProxyConfig()
+		}
+	})
 }
 
 func (p *Game) checkCollision(ary any) []Sprite {

--- a/internal/core/project/load.go
+++ b/internal/core/project/load.go
@@ -23,8 +23,10 @@ import (
 
 type SpriteInitConfig[T any] struct {
 	Items      []T
+	Setup      func([]T)
 	BeforeMain func(T)
 	RunMain    func(T)
+	OnLoaded   func()
 }
 
 func WalkZOrder(
@@ -51,13 +53,21 @@ func WalkZOrder(
 }
 
 func RunSpriteInitializers[T any](cfg SpriteInitConfig[T]) {
+	if cfg.Setup != nil {
+		cfg.Setup(cfg.Items)
+	}
 	for _, item := range cfg.Items {
 		if cfg.BeforeMain != nil {
 			cfg.BeforeMain(item)
 		}
+	}
+	for _, item := range cfg.Items {
 		if cfg.RunMain != nil {
 			cfg.RunMain(item)
 		}
+	}
+	if cfg.OnLoaded != nil {
+		cfg.OnLoaded()
 	}
 }
 

--- a/internal/core/project/project_test.go
+++ b/internal/core/project/project_test.go
@@ -476,14 +476,20 @@ func TestRunSpriteInitializers(t *testing.T) {
 	var got []string
 	RunSpriteInitializers(SpriteInitConfig[string]{
 		Items: []string{"a", "b"},
+		Setup: func(items []string) {
+			got = append(got, "setup")
+		},
 		BeforeMain: func(item string) {
 			got = append(got, "before:"+item)
 		},
 		RunMain: func(item string) {
 			got = append(got, "main:"+item)
 		},
+		OnLoaded: func() {
+			got = append(got, "loaded")
+		},
 	})
-	want := []string{"before:a", "main:a", "before:b", "main:b"}
+	want := []string{"setup", "before:a", "before:b", "main:a", "main:b", "loaded"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("RunSpriteInitializers got %v, want %v", got, want)
 	}

--- a/runtime_sync.go
+++ b/runtime_sync.go
@@ -195,6 +195,9 @@ func (sprite *SpriteImpl) handleAnimationLooped() {
 }
 
 func (sprite *SpriteImpl) applyPhysicsProxyConfig() {
+	if sprite.runtimeState.SyncSprite == nil {
+		return
+	}
 	sprite.physics().applyPhysicsProxyConfig(sprite.runtimeState.SyncSprite)
 }
 


### PR DESCRIPTION
## Summary
- add a one-time `Setup` phase to `RunSpriteInitializers`
- move `setupCollisionLayers` into that setup phase so it only queues once before sprite `Main`
- refresh auto collision layers when touch handlers register collision targets during `Main`

## Problem
Auto collision layer setup is bootstrap work, but the collision targets it reads are usually populated from `OnTouchStart...` registrations inside sprite `Main`. That created an awkward choice:

- keeping `setupCollisionLayers` inside `RunMain` repeated the work once per sprite
- moving it earlier made it run before the collision target set was populated

## Solution
This change separates sprite initialization into `Setup -> BeforeMain(all) -> RunMain(all)` and uses that setup phase to queue collision layer setup once per scene load.

To remove the remaining dependency on `Main` completion, `addCollisionTarget` now triggers an auto collision layer refresh for active sprites whenever a new target is registered. That keeps masks in sync even when handlers are declared during `Main`, and a nil-proxy guard keeps the refresh path safe during early bootstrap.

## Testing
- `go test ./... -run 'TestRunSpriteInitializers|TestRunSpriteCallbacks'`

Related to the phased bootstrap direction discussed in #1472.
