### PR TITLE
feat: add template editor workflow command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Config
 # ============================================
 .DEFAULT_GOAL := help
-.PHONY: help buildctl list-demos prepare-host prepare-web prepare-full prepare-all build-dev install clean-assets download download-engine build-editor build-desktop build-web build-wasm build-wasm-opt build-android build-ios install-apk editor run runnative rune runweb runwebworker format generate generate-bindings generate-runtime clean-projects export-pack export-web stop validate-web-mode validate-download-engine validate-install-web
+.PHONY: help buildctl list-demos prepare-host prepare-web prepare-full prepare-all build-dev install clean-assets download download-engine build-editor build-desktop build-web build-wasm build-wasm-opt build-android build-ios install-apk editor template-editor run runnative rune runweb runwebworker format generate generate-bindings generate-runtime clean-projects export-pack export-web stop validate-web-mode validate-download-engine validate-install-web
 
 export GODOT_SRC
 
@@ -16,7 +16,7 @@ BUILDCTL_ENGINE_DOWNLOAD_CMD := $(BUILDCTL_CMD) engine download
 BUILDCTL_ENGINE_BUILD_CMD := $(BUILDCTL_CMD) engine build
 BUILDCTL_RUNTIME_CMD := $(BUILDCTL_CMD) runtime
 BUILDCTL_WORKFLOW_CMD := $(BUILDCTL_CMD) workflow
-BUILDCTL_TARGETS := list-demos prepare-host prepare-web prepare-full build-dev install clean-assets download download-engine build-editor build-desktop build-web build-wasm build-wasm-opt build-android build-ios install-apk editor run runnative rune runweb runwebworker export-pack export-web stop
+BUILDCTL_TARGETS := list-demos prepare-host prepare-web prepare-full build-dev install clean-assets download download-engine build-editor build-desktop build-web build-wasm build-wasm-opt build-android build-ios install-apk editor template-editor run runnative rune runweb runwebworker export-pack export-web stop
 
 DEMO_INDEX ?= 3
 APK_PROJECT_DIR ?= tutorial/00-Hello
@@ -166,6 +166,9 @@ list-demos: ## List all demos with index
 
 editor: ## Open demo in editor: make editor DEMO_INDEX=N
 	$(BUILDCTL_WORKFLOW_CMD) run-demo --demo-index "$(DEMO_INDEX)" --mode editor --movie "$(MOVIE)"
+
+template-editor: ## Open cmd/spx template project in editor: make template-editor
+	$(BUILDCTL_WORKFLOW_CMD) open-template-editor
 
 run: ## Run demo in interpreted mode (spx run): make run DEMO_INDEX=N
 	$(BUILDCTL_WORKFLOW_CMD) run-demo --demo-index "$(DEMO_INDEX)" --mode run --movie "$(MOVIE)"

--- a/internal/cmd/buildctl/workflow/api.go
+++ b/internal/cmd/buildctl/workflow/api.go
@@ -38,6 +38,11 @@ type InstallAPKConfig struct {
 	ProjectDir string
 }
 
+type OpenTemplateEditorConfig struct {
+	TemplateDir  string
+	WorkspaceDir string
+}
+
 func Run(args []string) error {
 	return runWorkflow(args)
 }
