### PR TITLE
fix(sprite): align invalid costume handling with Scratch

### DIFF
--- a/baseobj.go
+++ b/baseobj.go
@@ -25,6 +25,7 @@ import (
 	coreproject "github.com/goplus/spx/v2/internal/core/project"
 	corestate "github.com/goplus/spx/v2/internal/core/state"
 	"github.com/goplus/spx/v2/internal/engine"
+	spxlog "github.com/goplus/spx/v2/internal/log"
 )
 
 // baseObj provides common functionality for sprites and backdrops.
@@ -232,7 +233,7 @@ func (p *baseObj) goSetCostume(val any) bool {
 	case float64:
 		return p.setCostumeByIndex(int(v))
 	default:
-		engine.Panic("setCostume: invalid argument type")
+		spxlog.Error("setCostume: invalid argument type")
 		return false
 	}
 }
@@ -240,7 +241,7 @@ func (p *baseObj) goSetCostume(val any) bool {
 // setCostumeByIndex sets the costume by its index.
 func (p *baseObj) setCostumeByIndex(idx int) bool {
 	if idx < 0 || idx >= len(p.costumes) {
-		engine.Panicf("invalid costume index: %d (count: %d)", idx, len(p.costumes))
+		spxlog.Error("invalid costume index: %d (count: %d)", idx, len(p.costumes))
 		return false
 	}
 	p.setCostumeIndex(idx)
@@ -252,7 +253,7 @@ func (p *baseObj) setCostumeByName(name SpriteCostumeName) bool {
 	if idx := p.findCostume(name); idx >= 0 {
 		return p.setCostumeByIndex(idx)
 	}
-	engine.Panicf("invalid costume name: %s", name)
+	spxlog.Error("invalid costume name: %s", name)
 	return false
 }
 

--- a/baseobj.go
+++ b/baseobj.go
@@ -233,7 +233,7 @@ func (p *baseObj) goSetCostume(val any) bool {
 	case float64:
 		return p.setCostumeByIndex(int(v))
 	default:
-		spxlog.Error("setCostume: invalid argument type")
+		spxlog.Error("setCostume: invalid argument type: %T", val)
 		return false
 	}
 }
@@ -241,7 +241,7 @@ func (p *baseObj) goSetCostume(val any) bool {
 // setCostumeByIndex sets the costume by its index.
 func (p *baseObj) setCostumeByIndex(idx int) bool {
 	if idx < 0 || idx >= len(p.costumes) {
-		spxlog.Error("invalid costume index: %d (count: %d)", idx, len(p.costumes))
+		spxlog.Error("setCostume: invalid index %d (count: %d)", idx, len(p.costumes))
 		return false
 	}
 	p.setCostumeIndex(idx)
@@ -253,7 +253,7 @@ func (p *baseObj) setCostumeByName(name SpriteCostumeName) bool {
 	if idx := p.findCostume(name); idx >= 0 {
 		return p.setCostumeByIndex(idx)
 	}
-	spxlog.Error("invalid costume name: %s", name)
+	spxlog.Error("setCostume: invalid name %s", name)
 	return false
 }
 

--- a/sprite_render.go
+++ b/sprite_render.go
@@ -66,7 +66,9 @@ func (p *SpriteImpl) setCostume(costume any) {
 	if isDebugInstrEnabled() {
 		spxlog.Debug("SetCostume: sprite=%s, costume=%v", p.name, costume)
 	}
-	p.goSetCostume(costume)
+	if !p.goSetCostume(costume) {
+		return
+	}
 	p.spriteState.DefaultCostumeIndex = p.costumeIndex
 	p.spriteState.IsDirty = true
 }

--- a/sprite_render_test.go
+++ b/sprite_render_test.go
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2021 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package spx
+
+import "testing"
+
+func newTestRenderSprite() *SpriteImpl {
+	return &SpriteImpl{
+		name: "TestSprite",
+		baseObj: baseObj{
+			costumes: []*costume{
+				{name: "idle"},
+				{name: "run"},
+			},
+			costumeIndex: 1,
+		},
+	}
+}
+
+func TestSpriteSetCostumeInvalidNameIsNoOp(t *testing.T) {
+	sprite := newTestRenderSprite()
+	sprite.spriteState.DefaultCostumeIndex = 0
+
+	sprite.setCostume(SpriteCostumeName("missing"))
+
+	if got := sprite.costumeIndex; got != 1 {
+		t.Fatalf("costumeIndex = %d, want 1", got)
+	}
+	if got := sprite.spriteState.DefaultCostumeIndex; got != 0 {
+		t.Fatalf("DefaultCostumeIndex = %d, want 0", got)
+	}
+	if sprite.spriteState.IsDirty {
+		t.Fatal("IsDirty = true, want false")
+	}
+	if sprite.runtimeState.IsCostumeDirty {
+		t.Fatal("IsCostumeDirty = true, want false")
+	}
+}
+
+func TestSpriteSetCostumeValidNameUpdatesState(t *testing.T) {
+	sprite := newTestRenderSprite()
+	sprite.spriteState.DefaultCostumeIndex = 1
+
+	sprite.setCostume(SpriteCostumeName("idle"))
+
+	if got := sprite.costumeIndex; got != 0 {
+		t.Fatalf("costumeIndex = %d, want 0", got)
+	}
+	if got := sprite.spriteState.DefaultCostumeIndex; got != 0 {
+		t.Fatalf("DefaultCostumeIndex = %d, want 0", got)
+	}
+	if !sprite.spriteState.IsDirty {
+		t.Fatal("IsDirty = false, want true")
+	}
+	if !sprite.runtimeState.IsCostumeDirty {
+		t.Fatal("IsCostumeDirty = false, want true")
+	}
+}


### PR DESCRIPTION
## Summary

This change aligns invalid costume handling with Scratch behavior.

Instead of panicking when `setCostume` receives an invalid argument, costume index, or costume name, we now log an error and return gracefully. This prevents the runtime from being interrupted by user-facing invalid costume operations.

## Changes

- replace `engine.Panic` in invalid `setCostume` argument handling with `spxlog.Error`
- replace `engine.Panicf` for invalid costume index with `spxlog.Error`
- replace `engine.Panicf` for invalid costume name with `spxlog.Error`

## Why

Scratch does not crash the project when a costume switch target is invalid. Logging the error while continuing execution makes SPX behavior more consistent with Scratch and avoids unnecessary runtime interruption.

## Testing

- `go test ./...`
