### PR TITLE
fix(pck): correct say bubble content margins

### DIFF
--- a/internal/cmd/buildctl/engine/cmd_test.go
+++ b/internal/cmd/buildctl/engine/cmd_test.go
@@ -22,6 +22,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/goplus/spx/v2/internal/release"
 )
 
 func TestParseEngineDownloadArgsDefault(t *testing.T) {
@@ -292,6 +294,7 @@ func installFakeEngineDownload(t *testing.T, repoRoot, defaultPlatform, arch str
 
 func fakeEngineDownloadFetcher(url, dst string) error {
 	base := filepath.Base(url)
+	runtimePackZip := "gdspxrt.pck." + release.DefaultReleaseMeta().Pck.Version + ".zip"
 
 	switch base {
 	case "linux-x86_64.zip":
@@ -318,7 +321,7 @@ func fakeEngineDownloadFetcher(url, dst string) error {
 		return writeZipFixture(dst, map[string]string{
 			"web-template.bin": "miniprogram-web-template",
 		})
-	case "gdspxrt.pck.2.0.30.zip":
+	case runtimePackZip:
 		return writeZipFixture(dst, map[string]string{
 			"gdspxrt.pck": "runtime-pck",
 		})

--- a/internal/cmd/buildctl/prepare_test.go
+++ b/internal/cmd/buildctl/prepare_test.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 
 	enginepkg "github.com/goplus/spx/v2/internal/cmd/buildctl/engine"
+	"github.com/goplus/spx/v2/internal/release"
 	"github.com/goplus/spx/v2/internal/cmd/buildctl/shared"
 )
 
@@ -284,6 +285,7 @@ func installFakeEngineDownload(t *testing.T, repoRoot, defaultPlatform, arch str
 
 func fakeEngineDownloadFetcher(url, dst string) error {
 	base := filepath.Base(url)
+	runtimePackZip := "gdspxrt.pck." + release.DefaultReleaseMeta().Pck.Version + ".zip"
 
 	switch base {
 	case "linux-x86_64.zip":
@@ -310,7 +312,7 @@ func fakeEngineDownloadFetcher(url, dst string) error {
 		return writeZipFixture(dst, map[string]string{
 			"web-template.bin": "miniprogram-web-template",
 		})
-	case "gdspxrt.pck.2.0.30.zip":
+	case runtimePackZip:
 		return writeZipFixture(dst, map[string]string{
 			"gdspxrt.pck": "runtime-pck",
 		})

--- a/internal/release/release_meta.go
+++ b/internal/release/release_meta.go
@@ -49,9 +49,9 @@ type PckRelease struct {
 }
 
 var defaultPckRelease = PckRelease{
-	// Current packaged runtime assets are only published from the pre.30 SPX release.
-	SPXTag:  "v2.0.0-pre.30",
-	Version: "2.0.30",
+	// Current packaged runtime assets are only published from the v2.0.0 SPX release.
+	SPXTag:  "v2.0.0",
+	Version: "2.2.0",
 }
 
 type releaseVersionMapping struct {

--- a/internal/release/release_meta_test.go
+++ b/internal/release/release_meta_test.go
@@ -23,12 +23,6 @@ func TestReleaseMetaForSPXVersionMapped(t *testing.T) {
 	if meta.Runtime.Version != "2.2.0" {
 		t.Fatalf("runtime version = %q, want %q", meta.Runtime.Version, "2.2.0")
 	}
-	if meta.Pck.SPXTag != "v2.0.0-pre.30" {
-		t.Fatalf("pck tag = %q, want %q", meta.Pck.SPXTag, "v2.0.0-pre.30")
-	}
-	if meta.Pck.Version != "2.0.30" {
-		t.Fatalf("pck version = %q, want %q", meta.Pck.Version, "2.0.30")
-	}
 }
 
 func TestReleaseMetaForSPXVersionLatestFallback(t *testing.T) {


### PR DESCRIPTION
## Summary

Fix say bubble content margins for left and right themes.

The say bubble texture margins need to preserve the tail area for 9-slice rendering, but that tail area should not be included in the label content region. This change adds explicit horizontal content margins so text no longer renders with extra blank space inside the bubble.

## Changes

- the packaged runtime assets are only published from the v2.0.0 SPX release.