@@ -60,6 +65,11 @@ func ParseWorkflowRunDemoArgs(args []string) (RunDemoConfig, error) {
 func ParseWorkflowInstallAPKArgs(args []string) (InstallAPKConfig, error) {
 	cfg, err := parseWorkflowInstallAPKArgs(args)
 	return InstallAPKConfig{ProjectDir: cfg.projectDir}, err
+}
+
+func ParseWorkflowOpenTemplateEditorArgs(args []string) (OpenTemplateEditorConfig, error) {
+	cfg, err := parseWorkflowOpenTemplateEditorArgs(args)
+	return OpenTemplateEditorConfig{TemplateDir: cfg.templateDir, WorkspaceDir: cfg.workspaceDir}, err
 }
 
 func ParseWorkflowListDemosArgs(args []string) error {
@@ -96,4 +106,8 @@ func StopWebWorkflow(runner shared.WorkflowRunner) error {
 
 func InstallAPKWorkflow(cfg InstallAPKConfig, runner shared.WorkflowRunner) error {
 	return installAPKWorkflow(workflowInstallAPKConfig{projectDir: cfg.ProjectDir}, sharedWorkflowRunnerAdapter{inner: runner})
+}
+
+func OpenTemplateEditorWorkflow(cfg OpenTemplateEditorConfig, runner shared.ScriptRunner) error {
+	return openTemplateEditorWorkflow(workflowOpenTemplateEditorConfig{templateDir: cfg.TemplateDir, workspaceDir: cfg.WorkspaceDir}, sharedScriptRunnerAdapter{inner: runner})
 }

--- a/internal/cmd/buildctl/workflow/cmd.go
+++ b/internal/cmd/buildctl/workflow/cmd.go
@@ -68,6 +68,8 @@ func runWorkflow(args []string) error {
 		return runWorkflowInstallAPK(args[1:])
 	case "list-demos":
 		return runWorkflowListDemos(args[1:])
+	case "open-template-editor":
+		return runWorkflowOpenTemplateEditor(args[1:])
 	case "run-demo":
 		return runWorkflowRunDemo(args[1:])
 	case "setup-dev":
@@ -84,13 +86,14 @@ func runWorkflow(args []string) error {
 }
 
 func printWorkflowUsage() {
-	fmt.Fprintln(osStderr, "Usage: buildctl workflow <build-dev|build-web|install-apk|list-demos|run-demo|stop-web> [options]")
+	fmt.Fprintln(osStderr, "Usage: buildctl workflow <build-dev|build-web|install-apk|list-demos|open-template-editor|run-demo|stop-web> [options]")
 	fmt.Fprintln(osStderr)
 	fmt.Fprintln(osStderr, "Commands:")
 	fmt.Fprintln(osStderr, "  build-dev  Run the full local development build workflow")
 	fmt.Fprintln(osStderr, "  build-web  Build web templates and export runtime assets")
 	fmt.Fprintln(osStderr, "  install-apk  Export and install an Android APK for a project")
 	fmt.Fprintln(osStderr, "  list-demos Print tutorial demo directories with their indexes")
+	fmt.Fprintln(osStderr, "  open-template-editor  Open the embedded template project in the Godot editor")
 	fmt.Fprintln(osStderr, "  run-demo   Run a tutorial demo in local/native/web modes")
 	fmt.Fprintln(osStderr, "  stop-web   Stop local gdspx web server processes")
 }
@@ -189,6 +192,24 @@ func runWorkflowListDemos(args []string) error {
 	return listDemosWorkflow(runner)
 }
 
+func runWorkflowOpenTemplateEditor(args []string) error {
+	cfg, err := parseWorkflowOpenTemplateEditorArgs(args)
+	if err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return nil
+		}
+		return err
+	}
+
+	repoRoot, err := findRepoRoot()
+	if err != nil {
+		return err
+	}
+
+	runner := commandRunner{repoRoot: repoRoot}
+	return openTemplateEditorWorkflow(cfg, runner)
+}
+
 func parseWorkflowListDemosArgs(args []string) error {
 	fs := flag.NewFlagSet("workflow list-demos", flag.ContinueOnError)
 	fs.SetOutput(osStderr)
@@ -225,6 +246,36 @@ func parseWorkflowInstallAPKArgs(args []string) (workflowInstallAPKConfig, error
 	}
 	if cfg.projectDir == "" {
 		return workflowInstallAPKConfig{}, errors.New("--project-dir must not be empty")
+	}
+	return cfg, nil
+}
+
+func parseWorkflowOpenTemplateEditorArgs(args []string) (workflowOpenTemplateEditorConfig, error) {
+	cfg := workflowOpenTemplateEditorConfig{
+		templateDir:  defaultTemplateProjectDir,
+		workspaceDir: defaultTemplateEditorWorkspaceDir,
+	}
+
+	fs := flag.NewFlagSet("workflow open-template-editor", flag.ContinueOnError)
+	fs.SetOutput(osStderr)
+	fs.StringVar(&cfg.templateDir, "template-dir", cfg.templateDir, "template project directory to open in the editor")
+	fs.StringVar(&cfg.workspaceDir, "workspace-dir", cfg.workspaceDir, "workspace directory used to stage the template editor project")
+	fs.Usage = func() {
+		fmt.Fprintln(osStderr, "Usage: buildctl workflow open-template-editor [--template-dir cmd/spx/template/project] [--workspace-dir .tmp/template-editor]")
+	}
+
+	if err := fs.Parse(args); err != nil {
+		return workflowOpenTemplateEditorConfig{}, err
+	}
+	if fs.NArg() != 0 {
+		fs.Usage()
+		return workflowOpenTemplateEditorConfig{}, errUsage
+	}
+	if cfg.templateDir == "" {
+		return workflowOpenTemplateEditorConfig{}, errors.New("--template-dir must not be empty")
+	}
+	if cfg.workspaceDir == "" {
+		return workflowOpenTemplateEditorConfig{}, errors.New("--workspace-dir must not be empty")
 	}
 	return cfg, nil
 }

--- a/internal/cmd/buildctl/workflow/template_editor.go
+++ b/internal/cmd/buildctl/workflow/template_editor.go
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2021 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package workflow
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/goplus/spx/v2/internal/cmd/buildctl/shared"
+)
+
+const (
+	defaultTemplateProjectDir         = "cmd/spx/template/project"
+	defaultTemplateEditorWorkspaceDir = ".tmp/template-editor"
+)
+
+type workflowOpenTemplateEditorConfig struct {
+	templateDir  string
+	workspaceDir string
+}
+
+func openTemplateEditorWorkflow(cfg workflowOpenTemplateEditorConfig, runner scriptRunner) error {
+	if cfg.templateDir == "" {
+		cfg.templateDir = defaultTemplateProjectDir
+	}
+	if cfg.workspaceDir == "" {
+		cfg.workspaceDir = defaultTemplateEditorWorkspaceDir
+	}
+
+	workspaceRoot, err := prepareTemplateEditorWorkspace(cfg, runner.repoRootDir())
+	if err != nil {
+		return err
+	}
+
+	version, err := shared.DefaultRuntimeVersion()
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(os.Stdout, "Opening template project via workspace: %s\n", workspaceRoot)
+	if err := runner.runCommand(workspaceRoot, "spx", "build"); err != nil {
+		return err
+	}
+	return runner.runCommand(workspaceRoot, "gdspx"+version, "--path", "./project", "--editor")
+}
+
+func prepareTemplateEditorWorkspace(cfg workflowOpenTemplateEditorConfig, repoRoot string) (string, error) {
+	templateProjectDir := cfg.templateDir
+	if !filepath.IsAbs(templateProjectDir) {
+		templateProjectDir = filepath.Join(repoRoot, templateProjectDir)
+	}
+	templateProjectDir = filepath.Clean(templateProjectDir)
+
+	info, err := os.Stat(templateProjectDir)
+	if err != nil {
+		return "", fmt.Errorf("template project directory %s: %w", templateProjectDir, err)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("template project path is not a directory: %s", templateProjectDir)
+	}
+
+	workspaceBase := cfg.workspaceDir
+	if !filepath.IsAbs(workspaceBase) {
+		workspaceBase = filepath.Join(repoRoot, workspaceBase)
+	}
+	workspaceBase = filepath.Clean(workspaceBase)
+	workspaceRoot := filepath.Join(workspaceBase, "spx")
+	workspaceProjectDir := filepath.Join(workspaceRoot, "project")
+
+	for _, dir := range []string{
+		workspaceRoot,
+		filepath.Join(workspaceProjectDir, ".builds"),
+		filepath.Join(workspaceProjectDir, ".godot"),
+		filepath.Join(workspaceProjectDir, "go"),
+	} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return "", fmt.Errorf("create workspace directory %s: %w", dir, err)
+		}
+	}
+
+	if err := os.WriteFile(filepath.Join(workspaceRoot, "main.spx"), nil, 0o644); err != nil {
+		return "", fmt.Errorf("create workspace main.spx: %w", err)
+	}
+
+	for _, name := range []string{
+		"engine",
+		"export_presets.cfg",
+		"gdspx.gdextension",
+		"gdspx.gdextension.uid",
+		"main.tscn",
+		"project.godot",
+		"runtime.gdextension.txt",
+	} {
+		if err := ensureSymlink(filepath.Join(templateProjectDir, name), filepath.Join(workspaceProjectDir, name)); err != nil {
+			return "", err
+		}
+	}
+
+	goTemplateDir := filepath.Join(templateProjectDir, "go")
+	goEntries, err := os.ReadDir(goTemplateDir)
+	if err != nil {
+		return "", fmt.Errorf("read template Go directory %s: %w", goTemplateDir, err)
+	}
+	for _, entry := range goEntries {
+		if err := ensureSymlink(filepath.Join(goTemplateDir, entry.Name()), filepath.Join(workspaceProjectDir, "go", entry.Name())); err != nil {
+			return "", err
+		}
+	}
+
+	return workspaceRoot, nil
+}
+
+func ensureSymlink(targetPath, linkPath string) error {
+	if err := os.MkdirAll(filepath.Dir(linkPath), 0o755); err != nil {
+		return fmt.Errorf("create parent directory for %s: %w", linkPath, err)
+	}
+
+	info, err := os.Lstat(linkPath)
+	if err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			existingTarget, err := os.Readlink(linkPath)
+			if err == nil {
+				resolvedTarget := existingTarget
+				if !filepath.IsAbs(resolvedTarget) {
+					resolvedTarget = filepath.Join(filepath.Dir(linkPath), resolvedTarget)
+				}
+				if filepath.Clean(resolvedTarget) == filepath.Clean(targetPath) {
+					return nil
+				}
+			}
+		}
+		if err := os.RemoveAll(linkPath); err != nil {
+			return fmt.Errorf("remove existing path %s: %w", linkPath, err)
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("inspect existing path %s: %w", linkPath, err)
+	}
+
+	if err := os.Symlink(targetPath, linkPath); err != nil {
+		return fmt.Errorf("create symlink %s -> %s: %w", linkPath, targetPath, err)
+	}
+	return nil
+}

