### PR TITLE
feat(codegen): require explicit SPX ABI annotations

### DIFF
--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -2,6 +2,17 @@ name: Static Checks
 
 on:
   workflow_call:
+    inputs:
+      godot-repository:
+        description: 'Godot repository URL used by binding generation'
+        required: false
+        type: string
+        default: ''
+      godot-ref:
+        description: 'Godot branch, tag, or commit used by binding generation'
+        required: false
+        type: string
+        default: ''
 
 jobs:
   static-checks:
@@ -23,20 +34,49 @@ jobs:
 
       - name: Check out Godot source
         env:
-          GODOT_REPOSITORY: https://github.com/goplus/godot.git
+          GODOT_REPOSITORY_INPUT: ${{ inputs.godot-repository }}
+          GODOT_REF_INPUT: ${{ inputs.godot-ref }}
+          GODOT_PR_HEAD_OWNER: ${{ github.event.pull_request.head.repo.owner.login }}
+          GODOT_DEFAULT_OWNER: ${{ github.repository_owner }}
+          GODOT_DEFAULT_REPOSITORY: https://github.com/goplus/godot.git
           GODOT_REF_CANDIDATE: ${{ github.head_ref || github.ref_name }}
           GODOT_FALLBACK_REF: spx4.4.1
         run: |
           set -euo pipefail
 
-          if git ls-remote --exit-code --heads "$GODOT_REPOSITORY" "$GODOT_REF_CANDIDATE" >/dev/null 2>&1; then
-            GODOT_REF="$GODOT_REF_CANDIDATE"
-          else
-            GODOT_REF="$GODOT_FALLBACK_REF"
+          GODOT_FORK_OWNER="${GODOT_PR_HEAD_OWNER:-$GODOT_DEFAULT_OWNER}"
+          GODOT_FORK_REPOSITORY="https://github.com/${GODOT_FORK_OWNER}/godot.git"
+
+          GODOT_REPOSITORIES=()
+          if [ -n "$GODOT_REPOSITORY_INPUT" ]; then
+            GODOT_REPOSITORIES+=("$GODOT_REPOSITORY_INPUT")
+          fi
+          GODOT_REPOSITORIES+=("$GODOT_FORK_REPOSITORY")
+          if [ "$GODOT_FORK_REPOSITORY" != "$GODOT_DEFAULT_REPOSITORY" ]; then
+            GODOT_REPOSITORIES+=("$GODOT_DEFAULT_REPOSITORY")
           fi
 
-          echo "[info] Checking out Godot source from $GODOT_REPOSITORY@$GODOT_REF"
-          git clone --depth 1 --branch "$GODOT_REF" "$GODOT_REPOSITORY" godot
+          GODOT_REFS=()
+          if [ -n "$GODOT_REF_INPUT" ]; then
+            GODOT_REFS+=("$GODOT_REF_INPUT")
+          else
+            GODOT_REFS+=("$GODOT_REF_CANDIDATE" "$GODOT_FALLBACK_REF")
+          fi
+
+          git init godot
+          for GODOT_REPOSITORY in "${GODOT_REPOSITORIES[@]}"; do
+            for GODOT_REF in "${GODOT_REFS[@]}"; do
+              echo "[info] Trying Godot source from $GODOT_REPOSITORY@$GODOT_REF"
+              if git -C godot fetch --depth 1 "$GODOT_REPOSITORY" "$GODOT_REF"; then
+                git -C godot checkout --detach FETCH_HEAD
+                echo "[info] Checked out Godot source from $GODOT_REPOSITORY@$GODOT_REF"
+                exit 0
+              fi
+            done
+          done
+
+          echo "[error] Failed to check out Godot source" >&2
+          exit 1
 
       - name: Run binding code generation
         run: make generate-bindings

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -21,6 +21,26 @@ jobs:
       - name: Download Go modules
         run: go mod download
 
+      - name: Check out Godot source
+        env:
+          GODOT_REPOSITORY: https://github.com/goplus/godot.git
+          GODOT_REF_CANDIDATE: ${{ github.head_ref || github.ref_name }}
+          GODOT_FALLBACK_REF: spx4.4.1
+        run: |
+          set -euo pipefail
+
+          if git ls-remote --exit-code --heads "$GODOT_REPOSITORY" "$GODOT_REF_CANDIDATE" >/dev/null 2>&1; then
+            GODOT_REF="$GODOT_REF_CANDIDATE"
+          else
+            GODOT_REF="$GODOT_FALLBACK_REF"
+          fi
+
+          echo "[info] Checking out Godot source from $GODOT_REPOSITORY@$GODOT_REF"
+          git clone --depth 1 --branch "$GODOT_REF" "$GODOT_REPOSITORY" godot
+
+      - name: Run binding code generation
+        run: make generate-bindings
+
       - name: Run go generate for pkg/ispx
         run: go generate ./pkg/ispx/...
 

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -2,17 +2,6 @@ name: Static Checks
 
 on:
   workflow_call:
