### PR TITLE
chore: unify log formatting across cli and runtime

### DIFF
--- a/cmd/ispxnative/main.go
+++ b/cmd/ispxnative/main.go
@@ -36,15 +36,15 @@ func main() {
 	// In both cases, the spx source files (.spx) are in the parent directory.
 	projDir, err := filepath.Abs("..")
 	if err != nil {
-		panic("failed to get project directory: " + err.Error())
+		panic("Failed to get project directory: " + err.Error())
 	}
 
 	if err := ispx.Init(nil); err != nil {
-		panic("failed to initialize: " + err.Error())
+		panic("Failed to initialize: " + err.Error())
 	}
 
 	if err := ispx.BuildFS(os.DirFS(projDir)); err != nil {
-		panic("failed to build: " + err.Error())
+		panic("Failed to build: " + err.Error())
 	}
 
 	if exitCode, err := ispx.Run(); err != nil {

--- a/cmd/spx/install.sh
+++ b/cmd/spx/install.sh
@@ -16,7 +16,7 @@ if [ ! -f "$font_path" ]; then
 fi
 
 if [ ! -f "$font_path" ]; then
-    echo "can not find font or download it, please checkout your network " $font_path
+    echo "Cannot find or download font. Please check your network: $font_path"
     exit 1
 fi
 
@@ -41,7 +41,7 @@ for arg in "$@"; do
         --opt)
             ;;
         *)
-            echo "warning: ignoring unknown install.sh flag: $arg"
+            echo "Warning: ignoring unknown install.sh flag: $arg"
             ;;
     esac
 done
@@ -117,7 +117,7 @@ ensure_runtime_assets_for_embedding() {
         return 0
     fi
 
-    echo "Preparing runtime assets for embedded spx build..."
+    echo "Preparing runtime assets for embedded SPX build..."
     GOFLAGS="-buildvcs=false" go run ../../internal/cmd/buildctl engine download --runtime
 }
 
