### PR TITLE
feat: add configurable animation action sounds

### DIFF
--- a/component_animation.go
+++ b/component_animation.go
@@ -290,9 +290,24 @@ func (a *animationComponent) hasActiveAnimationPlayback() bool {
 
 func (a *animationComponent) playAnimAudio(ani *coreproject.AniConfig, info *animState) {
 	if ani.OnStart != nil && ani.OnStart.Play != "" {
-		info.AudioName = ani.OnStart.Play
-		a.sprite.playAudio(info.AudioName, false)
+		loop := ani.OnStart.GetLoop(false)
+		if !loop {
+			info.AudioName = ani.OnStart.Play
+		}
+		a.sprite.playAudio(ani.OnStart.Play, loop)
 	}
+	if ani.OnPlay != nil && ani.OnPlay.Play != "" {
+		info.PlayAudioName = ani.OnPlay.Play
+		info.PlayAudioID = a.sprite.playAudio(info.PlayAudioName, ani.OnPlay.GetLoop(true))
+	}
+}
+
+func (a *animationComponent) stopAnimPlaybackAudio(state *animState) {
+	if state == nil || state.PlayAudioID == 0 {
+		return
+	}
+	a.sprite.stopAudioPlayback(state.PlayAudioID)
+	state.PlayAudioID = 0
 }
 
 func (a *animationComponent) adaptAnimBitmapResolution(ani *coreproject.AniConfig) {
@@ -334,6 +349,7 @@ func (a *animationComponent) stopAnimState(state *animState) {
 	if state == nil {
 		return
 	}
+	a.stopAnimPlaybackAudio(state)
 	state.IsCanceled = true
 }
 

--- a/component_animation.go
+++ b/component_animation.go
@@ -292,22 +292,21 @@ func (a *animationComponent) playAnimAudio(ani *coreproject.AniConfig, info *ani
 	if ani.OnStart != nil && ani.OnStart.Play != "" {
 		loop := ani.OnStart.GetLoop(false)
 		if !loop {
-			info.AudioName = ani.OnStart.Play
+			info.LoopReplayAudioName = ani.OnStart.Play
 		}
 		a.sprite.playAudio(ani.OnStart.Play, loop)
 	}
 	if ani.OnPlay != nil && ani.OnPlay.Play != "" {
-		info.PlayAudioName = ani.OnPlay.Play
-		info.PlayAudioID = a.sprite.playAudio(info.PlayAudioName, ani.OnPlay.GetLoop(true))
+		info.BoundAudioPlaybackID = a.sprite.playAudio(ani.OnPlay.Play, ani.OnPlay.GetLoop(true))
 	}
 }
 
 func (a *animationComponent) stopAnimPlaybackAudio(state *animState) {
-	if state == nil || state.PlayAudioID == 0 {
+	if state == nil || state.BoundAudioPlaybackID == 0 {
 		return
 	}
-	a.sprite.stopAudioPlayback(state.PlayAudioID)
-	state.PlayAudioID = 0
+	a.sprite.stopAudioPlayback(state.BoundAudioPlaybackID)
+	state.BoundAudioPlaybackID = 0
 }
 
 func (a *animationComponent) adaptAnimBitmapResolution(ani *coreproject.AniConfig) {

--- a/component_animation_test.go
+++ b/component_animation_test.go
@@ -241,17 +241,17 @@ func TestPlayAnimAudioStartsAndStopsOnPlaySound(t *testing.T) {
 		OnPlay: &coreproject.ActionConfig{Play: "walk"},
 	}, state)
 
-	if state.PlayAudioID == 0 {
+	if state.BoundAudioPlaybackID == 0 {
 		t.Fatal("onPlay did not capture a playback id")
 	}
 	if len(backend.plays) != 1 {
 		t.Fatalf("plays = %d, want 1", len(backend.plays))
 	}
-	if len(backend.loops) != 1 || backend.loops[0].id != state.PlayAudioID || !backend.loops[0].loop {
-		t.Fatalf("loop calls = %+v, want one loop call for playback %d", backend.loops, state.PlayAudioID)
+	if len(backend.loops) != 1 || backend.loops[0].id != state.BoundAudioPlaybackID || !backend.loops[0].loop {
+		t.Fatalf("loop calls = %+v, want one loop call for playback %d", backend.loops, state.BoundAudioPlaybackID)
 	}
 
-	playID := state.PlayAudioID
+	playID := state.BoundAudioPlaybackID
 	anim.onAnimationDone("walk")
 
 	if len(backend.stops) != 1 || backend.stops[0] != playID {
@@ -275,7 +275,7 @@ func TestPlayAnimAudioHonorsOnPlayLoopConfig(t *testing.T) {
 		},
 	}, state)
 
-	if state.PlayAudioID == 0 {
+	if state.BoundAudioPlaybackID == 0 {
 		t.Fatal("onPlay did not capture a playback id")
 	}
 	if len(backend.plays) != 1 {
@@ -305,8 +305,8 @@ func TestPlayAnimAudioHonorsOnStartLoopConfig(t *testing.T) {
 	if len(backend.loops) != 1 || !backend.loops[0].loop {
 		t.Fatalf("loop calls = %+v, want one looping playback", backend.loops)
 	}
-	if state.AudioName != "" {
-		t.Fatalf("AudioName = %q, want empty when onStart uses loop playback", state.AudioName)
+	if state.LoopReplayAudioName != "" {
+		t.Fatalf("LoopReplayAudioName = %q, want empty when onStart uses loop playback", state.LoopReplayAudioName)
 	}
 }
 

--- a/component_animation_test.go
+++ b/component_animation_test.go
@@ -3,9 +3,14 @@ package spx
 import (
 	"testing"
 
+	internalaudio "github.com/goplus/spx/v2/internal/audio"
 	coreproject "github.com/goplus/spx/v2/internal/core/project"
 	"github.com/goplus/spx/v2/internal/engine"
 )
+
+func boolPtr(v bool) *bool {
+	return &v
+}
 
 func newTestAnimationComponent() *animationComponent {
 	sprite := &SpriteImpl{
@@ -28,7 +33,100 @@ func newTestAnimationComponent() *animationComponent {
 		donedAnimations: make([]string, 0),
 	}
 	sprite.components.animation = anim
+	sprite.components.sound = &soundComponent{
+		componentBase: componentBase{sprite: sprite},
+		pendingAudios: make([]string, 0),
+	}
 	return anim
+}
+
+type animationAudioBackend struct {
+	nextID  int64
+	plays   []animationPlayCall
+	loops   []animationLoopCall
+	stops   []int64
+	playing map[int64]bool
+}
+
+type animationPlayCall struct {
+	path       string
+	owner      engine.Object
+	attenation float64
+	maxDist    float64
+}
+
+type animationLoopCall struct {
+	id   int64
+	loop bool
+}
+
+func (f *animationAudioBackend) CreateAudio() engine.Object {
+	return 77
+}
+
+func (f *animationAudioBackend) DestroyAudio(obj engine.Object) {}
+
+func (f *animationAudioBackend) SetPitch(obj engine.Object, pitch float64) {}
+
+func (f *animationAudioBackend) GetPitch(obj engine.Object) float64 {
+	return 0
+}
+
+func (f *animationAudioBackend) SetPan(obj engine.Object, pan float64) {}
+
+func (f *animationAudioBackend) GetPan(obj engine.Object) float64 {
+	return 0
+}
+
+func (f *animationAudioBackend) SetVolume(obj engine.Object, volume float64) {}
+
+func (f *animationAudioBackend) GetVolume(obj engine.Object) float64 {
+	return 1
+}
+
+func (f *animationAudioBackend) PlayWithAttenuation(obj engine.Object, path string, ownerID engine.Object, attenuation, maxDistance float64) int64 {
+	f.nextID++
+	if f.playing == nil {
+		f.playing = make(map[int64]bool)
+	}
+	f.playing[f.nextID] = true
+	f.plays = append(f.plays, animationPlayCall{
+		path:       path,
+		owner:      ownerID,
+		attenation: attenuation,
+		maxDist:    maxDistance,
+	})
+	return f.nextID
+}
+
+func (f *animationAudioBackend) Pause(aid int64) {}
+
+func (f *animationAudioBackend) Resume(aid int64) {}
+
+func (f *animationAudioBackend) Stop(aid int64) {
+	if f.playing != nil {
+		f.playing[aid] = false
+	}
+	f.stops = append(f.stops, aid)
+}
+
+func (f *animationAudioBackend) SetLoop(aid int64, loop bool) {
+	f.loops = append(f.loops, animationLoopCall{id: aid, loop: loop})
+}
+
+func (f *animationAudioBackend) IsPlaying(aid int64) bool {
+	return f.playing[aid]
+}
+
+func (f *animationAudioBackend) StopAll() {}
+
+func initTestAnimationAudio(anim *animationComponent, backend *animationAudioBackend) {
+	anim.sprite.g.soundMgr = internalaudio.Manager{}
+	anim.sprite.g.soundMgr.Init(backend)
+	anim.sprite.g.sounds = map[string]sound{
+		"walk": &coreproject.SoundConfig{Path: "sounds/walk.wav"},
+		"step": &coreproject.SoundConfig{Path: "sounds/step.wav"},
+	}
 }
 
 func TestStopCurrentAnimStateDoesNotClearReplacement(t *testing.T) {
@@ -129,5 +227,107 @@ func TestCleanupTweenRestoresDefaultForOwnedPlayback(t *testing.T) {
 	}
 	if anim.sprite.costumeIndex != 0 {
 		t.Fatalf("costumeIndex = %d, want default costume 0", anim.sprite.costumeIndex)
+	}
+}
+
+func TestPlayAnimAudioStartsAndStopsOnPlaySound(t *testing.T) {
+	anim := newTestAnimationComponent()
+	backend := &animationAudioBackend{}
+	initTestAnimationAudio(anim, backend)
+
+	state := &animState{Name: "walk"}
+	anim.curAnimState = state
+	anim.playAnimAudio(&coreproject.AniConfig{
+		OnPlay: &coreproject.ActionConfig{Play: "walk"},
+	}, state)
+
+	if state.PlayAudioID == 0 {
+		t.Fatal("onPlay did not capture a playback id")
+	}
+	if len(backend.plays) != 1 {
+		t.Fatalf("plays = %d, want 1", len(backend.plays))
+	}
+	if len(backend.loops) != 1 || backend.loops[0].id != state.PlayAudioID || !backend.loops[0].loop {
+		t.Fatalf("loop calls = %+v, want one loop call for playback %d", backend.loops, state.PlayAudioID)
+	}
+
+	playID := state.PlayAudioID
+	anim.onAnimationDone("walk")
+
+	if len(backend.stops) != 1 || backend.stops[0] != playID {
+		t.Fatalf("stops = %+v, want [%d]", backend.stops, playID)
+	}
+	if anim.curAnimState != nil {
+		t.Fatal("onAnimationDone did not clear the finished animation state")
+	}
+}
+
+func TestPlayAnimAudioHonorsOnPlayLoopConfig(t *testing.T) {
+	anim := newTestAnimationComponent()
+	backend := &animationAudioBackend{}
+	initTestAnimationAudio(anim, backend)
+
+	state := &animState{Name: "walk"}
+	anim.playAnimAudio(&coreproject.AniConfig{
+		OnPlay: &coreproject.ActionConfig{
+			Play: "walk",
+			Loop: boolPtr(false),
+		},
+	}, state)
+
+	if state.PlayAudioID == 0 {
+		t.Fatal("onPlay did not capture a playback id")
+	}
+	if len(backend.plays) != 1 {
+		t.Fatalf("plays = %d, want 1", len(backend.plays))
+	}
+	if len(backend.loops) != 0 {
+		t.Fatalf("loop calls = %+v, want none", backend.loops)
+	}
+}
+
+func TestPlayAnimAudioHonorsOnStartLoopConfig(t *testing.T) {
+	anim := newTestAnimationComponent()
+	backend := &animationAudioBackend{}
+	initTestAnimationAudio(anim, backend)
+
+	state := &animState{Name: "walk"}
+	anim.playAnimAudio(&coreproject.AniConfig{
+		OnStart: &coreproject.ActionConfig{
+			Play: "step",
+			Loop: boolPtr(true),
+		},
+	}, state)
+
+	if len(backend.plays) != 1 {
+		t.Fatalf("plays = %d, want 1", len(backend.plays))
+	}
+	if len(backend.loops) != 1 || !backend.loops[0].loop {
+		t.Fatalf("loop calls = %+v, want one looping playback", backend.loops)
+	}
+	if state.AudioName != "" {
+		t.Fatalf("AudioName = %q, want empty when onStart uses loop playback", state.AudioName)
+	}
+}
+
+func TestStopAnimStateLeavesOnStartSoundAlone(t *testing.T) {
+	anim := newTestAnimationComponent()
+	backend := &animationAudioBackend{}
+	initTestAnimationAudio(anim, backend)
+
+	state := &animState{Name: "walk"}
+	anim.playAnimAudio(&coreproject.AniConfig{
+		OnStart: &coreproject.ActionConfig{Play: "step"},
+	}, state)
+	anim.stopAnimState(state)
+
+	if len(backend.plays) != 1 {
+		t.Fatalf("plays = %d, want 1", len(backend.plays))
+	}
+	if len(backend.loops) != 0 {
+		t.Fatalf("loop calls = %+v, want none", backend.loops)
+	}
+	if len(backend.stops) != 0 {
+		t.Fatalf("stops = %+v, want none", backend.stops)
 	}
 }

--- a/component_sound.go
+++ b/component_sound.go
@@ -130,9 +130,13 @@ func (s *soundComponent) ChangeSoundEffect(kind SoundEffectKind, delta float64) 
 // Internal Audio Management
 // ============================================================================
 
-func (s *soundComponent) playAudio(name SoundName, loop bool) {
+func (s *soundComponent) playAudio(name SoundName, loop bool) int64 {
 	s.checkSoundObj()
-	s.sprite.g.playSound(s.sprite.runtimeState.SyncSprite, s.soundObj, name, loop, s.sprite.g.audioState.AudioAttenuation, s.sprite.g.audioState.AudioMaxDistance)
+	return s.sprite.g.playSound(s.sprite.runtimeState.SyncSprite, s.soundObj, name, loop, s.sprite.g.audioState.AudioAttenuation, s.sprite.g.audioState.AudioMaxDistance)
+}
+
+func (s *soundComponent) stopAudioPlayback(id int64) {
+	s.sprite.g.stopSoundPlayback(id)
 }
 
 func (s *soundComponent) checkSoundObj() {

--- a/game_sound.go
+++ b/game_sound.go
@@ -143,24 +143,24 @@ func (p *Game) loadSound(name SoundName) (media sound, err error) {
 	return
 }
 
-func (p *Game) playSound(sprite *engine.Sprite, audioId engine.Object, name SoundName, isLoop bool, attenuation, maxDistance float64) {
-	p.playSoundInternal(sprite, audioId, name, isLoop, false, attenuation, maxDistance)
+func (p *Game) playSound(sprite *engine.Sprite, audioId engine.Object, name SoundName, isLoop bool, attenuation, maxDistance float64) int64 {
+	return p.playSoundInternal(sprite, audioId, name, isLoop, false, attenuation, maxDistance)
 }
 
-func (p *Game) playSoundAndWait(sprite *engine.Sprite, audioId engine.Object, name SoundName, attenuation, maxDistance float64) {
-	p.playSoundInternal(sprite, audioId, name, false, true, attenuation, maxDistance)
+func (p *Game) playSoundAndWait(sprite *engine.Sprite, audioId engine.Object, name SoundName, attenuation, maxDistance float64) int64 {
+	return p.playSoundInternal(sprite, audioId, name, false, true, attenuation, maxDistance)
 }
 
-func (p *Game) playSoundInternal(sprite *engine.Sprite, audioId engine.Object, name SoundName, isLoop, wait bool, attenuation, maxDistance float64) {
+func (p *Game) playSoundInternal(sprite *engine.Sprite, audioId engine.Object, name SoundName, isLoop, wait bool, attenuation, maxDistance float64) int64 {
 	m, err := p.loadSound(name)
 	if err != nil {
-		return
+		return 0
 	}
 	ownerID := engine.Object(0)
 	if sprite != nil {
 		ownerID = sprite.Id
 	}
-	p.soundMgr.Play(audioId, m.Path, isLoop, wait, ownerID, attenuation, maxDistance)
+	return p.soundMgr.Play(audioId, m.Path, isLoop, wait, ownerID, attenuation, maxDistance)
 }
 
 func (p *Game) withSound(name SoundName, action func(m sound)) {
@@ -187,6 +187,10 @@ func (p *Game) stopSound(name SoundName) {
 	p.withSound(name, func(m sound) {
 		p.soundMgr.Stop(m.Path)
 	})
+}
+
+func (p *Game) stopSoundPlayback(id int64) {
+	p.soundMgr.StopID(id)
 }
 
 func (p *Game) checkSoundObj() {

--- a/internal/audio/manager.go
+++ b/internal/audio/manager.go
@@ -180,19 +180,17 @@ func (m *Manager) pruneDeadIDs(path string) []int64 {
 
 func (m *Manager) removeID(target int64) {
 	for path, ids := range m.path2ids {
-		live := ids[:0]
-		for _, id := range ids {
-			if id == target {
+		for i, id := range ids {
+			if id != target {
 				continue
 			}
-			if m.backend.IsPlaying(id) {
-				live = append(live, id)
+			ids = append(ids[:i], ids[i+1:]...)
+			if len(ids) == 0 {
+				delete(m.path2ids, path)
+			} else {
+				m.path2ids[path] = ids
 			}
+			return
 		}
-		if len(live) == 0 {
-			delete(m.path2ids, path)
-			continue
-		}
-		m.path2ids[path] = live
 	}
 }

--- a/internal/audio/manager.go
+++ b/internal/audio/manager.go
@@ -78,6 +78,14 @@ func (m *Manager) Stop(path string) {
 	delete(m.path2ids, path)
 }
 
+func (m *Manager) StopID(id int64) {
+	if id == 0 {
+		return
+	}
+	m.backend.Stop(id)
+	m.removeID(id)
+}
+
 func (m *Manager) Play(
 	soundObj engine.Object,
 	path string,
@@ -168,4 +176,23 @@ func (m *Manager) pruneDeadIDs(path string) []int64 {
 	}
 	m.path2ids[path] = live
 	return live
+}
+
+func (m *Manager) removeID(target int64) {
+	for path, ids := range m.path2ids {
+		live := ids[:0]
+		for _, id := range ids {
+			if id == target {
+				continue
+			}
+			if m.backend.IsPlaying(id) {
+				live = append(live, id)
+			}
+		}
+		if len(live) == 0 {
+			delete(m.path2ids, path)
+			continue
+		}
+		m.path2ids[path] = live
+	}
 }

--- a/internal/audio/manager_test.go
+++ b/internal/audio/manager_test.go
@@ -176,6 +176,28 @@ func TestManagerPlayPrunesFinishedIDs(t *testing.T) {
 	}
 }
 
+func TestManagerStopIDOnlyStopsRequestedPlayback(t *testing.T) {
+	backend := &fakeBackend{}
+	var mgr Manager
+	mgr.Init(backend)
+
+	first := mgr.Play(1, "sounds/a.wav", true, false, 0, 0, 0)
+	second := mgr.Play(1, "sounds/a.wav", true, false, 0, 0, 0)
+
+	mgr.StopID(first)
+	mgr.Pause("sounds/a.wav")
+
+	if len(backend.stops) != 1 || backend.stops[0] != first {
+		t.Fatalf("Stop calls = %+v, want [%d]", backend.stops, first)
+	}
+	if len(mgr.path2ids["sounds/a.wav"]) != 1 || mgr.path2ids["sounds/a.wav"][0] != second {
+		t.Fatalf("path2ids = %+v, want only second playback %d", mgr.path2ids["sounds/a.wav"], second)
+	}
+	if len(backend.pauses) != 1 || backend.pauses[0] != second {
+		t.Fatalf("Pause calls = %+v, want [%d]", backend.pauses, second)
+	}
+}
+
 func TestManagerVolumeAndEffects(t *testing.T) {
 	backend := &fakeBackend{pan: 0.25, pitch: 1.5, volume: 0.8}
 	var mgr Manager

--- a/internal/core/project/config.go
+++ b/internal/core/project/config.go
@@ -16,7 +16,10 @@
 
 package project
 
-import "github.com/goplus/spbase/mathf"
+import (
+	"github.com/goplus/spbase/mathf"
+	"github.com/goplus/spx/v2/internal/base/defaults"
+)
 
 type Config struct {
 	Title              string `json:"title,omitempty"`
@@ -170,7 +173,15 @@ type CostumesConfig struct {
 
 type ActionConfig struct {
 	Play     string          `json:"play"`
+	Loop     *bool           `json:"loop"`
 	Costumes *CostumesConfig `json:"costumes"`
+}
+
+func (p *ActionConfig) GetLoop(defaultLoop bool) bool {
+	if p == nil {
+		return defaultLoop
+	}
+	return defaults.OrDefault(p.Loop, defaultLoop)
 }
 
 type AniConfig struct {

--- a/internal/core/project/project_test.go
+++ b/internal/core/project/project_test.go
@@ -206,6 +206,19 @@ func TestProjectConfigHelpers(t *testing.T) {
 		t.Fatalf("GetCostumeIndex = %d, want 3", got)
 	}
 
+	action := &ActionConfig{}
+	if got := action.GetLoop(true); got != true {
+		t.Fatalf("ActionConfig.GetLoop(default true) = %v, want true", got)
+	}
+	if got := (*ActionConfig)(nil).GetLoop(false); got != false {
+		t.Fatalf("nil ActionConfig.GetLoop(default false) = %v, want false", got)
+	}
+	loop := false
+	action.Loop = &loop
+	if got := action.GetLoop(true); got != false {
+		t.Fatalf("ActionConfig.GetLoop(explicit false) = %v, want false", got)
+	}
+
 	if got := ToMapMode("repeat"); got != MapModeRepeat {
 		t.Fatalf("ToMapMode(repeat) = %d, want %d", got, MapModeRepeat)
 	}

--- a/runtime_sync.go
+++ b/runtime_sync.go
@@ -189,8 +189,8 @@ func (sprite *SpriteImpl) handleAnimationLooped() {
 		return
 	}
 	state := sprite.animation().getCurTweenState()
-	if state != nil && state.AudioName != "" {
-		sprite.sound().addPendingAudio(state.AudioName)
+	if state != nil && state.LoopReplayAudioName != "" {
+		sprite.sound().addPendingAudio(state.LoopReplayAudioName)
 	}
 }
 

--- a/sprite_animation.go
+++ b/sprite_animation.go
@@ -84,11 +84,13 @@ func buildAnimationSources(costumes []*costume) []intani.FrameSource {
 }
 
 type animState struct {
-	AniType    coreproject.AniType
-	Name       string
-	IsCanceled bool
-	Speed      float64
-	AudioName  string
+	AniType       coreproject.AniType
+	Name          string
+	IsCanceled    bool
+	Speed         float64
+	AudioName     string
+	PlayAudioName string
+	PlayAudioID   int64
 }
 
 // -----------------------------------------------------------------------------

--- a/sprite_animation.go
+++ b/sprite_animation.go
@@ -84,13 +84,12 @@ func buildAnimationSources(costumes []*costume) []intani.FrameSource {
 }
 
 type animState struct {
-	AniType       coreproject.AniType
-	Name          string
-	IsCanceled    bool
-	Speed         float64
-	AudioName     string
-	PlayAudioName string
-	PlayAudioID   int64
+	AniType              coreproject.AniType
+	Name                 string
+	IsCanceled           bool
+	Speed                float64
+	LoopReplayAudioName  string
+	BoundAudioPlaybackID int64
 }
 
 // -----------------------------------------------------------------------------

--- a/sprite_sound.go
+++ b/sprite_sound.go
@@ -92,8 +92,12 @@ func (p *SpriteImpl) ChangeSoundEffect(kind SoundEffectKind, delta float64) {
 // -----------------------------------------------------------------------------
 // Internals
 // -----------------------------------------------------------------------------
-func (p *SpriteImpl) playAudio(name SoundName, loop bool) {
-	p.sound().playAudio(name, loop)
+func (p *SpriteImpl) playAudio(name SoundName, loop bool) int64 {
+	return p.sound().playAudio(name, loop)
+}
+
+func (p *SpriteImpl) stopAudioPlayback(id int64) {
+	p.sound().stopAudioPlayback(id)
 }
 
 func (p *SpriteImpl) flushPendingAudios(buffer []string) []string {


### PR DESCRIPTION
## Summary

This PR adds configurable animation action sounds and wires `onPlay` into the runtime.

### What changed

- support `onPlay.play` as animation-bound audio
  - start playback when the animation starts
  - stop playback when the animation ends, is replaced, or is stopped
- add optional `loop` config to animation action sounds
  - `onStart.play` still defaults to non-looping
  - `onPlay.play` still defaults to looping
  - explicit `loop: true/false` can now override both
- stop animation-bound audio by playback id instead of by sound path
  - avoids accidentally stopping other concurrent uses of the same sound
- move action sound loop defaulting logic into `ActionConfig`

### Tests

- add animation audio tests covering:
  - `onPlay` start/stop behavior
  - explicit loop overrides for `onStart` and `onPlay`
  - preserving existing `onStart` behavior when not bound to animation lifecycle
- add audio manager test covering stop-by-id isolation

## Verification

- `go test ./...`
