### PR TITLE
support RGB color construction

### DIFF
--- a/color.go
+++ b/color.go
@@ -19,8 +19,11 @@ package spx
 import "github.com/goplus/spbase/mathf"
 
 // Color represents an RGBA color.
+//
+// XGo treats structs whose fields are named X_0, X_1, ... as tuple types, so
+// script code can construct colors with Color(r, g, b, a).
 type Color struct {
-	r, g, b, a float64
+	X_0, X_1, X_2, X_3 float64
 }
 
 // HSB creates a color from HSB values.
@@ -35,12 +38,22 @@ func HSB(h, s, b float64) Color {
 // h, s, b, a in range [0, 100], just like Scratch
 func HSBA(h, s, b, a float64) Color {
 	color := HSB(h, s, b)
-	color.a = a / 100
+	color.X_3 = a / 100
 	return color
 }
 
+// NewColor creates a color from a supported color value.
+// It accepts packed RGB numbers, hex strings, and color names.
+func NewColor(color any) Color {
+	c, err := mathf.NewColorAny(color)
+	if err != nil {
+		return Color{}
+	}
+	return toSpxColor(c)
+}
+
 func toMathfColor(c Color) mathf.Color {
-	return mathf.Color{R: c.r, G: c.g, B: c.b, A: c.a}
+	return mathf.Color{R: c.X_0, G: c.X_1, B: c.X_2, A: c.X_3}
 }
 
 func toSpxColor(c mathf.Color) Color {

--- a/color_test.go
+++ b/color_test.go
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2021 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package spx
+
+import (
+	"math"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNewColor(t *testing.T) {
+	want := Color{0x12 / 255.0, 0x34 / 255.0, 0x56 / 255.0, 1}
+	assertColor(t, NewColor(0x123456), want)
+	assertColor(t, NewColor(float64(0x123456)), want)
+	assertColor(t, NewColor("#123456"), want)
+}
+
+func TestNewColorUsesMathfPackedNumberBehavior(t *testing.T) {
+	assertColor(t, NewColor(-1), Color{1, 1, 1, 1})
+	assertColor(t, NewColor(float64(0x1000000)), Color{0, 0, 0, 1})
+}
+
+func writeTestFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0644); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+}
+
+func assertColor(t *testing.T, got, want Color) {
+	t.Helper()
+	const epsilon = 1e-12
+	if math.Abs(got.X_0-want.X_0) > epsilon ||
+		math.Abs(got.X_1-want.X_1) > epsilon ||
+		math.Abs(got.X_2-want.X_2) > epsilon ||
+		math.Abs(got.X_3-want.X_3) > epsilon {
+		t.Fatalf("Color = %#v, want %#v", got, want)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 )
 
 require (
+	github.com/goccy/go-yaml v1.19.2 // indirect
 	github.com/goplus/gogen v1.23.0-pre.3.0.20260414234848-6641c10c9d6f // indirect
 	github.com/qiniu/x v1.17.0 // indirect
 	github.com/timandy/routine v1.1.5 // indirect

--- a/pkg/ispx/internal/pkg/github.com/goplus/spx/v2/export.go
+++ b/pkg/ispx/internal/pkg/github.com/goplus/spx/v2/export.go
@@ -135,6 +135,7 @@ func init() {
 			"HSBA":               reflect.ValueOf(q.HSBA),
 			"Iround":             reflect.ValueOf(q.Iround),
 			"KeyFromString":      reflect.ValueOf(q.KeyFromString),
+			"NewColor":           reflect.ValueOf(q.NewColor),
 			"NewList":            reflect.ValueOf(q.NewList),
 			"NewValue":           reflect.ValueOf(q.NewValue),
 			"Rand__0":            reflect.ValueOf(q.Rand__0),


### PR DESCRIPTION
## Summary

- Support `Color(r, g, b, a)` construction in XGo/SPX by making `spx.Color` tuple-compatible.
- Add `NewColor(color any) Color` and `RGB(color float64) Color`, delegating packed RGB, hex strings, and color names to `mathf.NewColorAny`.
- Export color constructors to the embedded ispx package registry via generated runtime registration.
- Add tests for packed RGB conversion and XGo script-facing `Color(...)` generation.

## Tests

- `make generate-runtime`
- `go test ./...`
