### PR TITLE
ci: automate runtime asset release publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,7 @@ jobs:
     name: Prepare release inputs
     runs-on: ubuntu-22.04
     outputs:
+      release_tag: ${{ steps.set-version.outputs.release_tag }}
       version: ${{ steps.set-version.outputs.version }}
       run_runtime_assets: ${{ steps.set-platforms.outputs.run_runtime_assets }}
       run_web: ${{ steps.set-platforms.outputs.run_web }}
@@ -40,12 +41,15 @@ jobs:
           RELEASE_TAG_INPUT: ${{ github.event.inputs.release_tag }}
         run: |
           if [ "${{ github.event_name }}" == "release" ]; then
-            VERSION="${{ github.event.release.tag_name }}"
+            RELEASE_TAG="${{ github.event.release.tag_name }}"
+            VERSION="$RELEASE_TAG"
           else
+            RELEASE_TAG=""
             VERSION="$RELEASE_TAG_INPUT"
           fi
           VERSION="${VERSION#v}"  # Remove 'v' prefix (if present)
           echo "[info] Version: $VERSION"
+          echo "release_tag=$RELEASE_TAG" >> $GITHUB_OUTPUT
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Resolve target platforms
@@ -128,6 +132,7 @@ jobs:
     if: needs.setup.outputs.run_runtime_assets == 'true'
     uses: ./.github/workflows/release_runtime_assets.yml
     with:
+      release_tag: ${{ needs.setup.outputs.release_tag }}
       version: ${{ needs.setup.outputs.version }}
 
   web-build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ on:
         required: true
         default: 'v2.0.1'
       platforms:
-        description: 'Platforms to build (comma-separated: all,web,macos,windows,linux)'
+        description: 'Platforms to build (comma-separated: all,runtime-assets,web,macos,windows,linux)'
         required: true
         default: 'all'
 concurrency:
@@ -23,6 +23,7 @@ jobs:
     runs-on: ubuntu-22.04
     outputs:
       version: ${{ steps.set-version.outputs.version }}
+      run_runtime_assets: ${{ steps.set-platforms.outputs.run_runtime_assets }}
       run_web: ${{ steps.set-platforms.outputs.run_web }}
       run_macos: ${{ steps.set-platforms.outputs.run_macos }}
       run_windows: ${{ steps.set-platforms.outputs.run_windows }}
@@ -67,11 +68,12 @@ jobs:
 
           case ",$PLATFORMS," in
             *,all,*)
-              PLATFORMS="web,macos,windows,linux"
+              PLATFORMS="runtime-assets,web,macos,windows,linux"
               ;;
           esac
 
           IFS=',' read -r -a PLATFORM_ITEMS <<< "$PLATFORMS"
+          RUN_RUNTIME_ASSETS=false
           RUN_WEB=false
           RUN_MACOS=false
           RUN_WINDOWS=false
@@ -79,6 +81,9 @@ jobs:
 
           for PLATFORM in "${PLATFORM_ITEMS[@]}"; do
             case "$PLATFORM" in
+              runtime-assets)
+                RUN_RUNTIME_ASSETS=true
+                ;;
               web)
                 RUN_WEB=true
                 ;;
@@ -100,12 +105,13 @@ jobs:
             esac
           done
 
-          if [ "$RUN_WEB" = false ] && [ "$RUN_MACOS" = false ] && [ "$RUN_WINDOWS" = false ] && [ "$RUN_LINUX" = false ]; then
+          if [ "$RUN_RUNTIME_ASSETS" = false ] && [ "$RUN_WEB" = false ] && [ "$RUN_MACOS" = false ] && [ "$RUN_WINDOWS" = false ] && [ "$RUN_LINUX" = false ]; then
             echo "[error] No valid platforms resolved from: $RAW_PLATFORMS" >&2
             exit 1
           fi
 
           echo "[info] Platforms: $PLATFORMS"
