### PR TITLE
feat(sprite): add coordinate turn helpers

### DIFF
--- a/component_transform.go
+++ b/component_transform.go
@@ -429,6 +429,9 @@ func (t *transformComponent) calculateTargetAngle(obj any) float64 {
 }
 
 func (t *transformComponent) calculateTargetAngleToPos(x, y float64) float64 {
+	if t.x == x && t.y == y {
+		return t.direction
+	}
 	return engine.HeadingToPoint(mathf.NewVec2(t.x, t.y), mathf.NewVec2(x, y))
 }
 

--- a/component_transform.go
+++ b/component_transform.go
@@ -360,6 +360,18 @@ func (t *transformComponent) TurnTo(obj any, speed float64, animation SpriteAnim
 	})
 }
 
+// TurnToPos turns the sprite to face the specified position using an animation.
+func (t *transformComponent) TurnToPos(x, y, speed float64, animation SpriteAnimationName) {
+	targetAngle := t.calculateTargetAngleToPos(x, y)
+	fromAngle, toAngle := t.normalizeAngleRange(t.direction, targetAngle)
+
+	t.doTurnAnimation(fromAngle, toAngle, speed, animation, func() {
+		if t.applyDirection(targetAngle) && isDebugInstrEnabled() {
+			spxlog.Debug("TurnToPos: sprite=%s, x=%v, y=%v", t.sprite.name, x, y)
+		}
+	})
+}
+
 // BounceOffEdge bounces the sprite off the edge of the stage by reflecting
 // its direction vector based on the edge that was touched.
 func (t *transformComponent) BounceOffEdge() {
@@ -395,6 +407,16 @@ func (t *transformComponent) applyDirection(dir float64) bool {
 	return true
 }
 
+// DirectionTo returns the normalized heading needed to face the specified object.
+func (t *transformComponent) DirectionTo(obj any) Direction {
+	return normalizeDirection(t.calculateTargetAngle(obj))
+}
+
+// DirectionToPos returns the normalized heading needed to face the specified position.
+func (t *transformComponent) DirectionToPos(x, y float64) Direction {
+	return normalizeDirection(t.calculateTargetAngleToPos(x, y))
+}
+
 // calculateTargetAngle calculates the angle to turn toward the specified object.
 func (t *transformComponent) calculateTargetAngle(obj any) float64 {
 	switch v := obj.(type) {
@@ -402,10 +424,12 @@ func (t *transformComponent) calculateTargetAngle(obj any) float64 {
 		return v
 	default:
 		x, y := t.sprite.g.objectPos(obj)
-		dx := x - t.x
-		dy := y - t.y
-		return 90 - engine.RadToDeg(math.Atan2(dy, dx))
+		return t.calculateTargetAngleToPos(x, y)
 	}
+}
+
+func (t *transformComponent) calculateTargetAngleToPos(x, y float64) float64 {
+	return engine.HeadingToPoint(mathf.NewVec2(t.x, t.y), mathf.NewVec2(x, y))
 }
 
 // normalizeAngleRange normalizes two angles to minimize the rotation distance.

--- a/pkg/ispx/internal/pkg/github.com/goplus/spx/v2/pkg/spx/pkg/engine/export.go
+++ b/pkg/ispx/internal/pkg/github.com/goplus/spx/v2/pkg/spx/pkg/engine/export.go
@@ -108,6 +108,7 @@ func init() {
 			"DeleteUINode":                reflect.ValueOf(q.DeleteUINode),
 			"GetSprite":                   reflect.ValueOf(q.GetSprite),
 			"GetUINode":                   reflect.ValueOf(q.GetUINode),
+			"HeadingToPoint":              reflect.ValueOf(q.HeadingToPoint),
 			"InitSpriteInstance":          reflect.ValueOf(q.InitSpriteInstance),
 			"InitUINodeInstance":          reflect.ValueOf(q.InitUINodeInstance),
 			"InternalUpdateEngine":        reflect.ValueOf(q.InternalUpdateEngine),

--- a/pkg/spx/pkg/engine/math.go
+++ b/pkg/spx/pkg/engine/math.go
@@ -42,11 +42,18 @@ func RadToDeg(radians float64) float64 {
 	return radians * (180.0 / math.Pi)
 }
 
-func AngleToPoint(v mathf.Vec2, v2 mathf.Vec2) float64 {
-	return Angle(v.Sub(v2))
+func AngleToPoint(from, to mathf.Vec2) float64 {
+	return Angle(to.Sub(from))
 }
 
 // Angle returns the angle of v in radians, measured from the positive X axis.
 func Angle(v mathf.Vec2) float64 {
 	return float64(mathf.Atan2(float64(v.Y), float64(v.X)))
+}
+
+// HeadingToPoint returns the SPX heading in degrees needed to face from `from`
+// toward `to`. The result uses SPX heading semantics, where 0 points up and 90
+// points right, and is intentionally not normalized to (-180, 180].
+func HeadingToPoint(from, to mathf.Vec2) float64 {
+	return 90 - RadToDeg(AngleToPoint(from, to))
 }

--- a/pkg/spx/pkg/engine/math_test.go
+++ b/pkg/spx/pkg/engine/math_test.go
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2021 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package engine
+
+import (
+	"testing"
+
+	mathf "github.com/goplus/spbase/mathf"
+)
+
+func TestHeadingToPoint(t *testing.T) {
+	from := mathf.NewVec2(0, 0)
+
+	tests := []struct {
+		name string
+		to   mathf.Vec2
+		want float64
+	}{
+		{name: "right", to: mathf.NewVec2(10, 0), want: 90},
+		{name: "up", to: mathf.NewVec2(0, 10), want: 0},
+		{name: "left", to: mathf.NewVec2(-10, 0), want: -90},
+		{name: "down", to: mathf.NewVec2(0, -10), want: 180},
+		{name: "bottom left keeps raw heading", to: mathf.NewVec2(-10, -10), want: 225},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := HeadingToPoint(from, tt.to); Abs(got-tt.want) > 1e-9 {
+				t.Fatalf("HeadingToPoint(%v, %v) = %v, want %v", from, tt.to, got, tt.want)
+			}
+		})
+	}
+}

--- a/sprite.go
+++ b/sprite.go
@@ -139,13 +139,13 @@ type Speed = float64
 const (
 	XGoo_Sprite_GlideWith    = ".GlideToTarget,.GlideToXYpos"
 	XGoo_Sprite_StepToWith   = ".StepToTarget,.StepToXYpos"
-	XGoo_Sprite_TurnToWith   = ".TurnToDir,.TurnToTarget"
+	XGoo_Sprite_TurnToWith   = ".TurnToDir,.TurnToTarget,.TurnToXYpos"
 	XGoo_Sprite_SetLayerWith = ".SetLayerTo,.ChangeLayer"
 	XGoo_Sprite_QuoteWith    = ".QuoteMsg,.QuoteMsgEx"
 
 	XGoo_SpriteImpl_GlideWith    = ".GlideToTarget,.GlideToXYpos"
 	XGoo_SpriteImpl_StepToWith   = ".StepToTarget,.StepToXYpos"
-	XGoo_SpriteImpl_TurnToWith   = ".TurnToDir,.TurnToTarget"
+	XGoo_SpriteImpl_TurnToWith   = ".TurnToDir,.TurnToTarget,.TurnToXYpos"
 	XGoo_SpriteImpl_SetLayerWith = ".SetLayerTo,.ChangeLayer"
 	XGoo_SpriteImpl_QuoteWith    = ".QuoteMsg,.QuoteMsgEx"
 )
@@ -247,6 +247,7 @@ type Sprite interface {
 
 	TurnToDir(dir Direction, __xgo_optional_opts *MotionOptions)
 	TurnToTarget(target Target, __xgo_optional_opts *MotionOptions)
+	TurnToXYpos(x, y float64, __xgo_optional_opts *MotionOptions)
 
 	BounceOffEdge()
 
@@ -303,6 +304,14 @@ type Sprite interface {
 	DistanceTo__3(pos Pos) float64
 
 	DistanceToWith(target Target) float64
+
+	DirectionTo__0(sprite Sprite) Direction
+	DirectionTo__1(sprite SpriteName) Direction
+	DirectionTo__2(obj specialObj) Direction
+	DirectionTo__3(pos Pos) Direction
+	DirectionTo__4(x, y float64) Direction
+
+	DirectionToWith(target Target) Direction
 
 	Touching__0(sprite Sprite) bool
 	Touching__1(sprite SpriteName) bool

--- a/sprite_transform.go
+++ b/sprite_transform.go
@@ -48,6 +48,30 @@ func (p *SpriteImpl) DistanceToWith(target Target) float64 {
 	return p.transform().DistanceTo(target)
 }
 
+func (p *SpriteImpl) DirectionTo__0(sprite Sprite) Direction {
+	return p.transform().DirectionTo(sprite)
+}
+
+func (p *SpriteImpl) DirectionTo__1(sprite SpriteName) Direction {
+	return p.transform().DirectionTo(sprite)
+}
+
+func (p *SpriteImpl) DirectionTo__2(obj specialObj) Direction {
+	return p.transform().DirectionTo(obj)
+}
+
+func (p *SpriteImpl) DirectionTo__3(pos Pos) Direction {
+	return p.transform().DirectionTo(pos)
+}
+
+func (p *SpriteImpl) DirectionTo__4(x, y float64) Direction {
+	return p.transform().DirectionToPos(x, y)
+}
+
+func (p *SpriteImpl) DirectionToWith(target Target) Direction {
+	return p.transform().DirectionTo(target)
+}
+
 // -----------------------------------------------------------------------------
 // Movement
 // -----------------------------------------------------------------------------
@@ -313,6 +337,11 @@ func (p *SpriteImpl) TurnToDir(dir Direction, __xgo_optional_opts *MotionOptions
 func (p *SpriteImpl) TurnToTarget(target Target, __xgo_optional_opts *MotionOptions) {
 	speed, animation := motionOptions(__xgo_optional_opts)
 	p.transform().TurnTo(target, speed, animation)
+}
+
+func (p *SpriteImpl) TurnToXYpos(x, y float64, __xgo_optional_opts *MotionOptions) {
+	speed, animation := motionOptions(__xgo_optional_opts)
+	p.transform().TurnToPos(x, y, speed, animation)
 }
 
 func (p *SpriteImpl) SetHeading(dir Direction) {

--- a/sprite_transform_direction_test.go
+++ b/sprite_transform_direction_test.go
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2021 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package spx
+
+import (
+	"math"
+	"testing"
+
+	coreproject "github.com/goplus/spx/v2/internal/core/project"
+)
+
+func newTestTransformSprite(x, y float64) *SpriteImpl {
+	sprite := &SpriteImpl{
+		g:    &Game{},
+		name: "TestSprite",
+	}
+	sprite.components.initComponents(sprite, &coreproject.SpriteConfig{
+		X:             x,
+		Y:             y,
+		RotationStyle: "normal",
+		FAnimations:   map[SpriteAnimationName]*coreproject.AniConfig{},
+		AnimBindings:  map[string]string{},
+	})
+	return sprite
+}
+
+func TestSpriteDirectionToPosNormalizesAngle(t *testing.T) {
+	sprite := newTestTransformSprite(0, 0)
+
+	tests := []struct {
+		name string
+		x    float64
+		y    float64
+		want Direction
+	}{
+		{name: "right", x: 10, y: 0, want: 90},
+		{name: "up", x: 0, y: 10, want: 0},
+		{name: "left", x: -10, y: 0, want: -90},
+		{name: "down", x: 0, y: -10, want: 180},
+		{name: "bottom left stays normalized", x: -10, y: -10, want: -135},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sprite.DirectionTo__4(tt.x, tt.y); math.Abs(got-tt.want) > 1e-9 {
+				t.Fatalf("DirectionTo__4(%v, %v) = %v, want %v", tt.x, tt.y, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSpriteTurnToXYposFacesCoordinateTarget(t *testing.T) {
+	sprite := newTestTransformSprite(0, 0)
+
+	sprite.TurnToXYpos(-10, -10, nil)
+
+	if got := sprite.Heading(); got != -135 {
+		t.Fatalf("Heading() = %v, want -135", got)
+	}
+}

--- a/test/All/SpMotion.spx
+++ b/test/All/SpMotion.spx
@@ -34,46 +34,58 @@ onMsg "testMotion", => {
 	wait 0.1s
 	assertDir(this, -135, "Sprite::TurnTo")
 
+	// 8. Sprite::DirectionTo
+	setXYpos 0, 0
+	wait 0.1s
+	turnTo directionTo(-100, -100)
+	wait 0.1s
+	assertDir(this, -135, "Sprite::DirectionTo")
+
+	// 9. Sprite::TurnToXYpos
+	turnToWith 100, -100, speed = 2
+	wait 0.1s
+	assertDir(this, 135, "Sprite::TurnToXYpos")
+
 	// reset position
 	setXYpos 0, 0
 	wait 0.1s
 	assertPos(this, 0, 0, "Reset Position")
 
-	// 8. Sprite::ChangeXpos
+	// 10. Sprite::ChangeXpos
 	changeXpos 100
 	wait 0.1s
 	assertPos(this, 100, 0, "Sprite::ChangeXpos")
 
-	// 9. Sprite::SetXpos
+	// 11. Sprite::SetXpos
 	setXpos 100
 	wait 0.1s
 	assertPos(this, 100, 0, "Sprite::SetXpos")
 
-	// 10. Sprite::ChangeYpos
+	// 12. Sprite::ChangeYpos
 	changeYpos -100
 	wait 0.1s
 	assertPos(this, 100, -100, "Sprite::ChangeYpos")
 
-	// 11. Sprite::SetYpos
+	// 13. Sprite::SetYpos
 	setYpos 100
 	wait 0.1s
 	assertPos(this, 100, 100, "Sprite::SetYpos")
 
-	// 12. Sprite::Xpos
+	// 14. Sprite::Xpos
 	assertFloat(xpos, 100, "Sprite::Xpos")
 
-	// 13. Sprite::Ypos
+	// 15. Sprite::Ypos
 	assertFloat(ypos, 100, "Sprite::Ypos")
 
-	// 14. Sprite::Heading
+	// 16. Sprite::Heading
 	assertDir(this, -135, "Sprite::Heading")
 
-	// 15. Sprite::SetRotationStyle
+	// 17. Sprite::SetRotationStyle
 	wait 0.1s
 	setRotationStyle LeftRight // render face to right, but the direction is still -135
 	assertDir(this, -135, "Sprite::setRotationStyle LeftRight")
 
-	// 16. Sprite::BounceOffEdge
+	// 18. Sprite::BounceOffEdge
 	wait 0.1s
 	setRotationStyle Normal
 	setHeading -90


### PR DESCRIPTION
## Summary

This PR adds coordinate-based turn helpers to address #970 without breaking the existing `turnTo dir, speed` overloads.

### Added
- `directionTo(x, y)` support
- `directionTo(target)` support through sprite/target overloads
- `TurnToXYpos(x, y, ...)`
- `turnToWith x, y, speed = ...`

### Kept intentionally unchanged
- `turnTo x, y` is still not added directly

That form is ambiguous with the existing `turnTo dir, speed` overload, so adding it would introduce overload conflicts and compatibility risk.

## Implementation

- Added shared heading math in `pkg/spx/pkg/engine/math.go`
- Reused the shared heading helper from transform logic
- Exported the new engine helper for `ispx`
- Added Go tests for heading/coordinate turn behavior
- Added script-level coverage in `test/All/SpMotion.spx`

## Examples

```spx
turnTo directionTo(-100, -100)
turnToWith 100, -100, speed = 2