--- a/internal/cmd/buildctl/workflow/template_editor_test.go
+++ b/internal/cmd/buildctl/workflow/template_editor_test.go
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2021 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package workflow
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/goplus/spx/v2/internal/release"
+)
+
+func TestParseWorkflowOpenTemplateEditorArgsDefault(t *testing.T) {
+	cfg, err := parseWorkflowOpenTemplateEditorArgs(nil)
+	if err != nil {
+		t.Fatalf("parseWorkflowOpenTemplateEditorArgs returned error: %v", err)
+	}
+	if cfg.templateDir != defaultTemplateProjectDir {
+		t.Fatalf("unexpected templateDir: %q", cfg.templateDir)
+	}
+	if cfg.workspaceDir != defaultTemplateEditorWorkspaceDir {
+		t.Fatalf("unexpected workspaceDir: %q", cfg.workspaceDir)
+	}
+}
+
+func TestOpenTemplateEditorWorkflow(t *testing.T) {
+	repoRoot := t.TempDir()
+	templateProjectDir := filepath.Join(repoRoot, "cmd", "spx", "template", "project")
+
+	mustMkdirAll(t, filepath.Join(templateProjectDir, "engine"))
+	mustWriteFile(t, filepath.Join(templateProjectDir, "engine", "scene.tscn"), []byte("[gd_scene]\n"))
+	mustMkdirAll(t, filepath.Join(templateProjectDir, "go"))
+	mustWriteFile(t, filepath.Join(templateProjectDir, "go", "ios_adapter.go.txt"), []byte("package main\n"))
+	mustWriteFile(t, filepath.Join(templateProjectDir, "export_presets.cfg"), []byte("[preset.0]\n"))
+	mustWriteFile(t, filepath.Join(templateProjectDir, "gdspx.gdextension"), []byte("extension\n"))
+	mustWriteFile(t, filepath.Join(templateProjectDir, "gdspx.gdextension.uid"), []byte("uid\n"))
+	mustWriteFile(t, filepath.Join(templateProjectDir, "main.tscn"), []byte("[gd_scene]\n"))
+	mustWriteFile(t, filepath.Join(templateProjectDir, "project.godot"), []byte(`[application]`+"\n"+`config/name="spx"`+"\n"))
+	mustWriteFile(t, filepath.Join(templateProjectDir, "runtime.gdextension.txt"), []byte("runtime extension\n"))
+
+	runner := &recordingRunner{repoRoot: repoRoot}
+	cfg := workflowOpenTemplateEditorConfig{}
+	if err := openTemplateEditorWorkflow(cfg, runner); err != nil {
+		t.Fatalf("openTemplateEditorWorkflow returned error: %v", err)
+	}
+
+	workspaceRoot := filepath.Join(repoRoot, defaultTemplateEditorWorkspaceDir, "spx")
+	expectedCommands := []recordedCommand{
+		{dir: workspaceRoot, name: "spx", args: []string{"build"}},
+		{dir: workspaceRoot, name: "gdspx" + release.DefaultReleaseMeta().Runtime.Version, args: []string{"--path", "./project", "--editor"}},
+	}
+	if !reflect.DeepEqual(runner.commands, expectedCommands) {
+		t.Fatalf("unexpected commands: %#v", runner.commands)
+	}
+
+	assertFileExists(t, filepath.Join(workspaceRoot, "main.spx"))
+	assertDirExists(t, filepath.Join(workspaceRoot, "project", ".godot"))
+	assertDirExists(t, filepath.Join(workspaceRoot, "project", ".builds"))
+	assertDirExists(t, filepath.Join(workspaceRoot, "project", "go"))
+	assertSymlinkTarget(t, filepath.Join(workspaceRoot, "project", "engine"), filepath.Join(templateProjectDir, "engine"))
+	assertSymlinkTarget(t, filepath.Join(workspaceRoot, "project", "project.godot"), filepath.Join(templateProjectDir, "project.godot"))
+	assertSymlinkTarget(t, filepath.Join(workspaceRoot, "project", "go", "ios_adapter.go.txt"), filepath.Join(templateProjectDir, "go", "ios_adapter.go.txt"))
+}
+
+func assertFileExists(t *testing.T, path string) {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	if info.IsDir() {
+		t.Fatalf("expected file, got directory: %s", path)
+	}
+}
+
+func assertDirExists(t *testing.T, path string) {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("expected directory, got file: %s", path)
+	}
+}
+
+func assertSymlinkTarget(t *testing.T, linkPath, targetPath string) {
+	t.Helper()
+	info, err := os.Lstat(linkPath)
+	if err != nil {
+		t.Fatalf("lstat %s: %v", linkPath, err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("expected symlink: %s", linkPath)
+	}
+	got, err := os.Readlink(linkPath)
+	if err != nil {
+		t.Fatalf("readlink %s: %v", linkPath, err)
+	}
+	if filepath.Clean(got) != filepath.Clean(targetPath) {
+		t.Fatalf("symlink target = %s, want %s", got, targetPath)
+	}
+}


### PR DESCRIPTION
## Summary
- add `buildctl workflow open-template-editor` as the formal entrypoint for opening the embedded template project
- add `make template-editor` as a thin Makefile wrapper around the workflow command
- prepare a staged workspace under `.tmp/template-editor/spx` so the template can be opened as a valid SPX project
- symlink editable template files into the staged workspace while keeping generated artifacts such as `.godot`, `.builds`, `lib`, and generated Go files out of the real template directory

## Why
Opening `cmd/spx/template/project` directly does not work because it is a Godot project shell rather than a valid outer SPX project directory. This change gives us a supported workflow entrypoint without polluting the real template tree with build and editor artifacts.

## Testing
- `go test ./internal/cmd/buildctl/...`
- `make -n template-editor`
