### PR TITLE
fix: replay animation onPlay audio when loop is false

### DIFF
--- a/component_animation.go
+++ b/component_animation.go
@@ -50,6 +50,13 @@ type animationComponent struct {
 
 	// Animation tracking (per-instance)
 	donedAnimations []string
+
+	pendingBoundAudioReplays []boundAudioReplay
+}
+
+type boundAudioReplay struct {
+	state *animState
+	name  SoundName
 }
 
 // initialize initializes the animation component from configuration.
@@ -57,6 +64,7 @@ func (a *animationComponent) initialize(sprite *SpriteImpl, spriteCfg *coreproje
 	a.componentBase.initialize(sprite, spriteCfg)
 	a.initFromConfig(spriteCfg)
 	a.donedAnimations = make([]string, 0)
+	a.pendingBoundAudioReplays = make([]boundAudioReplay, 0)
 }
 
 // initFromConfig initializes animations from sprite configuration.
@@ -103,9 +111,10 @@ func (a *animationComponent) initFromConfig(spriteCfg *coreproject.SpriteConfig)
 func (a *animationComponent) cloneFrom(src component, newSprite *SpriteImpl) component {
 	srcAnim := src.(*animationComponent)
 	newAnim := &animationComponent{
-		componentBase:   componentBase{sprite: newSprite},
-		shared:          srcAnim.shared,
-		donedAnimations: make([]string, 0),
+		componentBase:            componentBase{sprite: newSprite},
+		shared:                   srcAnim.shared,
+		donedAnimations:          make([]string, 0),
+		pendingBoundAudioReplays: make([]boundAudioReplay, 0),
 	}
 	return newAnim
 }
