### PR TITLE
Optimize standalone release setup flow

### DIFF
--- a/.github/actions/deps/action.yml
+++ b/.github/actions/deps/action.yml
@@ -10,7 +10,7 @@ inputs:
     required: false
     default: '1.7.1'
   setup-mode:
-    description: 'Asset preparation mode: runtime, web, or full'
+    description: 'Asset preparation mode: none, runtime, web, or full'
     required: false
     default: 'runtime'
   web-mode:

--- a/.github/workflows/release_linux.yml
+++ b/.github/workflows/release_linux.yml
@@ -25,6 +25,8 @@ jobs:
 
       - name: Set up toolchain and engine assets
         uses: ./.github/actions/deps
+        with:
+          setup-mode: none
 
       - name: Prepare standalone release
         id: prepare_standalone_release

--- a/.github/workflows/release_macos.yml
+++ b/.github/workflows/release_macos.yml
@@ -29,6 +29,8 @@ jobs:
 
       - name: Set up toolchain and engine assets
         uses: ./.github/actions/deps
+        with:
+          setup-mode: none
 
       - name: Prepare standalone release
         id: prepare_standalone_release

--- a/.github/workflows/release_windows.yml
+++ b/.github/workflows/release_windows.yml
@@ -33,6 +33,8 @@ jobs:
 
       - name: Set up toolchain and engine assets
         uses: ./.github/actions/deps
+        with:
+          setup-mode: none
 
       - name: Prepare standalone release
         id: prepare_standalone_release

--- a/internal/cmd/buildctl/prepare.go
+++ b/internal/cmd/buildctl/prepare.go
@@ -63,7 +63,7 @@ func parsePrepareArgs(args []string) (prepareConfig, error) {
 	fs.StringVar(&cfg.webMode, "web-mode", cfg.webMode, "web mode: normal, worker, minigame, or miniprogram")
 
 	fs.Usage = func() {
-		fmt.Fprintln(os.Stderr, "Usage: buildctl prepare [--setup-mode runtime|web|full] [--web-mode normal|worker|minigame|miniprogram]")
+		fmt.Fprintln(os.Stderr, "Usage: buildctl prepare [--setup-mode none|runtime|web|full] [--web-mode normal|worker|minigame|miniprogram]")
 	}
 
 	if err := fs.Parse(args); err != nil {
@@ -93,6 +93,8 @@ func (cfg prepareConfig) validate() error {
 
 func prepareAssets(cfg prepareConfig, runner shared.ScriptRunner) error {
 	switch cfg.setupMode {
+	case "none":
+		return nil
 	case "runtime":
 		if err := runner.RunScript(filepath.Join("cmd", "spx", "install.sh")); err != nil {
 			return err

--- a/internal/cmd/buildctl/prepare_test.go
+++ b/internal/cmd/buildctl/prepare_test.go
@@ -188,6 +188,22 @@ func TestPrepareAssetsRuntime(t *testing.T) {
 	}
 }
 
+func TestPrepareAssetsNone(t *testing.T) {
+	runner := newRuntimeFixtureRunner(t)
+	cfg := prepareConfig{setupMode: "none", webMode: "normal"}
+
+	if err := prepareAssets(cfg, runner); err != nil {
+		t.Fatalf("prepareAssets returned error: %v", err)
+	}
+
+	if len(runner.calls) != 0 {
+		t.Fatalf("unexpected script calls: %#v", runner.calls)
+	}
+	if len(runner.commands) != 0 {
+		t.Fatalf("unexpected commands: %#v", runner.commands)
+	}
+}
+
 func TestPrepareAssetsWeb(t *testing.T) {
 	runner := newRuntimeFixtureRunner(t)
 	installFakeEngineDownload(t, runner.repoRoot, "linux", "x86_64")

--- a/internal/cmd/buildctl/shared/validate.go
+++ b/internal/cmd/buildctl/shared/validate.go
@@ -20,7 +20,7 @@ import "fmt"
 
 func validateSetupMode(mode string) error {
 	switch mode {
-	case "runtime", "web", "full":
+	case "none", "runtime", "web", "full":
 		return nil
 	default:
 		return fmt.Errorf("unsupported setup-mode: %s", mode)


### PR DESCRIPTION
## Background

The standalone release pipeline currently prepares runtime assets twice.

During the `deps` step, it runs `buildctl prepare --setup-mode runtime`, which invokes `cmd/spx/install.sh` and preloads runtime assets. Later, `prepare-standalone-release` runs `buildctl tool install` again to rebuild and reinstall `spx`.

For `spx` releases, this adds unnecessary setup work to the critical path. Godot/runtime builds are relatively low frequency and should not need to be eagerly prepared before the actual standalone packaging step.

## Changes

- Added `setup-mode=none` to `buildctl prepare`
- Updated the `deps` action documentation to include `none`
- Switched Linux, macOS, and Windows standalone release workflows to use `setup-mode: none`
- Kept existing web and other `prepare` flows unchanged
- Added test coverage for the new no-op prepare mode

## Result

- Standalone release jobs no longer perform redundant runtime/Godot preparation before the real `tool install`
- `spx` releases still resolve runtime versions through the existing `release_meta` mapping
- The release path is shorter and avoids one unnecessary install/build cycle

## Validation

- `go test ./internal/cmd/buildctl/...`
