### PR TITLE
feat(classfile): annotate spx resource schema

### DIFF
--- a/monitor.go
+++ b/monitor.go
@@ -39,6 +39,9 @@ const (
 // -----------------------------------------------------------------------------
 // Monitor
 // -----------------------------------------------------------------------------
+// Monitor is the concrete runtime widget used for stage monitor entries.
+//
+//xgo:class:resource widget
 type Monitor struct {
 	game        *Game
 	name        WidgetName

--- a/sprite.go
+++ b/sprite.go
@@ -110,6 +110,8 @@ const (
 // -----------------------------------------------------------------------------
 // Sprite Interface
 // -----------------------------------------------------------------------------
+//
+//xgo:class:resource sprite
 type Sprite interface {
 	IEventSinks
 	Shape
@@ -146,6 +148,7 @@ type Sprite interface {
 	// Movement Methods
 	Step__0(step float64)
 	Step__1(step float64, speed float64)
+	//xgo:class:resource-api-scope-binding param.2 receiver
 	Step__2(step float64, speed float64, animation SpriteAnimationName)
 	StepTo__0(sprite Sprite)
 	StepTo__1(sprite SpriteName)
@@ -155,9 +158,17 @@ type Sprite interface {
 	StepTo__5(sprite SpriteName, speed float64)
 	StepTo__6(obj specialObj, speed float64)
 	StepTo__7(x, y, speed float64)
+
+	//xgo:class:resource-api-scope-binding param.2 receiver
 	StepTo__8(sprite Sprite, speed float64, animation SpriteAnimationName)
+
+	//xgo:class:resource-api-scope-binding param.2 receiver
 	StepTo__9(sprite SpriteName, speed float64, animation SpriteAnimationName)
+
+	//xgo:class:resource-api-scope-binding param.2 receiver
 	StepTo__a(obj specialObj, speed float64, animation SpriteAnimationName)
+
+	//xgo:class:resource-api-scope-binding param.3 receiver
 	StepTo__b(x, y, speed float64, animation SpriteAnimationName)
 	Glide__0(sprite Sprite, secs float64)
 	Glide__1(sprite SpriteName, secs float64)
@@ -172,6 +183,7 @@ type Sprite interface {
 	SetRotationStyle(style RotationStyle)
 	Turn__0(dir Direction)
 	Turn__1(dir Direction, speed float64)
+	//xgo:class:resource-api-scope-binding param.2 receiver
 	Turn__2(dir Direction, speed float64, animation SpriteAnimationName)
 	TurnTo__0(target Sprite)
 	TurnTo__1(target SpriteName)
@@ -181,9 +193,17 @@ type Sprite interface {
 	TurnTo__5(target SpriteName, speed float64)
 	TurnTo__6(dir Direction, speed float64)
 	TurnTo__7(target specialObj, speed float64)
+
+	//xgo:class:resource-api-scope-binding param.2 receiver
 	TurnTo__8(target Sprite, speed float64, animation SpriteAnimationName)
+
+	//xgo:class:resource-api-scope-binding param.2 receiver
 	TurnTo__9(target SpriteName, speed float64, animation SpriteAnimationName)
+
+	//xgo:class:resource-api-scope-binding param.2 receiver
 	TurnTo__a(dir Direction, speed float64, animation SpriteAnimationName)
+
+	//xgo:class:resource-api-scope-binding param.2 receiver
 	TurnTo__b(target specialObj, speed float64, animation SpriteAnimationName)
 	BounceOffEdge()
 
@@ -199,15 +219,25 @@ type Sprite interface {
 	// Costume Methods
 	CostumeName() SpriteCostumeName
 	CostumeIndex() int
+
+	//xgo:class:resource-api-scope-binding param.0 receiver
 	SetCostume__0(costume SpriteCostumeName)
 	SetCostume__1(index float64)
 	SetCostume__2(index int)
 	SetCostume__3(action switchAction)
 
 	// Animation Methods
+
+	//xgo:class:resource-api-scope-binding param.0 receiver
 	Animate__0(name SpriteAnimationName)
+
+	//xgo:class:resource-api-scope-binding param.0 receiver
 	Animate__1(name SpriteAnimationName, loop bool)
+
+	//xgo:class:resource-api-scope-binding param.0 receiver
 	AnimateAndWait(name SpriteAnimationName)
+
+	//xgo:class:resource-api-scope-binding param.0 receiver
 	StopAnimation(name SpriteAnimationName)
 
 	// Graphic Effects Methods

--- a/sprite_animation.go
+++ b/sprite_animation.go
@@ -142,10 +142,12 @@ func (p *SpriteImpl) playDefaultAnim() {
 // -----------------------------------------------------------------------------
 // Playback
 // -----------------------------------------------------------------------------
+//xgo:class:resource-api-scope-binding param.0 receiver
 func (p *SpriteImpl) Animate__0(name SpriteAnimationName) {
 	p.Animate__1(name, false)
 }
 
+//xgo:class:resource-api-scope-binding param.0 receiver
 func (p *SpriteImpl) Animate__1(name SpriteAnimationName, loop bool) {
 	if isDebugInstrEnabled() {
 		spxlog.Debug("==> Animation %s", name)
@@ -153,6 +155,7 @@ func (p *SpriteImpl) Animate__1(name SpriteAnimationName, loop bool) {
 	p.animation().Animate(name, loop)
 }
 
+//xgo:class:resource-api-scope-binding param.0 receiver
 func (p *SpriteImpl) AnimateAndWait(name SpriteAnimationName) {
 	if isDebugInstrEnabled() {
 		spxlog.Debug("==> AnimateAndWait %s", name)
@@ -160,6 +163,7 @@ func (p *SpriteImpl) AnimateAndWait(name SpriteAnimationName) {
 	p.animation().AnimateAndWait(name)
 }
 
+//xgo:class:resource-api-scope-binding param.0 receiver
 func (p *SpriteImpl) StopAnimation(name SpriteAnimationName) {
 	p.animation().StopAnimation(name)
 }

--- a/sprite_core.go
+++ b/sprite_core.go
@@ -27,6 +27,8 @@ import (
 )
 
 // SpriteImpl is the concrete implementation of the Sprite interface.
+//
+//xgo:class:resource sprite
 type SpriteImpl struct {
 	baseObj
 	scriptEventBindings

--- a/sprite_render.go
+++ b/sprite_render.go
@@ -71,6 +71,7 @@ func (p *SpriteImpl) setCostume(costume any) {
 	p.spriteState.IsDirty = true
 }
 
+//xgo:class:resource-api-scope-binding param.0 receiver
 func (p *SpriteImpl) SetCostume__0(costume SpriteCostumeName) {
 	p.setCostume(costume)
 }

--- a/sprite_transform.go
+++ b/sprite_transform.go
@@ -66,6 +66,7 @@ func (p *SpriteImpl) Step__1(step float64, speed float64) {
 	p.transform().Step(step, speed, "")
 }
 
+//xgo:class:resource-api-scope-binding param.2 receiver
 func (p *SpriteImpl) Step__2(step float64, speed float64, animation SpriteAnimationName) {
 	p.transform().Step(step, speed, animation)
 }
@@ -110,18 +111,22 @@ func (p *SpriteImpl) StepTo__7(x, y, speed float64) {
 	p.transform().StepToPos(x, y, speed, "")
 }
 
+//xgo:class:resource-api-scope-binding param.2 receiver
 func (p *SpriteImpl) StepTo__8(sprite Sprite, speed float64, animation SpriteAnimationName) {
 	p.doStepTo(sprite, speed, animation)
 }
 
+//xgo:class:resource-api-scope-binding param.2 receiver
 func (p *SpriteImpl) StepTo__9(sprite SpriteName, speed float64, animation SpriteAnimationName) {
 	p.doStepTo(sprite, speed, animation)
 }
 
+//xgo:class:resource-api-scope-binding param.2 receiver
 func (p *SpriteImpl) StepTo__a(obj specialObj, speed float64, animation SpriteAnimationName) {
 	p.doStepTo(obj, speed, animation)
 }
 
+//xgo:class:resource-api-scope-binding param.3 receiver
 func (p *SpriteImpl) StepTo__b(x, y, speed float64, animation SpriteAnimationName) {
 	p.transform().StepToPos(x, y, speed, animation)
 }
@@ -205,6 +210,7 @@ func (p *SpriteImpl) Turn__1(dir Direction, speed float64) {
 	p.transform().Turn(dir, speed, "")
 }
 
+//xgo:class:resource-api-scope-binding param.2 receiver
 func (p *SpriteImpl) Turn__2(dir Direction, speed float64, animation SpriteAnimationName) {
 	p.transform().Turn(dir, speed, animation)
 }
@@ -241,18 +247,22 @@ func (p *SpriteImpl) TurnTo__7(target specialObj, speed float64) {
 	p.transform().TurnTo(target, speed, "")
 }
 
+//xgo:class:resource-api-scope-binding param.2 receiver
 func (p *SpriteImpl) TurnTo__8(target Sprite, speed float64, animation SpriteAnimationName) {
 	p.transform().TurnTo(target, speed, animation)
 }
 
+//xgo:class:resource-api-scope-binding param.2 receiver
 func (p *SpriteImpl) TurnTo__9(target SpriteName, speed float64, animation SpriteAnimationName) {
 	p.transform().TurnTo(target, speed, animation)
 }
 
+//xgo:class:resource-api-scope-binding param.2 receiver
 func (p *SpriteImpl) TurnTo__a(dir Direction, speed float64, animation SpriteAnimationName) {
 	p.transform().TurnTo(dir, speed, animation)
 }
 
+//xgo:class:resource-api-scope-binding param.2 receiver
 func (p *SpriteImpl) TurnTo__b(target specialObj, speed float64, animation SpriteAnimationName) {
 	p.transform().TurnTo(target, speed, animation)
 }

--- a/types.go
+++ b/types.go
@@ -31,6 +31,9 @@ type Shape any
 // Event types.
 type (
 	// BackdropName identifies a stage backdrop.
+	//
+	//xgo:class:resource backdrop
+	//xgo:class:resource-discovery backdrops.*
 	BackdropName = coreevent.BackdropName
 
 	// Direction represents a heading or swipe direction.
@@ -52,22 +55,39 @@ type (
 // Name types.
 type (
 	// SoundName identifies a registered sound asset.
+	//
+	//xgo:class:resource sound
+	//xgo:class:resource-discovery sounds.*
 	SoundName = string
 
 	// SpriteName identifies a sprite instance or prototype by name.
+	//
+	//xgo:class:resource sprite
+	//xgo:class:resource-discovery sprites.*
 	SpriteName = string
 
 	// SpriteCostumeName identifies a sprite costume by name.
+	//
+	//xgo:class:resource sprite.costume
+	//xgo:class:resource-discovery costumes.*
 	SpriteCostumeName = string
 
 	// SpriteAnimationName identifies a sprite animation by name.
+	//
+	//xgo:class:resource sprite.animation
+	//xgo:class:resource-discovery fAnimations.*
 	SpriteAnimationName = string
 
 	// WidgetName identifies a widget by name.
+	//
+	//xgo:class:resource widget
+	//xgo:class:resource-discovery zorder.*@($type == "monitor" || $type == "stageMonitor")
 	WidgetName = string
 )
 
 // Widget is the common interface for runtime UI objects stored by the game.
+//
+//xgo:class:resource widget
 type Widget interface {
 	GetName() WidgetName
 	Visible() bool


### PR DESCRIPTION
Add classfile resource directives to the exported resource name types and handle-bearing widget and sprite types in spx.

Also annotate the public `Sprite` API surface and the corresponding `SpriteImpl` methods with `resource-api-scope-binding` directives for scoped costume and animation resources.

Updates goplus/xgo#2704