### PR TITLE
fix(web): stop game execution after exit

### DIFF
--- a/internal/coroutine/thread.go
+++ b/internal/coroutine/thread.go
@@ -151,31 +151,14 @@ func (p *Coroutines) AbortAll() {
 }
 
 func (p *Coroutines) AbortAllAndWait(timeout stime.Duration) bool {
+	caller := p.currentCoroutineThread()
 	p.AbortAll()
 
-	if timeout <= 0 {
-		p.wg.Wait()
-		return true
+	if caller != nil {
+		return p.waitForThreadsToStopFromCoroutine(timeout, caller)
 	}
 
-	deadline := stime.Now().Add(timeout)
-	for {
-		p.mutex.Lock()
-		done := len(p.allThreads) == 0
-		p.mutex.Unlock()
-		if done {
-			return true
-		}
-
-		remaining := stime.Until(deadline)
-		if remaining <= 0 {
-			return false
-		}
-		if remaining > 10*stime.Millisecond {
-			remaining = 10 * stime.Millisecond
-		}
-		stime.Sleep(remaining)
-	}
+	return p.waitForThreadsToStop(timeout, nil)
 }
 
 func (p *Coroutines) StopIf(filter func(th Thread) bool) {
@@ -271,6 +254,61 @@ func (p *Coroutines) unregisterThread(th Thread) {
 	p.wg.Done()
 }
 
+func (p *Coroutines) currentCoroutineThread() Thread {
+	if !p.IsInCoroutine() {
+		return nil
+	}
+	return p.Current()
+}
+
+func (p *Coroutines) hasThreadsOtherThan(skip Thread) bool {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	for th := range p.allThreads {
+		if th != skip {
+			return true
+		}
+	}
+	return false
+}
+
+func (p *Coroutines) waitForThreadsToStopFromCoroutine(timeout stime.Duration, caller Thread) bool {
+	// Release the scheduler while waiting so aborted peer coroutines can
+	// observe cancellation and unregister.
+	p.sema.Unlock()
+	completed := p.waitForThreadsToStop(timeout, caller)
+	p.sema.Lock()
+	p.setCurrent(caller)
+	return completed
+}
+
+func (p *Coroutines) waitForThreadsToStop(timeout stime.Duration, skip Thread) bool {
+	hasTimeout := timeout > 0
+	deadline := stime.Time{}
+	if hasTimeout {
+		deadline = stime.Now().Add(timeout)
+	}
+
+	for {
+		if !p.hasThreadsOtherThan(skip) {
+			return true
+		}
+
+		sleepFor := 10 * stime.Millisecond
+		if hasTimeout {
+			remaining := stime.Until(deadline)
+			if remaining <= 0 {
+				return false
+			}
+			if remaining < sleepFor {
+				sleepFor = remaining
+			}
+		}
+		stime.Sleep(sleepFor)
+	}
+}
+
 func (p *Coroutines) handleThreadPanic(th Thread, recovered any) {
 	if recovered == nil || recovered == ErrAbortThread {
 		return
@@ -297,6 +335,9 @@ func (p *Coroutines) runThread(th Thread, fn func(me Thread) int) {
 		p.goroutineIDs.Delete(gid)
 		p.handleThreadPanic(th, recovered)
 	}()
+	if th.stopped.Load() {
+		panic(ErrAbortThread)
+	}
 	p.setWaitState(th, waitStatusAdd)
 	fn(th)
 }

--- a/internal/coroutine/thread_test.go
+++ b/internal/coroutine/thread_test.go
@@ -157,3 +157,81 @@ func TestStopIfEvaluatesFilterWithoutHoldingMutex(t *testing.T) {
 		t.Fatal("active coroutine did not stop after StopIf")
 	}
 }
+
+func TestAbortAllAndWaitFromCoroutineWaitsForPeersWithoutWaitingForCaller(t *testing.T) {
+	co := New(nil)
+	result := make(chan bool, 1)
+	otherYielding := make(chan struct{})
+	otherDone := make(chan struct{})
+
+	co.CreateAndStart(true, "other", func(other Thread) int {
+		defer close(otherDone)
+		close(otherYielding)
+		co.Yield(other)
+		return 0
+	})
+
+	timer := time.NewTimer(time.Second)
+	defer timer.Stop()
+	select {
+	case <-otherYielding:
+	case <-timer.C:
+		t.Fatal("other coroutine did not reach yield")
+	}
+
+	co.CreateAndStart(true, "caller", func(me Thread) int {
+		result <- co.AbortAllAndWait(time.Hour)
+		return 0
+	})
+
+	timer = time.NewTimer(time.Second)
+	defer timer.Stop()
+	select {
+	case completed := <-result:
+		if !completed {
+			t.Fatal("AbortAllAndWait should report success after other coroutines stop")
+		}
+	case <-timer.C:
+		t.Fatal("AbortAllAndWait did not finish after peer coroutine stopped")
+	}
+
+	timer = time.NewTimer(time.Second)
+	defer timer.Stop()
+	select {
+	case <-otherDone:
+	case <-timer.C:
+		t.Fatal("other coroutine did not exit while caller was waiting")
+	}
+}
+
+func TestAbortAllAndWaitFromCoroutineDoesNotStartStoppedPeer(t *testing.T) {
+	co := New(nil)
+	result := make(chan bool, 1)
+	peerRan := make(chan struct{}, 1)
+
+	co.CreateAndStart(true, "caller", func(me Thread) int {
+		co.CreateAndStart(false, "peer", func(peer Thread) int {
+			close(peerRan)
+			return 0
+		})
+		result <- co.AbortAllAndWait(time.Second)
+		return 0
+	})
+
+	timer := time.NewTimer(time.Second)
+	defer timer.Stop()
+	select {
+	case completed := <-result:
+		if !completed {
+			t.Fatal("AbortAllAndWait should wait for the stopped peer to unregister")
+		}
+	case <-timer.C:
+		t.Fatal("AbortAllAndWait did not finish after stopped peer unregistered")
+	}
+
+	select {
+	case <-peerRan:
+		t.Fatal("stopped peer coroutine should not run")
+	default:
+	}
+}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -306,9 +306,26 @@ func Panicf(format string, args ...any) {
 // abortCoroutinesAndReset aborts coroutines and resets the engine.
 // Used on web, where the process cannot exit.
 func abortCoroutinesAndReset(exitCode int64) {
-	completed := gco.AbortAllAndWait(2 * stime.Second)
-	spxlog.Debug("AbortAllAndWait completed: %v. Requesting engine reset.", completed)
+	completed, abortCurrent := abortCoroutinesForWebReset(2 * stime.Second)
+	if abortCurrent {
+		spxlog.Debug("Requested coroutine aborts from current coroutine. Requesting engine reset.")
+	} else {
+		spxlog.Debug("AbortAllAndWait completed: %v. Requesting engine reset.", completed)
+	}
 	extMgr.RequestReset(exitCode)
+	if abortCurrent {
+		gco.Abort()
+	}
+}
+
+func abortCoroutinesForWebReset(timeout stime.Duration) (completed bool, abortCurrent bool) {
+	if gco.IsInCoroutine() {
+		// Web exit must request reset immediately. Waiting here can let game code
+		// keep running before the reset is requested.
+		gco.AbortAll()
+		return false, true
+	}
+	return gco.AbortAllAndWait(timeout), false
 }
 
 func RequestExit(exitCode int64) {

--- a/internal/engine/exit_test.go
+++ b/internal/engine/exit_test.go
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2021 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package engine
+
+import (
+	"testing"
+	"time"
+
+	"github.com/goplus/spx/v2/internal/coroutine"
+)
+
+func TestAbortCoroutinesForWebResetFromCoroutineDoesNotWaitForPeers(t *testing.T) {
+	co := coroutine.New(nil)
+	original := gco
+	SetCoroutines(co)
+	t.Cleanup(func() {
+		SetCoroutines(original)
+	})
+
+	type resetState struct {
+		completed    bool
+		abortCurrent bool
+	}
+
+	result := make(chan resetState, 1)
+	peerYielding := make(chan struct{})
+	peerDone := make(chan struct{})
+
+	co.CreateAndStart(true, "peer", func(peer coroutine.Thread) int {
+		defer close(peerDone)
+		close(peerYielding)
+		co.Yield(peer)
+		return 0
+	})
+
+	timer := time.NewTimer(time.Second)
+	defer timer.Stop()
+	select {
+	case <-peerYielding:
+	case <-timer.C:
+		t.Fatal("peer coroutine did not reach yield")
+	}
+
+	co.CreateAndStart(true, "caller", func(me coroutine.Thread) int {
+		completed, abortCurrent := abortCoroutinesForWebReset(time.Hour)
+		result <- resetState{completed: completed, abortCurrent: abortCurrent}
+		return 0
+	})
+
+	timer = time.NewTimer(time.Second)
+	defer timer.Stop()
+	select {
+	case got := <-result:
+		if got.completed {
+			t.Fatal("web reset should not wait for peers from a coroutine")
+		}
+		if !got.abortCurrent {
+			t.Fatal("web reset should request current coroutine abort")
+		}
+	case <-timer.C:
+		t.Fatal("web reset waited for a peer coroutine")
+	}
+
+	timer = time.NewTimer(time.Second)
+	defer timer.Stop()
+	select {
+	case <-peerDone:
+	case <-timer.C:
+		t.Fatal("peer coroutine did not exit after caller returned")
+	}
+}


### PR DESCRIPTION
On web, exit() resets the engine instead of terminating the process. When exit() is called from a coroutine, abort the current coroutine and avoid waiting on it so the running game code stops cleanly.

Fixes #1518