### PR TITLE
fix: keep edge checks stage-based in camera projects

### DIFF
--- a/component_transform.go
+++ b/component_transform.go
@@ -372,14 +372,14 @@ func (t *transformComponent) TurnToPos(x, y, speed float64, animation SpriteAnim
 	})
 }
 
-// BounceOffEdge bounces the sprite off the edge of the stage by reflecting
+// BounceOffEdge bounces the sprite off the selected edge area by reflecting
 // its direction vector based on the edge that was touched.
-func (t *transformComponent) BounceOffEdge() {
+func (t *transformComponent) BounceOffEdge(area string) {
 	if isDebugInstrEnabled() {
 		spxlog.Debug("BounceOffEdge: %s", t.sprite.name)
 	}
 
-	nearestEdge := t.sprite.checkNearestTouchedBoundary()
+	nearestEdge := t.sprite.checkNearestTouchedBoundary(area)
 	if nearestEdge == 0 {
 		return
 	}

--- a/edge_options.go
+++ b/edge_options.go
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2021 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package spx
+
+import (
+	"strings"
+
+	spxlog "github.com/goplus/spx/v2/internal/log"
+)
+
+const (
+	edgeAreaStage    = "stage"
+	edgeAreaCamera   = "camera"
+	edgeAreaViewport = "viewport"
+)
+
+func normalizeEdgeArea(area string) string {
+	switch area = strings.ToLower(area); area {
+	case "", edgeAreaStage:
+		return edgeAreaStage
+	case edgeAreaCamera, edgeAreaViewport:
+		return edgeAreaCamera
+	default:
+		spxlog.Warn("unrecognized edge area %q, using %q", area, edgeAreaStage)
+		return edgeAreaStage
+	}
+}

--- a/sprite_edge_test.go
+++ b/sprite_edge_test.go
@@ -133,8 +133,11 @@ func TestSpriteTouchingTargetUsesRequestedEdgeArea(t *testing.T) {
 	if sprite.touching(EdgeLeft, edgeAreaCamera) {
 		t.Fatal("touching(EdgeLeft, camera) = true, want false")
 	}
-	if !sprite.touching(EdgeRight, normalizeEdgeArea(edgeAreaViewport)) {
+	if !sprite.touching(EdgeRight, edgeAreaViewport) {
 		t.Fatal("touching(EdgeRight, viewport) = false, want true")
+	}
+	if !sprite.touching(EdgeRight, "Camera") {
+		t.Fatal("touching(EdgeRight, Camera) = false, want true")
 	}
 }
 

--- a/sprite_edge_test.go
+++ b/sprite_edge_test.go
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2021 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package spx
+
+import (
+	"testing"
+
+	"github.com/goplus/spbase/mathf"
+	internalengine "github.com/goplus/spx/v2/internal/engine"
+	"github.com/goplus/spx/v2/internal/enginewrap"
+	pkgengine "github.com/goplus/spx/v2/pkg/spx/pkg/engine"
+)
+
+type fakeEdgePhysicsMgr struct {
+	stageTouching  int64
+	cameraTouching int64
+	stageNearest   int64
+	cameraNearest  int64
+}
+
+func (f *fakeEdgePhysicsMgr) Raycast(from, to mathf.Vec2, collisionMask int64) pkgengine.Object {
+	return 0
+}
+
+func (f *fakeEdgePhysicsMgr) CheckCollision(from, to mathf.Vec2, collisionMask int64, collideWithAreas, collideWithBodies bool) bool {
+	return false
+}
+
+func (f *fakeEdgePhysicsMgr) CheckTouchedCameraBoundaries(obj pkgengine.Object) int64 {
+	return f.cameraTouching
+}
+
+func (f *fakeEdgePhysicsMgr) CheckTouchedCameraBoundary(obj pkgengine.Object, boardType int64) bool {
+	return f.cameraTouching&boardType != 0
+}
+
+func (f *fakeEdgePhysicsMgr) CheckNearestTouchedCameraBoundary(obj pkgengine.Object) int64 {
+	return f.cameraNearest
+}
+
+func (f *fakeEdgePhysicsMgr) CheckTouchedStageBoundaries(obj pkgengine.Object) int64 {
+	return f.stageTouching
+}
+
+func (f *fakeEdgePhysicsMgr) CheckTouchedStageBoundary(obj pkgengine.Object, boardType int64) bool {
+	return f.stageTouching&boardType != 0
+}
+
+func (f *fakeEdgePhysicsMgr) CheckNearestTouchedStageBoundary(obj pkgengine.Object) int64 {
+	return f.stageNearest
+}
+
+func (f *fakeEdgePhysicsMgr) SetCollisionSystemType(bool) {}
+
+func (f *fakeEdgePhysicsMgr) SetGlobalGravity(float64) {}
+
+func (f *fakeEdgePhysicsMgr) GetGlobalGravity() float64 {
+	return 0
+}
+
+func (f *fakeEdgePhysicsMgr) SetGlobalFriction(float64) {}
+
+func (f *fakeEdgePhysicsMgr) GetGlobalFriction() float64 {
+	return 0
+}
+
+func (f *fakeEdgePhysicsMgr) SetGlobalAirDrag(float64) {}
+
+func (f *fakeEdgePhysicsMgr) GetGlobalAirDrag() float64 {
+	return 0
+}
+
+func (f *fakeEdgePhysicsMgr) CheckCollisionRect(pos, size mathf.Vec2, collisionMask int64) pkgengine.Array {
+	return nil
+}
+
+func (f *fakeEdgePhysicsMgr) CheckCollisionCircle(pos mathf.Vec2, radius float64, collisionMask int64) pkgengine.Array {
+	return nil
+}
+
+func (f *fakeEdgePhysicsMgr) RaycastWithDetails(from, to mathf.Vec2, ignoreSprites pkgengine.Array, collisionMask int64, collideWithAreas, collideWithBodies bool) pkgengine.Array {
+	return nil
+}
+
+func installEdgePhysicsMgr(t *testing.T, mgr pkgengine.IPhysicsMgr) {
+	t.Helper()
+
+	enginewrap.Init(func(call func()) {
+		call()
+	})
+
+	original := pkgengine.PhysicsMgr
+	pkgengine.PhysicsMgr = mgr
+	t.Cleanup(func() {
+		pkgengine.PhysicsMgr = original
+	})
+}
+
+func newEdgeTestSprite(direction Direction) *SpriteImpl {
+	sprite := newTestTransformSprite(0, 0)
+	sprite.spriteState.IsVisible = true
+	sprite.transform().direction = direction
+	sprite.runtimeState.SyncSprite = &internalengine.Sprite{}
+	sprite.runtimeState.SyncSprite.SetId(42)
+	return sprite
+}
+
+func TestSpriteTouchingTargetUsesRequestedEdgeArea(t *testing.T) {
+	installEdgePhysicsMgr(t, &fakeEdgePhysicsMgr{
+		stageTouching:  touchingScreenLeft,
+		cameraTouching: touchingScreenRight,
+	})
+
+	sprite := newEdgeTestSprite(0)
+
+	if !sprite.Touching__2(EdgeLeft) {
+		t.Fatal("Touching__2(EdgeLeft) = false, want true for default stage area")
+	}
+	if sprite.touching(EdgeLeft, edgeAreaCamera) {
+		t.Fatal("touching(EdgeLeft, camera) = true, want false")
+	}
+	if !sprite.touching(EdgeRight, normalizeEdgeArea(edgeAreaViewport)) {
+		t.Fatal("touching(EdgeRight, viewport) = false, want true")
+	}
+}
+
+func TestSpriteBounceOffEdgeDefaultsToStageArea(t *testing.T) {
+	installEdgePhysicsMgr(t, &fakeEdgePhysicsMgr{
+		stageNearest:  touchingScreenLeft,
+		cameraNearest: touchingScreenRight,
+	})
+
+	sprite := newEdgeTestSprite(-90)
+
+	sprite.BounceOffEdge()
+
+	if got := sprite.Heading(); got != 90 {
+		t.Fatalf("BounceOffEdge() heading = %v, want 90", got)
+	}
+}
+
+func TestSpriteBounceOffEdgeWithCameraArea(t *testing.T) {
+	installEdgePhysicsMgr(t, &fakeEdgePhysicsMgr{
+		stageNearest:  touchingScreenLeft,
+		cameraNearest: touchingScreenRight,
+	})
+
+	sprite := newEdgeTestSprite(-90)
+
+	sprite.transform().BounceOffEdge(edgeAreaCamera)
+
+	if got := sprite.Heading(); got != -90 {
+		t.Fatalf("BounceOffEdge(camera) heading = %v, want -90", got)
+	}
+}

--- a/sprite_query.go
+++ b/sprite_query.go
@@ -143,7 +143,7 @@ func (p *SpriteImpl) checkTouchingScreen(where int, area string) (touching int) 
 	if p.runtimeState.SyncSprite == nil {
 		return 0
 	}
-	switch area {
+	switch normalizeEdgeArea(area) {
 	case edgeAreaCamera:
 		touching = int(p.engine().PhysicsMgr.CheckTouchedCameraBoundaries(p.runtimeState.SyncSprite.GetId()))
 	default:
@@ -156,7 +156,7 @@ func (p *SpriteImpl) checkNearestTouchedBoundary(area string) int {
 	if p.runtimeState.SyncSprite == nil {
 		return 0
 	}
-	switch area {
+	switch normalizeEdgeArea(area) {
 	case edgeAreaCamera:
 		return int(p.engine().PhysicsMgr.CheckNearestTouchedCameraBoundary(p.runtimeState.SyncSprite.GetId()))
 	default:

--- a/sprite_query.go
+++ b/sprite_query.go
@@ -62,22 +62,22 @@ func (p *SpriteImpl) TouchingColor__1(spriteColor, targetColor Color) bool {
 }
 
 func (p *SpriteImpl) Touching__0(sprite Sprite) bool {
-	return p.touching(sprite)
+	return p.touching(sprite, edgeAreaStage)
 }
 
 func (p *SpriteImpl) Touching__1(sprite SpriteName) bool {
-	return p.touching(sprite)
+	return p.touching(sprite, edgeAreaStage)
 }
 
 func (p *SpriteImpl) Touching__2(obj specialObj) bool {
-	return p.touching(obj)
+	return p.touching(obj, edgeAreaStage)
 }
 
 func (p *SpriteImpl) TouchingWith(target Target) bool {
-	return p.touching(target)
+	return p.touching(target, edgeAreaStage)
 }
 
-func (p *SpriteImpl) touching(obj Target) bool {
+func (p *SpriteImpl) touching(obj Target, area string) bool {
 	if !p.spriteState.IsVisible || p.spriteState.IsDying {
 		return false
 	}
@@ -86,7 +86,7 @@ func (p *SpriteImpl) touching(obj Target) bool {
 		return p.g.touchingSpriteBy(p, v) != nil
 	case specialObj:
 		if v > 0 {
-			return p.checkTouchingScreen(int(v)) != 0
+			return p.checkTouchingScreen(int(v), area) != 0
 		}
 		if v == Mouse {
 			x, y := p.g.getMousePos()
@@ -139,19 +139,29 @@ func (p *SpriteImpl) touchingSprite(dst *SpriteImpl) bool {
 	return p.engine().SpriteMgr.CheckCollisionWithSprite(p.runtimeState.SyncSprite.GetId(), dst.runtimeState.SyncSprite.GetId(), alphaThreshold, !isPhysicsEnabled())
 }
 
-func (p *SpriteImpl) checkTouchingScreen(where int) (touching int) {
+func (p *SpriteImpl) checkTouchingScreen(where int, area string) (touching int) {
 	if p.runtimeState.SyncSprite == nil {
 		return 0
 	}
-	touching = int(p.engine().PhysicsMgr.CheckTouchedStageBoundaries(p.runtimeState.SyncSprite.GetId()))
+	switch area {
+	case edgeAreaCamera:
+		touching = int(p.engine().PhysicsMgr.CheckTouchedCameraBoundaries(p.runtimeState.SyncSprite.GetId()))
+	default:
+		touching = int(p.engine().PhysicsMgr.CheckTouchedStageBoundaries(p.runtimeState.SyncSprite.GetId()))
+	}
 	return touching & where
 }
 
-func (p *SpriteImpl) checkNearestTouchedBoundary() int {
+func (p *SpriteImpl) checkNearestTouchedBoundary(area string) int {
 	if p.runtimeState.SyncSprite == nil {
 		return 0
 	}
-	return int(p.engine().PhysicsMgr.CheckNearestTouchedStageBoundary(p.runtimeState.SyncSprite.GetId()))
+	switch area {
+	case edgeAreaCamera:
+		return int(p.engine().PhysicsMgr.CheckNearestTouchedCameraBoundary(p.runtimeState.SyncSprite.GetId()))
+	default:
+		return int(p.engine().PhysicsMgr.CheckNearestTouchedStageBoundary(p.runtimeState.SyncSprite.GetId()))
+	}
 }
 
 func (p *SpriteImpl) HideVar(name PropertyName) {

--- a/sprite_transform.go
+++ b/sprite_transform.go
@@ -353,7 +353,7 @@ func (p *SpriteImpl) ChangeHeading(dir Direction) {
 }
 
 func (p *SpriteImpl) BounceOffEdge() {
-	p.transform().BounceOffEdge()
+	p.transform().BounceOffEdge(edgeAreaStage)
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

This change fixes edge-related behavior in projects with camera enabled so that edge checks continue to use stage boundaries by default.

## Changes

- keep `Touching(Edge...)` stage-based by default even when a camera is present
- make internal edge-boundary helpers support both stage and camera areas
- update `BounceOffEdge` to use the internal stage-area path explicitly
- add focused tests covering stage vs camera boundary behavior
- do not export any new public/script-facing API yet

## Testing

- go test ./...
