### PR TITLE
feat(event): add stop kind for other scripts in game

### DIFF
--- a/internal/core/event/stop.go
+++ b/internal/core/event/stop.go
@@ -25,12 +25,21 @@ const (
 	ThisSprite           StopKind = -102
 	ThisScript           StopKind = -103
 	OtherScriptsInSprite StopKind = -104
+	OtherScriptsInGame   StopKind = -105
 )
 
 type StopFilter func(obj any, isCurrent bool) bool
 
 func ResolveStop(kind StopKind, owner any, isSprite func(any) bool, isGame func(any) bool) (StopFilter, bool) {
 	switch kind {
+	case AllStop:
+		return func(obj any, isCurrent bool) bool {
+			return isSprite(obj) || isGame(obj)
+		}, true
+	case AllOtherScripts:
+		return func(obj any, isCurrent bool) bool {
+			return !isCurrent && (isSprite(obj) || isGame(obj))
+		}, false
 	case AllSprites:
 		return func(obj any, isCurrent bool) bool {
 			return isSprite(obj)
@@ -39,20 +48,16 @@ func ResolveStop(kind StopKind, owner any, isSprite func(any) bool, isGame func(
 		return func(obj any, isCurrent bool) bool {
 			return obj == owner
 		}, false
-	case OtherScriptsInSprite:
-		return func(obj any, isCurrent bool) bool {
-			return obj == owner && !isCurrent
-		}, false
-	case AllOtherScripts:
-		return func(obj any, isCurrent bool) bool {
-			return !isCurrent && (isSprite(obj) || isGame(obj))
-		}, false
-	case AllStop:
-		return func(obj any, isCurrent bool) bool {
-			return isSprite(obj) || isGame(obj)
-		}, true
 	case ThisScript:
 		return nil, true
+	case OtherScriptsInSprite:
+		return func(obj any, isCurrent bool) bool {
+			return !isCurrent && obj == owner
+		}, false
+	case OtherScriptsInGame:
+		return func(obj any, isCurrent bool) bool {
+			return !isCurrent && isGame(obj)
+		}, false
 	default:
 		return nil, false
 	}

--- a/pkg/ispx/internal/pkg/github.com/goplus/spx/v2/export.go
+++ b/pkg/ispx/internal/pkg/github.com/goplus/spx/v2/export.go
@@ -299,6 +299,7 @@ func init() {
 			"NoPhysics":            {Typ: reflect.TypeOf(q.NoPhysics), Value: constant.MakeInt64(int64(q.NoPhysics))},
 			"None":                 {Typ: reflect.TypeOf(q.None), Value: constant.MakeInt64(int64(q.None))},
 			"Normal":               {Typ: reflect.TypeOf(q.Normal), Value: constant.MakeInt64(int64(q.Normal))},
+			"OtherScriptsInGame":   {Typ: reflect.TypeOf(q.OtherScriptsInGame), Value: constant.MakeInt64(int64(q.OtherScriptsInGame))},
 			"OtherScriptsInSprite": {Typ: reflect.TypeOf(q.OtherScriptsInSprite), Value: constant.MakeInt64(int64(q.OtherScriptsInSprite))},
 			"PenBrightness":        {Typ: reflect.TypeOf(q.PenBrightness), Value: constant.MakeInt64(int64(q.PenBrightness))},
 			"PenHue":               {Typ: reflect.TypeOf(q.PenHue), Value: constant.MakeInt64(int64(q.PenHue))},

--- a/sprite.go
+++ b/sprite.go
@@ -115,6 +115,7 @@ const (
 	ThisSprite           StopKind = coreevent.ThisSprite
 	ThisScript           StopKind = coreevent.ThisScript
 	OtherScriptsInSprite StopKind = coreevent.OtherScriptsInSprite
+	OtherScriptsInGame   StopKind = coreevent.OtherScriptsInGame
 )
 
 // VarName identifies a monitor variable by name.


### PR DESCRIPTION
## Summary
- add `OtherScriptsInGame` to `event.StopKind`
- handle `OtherScriptsInGame` in `ResolveStop` so it stops non-current game-level scripts
- reorder `ResolveStop` switch cases to follow enum declaration order for readability

## Testing
- `go test ./internal/core/event`
- `go test ./...`
