### PR TITLE
refactor: consolidate platform command helpers

### DIFF
--- a/cmd/spx/internal/command/cmd.go
+++ b/cmd/spx/internal/command/cmd.go
@@ -332,14 +332,11 @@ func (cmd *CmdTool) handleInterpretedRunCommand() error {
 	cmd.RuntimeMode = true
 	cmd.RuntimeTempDir, _ = filepath.Abs(filepath.Join(cmd.TargetDir, ".temp"))
 
-	cmd.BinPostfix = ""
 	GOOS := runtime.GOOS
 	if os.Getenv("GOOS") != "" {
 		GOOS = os.Getenv("GOOS")
 	}
-	if GOOS == "windows" {
-		cmd.BinPostfix = ".exe"
-	}
+	cmd.BinPostfix = executableSuffix(GOOS)
 	cmd.RuntimeCmdPath = filepath.Join(cmd.GoBinPath, "gdspxrt"+cmd.Version+cmd.BinPostfix)
 
 	args := cmd.checkMovieArgs(cmd.RuntimeTempDir)

--- a/cmd/spx/internal/command/env.go
+++ b/cmd/spx/internal/command/env.go
@@ -32,7 +32,8 @@ import (
 	"github.com/goplus/spx/v2/cmd/spx/internal/util"
 )
 
-var ENV_NAME = "gdspx"
+const envName = "gdspx"
+
 var projectNameReplacer = strings.NewReplacer("_", "", " ", "", "\"", "", "\n", "", "\r", "")
 var spxModuleReplaceLinePattern = regexp.MustCompile(`^(\s*)(replace\s+)?github\.com/goplus/spx/v2\s*=>\s*(\S+)(\s*//.*)?$`)
 
@@ -193,9 +194,9 @@ func (cmd *CmdTool) setupEnginePaths() error {
 		return nil
 	}
 
-	binPostfix, cmdPath, err := resolveAppPath(cmd.GoBinPath, ENV_NAME, cmd.Version, cmd.CustomGoEnv)
+	binPostfix, cmdPath, err := resolveAppPath(cmd.GoBinPath, envName, cmd.Version, cmd.CustomGoEnv)
 	if err != nil {
-		return fmt.Errorf("%s requires engine to be installed as a binary at %s: %w", ENV_NAME, cmd.GoBinPath, err)
+		return fmt.Errorf("%s requires engine to be installed as a binary at %s: %w", envName, cmd.GoBinPath, err)
 	}
 	cmd.BinPostfix = binPostfix
 	cmd.CmdPath = cmdPath
@@ -230,7 +231,7 @@ func (cmd *CmdTool) setupProjectPaths(goos, goarch string) error {
 		return fmt.Errorf("failed to create temp directory: %w", err)
 	}
 
-	libPath, err := filepath.Abs(path.Join(projectDir, "lib", libraryFileName(goos, goarch)))
+	libPath, err := filepath.Abs(path.Join(projectDir, "lib", libraryFileName(envName, goos, goarch)))
 	if err != nil {
 		return fmt.Errorf("failed to resolve library path: %w", err)
 	}

--- a/cmd/spx/internal/command/env.go
+++ b/cmd/spx/internal/command/env.go
@@ -188,10 +188,7 @@ func resolveTargetPlatform() (string, string, error) {
 
 func (cmd *CmdTool) setupEnginePaths() error {
 	if cmd.usesPureEngine() {
-		cmd.BinPostfix = ""
-		if runtime.GOOS == "windows" {
-			cmd.BinPostfix = ".exe"
-		}
+		cmd.BinPostfix = executableSuffix(runtime.GOOS)
 		cmd.CmdPath = ""
 		return nil
 	}
@@ -239,18 +236,6 @@ func (cmd *CmdTool) setupProjectPaths(goos, goarch string) error {
 	}
 	cmd.LibPath = libPath
 	return nil
-}
-
-func libraryFileName(goos, goarch string) string {
-	libraryName := fmt.Sprintf("%s-%s-%s", ENV_NAME, goos, goarch)
-	switch goos {
-	case "windows":
-		return libraryName + ".dll"
-	case "darwin":
-		return libraryName + ".dylib"
-	default:
-		return libraryName + ".so"
-	}
 }
 
 func (cmd *CmdTool) updateProjectName() error {
@@ -387,11 +372,7 @@ func printPortableGoEnv(cmd *CmdTool, goPaths portableGoPaths) {
 }
 
 func goBinaryPath(goRootBinPath string) string {
-	goExe := "go"
-	if runtime.GOOS == "windows" {
-		goExe = "go.exe"
-	}
-	return filepath.Join(goRootBinPath, goExe)
+	return filepath.Join(goRootBinPath, goBinaryName(runtime.GOOS))
 }
 
 func setEnvVars(vars ...envVar) error {
@@ -587,10 +568,7 @@ func hasGoModuleDeclaration(content, modulePath string) bool {
 }
 
 func resolveAppPath(gobinDir, tag, version string, customGoEnv bool) (string, string, error) {
-	binPostfix := ""
-	if runtime.GOOS == "windows" {
-		binPostfix = ".exe"
-	}
+	binPostfix := executableSuffix(runtime.GOOS)
 
 	tagName := tag + version
 	dstFileName := tagName + binPostfix

--- a/cmd/spx/internal/command/export.go
+++ b/cmd/spx/internal/command/export.go
@@ -17,6 +17,7 @@
 package command
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -41,19 +42,14 @@ func (cmd *CmdTool) ExportBuild(platform string) error {
 // Export exports the current project for the host desktop platform.
 func (cmd *CmdTool) Export() error {
 	targetDir := filepath.Join(cmd.ProjectDir, ".builds", "pc")
-	targetPath := filepath.Join(targetDir, PcExportName)
-	platformName := ""
-	if runtime.GOOS == "windows" {
-		targetPath += ".exe"
-		platformName = "Win"
-	} else if runtime.GOOS == "darwin" {
-		platformName = "Mac"
-		targetPath += ".app"
-	} else if runtime.GOOS == "linux" {
-		platformName = "Linux"
+	targetPath, platformName, err := resolveDesktopExportTarget(runtime.GOOS, filepath.Join(targetDir, PcExportName))
+	if err != nil {
+		return err
 	}
 
-	os.Mkdir(targetDir, 0o755)
+	if err := os.MkdirAll(targetDir, 0o755); err != nil {
+		return fmt.Errorf("failed to create export directory: %w", err)
+	}
 	return util.RunCommandInDir(cmd.ProjectDir, cmd.CmdPath, "--headless", "--quit", "--path", cmd.ProjectDir, "--export-debug", platformName, targetPath)
 }
 

--- a/cmd/spx/internal/command/platform.go
+++ b/cmd/spx/internal/command/platform.go
@@ -30,14 +30,14 @@ func sharedLibrarySuffix(goos string) string {
 	}
 }
 
-func libraryFileName(goos, goarch string) string {
-	return fmt.Sprintf("%s-%s-%s%s", ENV_NAME, goos, goarch, sharedLibrarySuffix(goos))
+func libraryFileName(prefix, goos, goarch string) string {
+	return fmt.Sprintf("%s-%s-%s%s", prefix, goos, goarch, sharedLibrarySuffix(goos))
 }
 
 func resolveDesktopExportTarget(goos, basePath string) (targetPath, platformName string, err error) {
 	switch goos {
 	case goosWindows:
-		return basePath + executableSuffix(goos), "Win", nil
+		return basePath + ".exe", "Win", nil
 	case goosDarwin:
 		return basePath + ".app", "Mac", nil
 	case goosLinux:

--- a/cmd/spx/internal/command/platform.go
+++ b/cmd/spx/internal/command/platform.go
@@ -1,0 +1,48 @@
+package command
+
+import "fmt"
+
+const (
+	goosWindows = "windows"
+	goosDarwin  = "darwin"
+	goosLinux   = "linux"
+)
+
+func executableSuffix(goos string) string {
+	if goos == goosWindows {
+		return ".exe"
+	}
+	return ""
+}
+
+func goBinaryName(goos string) string {
+	return "go" + executableSuffix(goos)
+}
+
+func sharedLibrarySuffix(goos string) string {
+	switch goos {
+	case goosWindows:
+		return ".dll"
+	case goosDarwin:
+		return ".dylib"
+	default:
+		return ".so"
+	}
+}
+
+func libraryFileName(goos, goarch string) string {
+	return fmt.Sprintf("%s-%s-%s%s", ENV_NAME, goos, goarch, sharedLibrarySuffix(goos))
+}
+
+func resolveDesktopExportTarget(goos, basePath string) (targetPath, platformName string, err error) {
+	switch goos {
+	case goosWindows:
+		return basePath + executableSuffix(goos), "Win", nil
+	case goosDarwin:
+		return basePath + ".app", "Mac", nil
+	case goosLinux:
+		return basePath, "Linux", nil
+	default:
+		return "", "", fmt.Errorf("unsupported operating system: %s", goos)
+	}
+}

--- a/cmd/spx/internal/command/run.go
+++ b/cmd/spx/internal/command/run.go
@@ -121,7 +121,7 @@ func (cmd *CmdTool) RunInterpreted(pargs ...string) error {
 	runtimeName := "gdspxrt" + cmd.Version + cmd.BinPostfix
 	GOOS := runtime.GOOS
 	GOARCH := runtime.GOARCH
-	libName := libraryFileName(GOOS, GOARCH)
+	libName := libraryFileName(envName, GOOS, GOARCH)
 	packName := runtimePackFileName(runtimeName)
 
 	runtimePath, libPath, err := cmd.resolveInterpretedRuntimeAssets(runtimeName, packName, libName)

--- a/cmd/spx/internal/command/run.go
+++ b/cmd/spx/internal/command/run.go
@@ -90,10 +90,7 @@ func (cmd *CmdTool) RunPureEngine(pargs ...string) error {
 	rawdir, _ := os.Getwd()
 	os.Chdir(cmd.GoDir)
 
-	binaryName := "main"
-	if runtime.GOOS == "windows" {
-		binaryName += ".exe"
-	}
+	binaryName := "main" + executableSuffix(runtime.GOOS)
 
 	envVars := []string{"CGO_ENABLED=0"}
 	if cmd.Args.Tags != nil && *cmd.Args.Tags != "" {
@@ -124,16 +121,7 @@ func (cmd *CmdTool) RunInterpreted(pargs ...string) error {
 	runtimeName := "gdspxrt" + cmd.Version + cmd.BinPostfix
 	GOOS := runtime.GOOS
 	GOARCH := runtime.GOARCH
-	var libExt string
-	switch GOOS {
-	case "windows":
-		libExt = ".dll"
-	case "darwin":
-		libExt = ".dylib"
-	default:
-		libExt = ".so"
-	}
-	libName := fmt.Sprintf("gdspx-%s-%s%s", GOOS, GOARCH, libExt)
+	libName := libraryFileName(GOOS, GOARCH)
 	packName := runtimePackFileName(runtimeName)
 
 	runtimePath, libPath, err := cmd.resolveInterpretedRuntimeAssets(runtimeName, packName, libName)

--- a/cmd/spx/internal/command/run_test.go
+++ b/cmd/spx/internal/command/run_test.go
@@ -281,16 +281,13 @@ func TestRunInterpretedCreatesRuntimeExtensionAndCopiesSharedLibrary(t *testing.
 	logPath := filepath.Join(t.TempDir(), "runtime.log")
 	version := "9.9.9-test"
 
-	runtimeName := "gdspxrt" + version
-	if runtime.GOOS == "windows" {
-		runtimeName += ".exe"
-	}
+	runtimeName := "gdspxrt" + version + executableSuffix(runtime.GOOS)
 	writeTestRuntimeExecutable(t, filepath.Join(goBinPath, runtimeName), logPath)
 	if err := os.WriteFile(filepath.Join(goBinPath, runtimePackFileName(runtimeName)), []byte("runtime pack"), 0o644); err != nil {
 		t.Fatalf("write runtime pack: %v", err)
 	}
 
-	libName := runtimeLibraryFileName()
+	libName := libraryFileName(runtime.GOOS, runtime.GOARCH)
 	if err := os.WriteFile(filepath.Join(goBinPath, libName), []byte("shared library"), 0o755); err != nil {
 		t.Fatalf("write shared library: %v", err)
 	}
@@ -300,9 +297,7 @@ func TestRunInterpretedCreatesRuntimeExtensionAndCopiesSharedLibrary(t *testing.
 		RuntimeTempDir: runtimeTempDir,
 		Version:        version,
 	}
-	if runtime.GOOS == "windows" {
-		cmd.BinPostfix = ".exe"
-	}
+	cmd.BinPostfix = executableSuffix(runtime.GOOS)
 
 	if err := cmd.RunInterpreted("--path", "ignored"); err != nil {
 		t.Fatalf("RunInterpreted returned error: %v", err)
@@ -360,7 +355,7 @@ func TestResolveInterpretedRuntimeAssetsPrefersEmbedded(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(goBinPath, runtimePackFileName(runtimeName)), []byte("external pack"), 0o644); err != nil {
 		t.Fatalf("write external runtime pack: %v", err)
 	}
-	libName := runtimeLibraryFileName()
+	libName := libraryFileName(runtime.GOOS, runtime.GOARCH)
 	if err := os.WriteFile(filepath.Join(goBinPath, libName), []byte("external library"), 0o755); err != nil {
 		t.Fatalf("write external shared library: %v", err)
 	}
@@ -404,7 +399,7 @@ func TestResolveInterpretedRuntimeAssetsFallsBackToExternalWhenEmbeddedUnavailab
 	if err := os.WriteFile(filepath.Join(goBinPath, runtimePackFileName(runtimeName)), []byte("external pack"), 0o644); err != nil {
 		t.Fatalf("write external runtime pack: %v", err)
 	}
-	libName := runtimeLibraryFileName()
+	libName := libraryFileName(runtime.GOOS, runtime.GOARCH)
 	libPathWant := filepath.Join(goBinPath, libName)
 	if err := os.WriteFile(libPathWant, []byte("external library"), 0o755); err != nil {
 		t.Fatalf("write external shared library: %v", err)
@@ -449,17 +444,14 @@ func TestRunCmdRunHonorsPortableGoEnv(t *testing.T) {
 	if err := os.MkdirAll(goRootBinPath, 0o755); err != nil {
 		t.Fatalf("mkdir gotoolchain/go/bin: %v", err)
 	}
-	writeTestRuntimeExecutable(t, filepath.Join(goRootBinPath, goBinaryName()), filepath.Join(t.TempDir(), "go.log"))
+	writeTestRuntimeExecutable(t, filepath.Join(goRootBinPath, goBinaryName(runtime.GOOS)), filepath.Join(t.TempDir(), "go.log"))
 
-	runtimeName := "gdspxrt" + version
-	if runtime.GOOS == "windows" {
-		runtimeName += ".exe"
-	}
+	runtimeName := "gdspxrt" + version + executableSuffix(runtime.GOOS)
 	writeTestRuntimeExecutable(t, filepath.Join(goBinPath, runtimeName), logPath)
 	if err := os.WriteFile(filepath.Join(goBinPath, runtimePackFileName(runtimeName)), []byte("runtime pack"), 0o644); err != nil {
 		t.Fatalf("write runtime pack: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(goBinPath, runtimeLibraryFileName()), []byte("shared library"), 0o755); err != nil {
+	if err := os.WriteFile(filepath.Join(goBinPath, libraryFileName(runtime.GOOS, runtime.GOARCH)), []byte("shared library"), 0o755); err != nil {
 		t.Fatalf("write shared library: %v", err)
 	}
 
@@ -626,25 +618,6 @@ func writeTestRuntimeExecutable(t *testing.T, path string, logPath string) {
 	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
 		t.Fatalf("write runtime executable: %v", err)
 	}
-}
-
-func runtimeLibraryFileName() string {
-	libName := fmt.Sprintf("gdspx-%s-%s", runtime.GOOS, runtime.GOARCH)
-	switch runtime.GOOS {
-	case "windows":
-		return libName + ".dll"
-	case "darwin":
-		return libName + ".dylib"
-	default:
-		return libName + ".so"
-	}
-}
-
-func goBinaryName() string {
-	if runtime.GOOS == "windows" {
-		return "go.exe"
-	}
-	return "go"
 }
 
 func fileExists(path string) bool {

--- a/cmd/spx/internal/command/run_test.go
+++ b/cmd/spx/internal/command/run_test.go
@@ -287,7 +287,7 @@ func TestRunInterpretedCreatesRuntimeExtensionAndCopiesSharedLibrary(t *testing.
 		t.Fatalf("write runtime pack: %v", err)
 	}
 
-	libName := libraryFileName(runtime.GOOS, runtime.GOARCH)
+	libName := libraryFileName(envName, runtime.GOOS, runtime.GOARCH)
 	if err := os.WriteFile(filepath.Join(goBinPath, libName), []byte("shared library"), 0o755); err != nil {
 		t.Fatalf("write shared library: %v", err)
 	}
@@ -355,7 +355,7 @@ func TestResolveInterpretedRuntimeAssetsPrefersEmbedded(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(goBinPath, runtimePackFileName(runtimeName)), []byte("external pack"), 0o644); err != nil {
 		t.Fatalf("write external runtime pack: %v", err)
 	}
-	libName := libraryFileName(runtime.GOOS, runtime.GOARCH)
+	libName := libraryFileName(envName, runtime.GOOS, runtime.GOARCH)
 	if err := os.WriteFile(filepath.Join(goBinPath, libName), []byte("external library"), 0o755); err != nil {
 		t.Fatalf("write external shared library: %v", err)
 	}
@@ -399,7 +399,7 @@ func TestResolveInterpretedRuntimeAssetsFallsBackToExternalWhenEmbeddedUnavailab
 	if err := os.WriteFile(filepath.Join(goBinPath, runtimePackFileName(runtimeName)), []byte("external pack"), 0o644); err != nil {
 		t.Fatalf("write external runtime pack: %v", err)
 	}
-	libName := libraryFileName(runtime.GOOS, runtime.GOARCH)
+	libName := libraryFileName(envName, runtime.GOOS, runtime.GOARCH)
 	libPathWant := filepath.Join(goBinPath, libName)
 	if err := os.WriteFile(libPathWant, []byte("external library"), 0o755); err != nil {
 		t.Fatalf("write external shared library: %v", err)
@@ -451,7 +451,7 @@ func TestRunCmdRunHonorsPortableGoEnv(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(goBinPath, runtimePackFileName(runtimeName)), []byte("runtime pack"), 0o644); err != nil {
 		t.Fatalf("write runtime pack: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(goBinPath, libraryFileName(runtime.GOOS, runtime.GOARCH)), []byte("shared library"), 0o755); err != nil {
+	if err := os.WriteFile(filepath.Join(goBinPath, libraryFileName(envName, runtime.GOOS, runtime.GOARCH)), []byte("shared library"), 0o755); err != nil {
 		t.Fatalf("write shared library: %v", err)
 	}
 


### PR DESCRIPTION
Title: Refactor platform-specific command helpers

## Summary
This PR consolidates repeated platform-specific command logic under `cmd/spx/internal/command`.

## Changes
- add `platform.go` to centralize:
  - executable suffix resolution
  - Go binary name resolution
  - shared library suffix and library file name generation
  - desktop export target/platform mapping
- simplify `Export()` by moving host desktop target resolution into a helper
- replace duplicated Windows `.exe` handling in command/runtime setup paths
- reuse shared library naming logic in interpreted run flow and related tests
- keep platform-specific behavior branches intact where they represent real behavioral differences

## Validation
- go test ./cmd/spx/internal/command/...
