### PR TITLE
fix: anchored sprite world bounds clamp

### DIFF
--- a/camera.go
+++ b/camera.go
@@ -76,12 +76,12 @@ func (c *cameraImpl) setLimits() {
 		return
 	}
 
-	// Calculate actual world boundaries (based on minWorld coordinates and world size)
+	worldLeft, worldTop, worldRight, worldBottom := p.worldBounds()
 	world := map[side]int{
-		sideLeft:   p.displayState.MinWorldX,
-		sideTop:    -p.displayState.MinWorldY - p.displayState.WorldHeight,
-		sideRight:  p.displayState.MinWorldX + p.displayState.WorldWidth,
-		sideBottom: -p.displayState.MinWorldY,
+		sideLeft:   worldLeft,
+		sideTop:    worldBottom,
+		sideRight:  worldRight,
+		sideBottom: worldTop,
 	}
 
 	// Apply camera limits

--- a/component_transform.go
+++ b/component_transform.go
@@ -304,12 +304,15 @@ func (t *transformComponent) fixWorldRange(x, y float64) (float64, float64) {
 		return x, y
 	}
 
-	worldW, worldH := t.sprite.g.worldSize()
-	maxW := float64(worldW)/2.0 + float64(rect.Size.X)
-	maxH := float64(worldH)/2.0 + float64(rect.Size.Y)
+	worldLeft, worldTop, worldRight, worldBottom := t.sprite.g.worldBounds()
 
-	x = mathf.Clamp(x, -maxW, maxW)
-	y = mathf.Clamp(y, -maxH, maxH)
+	leftOffset := t.x - rect.Position.X
+	rightOffset := rect.Position.X + rect.Size.X - t.x
+	bottomOffset := t.y - rect.Position.Y
+	topOffset := rect.Position.Y + rect.Size.Y - t.y
+
+	x = mathf.Clamp(x, float64(worldLeft)-rightOffset, float64(worldRight)+leftOffset)
+	y = mathf.Clamp(y, float64(worldBottom)-topOffset, float64(worldTop)+bottomOffset)
 
 	return x, y
 }

--- a/runtime_display.go
+++ b/runtime_display.go
@@ -78,6 +78,15 @@ func (p *Game) worldSize() (int, int) {
 	return p.displayState.WorldWidth, p.displayState.WorldHeight
 }
 
+func (p *Game) worldBounds() (left, top, right, bottom int) {
+	worldW, worldH := p.worldSize()
+	left = p.displayState.MinWorldX
+	right = left + worldW
+	top = -p.displayState.MinWorldY
+	bottom = top - worldH
+	return
+}
+
 func (p *Game) doWorldSize() {
 	if p.displayState.WorldWidth == 0 {
 		c := p.costumes[p.costumeIndex]


### PR DESCRIPTION
## Summary

This PR fixes incorrect world-bound clamping for anchored or offset sprites, and aligns camera limits with the actual world rectangle.

Previously, sprite movement was clamped against a symmetric range derived only from world width/height. That assumed the world was centered at `(0, 0)` and did not account for the sprite's real bounds. As a result, anchored sprites could stop too early, cross map edges, or behave inconsistently in worlds with non-zero `MinWorldX` / `MinWorldY`.

## Changes

- add `Game.worldBounds()` as a single source of truth for world left/top/right/bottom
- update sprite position clamping to use actual world bounds instead of half-size heuristics
- compute clamp offsets from the sprite's current bounds, so anchored/collider-shifted sprites are constrained by their rendered footprint
- update camera limit setup to use the same world-bounds calculation

## Impact

- anchored sprites now clamp correctly at all world edges
- non-centered worlds and tilemap-derived worlds behave consistently
- camera limits and sprite limits now use the same coordinate basis

## How to verify

- use a sprite with a non-centered anchor or collider pivot and move it to each world edge
- confirm the sprite no longer stops early or moves past the map boundary
- verify camera follow/clamping still respects the same world rectangle
