### PR TITLE
fix(ispx): emit structured panic logs for xbuilder

### DIFF
--- a/pkg/ispx/ispx.go
+++ b/pkg/ispx/ispx.go
@@ -89,6 +89,7 @@ func Init(ctx *ixgo.Context) error {
 	if ctx.Lookup == nil {
 		ctx.Lookup = defaultIXGoContextLookup
 	}
+	ctx.SetPanic(logRuntimePanic)
 
 	for _, pkg := range defaultPackagesToImport {
 		ctx.Loader.Import(pkg)

--- a/pkg/ispx/runtime_panic.go
+++ b/pkg/ispx/runtime_panic.go
@@ -39,18 +39,46 @@ func newRuntimePanicLogger(w io.Writer) *slog.Logger {
 }
 
 func logRuntimePanic(info *ixgo.PanicInfo) {
-	if info == nil {
+	if !shouldLogRuntimePanic(info) {
 		return
 	}
 
 	position := info.Position()
 	logRuntimePanicFields(runtimePanicLogger, runtimePanicFields{
 		Error:    info.Error,
-		Function: info.String(),
+		Function: runtimePanicFunction(info),
 		File:     position.Filename,
 		Line:     position.Line,
 		Column:   position.Column,
 	})
+}
+
+func shouldLogRuntimePanic(info *ixgo.PanicInfo) bool {
+	if info == nil {
+		return false
+	}
+
+	fatal, ok := info.Error.(ixgo.FatalError)
+	if !ok {
+		return true
+	}
+
+	switch fatal.Value.(type) {
+	case ixgo.RuntimeError, ixgo.PlainError, ixgo.PanicError:
+		return false
+	default:
+		return true
+	}
+}
+
+func runtimePanicFunction(info *ixgo.PanicInfo) string {
+	if info == nil {
+		return ""
+	}
+	if fn := info.Parent(); fn != nil {
+		return fn.String()
+	}
+	return info.String()
 }
 
 func logRuntimePanicFields(logger *slog.Logger, fields runtimePanicFields) {

--- a/pkg/ispx/runtime_panic.go
+++ b/pkg/ispx/runtime_panic.go
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2021 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ispx
+
+import (
+	"io"
+	"log/slog"
+	"os"
+
+	"github.com/goplus/ixgo"
+)
+
+type runtimePanicFields struct {
+	Error    error
+	Function string
+	File     string
+	Line     int
+	Column   int
+}
+
+var runtimePanicLogger = newRuntimePanicLogger(os.Stdout)
+
+func newRuntimePanicLogger(w io.Writer) *slog.Logger {
+	return slog.New(slog.NewJSONHandler(w, nil))
+}
+
+func logRuntimePanic(info *ixgo.PanicInfo) {
+	if info == nil {
+		return
+	}
+
+	position := info.Position()
+	logRuntimePanicFields(runtimePanicLogger, runtimePanicFields{
+		Error:    info.Error,
+		Function: info.String(),
+		File:     position.Filename,
+		Line:     position.Line,
+		Column:   position.Column,
+	})
+}
+
+func logRuntimePanicFields(logger *slog.Logger, fields runtimePanicFields) {
+	logger.Error(
+		"panic",
+		"error", fields.Error,
+		"function", fields.Function,
+		"file", fields.File,
+		"line", fields.Line,
+		"column", fields.Column,
+	)
+}

--- a/pkg/ispx/runtime_panic_test.go
+++ b/pkg/ispx/runtime_panic_test.go
@@ -20,7 +20,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
+
+	"github.com/goplus/ixgo"
 )
 
 func TestLogRuntimePanicFields(t *testing.T) {
@@ -61,4 +64,128 @@ func TestLogRuntimePanicFields(t *testing.T) {
 	if got, want := entry["column"], float64(3); got != want {
 		t.Fatalf("column = %v, want %v", got, want)
 	}
+}
+
+func TestShouldLogRuntimePanic(t *testing.T) {
+	tests := []struct {
+		name string
+		info *ixgo.PanicInfo
+		want bool
+	}{
+		{
+			name: "NilInfo",
+			info: nil,
+			want: false,
+		},
+		{
+			name: "PanicError",
+			info: &ixgo.PanicInfo{Error: ixgo.PanicError{}},
+			want: true,
+		},
+		{
+			name: "FatalWrappingRuntimeError",
+			info: &ixgo.PanicInfo{Error: ixgo.FatalError{Value: ixgo.RuntimeError("boom")}},
+			want: false,
+		},
+		{
+			name: "FatalWrappingPlainError",
+			info: &ixgo.PanicInfo{Error: ixgo.FatalError{Value: ixgo.PlainError("boom")}},
+			want: false,
+		},
+		{
+			name: "FatalWrappingPanicError",
+			info: &ixgo.PanicInfo{Error: ixgo.FatalError{Value: ixgo.PanicError{}}},
+			want: false,
+		},
+		{
+			name: "FatalWrappingExternalValue",
+			info: &ixgo.PanicInfo{Error: ixgo.FatalError{Value: "boom"}},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldLogRuntimePanic(tt.info); got != tt.want {
+				t.Fatalf("shouldLogRuntimePanic() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLogRuntimePanic_RuntimeError(t *testing.T) {
+	entry := runAndCaptureRuntimePanicLog(t, `package main
+func foo() {
+	var p *int
+	println(*p)
+}
+func main() { foo() }
+`)
+
+	if got, want := entry["msg"], "panic"; got != want {
+		t.Fatalf("msg = %v, want %v", got, want)
+	}
+	if got, want := entry["error"], "runtime error: invalid memory address or nil pointer dereference"; got != want {
+		t.Fatalf("error = %v, want %v", got, want)
+	}
+	if got, want := entry["function"], "main.foo"; got != want {
+		t.Fatalf("function = %v, want %v", got, want)
+	}
+	if got, want := entry["file"], "main.go"; got != want {
+		t.Fatalf("file = %v, want %v", got, want)
+	}
+	if got, want := entry["line"], float64(4); got != want {
+		t.Fatalf("line = %v, want %v", got, want)
+	}
+}
+
+func TestLogRuntimePanic_ExplicitPanic(t *testing.T) {
+	entry := runAndCaptureRuntimePanicLog(t, `package main
+func foo() {
+	panic("boom")
+}
+func main() { foo() }
+`)
+
+	if got, want := entry["error"], "boom"; got != want {
+		t.Fatalf("error = %v, want %v", got, want)
+	}
+	if got, want := entry["function"], "main.foo"; got != want {
+		t.Fatalf("function = %v, want %v", got, want)
+	}
+	if got, want := entry["file"], "main.go"; got != want {
+		t.Fatalf("file = %v, want %v", got, want)
+	}
+	if got, want := entry["line"], float64(3); got != want {
+		t.Fatalf("line = %v, want %v", got, want)
+	}
+}
+
+func runAndCaptureRuntimePanicLog(t *testing.T, src string) map[string]any {
+	t.Helper()
+
+	var buf bytes.Buffer
+	prev := runtimePanicLogger
+	runtimePanicLogger = newRuntimePanicLogger(&buf)
+	t.Cleanup(func() {
+		runtimePanicLogger = prev
+	})
+
+	ctx := ixgo.NewContext(0)
+	ctx.SetPanic(logRuntimePanic)
+
+	if _, err := ctx.RunFile("main.go", src, nil); err == nil {
+		t.Fatal("RunFile() error = nil, want panic error")
+	}
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if got, want := len(lines), 1; got != want {
+		t.Fatalf("log lines = %d, want %d\nlogs:\n%s", got, want, buf.String())
+	}
+
+	var entry map[string]any
+	if err := json.Unmarshal([]byte(lines[0]), &entry); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	return entry
 }

--- a/pkg/ispx/runtime_panic_test.go
+++ b/pkg/ispx/runtime_panic_test.go
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2021 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ispx
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"testing"
+)
+
+func TestLogRuntimePanicFields(t *testing.T) {
+	var buf bytes.Buffer
+	logger := newRuntimePanicLogger(&buf)
+
+	logRuntimePanicFields(logger, runtimePanicFields{
+		Error:    errors.New("boom"),
+		Function: "main.(*Game).Main",
+		File:     "Game.spx",
+		Line:     12,
+		Column:   3,
+	})
+
+	var entry map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &entry); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+
+	if got, want := entry["level"], "ERROR"; got != want {
+		t.Fatalf("level = %v, want %v", got, want)
+	}
+	if got, want := entry["msg"], "panic"; got != want {
+		t.Fatalf("msg = %v, want %v", got, want)
+	}
+	if got, want := entry["error"], "boom"; got != want {
+		t.Fatalf("error = %v, want %v", got, want)
+	}
+	if got, want := entry["function"], "main.(*Game).Main"; got != want {
+		t.Fatalf("function = %v, want %v", got, want)
+	}
+	if got, want := entry["file"], "Game.spx"; got != want {
+		t.Fatalf("file = %v, want %v", got, want)
+	}
+	if got, want := entry["line"], float64(12); got != want {
+		t.Fatalf("line = %v, want %v", got, want)
+	}
+	if got, want := entry["column"], float64(3); got != want {
+		t.Fatalf("column = %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
## Background

When a runtime panic occurs in `ispx`, there is currently no stable structured log output. This makes it difficult for `xbuilder` to reliably extract error details and source locations, which slows down debugging and error presentation.

## Changes

- Register a panic callback on `ixgo.Context` in `pkg/ispx.Init`
- Add a runtime panic logging helper that emits JSON logs to stdout
- Include the following fields in panic logs:
  - `error`
  - `function`
  - `file`
  - `line`
  - `column`
- Add unit tests to verify the log format and field values

## Expected Result

`xbuilder` can consume structured panic logs directly and present runtime errors with accurate source location information, improving debugging efficiency.

## Testing

- `go test ./pkg/ispx -run TestLogRuntimePanicFields`
