### PR TITLE
ci: tolerate completed Windows goenv warm-up exits

### DIFF
--- a/.github/actions/prepare-release-goenv/action.yml
+++ b/.github/actions/prepare-release-goenv/action.yml
@@ -62,6 +62,7 @@ runs:
         PACKAGED_SPX="$PACKAGED_BIN_DIR/spx$GOEXE"
         DEST="$GOENV_ROOT/.cache/mod/github.com/goplus/spx/v2@$RELEASE_VERSION"
         SMOKE_LOG_PATH="$GOENV_ROOT/prepare-release-goenv.log"
+        SMOKE_SUCCESS_MARKER_REGEX='Spx(CI)?RunSucc'
         TARGET_PLATFORM="$(normalize_platform "$PLATFORM")"
         TARGET_ARCH="$(normalize_arch "$PACKAGE_ARCH")"
         RUNNER_PLATFORM="$(normalize_platform "$RUNNER_OS_CONTEXT")"
@@ -160,9 +161,14 @@ runs:
           kill "$SPX_PID" 2>/dev/null || true
           wait "$SPX_PID" 2>/dev/null || true
         elif [ "$EXIT_STATUS" -ne 0 ]; then
-          echo "❌ Error: dependency warm-up run failed"
-          cat "$SMOKE_LOG_PATH"
-          exit 1
+          if [ "$RUNNER_PLATFORM" = "windows" ] && grep -Eq "$SMOKE_SUCCESS_MARKER_REGEX" "$SMOKE_LOG_PATH"; then
+            echo "Dependency warm-up reached success marker but exited with status $EXIT_STATUS."
+            echo "Continuing because Windows gdspxrt can occasionally fail during shutdown after the project completed."
+          else
+            echo "❌ Error: dependency warm-up run failed"
+            cat "$SMOKE_LOG_PATH"
+            exit 1
+          fi
         fi
 
         if ! find "$GOMODCACHE_DIR" -type d -name '*@*' ! -path "$DEST" -print -quit | grep -q .; then


### PR DESCRIPTION
## Summary
- Treat Windows goenv warm-up as successful when the smoke log already contains the SPX success marker
- Keep non-Windows failures and Windows failures without the marker as hard failures

## Verification
- Extracted prepare-release-goenv bash body and ran `bash -n`