@@ -297,16 +306,45 @@ func (a *animationComponent) playAnimAudio(ani *coreproject.AniConfig, info *ani
 		a.sprite.playAudio(ani.OnStart.Play, loop)
 	}
 	if ani.OnPlay != nil && ani.OnPlay.Play != "" {
-		info.BoundAudioPlaybackID = a.sprite.playAudio(ani.OnPlay.Play, ani.OnPlay.GetLoop(true))
+		loop := ani.OnPlay.GetLoop(true)
+		if !loop {
+			info.BoundLoopReplayAudio = ani.OnPlay.Play
+		}
+		a.trackBoundAudioPlayback(info, a.sprite.playAudio(ani.OnPlay.Play, loop))
 	}
 }
 
 func (a *animationComponent) stopAnimPlaybackAudio(state *animState) {
-	if state == nil || state.BoundAudioPlaybackID == 0 {
+	if state == nil {
 		return
 	}
-	a.sprite.stopAudioPlayback(state.BoundAudioPlaybackID)
-	state.BoundAudioPlaybackID = 0
+	for _, id := range state.BoundAudioPlaybackIDs {
+		a.sprite.stopAudioPlayback(id)
+	}
+	state.BoundAudioPlaybackIDs = state.BoundAudioPlaybackIDs[:0]
+}
+
+func (a *animationComponent) trackBoundAudioPlayback(state *animState, id int64) {
+	if state == nil || id == 0 {
+		return
+	}
+	state.BoundAudioPlaybackIDs = append(state.BoundAudioPlaybackIDs, id)
+}
+
+func (a *animationComponent) addPendingBoundAudioReplay(state *animState, name SoundName) {
+	if state == nil || name == "" {
+		return
+	}
+	a.pendingBoundAudioReplays = append(a.pendingBoundAudioReplays, boundAudioReplay{
+		state: state,
+		name:  name,
+	})
+}
+
+func (a *animationComponent) takePendingBoundAudioReplays() []boundAudioReplay {
+	pending := a.pendingBoundAudioReplays
+	a.pendingBoundAudioReplays = nil
+	return pending
 }
 
 func (a *animationComponent) adaptAnimBitmapResolution(ani *coreproject.AniConfig) {

--- a/component_animation_test.go
+++ b/component_animation_test.go
@@ -28,6 +28,13 @@ func boolPtr(v bool) *bool {
 	return &v
 }
 
+func lastBoundPlaybackID(state *animState) int64 {
+	if len(state.BoundAudioPlaybackIDs) == 0 {
+		return 0
+	}
+	return state.BoundAudioPlaybackIDs[len(state.BoundAudioPlaybackIDs)-1]
+}
+
 func newTestAnimationComponent() *animationComponent {
 	sprite := &SpriteImpl{
 		g:    &Game{},
@@ -257,17 +264,17 @@ func TestPlayAnimAudioStartsAndStopsOnPlaySound(t *testing.T) {
 		OnPlay: &coreproject.ActionConfig{Play: "walk"},
 	}, state)
 
-	if state.BoundAudioPlaybackID == 0 {
+	playID := lastBoundPlaybackID(state)
+	if playID == 0 {
 		t.Fatal("onPlay did not capture a playback id")
 	}
 	if len(backend.plays) != 1 {
 		t.Fatalf("plays = %d, want 1", len(backend.plays))
 	}
-	if len(backend.loops) != 1 || backend.loops[0].id != state.BoundAudioPlaybackID || !backend.loops[0].loop {
-		t.Fatalf("loop calls = %+v, want one loop call for playback %d", backend.loops, state.BoundAudioPlaybackID)
+	if len(backend.loops) != 1 || backend.loops[0].id != playID || !backend.loops[0].loop {
+		t.Fatalf("loop calls = %+v, want one loop call for playback %d", backend.loops, playID)
 	}
 
-	playID := state.BoundAudioPlaybackID
 	anim.onAnimationDone("walk")
 
 	if len(backend.stops) != 1 || backend.stops[0] != playID {
@@ -291,7 +298,7 @@ func TestPlayAnimAudioHonorsOnPlayLoopConfig(t *testing.T) {
 		},
 	}, state)
 
-	if state.BoundAudioPlaybackID == 0 {
+	if lastBoundPlaybackID(state) == 0 {
 		t.Fatal("onPlay did not capture a playback id")
 	}
 	if len(backend.plays) != 1 {
@@ -299,6 +306,68 @@ func TestPlayAnimAudioHonorsOnPlayLoopConfig(t *testing.T) {
 	}
 	if len(backend.loops) != 0 {
 		t.Fatalf("loop calls = %+v, want none", backend.loops)
+	}
+	if state.BoundLoopReplayAudio != "walk" {
+		t.Fatalf("BoundLoopReplayAudio = %q, want walk", state.BoundLoopReplayAudio)
+	}
+}
+
+func TestHandleAnimationLoopedReplaysOnStartSoundForCurrentAnimation(t *testing.T) {
+	anim := newTestAnimationComponent()
+	backend := &animationAudioBackend{}
+	initTestAnimationAudio(anim, backend)
+
+	state := &animState{Name: "walk"}
+	anim.curAnimState = state
+	anim.playAnimAudio(&coreproject.AniConfig{
+		OnStart: &coreproject.ActionConfig{
+			Play: "step",
+			Loop: boolPtr(false),
+		},
+	}, state)
+
+	anim.sprite.handleAnimationLooped()
+	anim.sprite.flushPendingAudios(nil)
+
+	if len(backend.plays) != 2 {
+		t.Fatalf("plays = %d, want 2", len(backend.plays))
+	}
+}
+
+func TestHandleAnimationLoopedReplaysLoopFalseOnPlaySound(t *testing.T) {
+	anim := newTestAnimationComponent()
+	backend := &animationAudioBackend{}
+	initTestAnimationAudio(anim, backend)
+
+	state := &animState{Name: "walk"}
+	anim.curAnimState = state
+	anim.playAnimAudio(&coreproject.AniConfig{
+		OnPlay: &coreproject.ActionConfig{
+			Play: "walk",
+			Loop: boolPtr(false),
+		},
+	}, state)
+
+	firstID := lastBoundPlaybackID(state)
+	anim.sprite.handleAnimationLooped()
+	anim.sprite.flushPendingAudios(nil)
+
+	if len(backend.plays) != 2 {
+		t.Fatalf("plays = %d, want 2", len(backend.plays))
+	}
+	if len(state.BoundAudioPlaybackIDs) != 2 {
+		t.Fatalf("BoundAudioPlaybackIDs = %+v, want 2 tracked playbacks", state.BoundAudioPlaybackIDs)
+	}
+
+	secondID := lastBoundPlaybackID(state)
+	if secondID == 0 || secondID == firstID {
+		t.Fatalf("last bound playback id = %d, want a new playback id after loop", secondID)
+	}
+
+	anim.onAnimationDone("walk")
+
+	if len(backend.stops) != 2 || backend.stops[0] != firstID || backend.stops[1] != secondID {
+		t.Fatalf("stops = %+v, want [%d %d]", backend.stops, firstID, secondID)
 	}
 }
 

--- a/runtime_sync.go
+++ b/runtime_sync.go
@@ -188,10 +188,8 @@ func (sprite *SpriteImpl) handleAnimationLooped() {
 	if sprite.isDestroyed() || sprite.runtimeState.SyncSprite == nil {
 		return
 	}
-	state := sprite.animation().getCurTweenState()
-	if state != nil && state.LoopReplayAudioName != "" {
-		sprite.sound().addPendingAudio(state.LoopReplayAudioName)
-	}
+	sprite.queueLoopReplayAudio(sprite.animation().getCurAnimState())
+	sprite.queueLoopReplayAudio(sprite.animation().getCurTweenState())
 }
 
 func (sprite *SpriteImpl) applyPhysicsProxyConfig() {

--- a/sprite_animation.go
+++ b/sprite_animation.go
@@ -84,12 +84,13 @@ func buildAnimationSources(costumes []*costume) []intani.FrameSource {
 }
 
 type animState struct {
-	AniType              coreproject.AniType
-	Name                 string
-	IsCanceled           bool
-	Speed                float64
-	LoopReplayAudioName  string
-	BoundAudioPlaybackID int64
+	AniType               coreproject.AniType
+	Name                  string
+	IsCanceled            bool
+	Speed                 float64
+	LoopReplayAudioName   string
+	BoundLoopReplayAudio  string
+	BoundAudioPlaybackIDs []int64
 }
 
 // -----------------------------------------------------------------------------

--- a/sprite_sound.go
+++ b/sprite_sound.go
@@ -100,9 +100,22 @@ func (p *SpriteImpl) stopAudioPlayback(id int64) {
 	p.sound().stopAudioPlayback(id)
 }
 
+func (p *SpriteImpl) queueLoopReplayAudio(state *animState) {
+	if state == nil {
+		return
+	}
+	if state.LoopReplayAudioName != "" {
+		p.sound().addPendingAudio(state.LoopReplayAudioName)
+	}
+	if state.BoundLoopReplayAudio != "" {
+		p.animation().addPendingBoundAudioReplay(state, state.BoundLoopReplayAudio)
+	}
+}
+
 func (p *SpriteImpl) flushPendingAudios(buffer []string) []string {
 	engine.Lock()
 	buffer = p.sound().takePendingAudios(buffer)
+	pendingBoundReplays := p.animation().takePendingBoundAudioReplays()
 	engine.Unlock()
 
 	if p.isDestroyed() || p.runtimeState.SyncSprite == nil {
@@ -111,6 +124,12 @@ func (p *SpriteImpl) flushPendingAudios(buffer []string) []string {
 
 	for _, audio := range buffer {
 		p.playAudio(audio, false)
+	}
+	for _, replay := range pendingBoundReplays {
+		if replay.state == nil || replay.state.IsCanceled {
+			continue
+		}
+		p.animation().trackBoundAudioPlayback(replay.state, p.playAudio(replay.name, false))
 	}
 	return buffer[:0]
 }


### PR DESCRIPTION
## Summary

This PR fixes animation audio replay behavior for issue #1574.

- replay `OnPlay` audio on each animation loop when `loop: false`
- keep single-play audio non-looping while still retriggering it on the next animation cycle
- track all bound playback IDs so animation cleanup stops every active replay instance
- handle animation loop callbacks for both regular animation state and tween state
- simplify animation playback state by keeping only `BoundAudioPlaybackIDs`

## Testing

- `go test ./...`