-    inputs:
-      godot-repository:
-        description: 'Godot repository URL used by binding generation'
-        required: false
-        type: string
-        default: ''
-      godot-ref:
-        description: 'Godot branch, tag, or commit used by binding generation'
-        required: false
-        type: string
-        default: ''
 
 jobs:
   static-checks:
@@ -33,53 +22,10 @@ jobs:
         run: go mod download
 
       - name: Check out Godot source
-        env:
-          GODOT_REPOSITORY_INPUT: ${{ inputs.godot-repository }}
-          GODOT_REF_INPUT: ${{ inputs.godot-ref }}
-          GODOT_PR_HEAD_OWNER: ${{ github.event.pull_request.head.repo.owner.login }}
-          GODOT_DEFAULT_OWNER: ${{ github.repository_owner }}
-          GODOT_DEFAULT_REPOSITORY: https://github.com/goplus/godot.git
-          GODOT_REF_CANDIDATE: ${{ github.head_ref || github.ref_name }}
-          GODOT_FALLBACK_REF: spx4.4.1
-        run: |
-          set -euo pipefail
-
-          GODOT_FORK_OWNER="${GODOT_PR_HEAD_OWNER:-$GODOT_DEFAULT_OWNER}"
-          GODOT_FORK_REPOSITORY="https://github.com/${GODOT_FORK_OWNER}/godot.git"
-
-          GODOT_REPOSITORIES=()
-          if [ -n "$GODOT_REPOSITORY_INPUT" ]; then
-            GODOT_REPOSITORIES+=("$GODOT_REPOSITORY_INPUT")
-          fi
-          GODOT_REPOSITORIES+=("$GODOT_FORK_REPOSITORY")
-          if [ "$GODOT_FORK_REPOSITORY" != "$GODOT_DEFAULT_REPOSITORY" ]; then
-            GODOT_REPOSITORIES+=("$GODOT_DEFAULT_REPOSITORY")
-          fi
-
-          GODOT_REFS=()
-          if [ -n "$GODOT_REF_INPUT" ]; then
-            GODOT_REFS+=("$GODOT_REF_INPUT")
-          else
-            GODOT_REFS+=("$GODOT_REF_CANDIDATE" "$GODOT_FALLBACK_REF")
-          fi
-
-          git init godot
-          for GODOT_REPOSITORY in "${GODOT_REPOSITORIES[@]}"; do
-            for GODOT_REF in "${GODOT_REFS[@]}"; do
-              echo "[info] Trying Godot source from $GODOT_REPOSITORY@$GODOT_REF"
-              if git -C godot fetch --depth 1 "$GODOT_REPOSITORY" "$GODOT_REF"; then
-                git -C godot checkout --detach FETCH_HEAD
-                echo "[info] Checked out Godot source from $GODOT_REPOSITORY@$GODOT_REF"
-                exit 0
-              fi
-            done
-          done
-
-          echo "[error] Failed to check out Godot source" >&2
-          exit 1
+        run: git clone --depth 1 --branch spx4.4.1 https://github.com/goplus/godot.git godot
 
       - name: Run binding code generation
-        run: make generate-bindings
+        run: cd internal/cmd/codegen && GODOT_SRC="$GITHUB_WORKSPACE/godot" go run .
 
       - name: Run go generate for pkg/ispx
         run: go generate ./pkg/ispx/...

--- a/docs/zh/dev/engine/code_generator.md
+++ b/docs/zh/dev/engine/code_generator.md
@@ -28,7 +28,7 @@ func generateManagerHeader(input string, rawFormat bool) string
 
 **处理流程**：
 1. 扫描spx*mgr.h文件
-2. 提取public方法
+2. 提取带 `SPX_API` / `SPX_BIND` 标记的 public 方法
 3. 生成typedef函数声明
 
 ### 2.2 AST生成 (parse.go)
