### PR TITLE
fix: sync stamp position and asset path

### DIFF
--- a/baseobj.go
+++ b/baseobj.go
@@ -284,6 +284,11 @@ func (p *baseObj) getCostumePath() string {
 	return p.costumes[p.costumeIndex].path
 }
 
+// getCostumeAssetPath returns the engine-ready asset path of the current costume.
+func (p *baseObj) getCostumeAssetPath() string {
+	return engine.ToAssetPath(p.getCostumePath())
+}
+
 // getCostumeRenderScale returns the render scale for the current costume.
 func (p *baseObj) getCostumeRenderScale() float64 {
 	return p.runtimeState.Scale / float64(p.getCurrentBitmapResolution())

--- a/baseobj_test.go
+++ b/baseobj_test.go
@@ -1,0 +1,21 @@
+package spx
+
+import (
+	"testing"
+
+	"github.com/goplus/spx/v2/internal/engine"
+)
+
+func TestBaseObjGetCostumeAssetPath(t *testing.T) {
+	obj := baseObj{
+		costumes: []*costume{{
+			path: "sprites/Eat/costume1.svg",
+		}},
+	}
+
+	got := obj.getCostumeAssetPath()
+	want := engine.ToAssetPath("sprites/Eat/costume1.svg")
+	if got != want {
+		t.Fatalf("getCostumeAssetPath() = %q, want %q", got, want)
+	}
+}

--- a/component_pen.go
+++ b/component_pen.go
@@ -97,7 +97,8 @@ func (p *penComponent) PenDown() {
 
 func (p *penComponent) Stamp() {
 	p.checkOrCreatePen()
-	p.engine().PenMgr.SetPenStampTexture(*p.penObj, p.sprite.getCostumePath())
+	p.syncPenPosition(p.sprite.getXY())
+	p.engine().PenMgr.SetPenStampTexture(*p.penObj, p.sprite.getCostumeAssetPath())
 	p.engine().PenMgr.PenStamp(*p.penObj)
 }
 
@@ -217,6 +218,13 @@ func (p *penComponent) destroyPen() {
 
 func (p *penComponent) movePen(x, y float64) {
 	if p.penObj == nil || !p.penDown {
+		return
+	}
+	p.syncPenPosition(x, y)
+}
+
+func (p *penComponent) syncPenPosition(x, y float64) {
+	if p.penObj == nil {
 		return
 	}
 	p.engine().PenMgr.MovePenTo(*p.penObj, mathf.NewVec2(x, -y))

--- a/test/All/SpPen.spx
+++ b/test/All/SpPen.spx
@@ -45,7 +45,8 @@ onMsg "testPen", => {
 
 	// 3. Sprite::Stamp
 	say "Stamp"
-	// stamp()
+	stamp
+	wait 0.2s
 
 	// 4. Sprite::SetPenColor
 	say "Sprite::SetPenColor"


### PR DESCRIPTION
## Summary

This PR fixes `stamp` so it uses the current sprite position and a runtime-resolvable asset path.

## Changes

- sync pen position before calling `PenStamp`, so stamping follows the sprite's latest location
- convert the current costume path to an engine asset path before setting the stamp texture
- enable the `Sprite::Stamp` scenario in `test/All/SpPen.spx`
- add a regression test for costume asset path resolution

## Testing

- go test .