### PR TITLE
fix(build): split generate targets and pack runner assets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Config
 # ============================================
 .DEFAULT_GOAL := help
-.PHONY: help buildctl list-demos prepare-host prepare-web prepare-full prepare-all build-dev install clean-assets download download-engine build-editor build-desktop build-web build-wasm build-wasm-opt build-android build-ios install-apk editor run rune run-web run-web-worker format generate clean-projects export-pack export-web stop validate-web-mode validate-download-engine validate-install-web
+.PHONY: help buildctl list-demos prepare-host prepare-web prepare-full prepare-all build-dev install clean-assets download download-engine build-editor build-desktop build-web build-wasm build-wasm-opt build-android build-ios install-apk editor run rune run-web run-web-worker format generate generate-bindings generate-runtime clean-projects export-pack export-web stop validate-web-mode validate-download-engine validate-install-web
 
 export GODOT_SRC
 
@@ -187,10 +187,17 @@ stop: ## Stop running processes
 format: ## Format Go code
 	go fmt ./...
 
-generate: ## Generate code
-	cd ./internal/cmd/codegen && GODOT_SRC="$(GODOT_SRC)" go run .
-	go generate ./cmd/spxrunner/runner
+generate: ## Generate all code
+	$(MAKE) generate-bindings
+	$(MAKE) generate-runtime
 	$(MAKE) format
+
+generate-bindings: ## Generate Godot/GDExtension binding code
+	cd ./internal/cmd/codegen && GODOT_SRC="$(GODOT_SRC)" go run .
+
+generate-runtime: ## Generate runtime registration code
+	go generate ./pkg/ispx
+	go generate ./cmd/spxrunner/runner
 
 clean-projects: ## Delete generated artifacts (.temp/, project/, .gdspx_web_server*.pid, go.mod, go.sum, gox.mod) from tutorial/test projects
 	@find -P tutorial test \( \

--- a/cmd/spxrunner/runner/gox.mod
+++ b/cmd/spxrunner/runner/gox.mod
@@ -4,4 +4,6 @@ project main.spx Game github.com/goplus/spx/v2 math
 
 class -embed *.spx SpriteImpl
 
+pack assets index.json
+
 runner github.com/goplus/spx/v2/cmd/spxrunner


### PR DESCRIPTION
## Summary
- split `make generate` into `generate-bindings` and `generate-runtime`
- make `generate` run both binding generation and runtime registration generation before formatting
- add `go generate ./pkg/ispx` to the runtime generation flow
- sync `cmd/spxrunner/runner/gox.mod` with the root template by adding `pack assets index.json`

## Testing
- `make -n generate`
- `go generate -n ./pkg/ispx ./cmd/spxrunner/runner`
- `git diff --check`