@@ -128,7 +128,7 @@ function getJsFuncBody(function *clang.TypedefFunction) string {
 
 ## 6. 开发工作流
 
-1. 修改 `spx_sprite_mgr.h` 添加新方法
+1. 修改 `spx_sprite_mgr.h` 添加新方法，并在需要导出到 Go/Web 绑定的声明前添加 `SPX_API`
 2. 运行 `make gen` 生成绑定
 3. 检查生成的 `gdextension_spx_ext.h` 和绑定代码
 4. 在 Go/JS 中调用新接口

--- a/internal/cmd/codegen/generate/gdext/header_generator.go
+++ b/internal/cmd/codegen/generate/gdext/header_generator.go
@@ -40,9 +40,10 @@ var (
 	// For mergeManagerHeader function
 	reClassDefinition = regexp.MustCompile(`class\s+(\w+)\s*:\s*(?:public\s+)?(?:SpxBaseMgr|SpxObjectMgr<\w+>)\s*{`)
 
-	// For generateManagerHeader function
-	reMethodVoid           = regexp.MustCompile(`\s*void\s+(\w+)\((.*)\);`)
-	reMethodReturn         = regexp.MustCompile(`\s*(\w+)\s+(\w+)\((.*)\);`)
+	// For generateManagerHeader function. Only methods explicitly marked with
+	// SPX_API or SPX_BIND become part of the cross-language ABI.
+	reMethodVoid           = regexp.MustCompile(`\s*(?:SPX_API|SPX_BIND)\s+void\s+(\w+)\((.*)\);`)
+	reMethodReturn         = regexp.MustCompile(`\s*(?:SPX_API|SPX_BIND)\s+(\w+)\s+(\w+)\((.*)\);`)
 	reSingleGdArrayParam   = regexp.MustCompile(`^\s*GdArray\s+([A-Za-z_][A-Za-z0-9_]*)\s*$`)
 	reRawNativeArrayParams = regexp.MustCompile(`^\s*((?:const\s+)?[A-Za-z_][A-Za-z0-9_]*\s*\*)\s*([A-Za-z_][A-Za-z0-9_]*)\s*,\s*(int32_t|int)\s+([A-Za-z_][A-Za-z0-9_]*)\s*$`)
 )

--- a/internal/cmd/codegen/generate/gdext/header_generator_test.go
+++ b/internal/cmd/codegen/generate/gdext/header_generator_test.go
@@ -28,10 +28,11 @@ func TestGenerateManagerHeaderSkipsRawMethods(t *testing.T) {
 	input := strings.TrimSpace(`
 class SpxSpriteMgr {
 public:
-	void batch_update_transforms(GdArray buffer);
-	void batch_update_transforms_raw(const float *buffer_data, int len);
-	GdBool destroy_sprite(GdObj obj);
-	void batch_update_visuals_raw(const float *buffer_data, int len);
+	SPX_API void batch_update_transforms(GdArray buffer);
+	SPX_API void batch_update_transforms_raw(const float *buffer_data, int len);
+	SPX_BIND GdBool destroy_sprite(GdObj obj);
+	SPX_API void batch_update_visuals_raw(const float *buffer_data, int len);
+	void helper_not_exported();
 };
 `)
 
@@ -39,6 +40,7 @@ public:
 
 	require.Contains(t, output, "GDExtensionSpxSpriteBatchUpdateTransforms")
 	require.Contains(t, output, "GDExtensionSpxSpriteDestroySprite")
+	require.NotContains(t, output, "GDExtensionSpxSpriteHelperNotExported")
 	require.NotContains(t, output, "GDExtensionSpxSpriteBatchUpdateTransformsRaw")
 	require.NotContains(t, output, "GDExtensionSpxSpriteBatchUpdateVisualsRaw")
 
@@ -54,7 +56,7 @@ func TestGenerateManagerHeaderRegistersDirectNativeArrayBridge(t *testing.T) {
 	input := strings.TrimSpace(`
 class SpxSpriteMgr {
 public:
-	void batch_update_transforms(const float *buffer_data, int len);
+	SPX_API void batch_update_transforms(const float *buffer_data, int len);
 };
 `)
 


### PR DESCRIPTION
## Summary

- Require SPX manager methods to be explicitly marked with `SPX_API` or `SPX_BIND` before entering generated bindings.
- Add generator tests to ensure unmarked public helper methods are not exported.
- Update codegen documentation to describe the explicit ABI contract.
- Add a static-checks CI step that runs `make generate-bindings` and verifies generated files do not drift.

## Notes

This PR depends on the matching Godot PR that marks existing manager ABI methods with `SPX_API`.

The CI Godot checkout first tries a same-named Godot branch, then falls back to `spx4.4.1`, so pushing both repos with branch name `codex/explicit-spx-abi-contract` lets CI validate the paired changes.

## Verification

- `make generate-bindings`
- `go test ./...` in `internal/cmd/codegen`
