### PR TITLE
fix: improve iOS export workflow visibility and project-only handling

### DIFF
--- a/.github/workflows/build_ios.yml
+++ b/.github/workflows/build_ios.yml
@@ -117,6 +117,7 @@ jobs:
     - name: Build unsigned IPA
       shell: bash
       run: |
+        set -o pipefail
         echo "[info] Building IPA from Xcode project"
         XCODE_PROJECT="tutorial/00-Hello/project/.builds/ios/Game.xcodeproj"
         IPA_DIR="tutorial/00-Hello/project/.builds/ios"
@@ -131,7 +132,11 @@ jobs:
         cd "$(dirname "$XCODE_PROJECT")"
 
         # Build for iOS device without code signing
-        xcodebuild -project "$(basename "$XCODE_PROJECT")" \
+        {
+          echo
+          echo "[info] Starting xcodebuild"
+        } | tee -a "$GITHUB_WORKSPACE/tutorial/00-Hello/build_ios.txt"
+        if ! xcodebuild -project "$(basename "$XCODE_PROJECT")" \
           -scheme Game \
           -configuration Debug \
           -destination 'generic/platform=iOS' \
@@ -140,7 +145,12 @@ jobs:
           CODE_SIGNING_ALLOWED=NO \
           ARCHS=arm64 \
           ONLY_ACTIVE_ARCH=NO \
-          build | tail -20
+          build 2>&1 | tee -a "$GITHUB_WORKSPACE/tutorial/00-Hello/build_ios.txt"; then
+          echo "[error] xcodebuild failed" >&2
+          echo "[info] Last 50 lines of build_ios.txt:"
+          tail -50 "$GITHUB_WORKSPACE/tutorial/00-Hello/build_ios.txt" || true
+          exit 1
+        fi
 
         # Find the app bundle in DerivedData
         echo "[info] Searching for Game.app in DerivedData"


### PR DESCRIPTION
## Summary
- stream `xcodebuild` output into `tutorial/00-Hello/build_ios.txt` instead of truncating it with `tail -20`
- enable `set -o pipefail` so xcodebuild failures are not masked by the log pipeline
- treat `application/export_project_only=true` as a successful Xcode-project export instead of requiring `Game.ipa` immediately
- return a clear error when `--install` is used with project-only iOS exports

## Why
The iOS CI workflow intentionally switches the export preset to `application/export_project_only=true` so Godot emits an Xcode project and the workflow can build the IPA separately with `xcodebuild`. After the recent logging cleanup, that path became more visible and exposed an existing mismatch in `spx exportios`: it still required `Game.ipa` to exist, so CI logged a red error even though the later Xcode build succeeded. This follow-up makes the workflow logs visible in real time and aligns `spx exportios` with project-only exports.

## Testing
- `go test ./cmd/spx/internal/command/...`
- `git diff --check`
