### PR TITLE
ci: share Windows gdspxrt shutdown tolerance

### DIFF
--- a/.github/actions/lib/release_platform.sh
+++ b/.github/actions/lib/release_platform.sh
@@ -33,3 +33,15 @@ normalize_arch() {
       ;;
   esac
 }
+
+spx_smoke_reached_success() {
+  local log_path="$1"
+  grep -Eq 'Spx(CI)?RunSucc' "$log_path"
+}
+
+should_tolerate_windows_gdspxrt_shutdown_exit() {
+  local runner_platform="$1"
+  local log_path="$2"
+
+  [ "$runner_platform" = "windows" ] && spx_smoke_reached_success "$log_path"
+}

--- a/.github/actions/prepare-release-goenv/action.yml
+++ b/.github/actions/prepare-release-goenv/action.yml
@@ -62,7 +62,6 @@ runs:
         PACKAGED_SPX="$PACKAGED_BIN_DIR/spx$GOEXE"
         DEST="$GOENV_ROOT/.cache/mod/github.com/goplus/spx/v2@$RELEASE_VERSION"
         SMOKE_LOG_PATH="$GOENV_ROOT/prepare-release-goenv.log"
-        SMOKE_SUCCESS_MARKER_REGEX='Spx(CI)?RunSucc'
         TARGET_PLATFORM="$(normalize_platform "$PLATFORM")"
         TARGET_ARCH="$(normalize_arch "$PACKAGE_ARCH")"
         RUNNER_PLATFORM="$(normalize_platform "$RUNNER_OS_CONTEXT")"
@@ -174,7 +173,7 @@ runs:
           kill "$SPX_PID" 2>/dev/null || true
           wait "$SPX_PID" 2>/dev/null || true
         elif [ "$EXIT_STATUS" -ne 0 ]; then
-          if [ "$RUNNER_PLATFORM" = "windows" ] && grep -Eq "$SMOKE_SUCCESS_MARKER_REGEX" "$SMOKE_LOG_PATH"; then
+          if should_tolerate_windows_gdspxrt_shutdown_exit "$RUNNER_PLATFORM" "$SMOKE_LOG_PATH"; then
             echo "Dependency warm-up reached success marker but exited with status $EXIT_STATUS."
             echo "Continuing because Windows gdspxrt can occasionally fail during shutdown after the project completed."
           else

--- a/.github/actions/verify-release/action.yml
+++ b/.github/actions/verify-release/action.yml
@@ -285,12 +285,25 @@ runs:
         "$STANDALONE_SPX" run --path="$TEST_PROJECT_DIR" --headless 2>&1 | tee "$VERIFY_LOG_PATH"
         SPX_STATUS=${PIPESTATUS[0]}
         set -e
-        if [ "$SPX_STATUS" -ne 0 ]; then
-          echo "❌ Error: smoke test command failed (exit $SPX_STATUS)"
-          exit 1
+
+        SMOKE_REACHED_SUCCESS=false
+        if spx_smoke_reached_success "$VERIFY_LOG_PATH"; then
+          SMOKE_REACHED_SUCCESS=true
         fi
 
-        if ! grep -q "===>SpxCIRunSucc" "$VERIFY_LOG_PATH"; then
+        if [ "$SPX_STATUS" -ne 0 ]; then
+          if should_tolerate_windows_gdspxrt_shutdown_exit "$RUNNER_PLATFORM" "$VERIFY_LOG_PATH"; then
+            echo "Smoke test reached success marker but exited with status $SPX_STATUS."
+            echo "Continuing because Windows gdspxrt can occasionally fail during shutdown after the project completed."
+          else
+            echo "❌ Error: smoke test command failed (exit $SPX_STATUS)"
+            echo "Smoke test log:"
+            cat "$VERIFY_LOG_PATH"
+            exit 1
+          fi
+        fi
+
+        if [ "$SMOKE_REACHED_SUCCESS" != true ]; then
           echo "❌ Error: smoke test success marker not found"
           echo "Smoke test log:"
           cat "$VERIFY_LOG_PATH"


### PR DESCRIPTION
## Summary
- Add shared release-action helpers for SPX smoke success marker detection and Windows gdspxrt shutdown tolerance
- Reuse the helper from prepare-release-goenv instead of keeping the marker regex inline
- Use the same helper in verify-release so Windows smoke runs that already reached the success marker are not failed by intermittent shutdown exits
- Keep non-Windows failures and Windows failures without the marker as hard failures

## Verification
- `bash -n .github/actions/lib/release_platform.sh`
- Extracted prepare-release-goenv bash body and ran `bash -n`
- Extracted verify-release bash body and ran `bash -n`
- Sourced release_platform.sh and smoke-tested the helper against a temp log marker