### PR TITLE
fix: avoid hanging in SpSensing test

### DIFF
--- a/color_test.go
+++ b/color_test.go
@@ -18,8 +18,6 @@ package spx
 
 import (
 	"math"
-	"os"
-	"path/filepath"
 	"testing"
 )
 
@@ -33,13 +31,6 @@ func TestNewColor(t *testing.T) {
 func TestNewColorUsesMathfPackedNumberBehavior(t *testing.T) {
 	assertColor(t, NewColor(-1), Color{1, 1, 1, 1})
 	assertColor(t, NewColor(float64(0x1000000)), Color{0, 0, 0, 1})
-}
-
-func writeTestFile(t *testing.T, dir, name, content string) {
-	t.Helper()
-	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0644); err != nil {
-		t.Fatalf("write %s: %v", name, err)
-	}
 }
 
 func assertColor(t *testing.T, got, want Color) {

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/goplus/xgo v1.7.2-0.20260414235301-df19f4a1b7c2
 	github.com/petermattis/goid v0.0.0-20250721140440-ea1c0173183e
 	golang.org/x/mobile v0.0.0-20220518205345-8578da9835fd
+	golang.org/x/mod v0.29.0
 )
 
 require (
@@ -21,6 +22,5 @@ require (
 	github.com/visualfc/funcval v0.1.4 // indirect
 	github.com/visualfc/xtype v0.3.0 // indirect
 	golang.org/x/image v0.23.0 // indirect
-	golang.org/x/mod v0.29.0 // indirect
 	golang.org/x/tools v0.38.0 // indirect
 )

--- a/test/All/SpSensing.spx
+++ b/test/All/SpSensing.spx
@@ -1,67 +1,98 @@
 import "fmt"
 import "math"
 
-onMsg "testSensing", => {
-	onTestStart(this)
+const sensingTargetName = "Red"
+const sensingRedHex = "#ED1C24"
+const sensingStartOffset = -100.0
+const sensingMoveSpeed = 80.0
+const sensingMoveDuration = 5.0
+const sensingMouseErr = 10.0
 
+func setupSensingScene() {
 	setXYpos 10, 10
 	Red.SetXYpos 0, 0
 	Red.SetSize 1
+}
 
-	startOffset := -100.0
-	mvSpeed := 10.0
-	// 1. Sprite::Touching
+func assertTouchingRed(startOffset, mvSpeed float64, byColor bool) {
+	detectMsg := "touching"
+	assertMsg := "Sprite::Touching"
+	redColor := NewColor(sensingRedHex)
+	if byColor {
+		detectMsg = "touching color"
+		assertMsg = "Sprite::TouchingColor"
+	}
+
+	setXYpos startOffset, 0
+	touched := false
 	tt := 0.0
-	for tt < 200 {
+	for tt < sensingMoveDuration {
 		tt += deltaTime()
-		setXpos startOffset*mvSpeed
-		//if Touching "Red" {
-		//	say "touching"
-		//}
+		setXpos startOffset + tt*mvSpeed
+
+		if byColor {
+			touched = touchingColor(redColor)
+		} else {
+			touched = touching(sensingTargetName)
+		}
+		if touched {
+			say detectMsg
+			break
+		}
 		waitNextFrame
 	}
+	assert(touched, assertMsg)
+}
+
+func waitForKeyPress(key Key, prompt, success string) {
+	say prompt
+	for !keyPressed(key) {
+		waitNextFrame
+	}
+	say success
+}
+
+func waitForMouseClick(prompt, success string) {
+	say prompt
+	for !mousePressed {
+		waitNextFrame
+	}
+	say success
+}
+
+onMsg "testSensing", => {
+	onTestStart(this)
+
+	setupSensingScene()
+
+	// 1. Sprite::Touching
+	assertTouchingRed(sensingStartOffset, sensingMoveSpeed, false)
 
 	// 2. Sprite::TouchingColor
-	tt = 0
-	for tt < 200 {
-		tt += deltaTime()
-		setXpos startOffset*mvSpeed
-		//if isTouchingColor "Red" {
-		say "touching color"
-		//}
-		waitNextFrame
-	}
+	assertTouchingRed(sensingStartOffset, sensingMoveSpeed, true)
 
 	// 3. Sprite::DistanceTo
-	Red.setXYpos 0, 0
+	Red.SetXYpos 0, 0
 	setXYpos 30, 40
-	dist := distanceTo("Red")
+	dist := distanceTo(sensingTargetName)
 	assertFloat(dist, 50, "Sprite::DistanceTo")
 	// 4. Sprite::Ask
 	ask "test ask"
 	// 5. Game::Answer
 	say answer
 	// 6. Game::KeyPressed
-	say "test key pressed A"
-	for !keyPressed(KeyA) {
-		waitNextFrame
-	}
-	say "key A pressed"
-	say "please click the red sprite"
+	waitForKeyPress(KeyA, "test key pressed A", "key A pressed")
 	// 7. Game::MousePressed
-	for !mousePressed {
-		waitNextFrame
-	}
-	say "mouse clicked"
+	waitForMouseClick("please click the red sprite", "mouse clicked")
 
-	Red.setXYpos 0, 0
+	Red.SetXYpos 0, 0
 	setXYpos 100, 200
 	// 8. Game::MouseX
 	mouseX := mouseX
-	assertPosWithErr(this, mouseX, 0, 10, "Game::MouseX")
+	assertPosWithErr(this, mouseX, 0, sensingMouseErr, "Game::MouseX")
 	// 9. Game::MouseY
 	mouseY := mouseY
-	assertPosWithErr(this, mouseY, 0, 10, "Game::MouseY")
+	assertPosWithErr(this, mouseY, 0, sensingMouseErr, "Game::MouseY")
 	// 10. Game::Timer
 	assert(timer > 1, "Game::Timer")
 	// 11. Game::ResetTimer


### PR DESCRIPTION
## Summary

This PR fixes the hanging behavior in `test/All/SpSensing.spx` and makes the sensing demo flow easier to follow.

## What changed

- bound the sprite/color touching checks to a short movement window instead of leaving them in long-running loops
- fixed the movement logic used by the touching demo so the sprite actually moves across the target
- updated `touchingColor` to use the actual red asset color (`#ED1C24`)
- extracted shared setup and input-wait helpers to reduce duplication and make the test flow clearer
- normalized `Red.SetXYpos` usage and centralized sensing constants

## Why

The previous sensing demo could appear stuck because the movement/update logic in the touching checks was not progressing as intended, which made the test case feel hung and harder to debug.

## Testing

- `go test ./...`