+          echo "run_runtime_assets=$RUN_RUNTIME_ASSETS" >> $GITHUB_OUTPUT
           echo "run_web=$RUN_WEB" >> $GITHUB_OUTPUT
           echo "run_macos=$RUN_MACOS" >> $GITHUB_OUTPUT
           echo "run_windows=$RUN_WINDOWS" >> $GITHUB_OUTPUT
@@ -115,6 +121,14 @@ jobs:
     name: Static checks
     needs: setup
     uses: ./.github/workflows/static_checks.yml
+
+  runtime-assets-build:
+    name: Release runtime assets
+    needs: [setup, static-checks]
+    if: needs.setup.outputs.run_runtime_assets == 'true'
+    uses: ./.github/workflows/release_runtime_assets.yml
+    with:
+      version: ${{ needs.setup.outputs.version }}
 
   web-build:
     name: Release web bundle

--- a/.github/workflows/release_runtime_assets.yml
+++ b/.github/workflows/release_runtime_assets.yml
@@ -1,0 +1,63 @@
+name: Release Runtime Assets
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: 'Release version without the leading v (for example, 2.0.1)'
+        required: true
+        type: string
+
+concurrency:
+  group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-release-runtime-assets
+  cancel-in-progress: true
+
+jobs:
+  runtime-assets:
+    name: Release runtime assets
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+
+      - name: Install Linux dependencies
+        run: sudo apt-get update && sudo apt-get install gcc libgl1-mesa-dev libegl1-mesa-dev libgles2-mesa-dev libx11-dev xorg-dev libasound2-dev libopenal-dev zip
+
+      - name: Set up toolchain and engine assets
+        uses: ./.github/actions/deps
+        with:
+          setup-mode: runtime
+
+      - name: Build runtime asset bundle
+        id: build_runtime_assets
+        run: |
+          set -euo pipefail
+
+          "$BUILDCTL" runtime export-pack
+
+          GOPATH_DIR="$(go env GOPATH | tr -d '\r\n')"
+          ASSET_ZIP="${GOPATH_DIR}/bin/spx-runtime-assets.zip"
+
+          if [ ! -f "$ASSET_ZIP" ]; then
+            echo "[error] Runtime asset bundle not found: $ASSET_ZIP" >&2
+            exit 1
+          fi
+
+          echo "[info] Built runtime asset bundle: $ASSET_ZIP"
+          echo "asset-zip=$ASSET_ZIP" >> "$GITHUB_OUTPUT"
+
+      - name: Upload runtime asset bundle
+        uses: actions/upload-artifact@v7
+        with:
+          name: spx-runtime-assets-${{ inputs.version }}
+          path: ${{ steps.build_runtime_assets.outputs.asset-zip }}
+          retention-days: 14
+
+      - name: Publish runtime asset bundle
+        if: github.event_name == 'release'
+        uses: softprops/action-gh-release@v3
+        with:
+          files: ${{ steps.build_runtime_assets.outputs.asset-zip }}
+          tag_name: ${{ github.event.release.tag_name }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release_runtime_assets.yml
+++ b/.github/workflows/release_runtime_assets.yml
@@ -7,6 +7,10 @@ on:
         description: 'Release version without the leading v (for example, 2.0.1)'
         required: true
         type: string
+      release_tag:
+        description: 'Release tag with leading v when publishing release assets'
+        required: false
+        type: string
 
 concurrency:
   group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-release-runtime-assets
@@ -54,10 +58,10 @@ jobs:
           retention-days: 14
 
       - name: Publish runtime asset bundle
-        if: github.event_name == 'release'
+        if: inputs.release_tag != ''
         uses: softprops/action-gh-release@v3
         with:
           files: ${{ steps.build_runtime_assets.outputs.asset-zip }}
-          tag_name: ${{ github.event.release.tag_name }}
+          tag_name: ${{ inputs.release_tag }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -215,7 +215,7 @@ clean-projects: ## Delete generated artifacts (.temp/, project/, .gdspx_web_serv
 		echo "removed $$path"; \
 	done
 
-export-pack: ## Export runtime pck file
+export-pack: ## Export runtime asset bundle
 	$(BUILDCTL_RUNTIME_CMD) export-pack
 
 export-web: ## Export web engine. Usage: make export-web MODE=normal (MODE: normal|worker|minigame|miniprogram)

--- a/cmd/spxrunner/runner/release_meta.go
+++ b/cmd/spxrunner/runner/release_meta.go
@@ -35,14 +35,14 @@ package runner
 import "github.com/goplus/spx/v2/internal/release"
 
 const (
-	RuntimeURLBase    = release.RuntimeURLBase
-	SpxReleaseURLBase = release.SpxReleaseURLBase
-	RuntimeTag        = release.RuntimeTag
+	RuntimeURLBase      = release.RuntimeURLBase
+	SpxReleaseURLBase   = release.SpxReleaseURLBase
+	RuntimeTag          = release.RuntimeTag
+	RuntimeAssetZipName = release.RuntimeAssetZipName
 )
 
 type ReleaseMeta = release.ReleaseMeta
 type RuntimeRelease = release.RuntimeRelease
-type PckRelease = release.PckRelease
 
 func ReleaseMetaForSPXVersion(spxVersion string) ReleaseMeta {
 	return release.ReleaseMetaForSPXVersion(spxVersion)

--- a/cmd/spxrunner/runner/runner.go
+++ b/cmd/spxrunner/runner/runner.go
@@ -184,7 +184,7 @@ func (r *Runner) ensureRuntime() error {
 
 	// Check if pck file exists
 	if _, err := os.Stat(r.RuntimePckPath); os.IsNotExist(err) {
-		fmt.Println("Downloading runtime pck...")
+		fmt.Println("Downloading runtime assets...")
 		if err := r.downloadRuntimePck(); err != nil {
 			return err
 		}
@@ -255,15 +255,15 @@ func (r *Runner) downloadRuntime() error {
 	return nil
 }
 
-// downloadRuntimePck downloads the Godot runtime pck file from spx releases
-// URL format: https://github.com/goplus/spx/releases/download/{spxTag}/gdspxrt.pck.{pckVersion}.zip
+// downloadRuntimePck downloads the runtime asset bundle from spx releases.
+// URL format: https://github.com/goplus/spx/releases/download/{spxTag}/spx-runtime-assets.zip
 func (r *Runner) downloadRuntimePck() error {
-	zipName := fmt.Sprintf("gdspxrt.pck.%s.zip", r.ReleaseMeta.Pck.Version)
-	url := r.ReleaseMeta.PckDownloadURL(zipName)
+	zipName := RuntimeAssetZipName
+	url := r.ReleaseMeta.RuntimeAssetDownloadURL(zipName)
 
 	// Download to temp file
 	tmpZip := filepath.Join(r.GoBinPath, zipName)
-	fmt.Printf("Downloading pck from: %s\n", url)
+	fmt.Printf("Downloading runtime assets from: %s\n", url)
 
 	if err := downloadFile(url, tmpZip); err != nil {
 		return fmt.Errorf("failed to download pck: %w", err)

--- a/docs/zh/dev/engine/cmd_make.md
+++ b/docs/zh/dev/engine/cmd_make.md
@@ -149,7 +149,7 @@ make install-apk APK_PROJECT_DIR=tutorial/00-Hello
 
 | 命令 | 说明 |
 | --- | --- |
-| `make export-pack` | 导出 runtime pck zip 到 `GOPATH/bin` |
+| `make export-pack` | 导出 runtime assets zip `spx-runtime-assets.zip` 到 `GOPATH/bin` |
 | `make export-web [MODE=...]` | 导出 Web bundle，输出 zip 到仓库根目录 |
 
 `make export-web` 的输出文件：

--- a/internal/cmd/buildctl/engine/cmd_test.go
+++ b/internal/cmd/buildctl/engine/cmd_test.go
@@ -226,6 +226,43 @@ func TestDownloadEngineAssetsRuntimeOverwritesStaleDesktopBinariesInGitHubAction
 	}
 }
 
+func TestDownloadRuntimePackUsesRequestedRuntimeVersionMeta(t *testing.T) {
+	root := t.TempDir()
+	env := engineDownloadEnv{
+		version:  "2.2.0",
+		goBinDir: filepath.Join(root, "bin"),
+		cacheDir: filepath.Join(root, "cache"),
+	}
+	if err := os.MkdirAll(env.goBinDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s) returned error: %v", env.goBinDir, err)
+	}
+	if err := os.MkdirAll(env.cacheDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s) returned error: %v", env.cacheDir, err)
+	}
+
+	var gotURL string
+	oldFetcher := EngineDownloadFetcher
+	EngineDownloadFetcher = func(url, dst string) error {
+		gotURL = url
+		return writeZipFixture(dst, map[string]string{
+			"gdspxrt.pck": "runtime-pck",
+		})
+	}
+	t.Cleanup(func() { EngineDownloadFetcher = oldFetcher })
+
+	if err := downloadRuntimePack(env); err != nil {
+		t.Fatalf("downloadRuntimePack returned error: %v", err)
+	}
+
+	wantURL := release.SpxReleaseURLBase + "v2.0.0/" + release.RuntimeAssetZipName
+	if gotURL != wantURL {
+		t.Fatalf("download url = %q, want %q", gotURL, wantURL)
+	}
+	if !fileExists(filepath.Join(env.goBinDir, "gdspxrt2.2.0.pck")) {
+		t.Fatalf("expected versioned runtime pck to exist")
+	}
+}
+
 func TestDownloadEngineAssetsWebSkipsExistingCachedTemplateLocally(t *testing.T) {
 	runner := newRuntimeFixtureRunner(t)
 	installFakeEngineDownload(t, runner.repoRoot, "linux", "x86_64")

--- a/internal/cmd/buildctl/engine/cmd_test.go
+++ b/internal/cmd/buildctl/engine/cmd_test.go
@@ -294,7 +294,7 @@ func installFakeEngineDownload(t *testing.T, repoRoot, defaultPlatform, arch str
 
 func fakeEngineDownloadFetcher(url, dst string) error {
 	base := filepath.Base(url)
-	runtimePackZip := "gdspxrt.pck." + release.DefaultReleaseMeta().Pck.Version + ".zip"
+	runtimePackZip := release.RuntimeAssetZipName
 
 	switch base {
 	case "linux-x86_64.zip":

--- a/internal/cmd/buildctl/engine/download.go
+++ b/internal/cmd/buildctl/engine/download.go
@@ -124,7 +124,7 @@ func downloadPlatformAssets(env engineDownloadEnv, mode string, editor bool) err
 func downloadRuntimePack(env engineDownloadEnv) error {
 	versionedPack := filepath.Join(env.goBinDir, fmt.Sprintf("gdspxrt%s.pck", env.version))
 	defaultPack := filepath.Join(env.goBinDir, "gdspxrt.pck")
-	meta := release.DefaultReleaseMeta()
+	meta := release.ReleaseMetaForRuntimeVersion(env.version)
 	zipName := release.RuntimeAssetZipName
 	url := meta.RuntimeAssetDownloadURL(zipName)
 	zipPath := filepath.Join(env.cacheDir, zipName)

--- a/internal/cmd/buildctl/engine/download.go
+++ b/internal/cmd/buildctl/engine/download.go
@@ -59,7 +59,7 @@ func downloadEngineAssets(cfg engineDownloadConfig, repoRoot string) error {
 			return err
 		}
 		if err := downloadRuntimePack(env); err != nil {
-			fmt.Fprintf(osStderr, "Warning: failed to download runtime pack: %v\n", err)
+			fmt.Fprintf(osStderr, "Warning: failed to download runtime asset bundle: %v\n", err)
 		}
 		return nil
 	}
@@ -125,8 +125,8 @@ func downloadRuntimePack(env engineDownloadEnv) error {
 	versionedPack := filepath.Join(env.goBinDir, fmt.Sprintf("gdspxrt%s.pck", env.version))
 	defaultPack := filepath.Join(env.goBinDir, "gdspxrt.pck")
 	meta := release.DefaultReleaseMeta()
-	zipName := fmt.Sprintf("gdspxrt.pck.%s.zip", meta.Pck.Version)
-	url := meta.PckDownloadURL(zipName)
+	zipName := release.RuntimeAssetZipName
+	url := meta.RuntimeAssetDownloadURL(zipName)
 	zipPath := filepath.Join(env.cacheDir, zipName)
 	if err := EngineDownloadFetcher(url, zipPath); err != nil {
 		return err

--- a/internal/cmd/buildctl/prepare_test.go
+++ b/internal/cmd/buildctl/prepare_test.go
@@ -27,8 +27,8 @@ import (
 	"testing"
 
 	enginepkg "github.com/goplus/spx/v2/internal/cmd/buildctl/engine"
-	"github.com/goplus/spx/v2/internal/release"
 	"github.com/goplus/spx/v2/internal/cmd/buildctl/shared"
+	"github.com/goplus/spx/v2/internal/release"
 )
 
 type recordedCall struct {
@@ -285,7 +285,7 @@ func installFakeEngineDownload(t *testing.T, repoRoot, defaultPlatform, arch str
 
 func fakeEngineDownloadFetcher(url, dst string) error {
 	base := filepath.Base(url)
-	runtimePackZip := "gdspxrt.pck." + release.DefaultReleaseMeta().Pck.Version + ".zip"
+	runtimePackZip := release.RuntimeAssetZipName
 
 	switch base {
 	case "linux-x86_64.zip":

--- a/internal/cmd/buildctl/runtimecmd/assets.go
+++ b/internal/cmd/buildctl/runtimecmd/assets.go
@@ -21,6 +21,8 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+
+	"github.com/goplus/spx/v2/internal/release"
 )
 
 const runtimeIndexJSON = `{"map":{"width":480,"height":360}}`
@@ -57,7 +59,7 @@ func exportPackRuntime(runner scriptRunner) error {
 		return fmt.Errorf("runtime extension not found at %s", runtimeExtension)
 	}
 
-	dstZip := filepath.Join(workspace.goBinDir, fmt.Sprintf("gdspxrt.pck.%s.zip", workspace.version))
+	dstZip := filepath.Join(workspace.goBinDir, release.RuntimeAssetZipName)
 	return writeNamedZip(dstZip, map[string]string{
 		"gdspxrt.pck":         workspace.outputPack,
 		"runtime.gdextension": runtimeExtension,

--- a/internal/cmd/buildctl/runtimecmd/cmd.go
+++ b/internal/cmd/buildctl/runtimecmd/cmd.go
@@ -62,7 +62,7 @@ func printRuntimeUsage() {
 	fmt.Fprintln(osStderr, "Commands:")
 	fmt.Fprintln(osStderr, "  build-wasm   Build ispx.wasm assets")
 	fmt.Fprintln(osStderr, "  compress-wasm Compress prebuilt web wasm assets with brotli")
-	fmt.Fprintln(osStderr, "  export-pack  Export runtime pck artifacts")
+	fmt.Fprintln(osStderr, "  export-pack  Export runtime asset bundle")
 	fmt.Fprintln(osStderr, "  export-web   Export web runtime bundles")
 	fmt.Fprintln(osStderr, "  export-web-template Export web runtime template bundles")
 }

--- a/internal/cmd/buildctl/runtimecmd/cmd_test.go
+++ b/internal/cmd/buildctl/runtimecmd/cmd_test.go
@@ -22,6 +22,8 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/goplus/spx/v2/internal/release"
 )
 
 func TestParseRuntimeExportPackArgsDefault(t *testing.T) {
@@ -127,7 +129,7 @@ func TestRuntimeExportPackSequence(t *testing.T) {
 	if !fileExists(filepath.Join(gopathBin, "gdspxrt"+version+".pck")) {
 		t.Fatalf("expected exported pck to exist")
 	}
-	if !fileExists(filepath.Join(gopathBin, "gdspxrt.pck."+version+".zip")) {
+	if !fileExists(filepath.Join(gopathBin, release.RuntimeAssetZipName)) {
 		t.Fatalf("expected exported zip to exist")
 	}
 }

--- a/internal/release/release_meta.go
+++ b/internal/release/release_meta.go
@@ -28,30 +28,20 @@ const (
 
 	// RuntimeTag is the filename prefix for the runtime binary/pck files.
 	RuntimeTag = "gdspxrt"
+
+	// RuntimeAssetZipName is the fixed runtime asset bundle name published under each SPX release tag.
+	RuntimeAssetZipName = "spx-runtime-assets.zip"
 )
 
 // ReleaseMeta captures the selected SPX/runtime asset mapping.
 type ReleaseMeta struct {
 	SPXVersion string
 	Runtime    RuntimeRelease
-	Pck        PckRelease
 }
 
 // RuntimeRelease describes the Godot runtime bundle used by SPX.
 type RuntimeRelease struct {
 	Version string
-}
-
-// PckRelease describes the packaged SPX runtime assets published from the spx repo.
-type PckRelease struct {
-	SPXTag  string
-	Version string
-}
-
-var defaultPckRelease = PckRelease{
-	// Current packaged runtime assets are only published from the v2.0.0 SPX release.
-	SPXTag:  "v2.0.0",
-	Version: "2.2.0",
 }
 
 type releaseVersionMapping struct {
@@ -60,24 +50,29 @@ type releaseVersionMapping struct {
 }
 
 var releaseVersionMappings = []releaseVersionMapping{
-	{"v2.0.0", "2.2.0"},
-	{"v2.0.1", "2.2.1"},
+	{
+		spxVersion:     "v2.0.0",
+		runtimeVersion: "2.2.0",
+	},
+	{
+		spxVersion:     "v2.0.1",
+		runtimeVersion: "2.2.1",
+	},
 }
 
-func newReleaseMeta(spxVersion, runtimeVersion string) ReleaseMeta {
+func newReleaseMeta(mapping releaseVersionMapping) ReleaseMeta {
 	return ReleaseMeta{
-		SPXVersion: spxVersion,
+		SPXVersion: mapping.spxVersion,
 		Runtime: RuntimeRelease{
-			Version: runtimeVersion,
+			Version: mapping.runtimeVersion,
 		},
-		Pck: defaultPckRelease,
 	}
 }
 
 var releaseMetaBySPXVersion = func() map[string]ReleaseMeta {
 	result := make(map[string]ReleaseMeta, len(releaseVersionMappings))
 	for _, item := range releaseVersionMappings {
-		result[item.spxVersion] = newReleaseMeta(item.spxVersion, item.runtimeVersion)
+		result[item.spxVersion] = newReleaseMeta(item)
 	}
 	return result
 }()
@@ -88,7 +83,7 @@ func DefaultReleaseMeta() ReleaseMeta {
 		panic("release: releaseVersionMappings is empty")
 	}
 	item := releaseVersionMappings[len(releaseVersionMappings)-1]
-	return newReleaseMeta(item.spxVersion, item.runtimeVersion)
+	return newReleaseMeta(item)
 }
 
 // CurrentReleaseMeta is kept as a compatibility alias for the default release metadata.
@@ -115,7 +110,7 @@ func (m ReleaseMeta) RuntimeDownloadURL(zipName string) string {
 	return RuntimeURLBase + "spx" + m.Runtime.Version + "/" + zipName
 }
 
-// PckDownloadURL returns the packaged runtime asset URL for the given zip asset name.
-func (m ReleaseMeta) PckDownloadURL(zipName string) string {
-	return SpxReleaseURLBase + m.Pck.SPXTag + "/" + zipName
+// RuntimeAssetDownloadURL returns the packaged runtime asset bundle URL for the given zip asset name.
+func (m ReleaseMeta) RuntimeAssetDownloadURL(zipName string) string {
+	return SpxReleaseURLBase + m.SPXVersion + "/" + zipName
 }

--- a/internal/release/release_meta.go
+++ b/internal/release/release_meta.go
@@ -71,6 +71,14 @@ var releaseMetaBySPXVersion = func() map[string]ReleaseMeta {
 	return result
 }()
 
+var releaseMetaByRuntimeVersion = func() map[string]ReleaseMeta {
+	result := make(map[string]ReleaseMeta, len(releaseVersionMappings))
+	for _, item := range releaseVersionMappings {
+		result[item.runtimeVersion] = newReleaseMeta(item)
+	}
+	return result
+}()
+
 // DefaultReleaseMeta returns the latest known released metadata.
 func DefaultReleaseMeta() ReleaseMeta {
 	if len(releaseVersionMappings) == 0 {
@@ -89,6 +97,15 @@ func CurrentReleaseMeta() ReleaseMeta {
 // Unknown versions fall back to the latest known runtime assets.
 func ReleaseMetaForSPXVersion(spxVersion string) ReleaseMeta {
 	if meta, ok := releaseMetaBySPXVersion[spxVersion]; ok {
+		return meta
+	}
+	return DefaultReleaseMeta()
+}
+
+// ReleaseMetaForRuntimeVersion resolves runtime/pck metadata for a runtime version.
+// Unknown versions fall back to the latest known runtime assets.
+func ReleaseMetaForRuntimeVersion(runtimeVersion string) ReleaseMeta {
+	if meta, ok := releaseMetaByRuntimeVersion[runtimeVersion]; ok {
 		return meta
 	}
 	return DefaultReleaseMeta()

--- a/internal/release/release_meta.go
+++ b/internal/release/release_meta.go
@@ -50,14 +50,8 @@ type releaseVersionMapping struct {
 }
 
 var releaseVersionMappings = []releaseVersionMapping{
-	{
-		spxVersion:     "v2.0.0",
-		runtimeVersion: "2.2.0",
-	},
-	{
-		spxVersion:     "v2.0.1",
-		runtimeVersion: "2.2.1",
-	},
+	{"v2.0.0", "2.2.0"},
+	{"v2.0.1", "2.2.1"},
 }
 
 func newReleaseMeta(mapping releaseVersionMapping) ReleaseMeta {

--- a/internal/release/release_meta_test.go
+++ b/internal/release/release_meta_test.go
@@ -28,6 +28,16 @@ func TestReleaseMetaForSPXVersionMapped(t *testing.T) {
 	}
 }
 
+func TestReleaseMetaForRuntimeVersionMapped(t *testing.T) {
+	meta := ReleaseMetaForRuntimeVersion("2.2.0")
+	if meta.SPXVersion != "v2.0.0" {
+		t.Fatalf("spx version = %q, want %q", meta.SPXVersion, "v2.0.0")
+	}
+	if got := meta.RuntimeAssetDownloadURL(RuntimeAssetZipName); got != SpxReleaseURLBase+"v2.0.0/"+RuntimeAssetZipName {
+		t.Fatalf("runtime asset download url = %q, want %q", got, SpxReleaseURLBase+"v2.0.0/"+RuntimeAssetZipName)
+	}
+}
+
 func TestDefaultReleaseMetaUsesLatestSPXVersionForRuntimeAssets(t *testing.T) {
 	meta := DefaultReleaseMeta()
 	if meta.SPXVersion != "v2.0.1" {
@@ -38,6 +48,17 @@ func TestDefaultReleaseMetaUsesLatestSPXVersionForRuntimeAssets(t *testing.T) {
 	}
 	if got := meta.RuntimeAssetDownloadURL(RuntimeAssetZipName); got != SpxReleaseURLBase+"v2.0.1/"+RuntimeAssetZipName {
 		t.Fatalf("runtime asset download url = %q, want %q", got, SpxReleaseURLBase+"v2.0.1/"+RuntimeAssetZipName)
+	}
+}
+
+func TestReleaseMetaForRuntimeVersionUnknownFallback(t *testing.T) {
+	meta := ReleaseMetaForRuntimeVersion("2.2.0-unknown")
+	defaultMeta := DefaultReleaseMeta()
+	if meta.SPXVersion != defaultMeta.SPXVersion {
+		t.Fatalf("spx version = %q, want default %q", meta.SPXVersion, defaultMeta.SPXVersion)
+	}
+	if meta.Runtime.Version != defaultMeta.Runtime.Version {
+		t.Fatalf("runtime version = %q, want default %q", meta.Runtime.Version, defaultMeta.Runtime.Version)
 	}
 }
 

--- a/internal/release/release_meta_test.go
+++ b/internal/release/release_meta_test.go
@@ -23,6 +23,22 @@ func TestReleaseMetaForSPXVersionMapped(t *testing.T) {
 	if meta.Runtime.Version != "2.2.0" {
 		t.Fatalf("runtime version = %q, want %q", meta.Runtime.Version, "2.2.0")
 	}
+	if got := meta.RuntimeAssetDownloadURL(RuntimeAssetZipName); got != SpxReleaseURLBase+"v2.0.0/"+RuntimeAssetZipName {
+		t.Fatalf("runtime asset download url = %q, want %q", got, SpxReleaseURLBase+"v2.0.0/"+RuntimeAssetZipName)
+	}
+}
+
+func TestDefaultReleaseMetaUsesLatestSPXVersionForRuntimeAssets(t *testing.T) {
+	meta := DefaultReleaseMeta()
+	if meta.SPXVersion != "v2.0.1" {
+		t.Fatalf("spx version = %q, want %q", meta.SPXVersion, "v2.0.1")
+	}
+	if meta.Runtime.Version != "2.2.1" {
+		t.Fatalf("runtime version = %q, want %q", meta.Runtime.Version, "2.2.1")
+	}
+	if got := meta.RuntimeAssetDownloadURL(RuntimeAssetZipName); got != SpxReleaseURLBase+"v2.0.1/"+RuntimeAssetZipName {
+		t.Fatalf("runtime asset download url = %q, want %q", got, SpxReleaseURLBase+"v2.0.1/"+RuntimeAssetZipName)
+	}
 }
 
 func TestReleaseMetaForSPXVersionLatestFallback(t *testing.T) {


### PR DESCRIPTION
## Summary

This PR automates SPX runtime asset publishing and simplifies how runtime asset downloads are resolved.

## Changes

- add a dedicated reusable workflow to build and publish runtime assets
- wire the main release workflow to support `runtime-assets` as a release target
- rename the published runtime bundle to `spx-runtime-assets.zip`
- keep the bundle contents as `gdspxrt.pck` and `runtime.gdextension`
- simplify release metadata so runtime asset downloads resolve directly from `SPXVersion`
- update runner, buildctl download/export logic, tests, Makefile help text, and docs to match the new naming

## Testing

```bash
go test ./internal/release ./internal/cmd/buildctl/engine ./internal/cmd/buildctl/runtimecmd ./cmd/spxrunner/runner