@@ -169,7 +169,7 @@ install_web_runtime() {
     rm -rf "$gopath_bin_dir/ispx"
     mkdir -p "$gopath_bin_dir/ispx"
     cp ../ispx/web/* "$gopath_bin_dir/ispx/"
-    echo "ispx web runtime installed to $gopath_bin_dir/ispx/"
+    echo "Installed ispx web runtime to $gopath_bin_dir/ispx/"
 }
 
 if is_truthy "$embed_runtime"; then

--- a/cmd/spx/internal/command/args.go
+++ b/cmd/spx/internal/command/args.go
@@ -100,7 +100,7 @@ func (cmd *CmdTool) CheckCmdWithError(ext ...string) (err error) {
 		return
 	}
 	if !cmd.CheckCmd(ext...) {
-		fmt.Fprintf(os.Stderr, "Error: invalid cmd, please refer to help\n")
+		logErrorf("Invalid command; please refer to help")
 		cmd.ShowHelpInfo()
 	}
 	return

--- a/cmd/spx/internal/command/build.go
+++ b/cmd/spx/internal/command/build.go
@@ -26,7 +26,6 @@ import (
 	"strings"
 
 	"github.com/goplus/spx/v2/cmd/spx/internal/util"
-	spxlog "github.com/goplus/spx/v2/internal/log"
 )
 
 func (cmd *CmdTool) BuildWasm() error {
@@ -39,7 +38,7 @@ func (cmd *CmdTool) BuildWasm() error {
 	filePath := path.Join(webBuildDir, "ispx.wasm")
 
 	return cmd.withGoDir(func() error {
-		spxlog.Debug("building WebAssembly binary: %s", filePath)
+		logDebugf("Building WebAssembly binary: %s", filePath)
 		envVars := []string{"GOOS=js", "GOARCH=wasm"}
 
 		util.RunGolang(envVars, "build", "-o", filePath)
@@ -79,7 +78,7 @@ func (cmd *CmdTool) BuildTinyGoLib() error {
 	envVars := []string{"GODEBUG=gotypesalias=0"}
 
 	if err := cmd.withGoDir(func() error {
-		spxlog.Info("building TinyGo static library for target: %s", target)
+		logInfof("Building TinyGo static library for target: %s", target)
 		if err := util.RunTinyGo(envVars, args...); err != nil {
 			return fmt.Errorf("tinygo build failed: %w", err)
 		}
@@ -88,7 +87,7 @@ func (cmd *CmdTool) BuildTinyGoLib() error {
 		return err
 	}
 
-	spxlog.Info("built TinyGo static library: %s", outputPath)
+	logInfof("Built TinyGo static library: %s", outputPath)
 	return nil
 }
 
@@ -128,7 +127,7 @@ func (cmd *CmdTool) withGoDir(f func() error) error {
 
 	defer func() {
 		if err := os.Chdir(rawdir); err != nil {
-			spxlog.Warn("failed to restore working directory to %s: %v", rawdir, err)
+			logWarnf("Failed to restore working directory to %s: %v", rawdir, err)
 		}
 	}()
 
@@ -140,7 +139,7 @@ func (cmd *CmdTool) hideIOSFiles() error {
 	searchPattern := filepath.Join(cmd.ProjectDir, "go", "ios*")
 	files, err := filepath.Glob(searchPattern)
 	if err != nil {
-		spxlog.Warn("glob failed for pattern %s: %v", searchPattern, err)
+		logWarnf("Glob failed for pattern %s: %v", searchPattern, err)
 		return nil
 	}
 
@@ -148,7 +147,7 @@ func (cmd *CmdTool) hideIOSFiles() error {
 		if !strings.HasSuffix(file, ".txt") {
 			newName := file + ".txt"
 			if err := os.Rename(file, newName); err != nil {
-				spxlog.Warn("failed to rename %s to %s: %v", file, newName, err)
+				logWarnf("Failed to rename %s to %s: %v", file, newName, err)
 			}
 		}
 	}
@@ -193,13 +192,13 @@ func (cmd *CmdTool) determineTargetArchs() ([]string, error) {
 func (cmd *CmdTool) genGo() string {
 	rawdir, err := os.Getwd()
 	if err != nil {
-		spxlog.Fatalf("failed to get current working directory: %v", err)
+		logFatalf("Failed to get current working directory: %v", err)
 	}
 
 	spxProjPath := filepath.Join(cmd.ProjectDir, "..")
 
 	if err := cmd.genGoUsingXgoCLI(rawdir, spxProjPath); err != nil {
-		spxlog.Fatalf("code generation failed using xgo CLI: %v", err)
+		logFatalf("Code generation failed using xgo CLI: %v", err)
 	}
 
 	return cmd.SafeTagArgs()
@@ -212,12 +211,12 @@ func (cmd *CmdTool) genGoUsingXgoCLI(rawdir, spxProjPath string) error {
 	}
 	defer func() {
 		if err := os.Chdir(rawdir); err != nil {
-			spxlog.Warn("failed to restore working directory to %s: %v", rawdir, err)
+			logWarnf("Failed to restore working directory to %s: %v", rawdir, err)
 		}
 	}()
 
 	tagStr := cmd.SafeTagArgs()
-	spxlog.Debug("genGo tags: %s", tagStr)
+	logDebugf("GenGo tags: %s", tagStr)
 	envVars := []string{""}
 
 	args := []string{"go"}
@@ -277,7 +276,7 @@ func (cmd *CmdTool) executeDllBuild(archs []string, tagStr string) error {
 		envs := append(baseEnvs, "GOARCH="+arch)
 		currentArgs := append(buildArgs, "-o", newPath)
 
-		spxlog.Debug("building shared library: envs=%s, args=%s", envs, currentArgs)
+		logDebugf("Building shared library: envs=%s, args=%s", envs, currentArgs)
 		util.RunGolang(envs, currentArgs...)
 	}
 	return nil

--- a/cmd/spx/internal/command/cmd.go
+++ b/cmd/spx/internal/command/cmd.go
@@ -26,7 +26,6 @@ import (
 	"strings"
 
 	"github.com/goplus/spx/v2/cmd/spx/internal/util"
-	spxlog "github.com/goplus/spx/v2/internal/log"
 )
 
 const PcExportName = "gdexport"
@@ -96,20 +95,24 @@ func (cmd *CmdTool) RunCmd(projectName, fileSuffix, version string, fs embed.FS,
 
 	err = cmd.parseCommandLineArgs(help, ext...)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		logErrorf("%v", err)
 		return err
 	}
 	if cmd.Args.Verbose != nil && *cmd.Args.Verbose {
-		spxlog.SetLevel(spxlog.LevelDebug)
+		enableDebugLogging()
 	}
 
 	if cmd.Args.CmdName == "init" {
-		return cmd.Init()
+		err = cmd.Init()
+		if err != nil {
+			logErrorf("Initializing project: %v", err)
+		}
+		return err
 	}
 
 	err = cmd.setupPaths(dstRelDir)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error setting up paths: %v\n", err)
+		logErrorf("Setting up paths: %v", err)
 		return err
 	}
 
@@ -119,13 +122,17 @@ func (cmd *CmdTool) RunCmd(projectName, fileSuffix, version string, fs embed.FS,
 
 	if cmd.Args.GoEnv != nil && *cmd.Args.GoEnv != "" {
 		if err := cmd.setupPortableGoEnv(); err != nil {
-			fmt.Fprintf(os.Stderr, "Failed to setup portable Go environment: %v\n", err)
+			logErrorf("Setting up portable Go environment: %v", err)
 			return fmt.Errorf("failed to setup portable Go environment: %w", err)
 		}
 	}
 
 	if isInterpretedRunCommand(cmd.Args.CmdName) {
-		return cmd.handleInterpretedRunCommand()
+		err = cmd.handleInterpretedRunCommand()
+		if err != nil {
+			logErrorf("Executing interpreted run command: %v", err)
+		}
+		return err
 	}
 
 	if isRuntimeModeCommand(cmd.Args.CmdName) {
@@ -134,7 +141,7 @@ func (cmd *CmdTool) RunCmd(projectName, fileSuffix, version string, fs embed.FS,
 
 	err = cmd.CheckEnv()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Environment check failed: %v\n", err)
+		logErrorf("Environment check failed: %v", err)
 		return err
 	}
 
@@ -145,7 +152,7 @@ func (cmd *CmdTool) RunCmd(projectName, fileSuffix, version string, fs embed.FS,
 
 	err = cmd.SetupEnv(version, fs, fsRelDir, dstRelDir)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to setup environment: %v\n", err)
+		logErrorf("Setting up environment: %v", err)
 		return err
 	}
 
@@ -160,12 +167,12 @@ func (cmd *CmdTool) handleSpecialCommands() bool {
 		return true
 	case "clear":
 		if err := cmd.Clear(); err != nil {
-			fmt.Fprintf(os.Stderr, "Failed to clear project: %v\n", err)
+			logErrorf("Clearing project: %v", err)
 		}
 		return true
 	case "stopweb":
 		if err := cmd.StopWeb(); err != nil {
-			fmt.Fprintf(os.Stderr, "Failed to stop web server: %v\n", err)
+			logErrorf("Stopping web server: %v", err)
 		}
 		return true
 	}
@@ -180,7 +187,7 @@ func (cmd *CmdTool) executeCommand() error {
 
 	err := cmd.handleExecutionPhase()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "error executing command: %v\n", err)
+		logErrorf("Executing command: %v", err)
 	}
 	return err
 
@@ -188,26 +195,26 @@ func (cmd *CmdTool) executeCommand() error {
 
 // handleBuildPhase runs the build step.
 func (cmd *CmdTool) handleBuildPhase() error {
-	spxlog.Debug("handling build phase: command=%s %s", cmd.Args.CmdName, cmd.SafeTagArgs())
+	logDebugf("Handling build phase: command=%s %s", cmd.Args.CmdName, cmd.SafeTagArgs())
 
 	switch cmd.Args.CmdName {
 	case "buildtinygo":
-		spxlog.Debug("running TinyGo library build")
+		logDebugf("Running TinyGo library build")
 		return cmd.BuildTinyGoLib()
 	case "editor", "rune", "export", "build", "runnative":
-		spxlog.Debug("checking DLL build conditions")
+		logDebugf("Checking DLL build conditions")
 		if cmd.Args.Tags == nil || !strings.Contains(*cmd.Args.Tags, "pure_engine") {
-			spxlog.Debug("running DLL build")
+			logDebugf("Running DLL build")
 			return cmd.BuildDll()
 		} else {
-			spxlog.Debug("skipping DLL build for pure_engine mode")
+			logDebugf("Skipping DLL build for pure_engine mode")
 		}
 	default:
 		if shouldBuildWasmForCommand(cmd.Args.CmdName) {
-			spxlog.Debug("running WebAssembly build")
+			logDebugf("Running WebAssembly build")
 			return cmd.BuildWasm()
 		}
-		spxlog.Debug("no build phase needed for command: %s", cmd.Args.CmdName)
+		logDebugf("No build phase needed for command: %s", cmd.Args.CmdName)
 	}
 	return nil
 }

--- a/cmd/spx/internal/command/env.go
+++ b/cmd/spx/internal/command/env.go
@@ -142,7 +142,7 @@ func (cmd *CmdTool) Reimport() {
 	default:
 		cmd.BuildDll()
 	}
-	fmt.Println(" ================= importing ... ================= ")
+	logInfof("Importing project resources")
 	execCmd := exec.Command(cmd.CmdPath, "--import", "--headless")
 	execCmd.Dir = cmd.ProjectDir
 	execCmd.Start()

--- a/cmd/spx/internal/command/export.go
+++ b/cmd/spx/internal/command/export.go
@@ -17,7 +17,6 @@
 package command
 
 import (
-	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -29,12 +28,12 @@ import (
 
 // ExportBuild runs a platform export with the current Godot project.
 func (cmd *CmdTool) ExportBuild(platform string) error {
-	fmt.Printf("starting export: platform=%s, project=%s\n", platform, cmd.ProjectDir)
+	logInfof("Starting export: platform=%s, project=%s", platform, cmd.ProjectDir)
 	os.MkdirAll(filepath.Join(cmd.ProjectDir, ".builds", strings.ToLower(platform)), 0o755)
 	execCmd := exec.Command(cmd.CmdPath, "--headless", "--quit", "--path", cmd.ProjectDir, "--export-debug", platform)
 	err := execCmd.Run()
 	if err != nil {
-		fmt.Println("exporting to web failed:", err)
+		logWarnf("Export failed for platform=%s: %v", platform, err)
 	}
 	return err
 }

--- a/cmd/spx/internal/command/export_android_impl.go
+++ b/cmd/spx/internal/command/export_android_impl.go
@@ -18,7 +18,6 @@ package command
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -68,15 +67,15 @@ func (cmd *CmdTool) ExportApk() error {
 		return fmt.Errorf("godot project file not found at %s", projectFilePath)
 	}
 
-	fmt.Println("importing project resources...")
+	logInfof("Importing project resources")
 	execCmd := exec.Command(cmd.CmdPath, "--headless", "--path", cmd.ProjectDir, "--editor", "--quit")
 	execCmd.Stdout = os.Stdout
 	execCmd.Stderr = os.Stderr
 	if err := execCmd.Run(); err != nil {
-		fmt.Printf("warning: project import failed: %v\n", err)
+		logWarnf("Project import failed: %v", err)
 	}
 
-	fmt.Println("exporting Godot project to APK...")
+	logInfof("Exporting Godot project to APK")
 	execCmd = exec.Command(cmd.CmdPath, "--headless", "--path", cmd.ProjectDir, "--export-debug", "Android", apkPath)
 	execCmd.Stdout = os.Stdout
 	execCmd.Stderr = os.Stderr
@@ -90,7 +89,7 @@ func (cmd *CmdTool) ExportApk() error {
 	} else if err != nil {
 		return fmt.Errorf("failed to verify APK output: %w", err)
 	}
-	log.Println("exported APK successfully:", apkPath)
+	logInfof("Exported APK successfully: %s", apkPath)
 
 	if !*cmd.Args.Install {
 		return nil
@@ -108,11 +107,11 @@ func (cmd *CmdTool) ExportApk() error {
 	if !strings.Contains(string(output), "device\n") {
 		return fmt.Errorf("no Android device connected; connect a device and enable USB debugging")
 	}
-	fmt.Println("installing APK...")
+	logInfof("Installing APK")
 	if err := util.ExecCommand(util.CommandOptions{}, "adb", "install", "-r", apkPath); err != nil {
 		return fmt.Errorf("failed to install APK: %w", err)
 	}
-	fmt.Println("installed APK successfully")
+	logInfof("Installed APK successfully")
 	return nil
 }
 
@@ -133,7 +132,7 @@ func (cmd *CmdTool) buildAndroidLibraries() error {
 		return err
 	}
 
-	fmt.Println("built Android shared libraries successfully")
+	logInfof("Built Android shared libraries successfully")
 	return nil
 }
 
@@ -180,7 +179,7 @@ func prepareAndroidLibraryDir(libDir string) error {
 
 func (cmd *CmdTool) buildAndroidSharedLibraries(paths androidBuildContext) error {
 	for _, build := range androidBuildConfigs() {
-		fmt.Printf("building for %s: %s\n", build.name, paths.goDir)
+		logInfof("Building Android shared library for %s: %s", build.name, paths.goDir)
 		if err := cmd.buildAndroidSharedLibrary(paths, build); err != nil {
 			return err
 		}

--- a/cmd/spx/internal/command/export_ios_impl.go
+++ b/cmd/spx/internal/command/export_ios_impl.go
@@ -18,7 +18,6 @@ package command
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -50,7 +49,7 @@ type iosArchiveBuild struct {
 
 // ExportIos exports the current project as an iOS IPA.
 func (cmd *CmdTool) ExportIos() error {
-	fmt.Println("===> starting iOS IPA export process...")
+	logInfof("Starting iOS IPA export process")
 
 	if err := cmd.prepareExport(); err != nil {
 		return err
@@ -60,11 +59,11 @@ func (cmd *CmdTool) ExportIos() error {
 		return err
 	}
 
-	fmt.Println("===> building iOS libraries...")
+	logInfof("Building iOS libraries")
 	if err := cmd.buildIosLibraries(); err != nil {
 		return fmt.Errorf("failed to build iOS libraries: %w", err)
 	}
-	fmt.Println("===> built iOS libraries successfully")
+	logInfof("Built iOS libraries successfully")
 
 	ipaPath, err := cmd.prepareIosOutput()
 	if err != nil {
@@ -104,12 +103,12 @@ func (cmd *CmdTool) renameIosArtifacts() error {
 func (cmd *CmdTool) prepareIosOutput() (string, error) {
 	ipaPath := filepath.Join(cmd.ProjectDir, ".builds", "ios", "Game.ipa")
 	buildDir := filepath.Dir(ipaPath)
-	fmt.Printf("===> output IPA path: %s\n", ipaPath)
+	logInfof("Output IPA path: %s", ipaPath)
 
 	if err := os.MkdirAll(buildDir, 0o755); err != nil {
 		return "", fmt.Errorf("failed to create build directory: %w", err)
 	}
-	fmt.Printf("===> build directory created: %s\n", buildDir)
+	logInfof("Build directory created: %s", buildDir)
 	return ipaPath, nil
 }
 
@@ -117,13 +116,13 @@ func (cmd *CmdTool) validateIosExportInputs() error {
 	if _, err := os.Stat(cmd.CmdPath); os.IsNotExist(err) {
 		return fmt.Errorf("godot binary not found at %s", cmd.CmdPath)
 	}
-	fmt.Printf("===> found Godot binary at: %s\n", cmd.CmdPath)
+	logInfof("Found Godot binary at: %s", cmd.CmdPath)
 
 	projectFilePath := filepath.Join(cmd.ProjectDir, "project.godot")
 	if _, err := os.Stat(projectFilePath); os.IsNotExist(err) {
 		return fmt.Errorf("godot project file not found at %s", projectFilePath)
 	}
-	fmt.Printf("===> found Godot project file at: %s\n", projectFilePath)
+	logInfof("Found Godot project file at: %s", projectFilePath)
 	return nil
 }
 
@@ -146,20 +145,20 @@ func (cmd *CmdTool) logIosExportTemplates() {
 		return
 	}
 
-	fmt.Printf("===> checking export templates at: %s\n", templateDir)
+	logInfof("Checking export templates at: %s", templateDir)
 	entries, err := os.ReadDir(templateDir)
 	if err != nil {
-		fmt.Printf("===> warning: could not read template directory: %v\n", err)
+		logWarnf("Could not read export template directory: %v", err)
 		return
 	}
 
-	fmt.Println("===> available export template versions:")
+	logInfof("Available export template versions")
 	for _, entry := range entries {
 		if !entry.IsDir() {
 			continue
 		}
 		versionDir := filepath.Join(templateDir, entry.Name())
-		fmt.Printf("     - %s\n", entry.Name())
+		logInfof("Export template version: %s", entry.Name())
 
 		files, err := os.ReadDir(versionDir)
 		if err != nil {
@@ -173,24 +172,24 @@ func (cmd *CmdTool) logIosExportTemplates() {
 			}
 		}
 		if len(iosFiles) > 0 {
-			fmt.Printf("       iOS templates: %v\n", iosFiles)
+			logInfof("Templates for iOS in %s: %v", entry.Name(), iosFiles)
 		}
 	}
 }
 
 func (cmd *CmdTool) importIosProjectResources() {
-	fmt.Println("===> importing project resources...")
+	logInfof("Importing project resources")
 	if err := util.ExecCommand(
 		util.CommandOptions{},
 		cmd.CmdPath, "--headless", "--path", cmd.ProjectDir, "--editor", "--quit",
 	); err != nil {
-		fmt.Printf("===> warning: project import had issues: %v\n", err)
+		logWarnf("Project import had issues: %v", err)
 	}
 }
 
 func (cmd *CmdTool) exportIosIPA(ipaPath string) error {
-	fmt.Println("===> exporting Godot project to IPA...")
-	fmt.Printf("===> export command: %s --headless --path %s --export-debug iOS %s\n",
+	logInfof("Exporting Godot project to IPA")
+	logInfof("Export command: %s --headless --path %s --export-debug iOS %s",
 		cmd.CmdPath, cmd.ProjectDir, ipaPath)
 
 	if err := util.ExecCommand(
@@ -203,7 +202,7 @@ func (cmd *CmdTool) exportIosIPA(ipaPath string) error {
 		return fmt.Errorf("failed to export IPA: file not created at %s", ipaPath)
 	}
 
-	log.Println("===> exported IPA successfully:", ipaPath)
+	logInfof("Exported IPA successfully: %s", ipaPath)
 	return nil
 }
 
@@ -212,7 +211,7 @@ func (cmd *CmdTool) installIosIPA(ipaPath string) error {
 		return nil
 	}
 
-	log.Println("trying to install IPA to devices...")
+	logInfof("Installing IPA on connected devices")
 	if err := util.ExecCommand(util.CommandOptions{}, "ios-deploy", "--bundle", ipaPath); err != nil {
 		return fmt.Errorf("failed to install IPA: %w", err)
 	}
@@ -225,7 +224,7 @@ func (cmd *CmdTool) buildIosLibraries() error {
 		return err
 	}
 
-	fmt.Println("📦 building Go libraries for iOS...")
+	logInfof("Building Go libraries for iOS")
 	if err := cmd.prepareIosHeaders(paths); err != nil {
 		return err
 	}
@@ -244,13 +243,13 @@ func (cmd *CmdTool) buildIosLibraries() error {
 		return err
 	}
 
-	fmt.Println("🧹 cleaning up temporary build files...")
+	logInfof("Cleaning up temporary build files")
 	if err := os.RemoveAll(paths.buildDir); err != nil {
 		return fmt.Errorf("failed to remove temporary build directory: %w", err)
 	}
 
-	fmt.Println("✅ built libgdspx.ios.xcframework successfully")
-	fmt.Println("📍 location:", paths.xcframeworkPath)
+	logInfof("Built libgdspx.ios.xcframework successfully")
+	logInfof("XCFramework location: %s", paths.xcframeworkPath)
 	return nil
 }
 
@@ -372,7 +371,7 @@ func (cmd *CmdTool) buildIosArchives(paths iosLibraryPaths, sdkPaths iosSDKPaths
 	}
 
 	for _, build := range builds {
-		fmt.Printf("🔨 building for %s...\n", build.name)
+		logInfof("Building iOS archive for %s", build.name)
 		if err := util.ExecCommand(util.CommandOptions{Env: build.env, Dir: paths.goSrcDir}, "go",
 			"build", "-tags=ios,packmode", "-buildmode=c-archive", "-trimpath", "-ldflags=-w -s",
 			"-o", build.outputPath, ".",
@@ -399,7 +398,7 @@ func newIosArchiveBuild(name, outputPath, sdkPath, goarch, cgoCFlags, cgoLDFlags
 }
 
 func createIosSimulatorFatBinary(paths iosLibraryPaths) error {
-	fmt.Println("🔗 creating fat binary for simulator...")
+	logInfof("Creating fat binary for simulator")
 	if err := util.ExecCommand(util.CommandOptions{}, "lipo", "-create", "-output",
 		filepath.Join(paths.simulatorDir, "libgdspx.a"),
 		filepath.Join(paths.simulatorDir, "libgdspx-x86_64.a"),
@@ -411,7 +410,7 @@ func createIosSimulatorFatBinary(paths iosLibraryPaths) error {
 }
 
 func createIosXCFramework(paths iosLibraryPaths) error {
-	fmt.Println("🎁 creating XCFramework...")
+	logInfof("Creating XCFramework")
 	if err := util.ExecCommand(util.CommandOptions{}, "xcrun", "xcodebuild", "-create-xcframework",
 		"-library", filepath.Join(paths.simulatorDir, "libgdspx.a"), "-headers", paths.headersDir,
 		"-library", filepath.Join(paths.deviceDir, "libgdspx-arm64.a"), "-headers", paths.headersDir,

--- a/cmd/spx/internal/command/export_web.go
+++ b/cmd/spx/internal/command/export_web.go
@@ -31,10 +31,10 @@ import (
 )
 
 const (
+	webNormalMode      = "normal"
 	webWorkerMode      = "worker"
 	webMinigameMode    = "minigame"
 	webMiniprogramMode = "miniprogram"
-	webNormalMode      = "normal"
 )
 
 type minigamePaths struct {
@@ -61,6 +61,27 @@ func (cmd *CmdTool) ExportWeb() error {
 		return err
 	}
 	util.CopyDir(cmd.PlatformFS, "template/platform/web"+webNormalMode, cmd.WebDir, true)
+	return nil
+}
+
+// ExportWebWorker exports the project for the worker-based web runtime.
+func (cmd *CmdTool) ExportWebWorker() error {
+	if err := cmd.exportWebCommon(webWorkerMode); err != nil {
+		return err
+	}
+	extDir := filepath.Join(cmd.WebDir, "__"+webWorkerMode)
+	util.CopyDir(cmd.PlatformFS, "template/platform/web"+webWorkerMode, extDir, true)
+	defer func() {
+		_ = os.RemoveAll(extDir)
+	}()
+
+	insertCode, err := cmd.readWebWorkerBundle(extDir)
+	if err != nil {
+		return err
+	}
+	if err := cmd.patchWebWorkerEngine(insertCode); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -91,25 +112,6 @@ func (cmd *CmdTool) ExportMiniprogram() error {
 		return err
 	}
 	util.CopyDir(cmd.PlatformFS, "template/platform/web"+webMiniprogramMode, cmd.WebDir, true)
-	return nil
-}
-
-// ExportWebWorker exports the project for the worker-based web runtime.
-func (cmd *CmdTool) ExportWebWorker() error {
-	if err := cmd.exportWebCommon(webWorkerMode); err != nil {
-		return err
-	}
-	extDir := filepath.Join(cmd.WebDir, "__"+webWorkerMode)
-	util.CopyDir(cmd.PlatformFS, "template/platform/web"+webWorkerMode, extDir, true)
-
-	insertCode, err := cmd.readWebWorkerBundle(extDir)
-	if err != nil {
-		return err
-	}
-	if err := cmd.patchWebWorkerEngine(insertCode); err != nil {
-		return err
-	}
-	os.RemoveAll(extDir)
 	return nil
 }
 
@@ -157,11 +159,11 @@ func (cmd *CmdTool) prepareMinigameEngineAssets(paths minigamePaths, buildMode s
 			return fmt.Errorf("error: brotli is not installed")
 		}
 
-		fmt.Printf("compress %s...\n", godotEditorWasm)
+		logInfof("Compressing %s", godotEditorWasm)
 		if err := cmd.compressBrotli(godotEditorWasm); err != nil {
 			return fmt.Errorf("failed to compress %s: %w", godotEditorWasm, err)
 		}
-		fmt.Printf("compress %s...\n", ispxWasm)
+		logInfof("Compressing %s", ispxWasm)
 		if err := cmd.compressBrotli(ispxWasm); err != nil {
 			return fmt.Errorf("failed to compress %s: %w", ispxWasm, err)
 		}
@@ -191,12 +193,12 @@ func (cmd *CmdTool) finalizeMinigameJS(paths minigamePaths, isCompressed bool) e
 
 func (cmd *CmdTool) openWeChatDevTools(workDir string) {
 	if wechatDevTools := os.Getenv("WECHAT_DEV_TOOLS"); wechatDevTools != "" {
-		fmt.Printf("open wechat dev tools %s\n", workDir)
+		logInfof("Opening WeChat DevTools for %s", workDir)
 		execCmd := exec.Command(filepath.Join(wechatDevTools, "cli"), "open", "--project", workDir, "-y")
 		execCmd.Run()
 		return
 	}
-	fmt.Printf("WECHAT_DEV_TOOLS is not set, please open project manually %s\n", workDir)
+	logWarnf("WECHAT_DEV_TOOLS is not set; open the project manually: %s", workDir)
 }
 
 func (cmd *CmdTool) readWebWorkerBundle(extDir string) (string, error) {
@@ -262,7 +264,7 @@ func (cmd *CmdTool) exportWebCommon(mode string) error {
 	os.MkdirAll(dstPath, 0o755)
 	util.CopyDir2(templateDir, dstPath)
 
-	println("==> _exportWeb", dstPath)
+	logInfof("Exporting web assets to %s", dstPath)
 	util.CopyDir(cmd.ProjectFS, "template/project", cmd.ProjectDir, true)
 
 	os.Rename(filepath.Join(dstPath, "godot.editor.html"), filepath.Join(dstPath, "index.html"))

--- a/cmd/spx/internal/command/init.go
+++ b/cmd/spx/internal/command/init.go
@@ -43,7 +43,7 @@ func (cmd *CmdTool) Init() error {
 		}
 	}
 
-	fmt.Printf("initializing SPX project in: %s\n", targetPath)
+	logInfof("Initializing SPX project in: %s", targetPath)
 
 	assetsDir := filepath.Join(targetPath, "assets")
 	if err := os.MkdirAll(assetsDir, 0755); err != nil {
@@ -79,9 +79,8 @@ onStart => {
 		return fmt.Errorf("failed to create go.mod: %w", err)
 	}
 
-	fmt.Println("")
-	fmt.Println("initialized SPX project successfully")
-	fmt.Println("run 'spx run' to start your project")
+	logInfof("Initialized SPX project successfully")
+	logInfof("Run 'spx run' to start your project")
 
 	return nil
 }

--- a/cmd/spx/internal/command/logging.go
+++ b/cmd/spx/internal/command/logging.go
@@ -1,0 +1,27 @@
+package command
+
+import "github.com/goplus/spx/v2/cmd/spx/internal/logutil"
+
+func enableDebugLogging() {
+	logutil.EnableDebug()
+}
+
+func logDebugf(format string, args ...any) {
+	logutil.Debugf(format, args...)
+}
+
+func logInfof(format string, args ...any) {
+	logutil.Infof(format, args...)
+}
+
+func logWarnf(format string, args ...any) {
+	logutil.Warnf(format, args...)
+}
+
+func logErrorf(format string, args ...any) {
+	logutil.Errorf(format, args...)
+}
+
+func logFatalf(format string, args ...any) {
+	logutil.Fatalf(format, args...)
+}

--- a/cmd/spx/internal/command/run.go
+++ b/cmd/spx/internal/command/run.go
@@ -380,7 +380,7 @@ func (cmd *CmdTool) runWebServer() error {
 		return fmt.Errorf("web server exited unexpectedly without an error")
 	case <-time.After(500 * time.Millisecond):
 	}
-	fmt.Printf("web server running at http://127.0.0.1:%d\n", port)
+	logInfof("Web server running at http://127.0.0.1:%d", port)
 	return nil
 }
 

--- a/cmd/spx/internal/logutil/logutil.go
+++ b/cmd/spx/internal/logutil/logutil.go
@@ -1,0 +1,27 @@
+package logutil
+
+import spxlog "github.com/goplus/spx/v2/internal/log"
+
+func EnableDebug() {
+	spxlog.SetLevel(spxlog.LevelDebug)
+}
+
+func Debugf(format string, args ...any) {
+	spxlog.Debug(format, args...)
+}
+
+func Infof(format string, args ...any) {
+	spxlog.Info(format, args...)
+}
+
+func Warnf(format string, args ...any) {
+	spxlog.Warn(format, args...)
+}
+
+func Errorf(format string, args ...any) {
+	spxlog.Error(format, args...)
+}
+
+func Fatalf(format string, args ...any) {
+	spxlog.Fatalf(format, args...)
+}

--- a/cmd/spx/internal/util/cmd.go
+++ b/cmd/spx/internal/util/cmd.go
@@ -20,7 +20,7 @@ import (
 	"os"
 	"os/exec"
 
-	spxlog "github.com/goplus/spx/v2/internal/log"
+	"github.com/goplus/spx/v2/cmd/spx/internal/logutil"
 )
 
 type CommandOptions struct {
@@ -41,7 +41,7 @@ func RunCommandWithEnv(envVars []string, name string, args ...string) error {
 // RunCommand runs a command and terminates the process if it fails.
 func RunCommand(envVars []string, dir string, name string, args ...string) error {
 	if err := ExecCommand(CommandOptions{Env: envVars, Dir: dir}, name, args...); err != nil {
-		spxlog.Fatalf("command %s failed: %v", name, err)
+		logutil.Fatalf("command %s failed: %v", name, err)
 	}
 	return nil
 }

--- a/cmd/spx/main.go
+++ b/cmd/spx/main.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"embed"
-	"fmt"
 	"os"
 
 	"github.com/goplus/spx/v2/cmd/spx/internal/command"
@@ -56,7 +55,6 @@ func main() {
 	// Initialize the Args field if not already initialized
 	err := cmd.RunCmd(appName, appName, cmd.Version, projectFS, "template/project", "project")
 	if err != nil {
-		fmt.Fprintln(os.Stderr, "failed to run cmd:", err)
 		os.Exit(1)
 	}
 }

--- a/cmd/spx/setup_font.sh
+++ b/cmd/spx/setup_font.sh
@@ -6,7 +6,7 @@ cd $SCRIPT_DIR
 target_font_path="./template/project/engine/fonts/CnFont.ttf"
 
 if [ -e "$target_font_path" ]; then
-    echo font path: $target_font_path
+    echo "Font path: $target_font_path"
     exit 0  
 fi
 

--- a/component_animation.go
+++ b/component_animation.go
@@ -73,7 +73,7 @@ func (a *animationComponent) initFromConfig(spriteCfg *coreproject.SpriteConfig)
 		var ani = val
 		_, ok := a.shared.animations[key]
 		if ok {
-			spxlog.Panicf("animation key [%s] already exists", key)
+			spxlog.Panicf("Animation key [%s] already exists", key)
 		}
 
 		defaults.SetDefaultIfZero(&ani.FrameFps, 25)
@@ -157,11 +157,11 @@ func (a *animationComponent) unRegisterOnAnimationFinished() {
 }
 
 func (a *animationComponent) Animate(name SpriteAnimationName, loop bool) {
-	a.playAnimation(name, loop, false, "==> Animation %s")
+	a.playAnimation(name, loop, false, "Animation: %s")
 }
 
 func (a *animationComponent) AnimateAndWait(name SpriteAnimationName) {
-	a.playAnimation(name, false, true, "==> AnimateAndWait %s")
+	a.playAnimation(name, false, true, "AnimateAndWait: %s")
 }
 
 func (a *animationComponent) StopAnimation(name SpriteAnimationName) {
@@ -357,7 +357,7 @@ func (a *animationComponent) costumeIndex(nameOrIndex any) int {
 	case SpriteCostumeName:
 		idx := a.sprite.findCostume(v)
 		if idx < 0 {
-			spxlog.Panicf("findCostume %s failed", v)
+			spxlog.Panicf("FindCostume failed for %s", v)
 		}
 		return idx
 	default:

--- a/game.go
+++ b/game.go
@@ -231,7 +231,7 @@ func (p *Game) getSpriteProtoByName(name string, g reflect.Value) Sprite {
 	if !ok {
 		tySpr, ok := p.typs[name]
 		if !ok {
-			spxlog.Panicf("sprite %s is not defined", name)
+			spxlog.Panicf("Sprite %s is not defined", name)
 		}
 		spr = p.newSpriteAndLoad(name, tySpr, g)
 	}

--- a/game_build.go
+++ b/game_build.go
@@ -191,7 +191,7 @@ func setupGameSystems(g *Game, proj *coreproject.ProjectConfig) {
 // Loading
 // -----------------------------------------------------------------------------
 func loadGameSprites(g *Game, v reflect.Value, fs spxfs.Dir, proj *coreproject.ProjectConfig) {
-	spxlog.Debug("==> StartLoad")
+	spxlog.Debug("StartLoad")
 
 	g.startLoad(fs)
 	err := coreproject.WalkFields(v, func(fieldIndex int) (string, any) {

--- a/game_load.go
+++ b/game_load.go
@@ -29,7 +29,7 @@ import (
 )
 
 func (p *Game) loadSprite(sprite Sprite, name string, gamer reflect.Value) error {
-	spxlog.Debug("==> LoadSprite: %s", name)
+	spxlog.Debug("LoadSprite: %s", name)
 	loaded, err := coreproject.LoadSpriteConfig(p.fs, name)
 	if err != nil {
 		return err
@@ -87,7 +87,7 @@ func (p *Game) setupWorldAndWindow(proj *coreproject.ProjectConfig) {
 	} else {
 		p.baseObj.initWithSize(p.displayState.WorldWidth, p.displayState.WorldHeight)
 	}
-	spxlog.Debug("==> SetWorldSize: %d, %d", p.displayState.WorldWidth, p.displayState.WorldHeight)
+	spxlog.Debug("SetWorldSize: %d, %d", p.displayState.WorldWidth, p.displayState.WorldHeight)
 
 	metrics := coreproject.ResolveWorldWindowMetrics(
 		p.displayState.WorldWidth,
@@ -102,7 +102,7 @@ func (p *Game) setupWorldAndWindow(proj *coreproject.ProjectConfig) {
 	p.displayState.MinWorldY = metrics.MinWorldY
 	p.displayState.MapMode = metrics.MapMode
 	p.doWindowSize()
-	spxlog.Debug("==> SetWindowSize: %d, %d", p.displayState.WindowWidth, p.displayState.WindowHeight)
+	spxlog.Debug("SetWindowSize: %d, %d", p.displayState.WindowWidth, p.displayState.WindowHeight)
 
 	metrics = coreproject.ResolveWorldWindowMetrics(
 		p.displayState.WorldWidth,
@@ -239,7 +239,7 @@ func (p *Game) setupAudioAndTilemap(proj *coreproject.ProjectConfig) {
 }
 
 func (p *Game) endLoad(g reflect.Value, proj *coreproject.ProjectConfig, generation uint64) (err error) {
-	spxlog.Debug("==> EndLoad")
+	spxlog.Debug("EndLoad")
 	return p.loadIndex(g, proj, generation)
 }
 
@@ -248,7 +248,7 @@ func (p *Game) addSpecialShape(g reflect.Value, v coreproject.StageShape, inits 
 		StageMonitor: func(shape coreproject.StageShape) error {
 			sm, err := newMonitor(g, shape)
 			if err != nil {
-				spxlog.Error("addSpecialShape type: %s", shape["type"])
+				spxlog.Error("AddSpecialShape type: %s", shape["type"])
 				return nil
 			}
 			sm.game = p

--- a/game_physics.go
+++ b/game_physics.go
@@ -152,8 +152,8 @@ type spriteCollisionData struct {
 func (p *Game) applyPhysicsSettings(settings coreproject.SystemSettings) {
 	p.isCollisionByPixel = settings.CollisionByPixel
 	p.isAutoSetCollisionLayer = settings.AutoSetCollisionLayer
-	spxlog.Debug("==> isCollisionByPixel: %v", p.isCollisionByPixel)
-	spxlog.Debug("==> isAutoSetCollisionLayer: %v", p.isAutoSetCollisionLayer)
+	spxlog.Debug("IsCollisionByPixel: %v", p.isCollisionByPixel)
+	spxlog.Debug("IsAutoSetCollisionLayer: %v", p.isAutoSetCollisionLayer)
 
 	p.engine().SpriteMgr.SetPixelCollisionSamplingStep(settings.PixelCollisionPrecision)
 
@@ -250,7 +250,7 @@ func (p *Game) applyCollisionLayers(spriteData []*spriteCollisionData) {
 
 	for _, data := range spriteData {
 		data.info.Mask = maskMap[data.modIdx]
-		spxlog.Debug("init sprite collision info: name=%s, layer=%d, mask=%d", data.sprite.name, data.info.Layer, data.info.Mask)
+		spxlog.Debug("Init sprite collision info: name=%s, layer=%d, mask=%d", data.sprite.name, data.info.Layer, data.info.Mask)
 	}
 
 	engine.WaitMainThread(func() {

--- a/game_sound.go
+++ b/game_sound.go
@@ -132,10 +132,10 @@ func (p *Game) loadSound(name SoundName) (media sound, err error) {
 		return media, nil
 	}
 
-	spxlog.Debug("==> LoadSound: %s", name)
+	spxlog.Debug("LoadSound: %s", name)
 	loaded, err := coreproject.LoadSoundConfig(p.fs, name)
 	if err != nil {
-		spxlog.Error("loadSound failed: %v", err)
+		spxlog.Error("LoadSound failed: %v", err)
 		return
 	}
 	media = &loaded.Config

--- a/game_stage.go
+++ b/game_stage.go
@@ -180,7 +180,7 @@ func (p *Game) Ask(msg any) {
 		msgStr = fmt.Sprint(msg)
 	}
 	if msgStr == "" {
-		spxlog.Warn("ask: msg should not be empty")
+		spxlog.Warn("Ask: message should not be empty")
 		return
 	}
 	p.ask(false, msgStr, func(answer string) {})

--- a/internal/cmd/buildctl/dockercmd/docker.go
+++ b/internal/cmd/buildctl/dockercmd/docker.go
@@ -160,8 +160,8 @@ func runDockerBuildEngine(cfg dockerBuildEngineConfig) error {
 		return err
 	}
 
-	fmt.Fprintln(os.Stdout, "All builds completed successfully!")
-	fmt.Fprintln(os.Stdout, "Build logs can be found in the logs directory")
+	fmt.Fprintln(os.Stdout, "All builds completed successfully.")
+	fmt.Fprintln(os.Stdout, "Build logs are available in the logs directory.")
 	return nil
 }
 
@@ -188,11 +188,9 @@ func resolveDockerGodotPath(repoRoot, explicit string) (string, error) {
 
 func runPodmanSConsBuild(podmanPath, logsDir, godotPath, platform string, sconsArgs ...string) error {
 	fmt.Fprintf(os.Stdout, "Building for platform: %s\n", platform)
-	fmt.Fprintf(os.Stdout, "Build arguments: %s\n", strings.Join(sconsArgs, " "))
-	fmt.Fprintf(os.Stdout, "Platform: %s\n", platform)
 	fmt.Fprintf(os.Stdout, "Using image version: %s\n", DockerImageVersion)
 	fmt.Fprintf(os.Stdout, "Godot source path: %s\n", godotPath)
-	fmt.Fprintf(os.Stdout, "Scons arguments: %s\n", strings.Join(sconsArgs, " "))
+	fmt.Fprintf(os.Stdout, "SCons arguments: %s\n", strings.Join(sconsArgs, " "))
 	fmt.Fprintln(os.Stdout, "----------------------------------------")
 
 	args := buildPodmanSConsArgs(godotPath, platform, sconsArgs, stdinHasTTY())
@@ -201,7 +199,7 @@ func runPodmanSConsBuild(podmanPath, logsDir, godotPath, platform string, sconsA
 		return fmt.Errorf("build failed for platform %s: %w", platform, err)
 	}
 
-	fmt.Fprintf(os.Stdout, "Build completed successfully for %s\n", platform)
+	fmt.Fprintf(os.Stdout, "Completed build for %s\n", platform)
 	fmt.Fprintln(os.Stdout, "----------------------------------------")
 	return nil
 }

--- a/internal/cmd/buildctl/engine/build.go
+++ b/internal/cmd/buildctl/engine/build.go
@@ -100,7 +100,7 @@ func prepareEngineBuildEnvironment(repoRoot, requestedPlatform string) (buildEnv
 
 	commandEnv := currentEnvMap()
 	if runtime.GOOS == "darwin" {
-		fmt.Fprintln(os.Stdout, "try to install macos vulkan sdk")
+		fmt.Fprintf(os.Stdout, "Installing macOS Vulkan SDK...\n")
 		if err := runStreamingCommand(buildEnv.EngineDir, filepath.Join("misc", "scripts", "install_vulkan_sdk_macos.sh")); err != nil {
 			return buildEnvironment{}, nil, err
 		}
@@ -110,10 +110,10 @@ func prepareEngineBuildEnvironment(repoRoot, requestedPlatform string) (buildEnv
 				commandEnv["PATH"] = prependToPath(commandEnv["PATH"], filepath.Join(sdkRoot, "bin"))
 				fmt.Fprintf(os.Stdout, "Using macOS Vulkan SDK from %s\n", sdkRoot)
 				if _, err := runCommandOutputWithEnv("", envMapToSlice(commandEnv), "vulkaninfo", "--summary"); err != nil {
-					fmt.Fprintln(os.Stdout, "Warning: vulkaninfo check failed, continuing with configured Vulkan SDK.")
+					fmt.Fprintf(os.Stdout, "Warning: vulkaninfo check failed. Continuing with the configured Vulkan SDK.\n")
 				}
 			} else {
-				fmt.Fprintln(os.Stdout, "Warning: vulkaninfo not found after Vulkan SDK setup, continuing anyway.")
+				fmt.Fprintf(os.Stdout, "Warning: vulkaninfo was not found after Vulkan SDK setup. Continuing anyway.\n")
 			}
 		}
 	}
@@ -122,15 +122,12 @@ func prepareEngineBuildEnvironment(repoRoot, requestedPlatform string) (buildEnv
 }
 
 func printBuildEnvironmentSummary(buildEnv buildEnvironment) {
-	fmt.Fprintf(os.Stdout, "version=%s GOPATH=%s\n", buildEnv.Version, buildEnv.GoPath)
 	fmt.Fprintf(os.Stdout, "PROJ_DIR=%s\n", buildEnv.ProjectDir)
 	fmt.Fprintf(os.Stdout, "ENGINE_DIR=%s\n", buildEnv.EngineDir)
 	fmt.Fprintf(os.Stdout, "GODOT_SRC=%s\n", buildEnv.GodotSrc)
 	fmt.Fprintf(os.Stdout, "ENGINE_VERSION=%s\n", buildEnv.EngineVersion)
 	fmt.Fprintf(os.Stdout, "GOPATH=%s\n", buildEnv.GoPath)
 	fmt.Fprintf(os.Stdout, "VERSION=%s\n", buildEnv.Version)
-	fmt.Fprintln(os.Stdout, "Detecting platform...")
-	fmt.Fprintln(os.Stdout, runtime.GOOS)
 	fmt.Fprintf(os.Stdout, "Platform: %s\n", buildEnv.Platform)
 	fmt.Fprintf(os.Stdout, "Architecture: %s\n", buildEnv.Arch)
 	fmt.Fprintf(os.Stdout, "Destination directory: %s\n", buildEnv.TemplateDir)
@@ -138,7 +135,7 @@ func printBuildEnvironmentSummary(buildEnv buildEnvironment) {
 }
 
 func buildEngineEditor(buildEnv buildEnvironment, commandEnv map[string]string, plan engineBuildShellPlan) error {
-	fmt.Fprintln(os.Stdout, "scons target=editor dev_build=yes "+strings.Join(engineCommonArgs, " "))
+	fmt.Fprintf(os.Stdout, "scons target=editor dev_build=yes %s\n", strings.Join(engineCommonArgs, " "))
 	args := append([]string{"target=editor", "dev_build=yes"}, engineCommonArgs...)
 	if plan.EditorUseVSProj {
 		args = append(args, "vsproj=yes")
@@ -152,7 +149,7 @@ func buildEngineEditor(buildEnv buildEnvironment, commandEnv map[string]string, 
 }
 
 func buildEngineTemplate(buildEnv buildEnvironment, commandEnv map[string]string, plan engineBuildShellPlan) error {
-	fmt.Fprintf(os.Stdout, "save to %s\n", buildEnv.TemplateDir)
+	fmt.Fprintf(os.Stdout, "Output directory: %s\n", buildEnv.TemplateDir)
 	fmt.Fprintf(os.Stdout, "Destination binary path: %s\n", filepath.Join(buildEnv.GoPath, "bin", "gdspxrt"+buildEnv.Version))
 
 	switch plan.Platform {
@@ -200,7 +197,7 @@ func buildEngineTemplate(buildEnv buildEnvironment, commandEnv map[string]string
 		if plan.WebProxyToPThread {
 			webArgs = append(webArgs, "proxy_to_pthread=true")
 		}
-		fmt.Fprintln(os.Stdout, "scons "+strings.Join(webArgs, " "))
+		fmt.Fprintf(os.Stdout, "scons %s\n", strings.Join(webArgs, " "))
 		if err := runLockedEngineCommandWithEnv(buildEnv.EngineDir, commandEnv, "scons", webArgs...); err != nil {
 			return err
 		}

--- a/internal/cmd/buildctl/engine/download.go
+++ b/internal/cmd/buildctl/engine/download.go
@@ -59,7 +59,7 @@ func downloadEngineAssets(cfg engineDownloadConfig, repoRoot string) error {
 			return err
 		}
 		if err := downloadRuntimePack(env); err != nil {
-			fmt.Fprintf(osStderr, "warning: failed to download runtime pack: %v\n", err)
+			fmt.Fprintf(osStderr, "Warning: failed to download runtime pack: %v\n", err)
 		}
 		return nil
 	}

--- a/internal/cmd/buildctl/runtimecmd/compress.go
+++ b/internal/cmd/buildctl/runtimecmd/compress.go
@@ -69,7 +69,7 @@ func ensureBrotliAvailable() error {
 		return nil
 	}
 
-	fmt.Fprintln(os.Stdout, "brotli not detected, trying to install...")
+	fmt.Fprintln(os.Stdout, "Brotli not detected. Installing...")
 	switch runtime.GOOS {
 	case "linux":
 		if err := installBrotliLinux(); err != nil {
@@ -141,7 +141,7 @@ func compressWithBrotli(inputFile, outputFile string) error {
 	if err := runStreamingCommand("", "brotli", "-q", "11", "-o", outputFile, inputFile); err != nil {
 		return err
 	}
-	fmt.Fprintf(os.Stdout, "%s has been created\n", outputFile)
+	fmt.Fprintf(os.Stdout, "Created %s\n", outputFile)
 	return nil
 }
 

--- a/internal/cmd/buildctl/shared/env_tools.go
+++ b/internal/cmd/buildctl/shared/env_tools.go
@@ -35,7 +35,7 @@ func ensureEngineSource(repoRoot string, run func(name string, args ...string) e
 		return nil
 	}
 
-	fmt.Fprintf(os.Stdout, "Godot directory not found. Cloning to %s ...\n", env.EngineDir)
+	fmt.Fprintf(os.Stdout, "Godot directory not found. Cloning to %s...\n", env.EngineDir)
 	if err := os.MkdirAll(filepath.Dir(env.EngineDir), 0o755); err != nil {
 		return err
 	}

--- a/internal/cmd/buildctl/tool/setup_env.go
+++ b/internal/cmd/buildctl/tool/setup_env.go
@@ -177,13 +177,13 @@ func setupEMSDK() error {
 		return err
 	}
 
-	fmt.Fprintf(os.Stdout, "Using emsdk installation directory: %s\n", env.rootDir)
+	fmt.Fprintf(os.Stdout, "EMSDK installation directory: %s\n", env.rootDir)
 	if err := os.MkdirAll(env.rootDir, 0o755); err != nil {
 		return err
 	}
 
 	if !fileExists(env.repoDir) {
-		fmt.Fprintln(os.Stdout, "emsdk not found in global location, installing emsdk...")
+		fmt.Fprintln(os.Stdout, "EMSDK not found in the global location. Installing...")
 		if err := buildEnvRunStreaming(env.rootDir, "git", "clone", "https://github.com/emscripten-core/emsdk.git"); err != nil {
 			return err
 		}
@@ -198,16 +198,16 @@ func setupEMSDK() error {
 
 	currentVersion, ok := detectEMSDKVersion(env)
 	if ok {
-		fmt.Fprintf(os.Stdout, "current emcc version: %s, target version: %s\n", currentVersion, requiredEMSDKVersion)
+		fmt.Fprintf(os.Stdout, "Current emcc version: %s; target version: %s\n", currentVersion, requiredEMSDKVersion)
 	}
 
 	if !ok || currentVersion != requiredEMSDKVersion {
-		fmt.Fprintf(os.Stdout, "emcc version mismatch, installing target version %s...\n", requiredEMSDKVersion)
+		fmt.Fprintf(os.Stdout, "Installing target emcc version %s...\n", requiredEMSDKVersion)
 		if err := buildEnvRunStreaming(env.repoDir, "./emsdk", "install", requiredEMSDKVersion); err != nil {
 			return err
 		}
 	} else {
-		fmt.Fprintln(os.Stdout, "emcc version matches, no need to re-install")
+		fmt.Fprintln(os.Stdout, "Current emcc version matches the target version. No reinstall needed.")
 	}
 	if err := buildEnvRunStreaming(env.repoDir, "./emsdk", "activate", requiredEMSDKVersion); err != nil {
 		return err
@@ -224,7 +224,7 @@ func verifyEMSDK(env emsdkEnvironment) error {
 	if err != nil {
 		return fmt.Errorf("failed to set up emsdk. Please check the installation: %w", err)
 	}
-	fmt.Fprintln(os.Stdout, "emsdk is set up successfully:")
+	fmt.Fprintln(os.Stdout, "EMSDK setup completed:")
 	fmt.Fprint(os.Stdout, string(output))
 	return nil
 }

--- a/internal/cmd/buildctl/workflow/cmd.go
+++ b/internal/cmd/buildctl/workflow/cmd.go
@@ -386,7 +386,7 @@ func buildDevWorkflow(cfg workflowBuildDevConfig, runner scriptRunner) error {
 		return err
 	}
 
-	fmt.Fprintln(os.Stdout, "===> build-dev done, use 'make run DEMO_INDEX=N' to run demo")
+	fmt.Fprintln(os.Stdout, "Build complete. Run a demo with: make run DEMO_INDEX=N")
 	return nil
 }
 
@@ -485,5 +485,5 @@ func runEngineBuildWorkflow(runner scriptRunner, cfg engineBuildConfig) error {
 }
 
 func printWorkflowStep(step, total int, label string) {
-	fmt.Fprintf(os.Stdout, "===> Step %d/%d: %s\n", step, total, label)
+	fmt.Fprintf(os.Stdout, "Step %d/%d: %s\n", step, total, label)
 }

--- a/internal/cmd/codegen/generate/common/funcs.go
+++ b/internal/cmd/codegen/generate/common/funcs.go
@@ -738,6 +738,6 @@ func GenerateFile(funcs template.FuncMap, name string, text string, data any, ds
 		exec.Command("go", "fmt", dstPath).Run()
 		exec.Command("goimports", "-w", dstPath).Run()
 	}
-	spxlog.Info("generate file: %s", dstPath)
+	spxlog.Info("Generated file: %s", dstPath)
 	return nil
 }

--- a/internal/cmd/codegen/generate/gdext/generate.go
+++ b/internal/cmd/codegen/generate/gdext/generate.go
@@ -70,7 +70,7 @@ func GenerateHeader(projectPath, godotPath string) {
 	dir := filepath.Join(godotPath, "modules", "spx")
 	_, err := os.Stat(dir)
 	if os.IsNotExist(err) {
-		spxlog.Warn("dir not exist %s", dir)
+		spxlog.Warn("Directory does not exist: %s", dir)
 		return
 	}
 	outputFile := filepath.Join(projectPath, NativeRelDir, "gdextension_spx_ext.h")
@@ -80,7 +80,7 @@ func Generate(projectPath, godotPath string, ast clang.CHeaderFileAST) {
 	dir := filepath.Join(godotPath, "modules", "spx")
 	_, err := os.Stat(dir)
 	if os.IsNotExist(err) {
-		spxlog.Warn("dir not exist %s", dir)
+		spxlog.Warn("Directory does not exist: %s", dir)
 		return
 	}
 	err = generateGdCppFile(projectPath, gdSpxExtCpp, ast, "gdextension_spx_ext.cpp")

--- a/internal/cmd/codegen/internal/log/log.go
+++ b/internal/cmd/codegen/internal/log/log.go
@@ -37,19 +37,31 @@ const (
 )
 
 type Logger struct {
-	mu     sync.Mutex
-	level  Level
-	logger *stdlog.Logger
-	prefix string
+	mu           sync.Mutex
+	level        Level
+	stdoutLogger *stdlog.Logger
+	stderrLogger *stdlog.Logger
+	prefix       string
 }
 
-var defaultLogger = New("SPX-CODEGEN", LevelInfo, os.Stdout)
+var defaultLogger = NewWithOutputs("SPX-CODEGEN", LevelInfo, os.Stdout, os.Stderr)
 
 func New(prefix string, level Level, out io.Writer) *Logger {
+	return NewWithOutputs(prefix, level, out, out)
+}
+
+func NewWithOutputs(prefix string, level Level, stdout, stderr io.Writer) *Logger {
+	if stdout == nil {
+		stdout = io.Discard
+	}
+	if stderr == nil {
+		stderr = io.Discard
+	}
 	return &Logger{
-		level:  level,
-		logger: stdlog.New(out, "", stdlog.Ldate|stdlog.Ltime|stdlog.Lmicroseconds),
-		prefix: prefix,
+		level:        level,
+		stdoutLogger: stdlog.New(stdout, "", stdlog.Ldate|stdlog.Ltime|stdlog.Lmicroseconds),
+		stderrLogger: stdlog.New(stderr, "", stdlog.Ldate|stdlog.Ltime|stdlog.Lmicroseconds),
+		prefix:       prefix,
 	}
 }
 
@@ -60,7 +72,18 @@ func (l *Logger) SetLevel(level Level) {
 func (l *Logger) SetOutput(w io.Writer) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	l.logger.SetOutput(w)
+	if w == nil {
+		w = io.Discard
+	}
+	l.stdoutLogger.SetOutput(w)
+	l.stderrLogger.SetOutput(w)
+}
+
+func (l *Logger) targetLogger(level Level) *stdlog.Logger {
+	if level >= LevelError {
+		return l.stderrLogger
+	}
+	return l.stdoutLogger
 }
 
 func (l *Logger) log(level Level, format string, args ...any) {
@@ -78,7 +101,7 @@ func (l *Logger) log(level Level, format string, args ...any) {
 	if len(args) > 0 {
 		msg = fmt.Sprintf(format, args...)
 	}
-	l.logger.Printf("[%s] [%s] %s", level.String(), l.prefix, msg)
+	l.targetLogger(level).Printf("[%s] [%s] %s", level.String(), l.prefix, msg)
 }
 
 func (l *Logger) Panicf(format string, args ...any) {
@@ -93,7 +116,7 @@ func (l *Logger) Panicf(format string, args ...any) {
 	if Level(atomic.LoadInt32((*int32)(&l.level))) > LevelError {
 		panic(msg)
 	}
-	l.logger.Panicf("[%s] [%s] %s", LevelError.String(), l.prefix, msg)
+	l.stderrLogger.Panicf("[%s] [%s] %s", LevelError.String(), l.prefix, msg)
 }
 
 func (l *Logger) format(format string, args ...any) string {

--- a/internal/cmd/codegen/main.go
+++ b/internal/cmd/codegen/main.go
@@ -31,13 +31,13 @@ import (
 )
 
 var (
-	verbose          bool
-	genClangAPI      bool
-	genExtensionAPI  bool
-	packagePath      string
-	godotPath        string
-	parsedASTPath    string
-	buildConfig      string
+	verbose         bool
+	genClangAPI     bool
+	genExtensionAPI bool
+	packagePath     string
+	godotPath       string
+	parsedASTPath   string
+	buildConfig     string
 )
 
 func init() {
@@ -100,7 +100,7 @@ func generateCode() error {
 	}
 
 	if verbose {
-		spxlog.Info("cli tool done")
+		spxlog.Info("CLI tool completed")
 	}
 	return nil
 }

--- a/internal/core/project/resources.go
+++ b/internal/core/project/resources.go
@@ -95,7 +95,7 @@ func LoadJSON(ret any, fs spxfs.Dir, file string) error {
 
 	f, err := fs.Open(file)
 	if err != nil {
-		spxlog.Error("failed to open file %s: %v", file, err)
+		spxlog.Error("Failed to open file %s: %v", file, err)
 		return err
 	}
 	defer f.Close()

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -63,10 +63,11 @@ func (l Level) String() string {
 
 // Logger represents a logger instance
 type Logger struct {
-	mu     sync.Mutex
-	level  Level
-	logger *log.Logger
-	prefix string
+	mu           sync.Mutex
+	level        Level
+	stdoutLogger *log.Logger
+	stderrLogger *log.Logger
+	prefix       string
 }
 
 var (
@@ -75,15 +76,27 @@ var (
 
 // init initializes the default logger
 func init() {
-	defaultLogger = New("SPX", LevelInfo, os.Stdout)
+	defaultLogger = NewWithOutputs("SPX", LevelInfo, os.Stdout, os.Stderr)
 }
 
 // New creates a new logger with the specified prefix, level, and output
 func New(prefix string, level Level, out io.Writer) *Logger {
+	return NewWithOutputs(prefix, level, out, out)
+}
+
+// NewWithOutputs creates a new logger with independent stdout/stderr outputs.
+func NewWithOutputs(prefix string, level Level, stdout, stderr io.Writer) *Logger {
+	if stdout == nil {
+		stdout = io.Discard
+	}
+	if stderr == nil {
+		stderr = io.Discard
+	}
 	return &Logger{
-		level:  level,
-		logger: log.New(out, "", log.Ldate|log.Ltime|log.Lmicroseconds),
-		prefix: prefix,
+		level:        level,
+		stdoutLogger: log.New(stdout, "", log.Ldate|log.Ltime|log.Lmicroseconds),
+		stderrLogger: log.New(stderr, "", log.Ldate|log.Ltime|log.Lmicroseconds),
+		prefix:       prefix,
 	}
 }
 
@@ -102,16 +115,57 @@ func (l *Logger) SetLevel(level Level) {
 	atomic.StoreInt32((*int32)(&l.level), int32(level))
 }
 
-// SetOutput sets the output destination for the default logger
+// SetOutput sets both stdout/stderr destinations for the default logger.
 func SetOutput(w io.Writer) {
 	defaultLogger.SetOutput(w)
 }
 
-// SetOutput sets the output destination for this logger
+// SetOutput sets both stdout/stderr destinations for this logger.
 func (l *Logger) SetOutput(w io.Writer) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	l.logger.SetOutput(w)
+	if w == nil {
+		w = io.Discard
+	}
+	l.stdoutLogger.SetOutput(w)
+	l.stderrLogger.SetOutput(w)
+}
+
+// SetStdoutOutput sets the stdout destination for the default logger.
+func SetStdoutOutput(w io.Writer) {
+	defaultLogger.SetStdoutOutput(w)
+}
+
+// SetStdoutOutput sets the stdout destination for this logger.
+func (l *Logger) SetStdoutOutput(w io.Writer) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if w == nil {
+		w = io.Discard
+	}
+	l.stdoutLogger.SetOutput(w)
+}
+
+// SetStderrOutput sets the stderr destination for the default logger.
+func SetStderrOutput(w io.Writer) {
+	defaultLogger.SetStderrOutput(w)
+}
+
+// SetStderrOutput sets the stderr destination for this logger.
+func (l *Logger) SetStderrOutput(w io.Writer) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if w == nil {
+		w = io.Discard
+	}
+	l.stderrLogger.SetOutput(w)
+}
+
+func (l *Logger) targetLogger(level Level) *log.Logger {
+	if level >= LevelError {
+		return l.stderrLogger
+	}
+	return l.stdoutLogger
 }
 
 // log is the internal logging function
@@ -133,7 +187,7 @@ func (l *Logger) log(level Level, format string, args ...any) {
 	} else {
 		msg = format
 	}
-	l.logger.Printf("[%s] [%s] %s", level, l.prefix, msg)
+	l.targetLogger(level).Printf("[%s] [%s] %s", level, l.prefix, msg)
 }
 
 func (l *Logger) format(format string, args ...any) string {
@@ -175,7 +229,7 @@ func (l *Logger) Fatalf(format string, args ...any) {
 		l.mu.Unlock()
 		os.Exit(1)
 	}
-	l.logger.Fatalf("[%s] [%s] %s", LevelError.String(), l.prefix, msg)
+	l.stderrLogger.Fatalf("[%s] [%s] %s", LevelError.String(), l.prefix, msg)
 }
 
 // Panicf panics with the formatted message, also logging it at error level if the current log level permits.
@@ -191,7 +245,7 @@ func (l *Logger) Panicf(format string, args ...any) {
 	if Level(atomic.LoadInt32((*int32)(&l.level))) > LevelError {
 		panic(msg)
 	}
-	l.logger.Panicf("[%s] [%s] %s", LevelError.String(), l.prefix, msg)
+	l.stderrLogger.Panicf("[%s] [%s] %s", LevelError.String(), l.prefix, msg)
 }
 
 // Package-level convenience functions using the default logger

--- a/runtime_engine.go
+++ b/runtime_engine.go
@@ -87,7 +87,7 @@ func (p *Game) OnEnginePause(bool) {
 // Loop Setup
 // -----------------------------------------------------------------------------
 func (p *Game) runLoop(cfg *Config) (err error) {
-	spxlog.Debug("==> RunLoop")
+	spxlog.Debug("RunLoop")
 	if !cfg.DontRunOnUnfocused {
 		p.engine().PlatformMgr.SetRunnableOnUnfocused(true)
 	}

--- a/runtime_events.go
+++ b/runtime_events.go
@@ -86,7 +86,7 @@ func (p *scriptEventBindings) OnStart(onStart func()) {
 	if sprite, ok := sink.Owner.(*SpriteImpl); ok && sprite.spriteState.Cloned {
 		return
 	}
-	spxlog.Warn("event: ignoring late OnStart registration for %s", nameOf(sink.Owner))
+	spxlog.Warn("Event: ignoring late OnStart registration for %s", nameOf(sink.Owner))
 }
 
 func (p *scriptEventBindings) OnClick(onClick func()) {
@@ -103,7 +103,7 @@ func (p *scriptEventBindings) OnTimer(time float64, call func()) {
 	p.scriptEventRegistry.manager.AddTimer(coreevent.NewSink(
 		p.pthis,
 		coreevent.TapVoid1(call, coreevent.If1(isDebugEventEnabled, func(float64) {
-			spxlog.Debug("==> onTimer: %s", nameOf(p.pthis))
+			spxlog.Debug("OnTimer: %s", nameOf(p.pthis))
 		})),
 		coreevent.MatchApproxFloat(time, 0.001),
 	))
@@ -113,7 +113,7 @@ func (p *scriptEventBindings) OnKey__0(key Key, onKey func()) {
 	p.scriptEventRegistry.manager.AddKeyPressed(coreevent.NewSink(
 		p.pthis,
 		coreevent.TapVoid1(onKey, coreevent.If1(isDebugEventEnabled, func(Key) {
-			spxlog.Debug("==> onKey: %v, %s", key, nameOf(p.pthis))
+			spxlog.Debug("OnKey: %v, %s", key, nameOf(p.pthis))
 		})),
 		coreevent.MatchValue(key),
 	))
@@ -123,7 +123,7 @@ func (p *scriptEventBindings) OnSwipe__0(direction Direction, onSwipe func()) {
 	p.scriptEventRegistry.manager.AddSwipe(coreevent.NewSink(
 		p.pthis,
 		coreevent.TapVoid1(onSwipe, coreevent.If1(isDebugEventEnabled, func(Direction) {
-			spxlog.Debug("==> onSwipe: %v, %s", direction, nameOf(p.pthis))
+			spxlog.Debug("OnSwipe: %v, %s", direction, nameOf(p.pthis))
 		})),
 		coreevent.MatchValue(direction),
 	))
@@ -133,7 +133,7 @@ func (p *scriptEventBindings) OnKey__1(keys []Key, onKey func(Key)) {
 	p.scriptEventRegistry.manager.AddKeyPressed(coreevent.NewSink(
 		p.pthis,
 		coreevent.Tap1(onKey, coreevent.If1(isDebugEventEnabled, func(key Key) {
-			spxlog.Debug("==> onKey: %v, %s", keys, nameOf(p.pthis))
+			spxlog.Debug("OnKey: %v, %s", keys, nameOf(p.pthis))
 		})),
 		coreevent.MatchAnyOf(keys),
 	))
@@ -151,7 +151,7 @@ func (p *scriptEventBindings) OnMsg__1(msg MsgName, onMsg func()) {
 	p.scriptEventRegistry.manager.AddIReceive(coreevent.NewSink(
 		p.pthis,
 		coreevent.TapVoid2(onMsg, coreevent.If2(isDebugEventEnabled, func(msg string, data any) {
-			spxlog.Debug("==> onMsg: %s, %s", msg, nameOf(p.pthis))
+			spxlog.Debug("OnMsg: %s, %s", msg, nameOf(p.pthis))
 		})),
 		coreevent.MatchValue(msg),
 	))
@@ -165,7 +165,7 @@ func (p *scriptEventBindings) OnBackdrop__1(name BackdropName, onBackdrop func()
 	p.scriptEventRegistry.manager.AddBackdropChanged(coreevent.NewSink(
 		p.pthis,
 		coreevent.TapVoid1(onBackdrop, coreevent.If1(isDebugEventEnabled, func(name BackdropName) {
-			spxlog.Debug("==> onBackdrop: %s, %s", name, nameOf(p.pthis))
+			spxlog.Debug("OnBackdrop: %s, %s", name, nameOf(p.pthis))
 		})),
 		coreevent.MatchValue(name),
 	))
@@ -310,7 +310,7 @@ func (p *Game) fireEvent(ev event) {
 func (p *scriptEventRegistry) doWhenStart() {
 	p.dispatchStartOnce(nil, func(ev *eventSink) {
 		coreevent.If0(isDebugEventEnabled, func() {
-			spxlog.Debug("==> onStart: %s", nameOf(ev.Owner))
+			spxlog.Debug("OnStart: %s", nameOf(ev.Owner))
 		})()
 		ev.Handler.(func())()
 	})
@@ -319,7 +319,7 @@ func (p *scriptEventRegistry) doWhenStart() {
 func (p *scriptEventRegistry) doWhenAwake(this threadObj) {
 	p.dispatchSync(coreevent.BucketAwake, this, func(ev *eventSink) {
 		coreevent.If0(isDebugEventEnabled, func() {
-			spxlog.Debug("==> onAwake: %s", nameOf(ev.Owner))
+			spxlog.Debug("OnAwake: %s", nameOf(ev.Owner))
 		})()
 		ev.Handler.(func())()
 	})
@@ -348,7 +348,7 @@ func (p *scriptEventRegistry) doWhenSwipe(direction Direction, this threadObj) {
 func (p *scriptEventRegistry) doWhenClick(this threadObj) {
 	p.dispatchAsync(coreevent.BucketClick, false, this, func(ev *eventSink) {
 		coreevent.If0(isDebugEventEnabled, func() {
-			spxlog.Debug("==> onClick: %s", nameOf(this))
+			spxlog.Debug("OnClick: %s", nameOf(this))
 		})()
 		ev.Handler.(func())()
 	})
@@ -357,7 +357,7 @@ func (p *scriptEventRegistry) doWhenClick(this threadObj) {
 func (p *scriptEventRegistry) doWhenTouchStart(this threadObj, obj *SpriteImpl) {
 	p.dispatchAsync(coreevent.BucketTouchStart, false, this, func(ev *eventSink) {
 		coreevent.If0(isDebugEventEnabled, func() {
-			spxlog.Debug("===> onTouchStart: %s, %s", nameOf(this), obj.name)
+			spxlog.Debug("OnTouchStart: %s, %s", nameOf(this), obj.name)
 		})()
 		ev.Handler.(func(Sprite))(obj.sprite)
 	})
@@ -366,7 +366,7 @@ func (p *scriptEventRegistry) doWhenTouchStart(this threadObj, obj *SpriteImpl) 
 func (p *scriptEventRegistry) doWhenCloned(this threadObj, data any) {
 	p.dispatchAsync(coreevent.BucketCloned, true, this, func(ev *eventSink) {
 		coreevent.If0(isDebugEventEnabled, func() {
-			spxlog.Debug("==> onCloned: %s", nameOf(this))
+			spxlog.Debug("OnCloned: %s", nameOf(this))
 		})()
 		ev.Handler.(func(any))(data)
 	})

--- a/shape_manager.go
+++ b/shape_manager.go
@@ -132,7 +132,7 @@ func (s *shapeManager) addShape(child Shape) {
 func (s *shapeManager) addClonedShape(src, clone Shape) {
 	idx := s.findShapeIndex(src)
 	if idx < 0 {
-		spxlog.Debug("addClonedShape: clone a deleted sprite")
+		spxlog.Debug("AddClonedShape: cloning a deleted sprite")
 		gco.Abort()
 		return
 	}

--- a/sprite_animation.go
+++ b/sprite_animation.go
@@ -153,14 +153,14 @@ func (p *SpriteImpl) Animate__1(name SpriteAnimationName, loop bool) {
 
 func (p *SpriteImpl) AnimateWith(name SpriteAnimationName, __xgo_optional_loop bool) {
 	if isDebugInstrEnabled() {
-		spxlog.Debug("==> Animate %s", name)
+		spxlog.Debug("Animate: %s", name)
 	}
 	p.animation().Animate(name, __xgo_optional_loop)
 }
 
 func (p *SpriteImpl) AnimateAndWait(name SpriteAnimationName) {
 	if isDebugInstrEnabled() {
-		spxlog.Debug("==> AnimateAndWait %s", name)
+		spxlog.Debug("AnimateAndWait: %s", name)
 	}
 	p.animation().AnimateAndWait(name)
 }

--- a/sprite_bubble.go
+++ b/sprite_bubble.go
@@ -37,7 +37,7 @@ func (p *SpriteImpl) Ask(msg any) {
 		msgStr = fmt.Sprint(msg)
 	}
 	if msgStr == "" {
-		spxlog.Warn("ask: msg should not be empty")
+		spxlog.Warn("Ask: message should not be empty")
 		return
 	}
 	p.Say__0(msgStr)

--- a/sprite_clone.go
+++ b/sprite_clone.go
@@ -40,7 +40,7 @@ func (p *SpriteImpl) CloneWith(__xgo_optional_data any) {
 // TODO(xsw): use classfile clone mechanism instead of reflection.
 func doClone(sprite Sprite, data any, isAsync bool, onCloned func(sprite *SpriteImpl)) {
 	if sprite == nil {
-		spxlog.Panicf("doClone: sprite is nil")
+		spxlog.Panicf("DoClone: sprite is nil")
 	}
 	src := spriteOf(sprite)
 	if isDebugInstrEnabled() {

--- a/sprite_physics.go
+++ b/sprite_physics.go
@@ -59,7 +59,7 @@ func toPhysicsMode(mode string) PhysicsMode {
 	case "no":
 		return NoPhysics
 	}
-	spxlog.Warn("config error: unknown physics mode %s", mode)
+	spxlog.Warn("Config error: unknown physics mode %s", mode)
 	return NoPhysics
 }
 

--- a/tilemap.go
+++ b/tilemap.go
@@ -76,7 +76,7 @@ func (p *gameTilemapMgr) loadMap(mapDir string) {
 	}
 	loaded, err := tm.Load(p.fs, mapDir)
 	if err != nil {
-		spxlog.Panicf("failed to load tilemap JSON file %s: %v", mapDir, err)
+		spxlog.Panicf("Failed to load tilemap JSON file %s: %v", mapDir, err)
 	}
 	p.datas = loaded.Data
 	p.decoratorDatas = loaded.DecoratorData


### PR DESCRIPTION
1. Unify log capitalization and phrasing across cmd/spx, buildctl, codegen, runtime, and helper scripts.
2. Add a shared CLI logging path so log output stays consistent across stdout/stderr handling.
3. Normalize user-facing status messages in shell scripts and command entrypoints.
4. Remove legacy arrow-style debug trace prefixes like ==> from Go runtime logs.
5. Trim redundant log output in a few build/workflow paths and make completion messages easier to scan.