### PR TITLE
fix: make pen commands idempotent

### DIFF
--- a/component_pen.go
+++ b/component_pen.go
@@ -17,6 +17,8 @@
 package spx
 
 import (
+	"math"
+
 	"github.com/goplus/spbase/mathf"
 	coreproject "github.com/goplus/spx/v2/internal/core/project"
 	engine "github.com/goplus/spx/v2/pkg/spx/pkg/engine"
@@ -83,12 +85,20 @@ func (p *penComponent) onDestroy() {
 // ============================================================================
 
 func (p *penComponent) PenUp() {
-	p.checkOrCreatePen()
+	if !p.penDown {
+		return
+	}
 	p.penDown = false
+	if p.penObj == nil {
+		return
+	}
 	p.engine().PenMgr.PenUp(*p.penObj)
 }
 
 func (p *penComponent) PenDown() {
+	if p.penDown && p.penObj != nil {
+		return
+	}
 	p.checkOrCreatePen()
 	p.penDown = true
 	p.movePen(p.sprite.getXY())
@@ -97,7 +107,9 @@ func (p *penComponent) PenDown() {
 
 func (p *penComponent) Stamp() {
 	p.checkOrCreatePen()
-	p.syncPenPosition(p.sprite.getXY())
+	x, y := p.sprite.getXY()
+	applyRenderOffset(p.sprite, &x, &y)
+	p.syncPenPosition(x, y)
 	p.engine().PenMgr.SetPenStampTexture(*p.penObj, p.sprite.getCostumeAssetPath())
 	p.engine().PenMgr.PenStamp(*p.penObj)
 }
@@ -107,6 +119,9 @@ func (p *penComponent) Stamp() {
 // ============================================================================
 
 func (p *penComponent) SetPenSize(size float64) {
+	if nearlyEqualPenValue(p.penWidth, size) {
+		return
+	}
 	p.checkOrCreatePen()
 	p.penWidth = size
 	p.engine().PenMgr.SetPenSizeTo(*p.penObj, size)
@@ -122,8 +137,12 @@ func (p *penComponent) ChangePenSize(delta float64) {
 // ============================================================================
 
 func (p *penComponent) SetPenColor(color Color) {
+	nextColor := toMathfColor(color)
+	if samePenColor(p.penColor, nextColor) {
+		return
+	}
 	p.checkOrCreatePen()
-	p.penColor = toMathfColor(color)
+	p.penColor = nextColor
 	p.applyPenColorProperty()
 }
 
@@ -158,8 +177,12 @@ func (p *penComponent) ChangePenColor(kind PenColorParam, delta float64) {
 // ============================================================================
 
 func (p *penComponent) setPenHue(value float64) {
+	nextValue := mathf.Clamp(value, 0, 100)
+	if nearlyEqualPenValue(p.penHue, nextValue) {
+		return
+	}
 	p.checkOrCreatePen()
-	p.penHue = mathf.Clamp(value, 0, 100)
+	p.penHue = nextValue
 	p.applyPenHsvProperty()
 }
 
@@ -168,8 +191,12 @@ func (p *penComponent) changePenHue(delta float64) {
 }
 
 func (p *penComponent) setPenSaturation(value float64) {
+	nextValue := mathf.Clamp(value, 0, 100)
+	if nearlyEqualPenValue(p.penSaturation, nextValue) {
+		return
+	}
 	p.checkOrCreatePen()
-	p.penSaturation = mathf.Clamp(value, 0, 100)
+	p.penSaturation = nextValue
 	p.applyPenHsvProperty()
 }
 
@@ -178,8 +205,12 @@ func (p *penComponent) changePenSaturation(delta float64) {
 }
 
 func (p *penComponent) setPenBrightness(value float64) {
+	nextValue := mathf.Clamp(value, 0, 100)
+	if nearlyEqualPenValue(p.penBrightness, nextValue) {
+		return
+	}
 	p.checkOrCreatePen()
-	p.penBrightness = mathf.Clamp(value, 0, 100)
+	p.penBrightness = nextValue
 	p.applyPenHsvProperty()
 }
 
@@ -188,8 +219,12 @@ func (p *penComponent) changePenBrightness(delta float64) {
 }
 
 func (p *penComponent) setPenTransparency(value float64) {
+	nextValue := mathf.Clamp(value, 0, 100)
+	if nearlyEqualPenValue(p.penTransparency, nextValue) {
+		return
+	}
 	p.checkOrCreatePen()
-	p.penTransparency = mathf.Clamp(value, 0, 100)
+	p.penTransparency = nextValue
 	p.applyPenHsvProperty()
 }
 
@@ -264,4 +299,15 @@ func percentToNormalized(percent float64) float64 {
 
 func (p *penComponent) updatePenColor() {
 	p.engine().PenMgr.SetPenColorTo(*p.penObj, p.penColor)
+}
+
+func nearlyEqualPenValue(a, b float64) bool {
+	return math.Abs(a-b) <= 1e-9
+}
+
+func samePenColor(a, b mathf.Color) bool {
+	return nearlyEqualPenValue(a.R, b.R) &&
+		nearlyEqualPenValue(a.G, b.G) &&
+		nearlyEqualPenValue(a.B, b.B) &&
+		nearlyEqualPenValue(a.A, b.A)
 }

--- a/component_pen.go
+++ b/component_pen.go
@@ -119,7 +119,7 @@ func (p *penComponent) Stamp() {
 // ============================================================================
 
 func (p *penComponent) SetPenSize(size float64) {
-	if nearlyEqualPenValue(p.penWidth, size) {
+	if p.penObj != nil && nearlyEqualPenValue(p.penWidth, size) {
 		return
 	}
 	p.checkOrCreatePen()
@@ -138,10 +138,9 @@ func (p *penComponent) ChangePenSize(delta float64) {
 
 func (p *penComponent) SetPenColor(color Color) {
 	nextColor := toMathfColor(color)
-	if samePenColor(p.penColor, nextColor) {
+	if p.penObj != nil && samePenColor(p.penColor, nextColor) {
 		return
 	}
-	p.checkOrCreatePen()
 	p.penColor = nextColor
 	p.applyPenColorProperty()
 }
@@ -178,7 +177,7 @@ func (p *penComponent) ChangePenColor(kind PenColorParam, delta float64) {
 
 func (p *penComponent) setPenHue(value float64) {
 	nextValue := mathf.Clamp(value, 0, 100)
-	if nearlyEqualPenValue(p.penHue, nextValue) {
+	if p.penObj != nil && nearlyEqualPenValue(p.penHue, nextValue) {
 		return
 	}
 	p.checkOrCreatePen()
@@ -192,7 +191,7 @@ func (p *penComponent) changePenHue(delta float64) {
 
 func (p *penComponent) setPenSaturation(value float64) {
 	nextValue := mathf.Clamp(value, 0, 100)
-	if nearlyEqualPenValue(p.penSaturation, nextValue) {
+	if p.penObj != nil && nearlyEqualPenValue(p.penSaturation, nextValue) {
 		return
 	}
 	p.checkOrCreatePen()
@@ -206,7 +205,7 @@ func (p *penComponent) changePenSaturation(delta float64) {
 
 func (p *penComponent) setPenBrightness(value float64) {
 	nextValue := mathf.Clamp(value, 0, 100)
-	if nearlyEqualPenValue(p.penBrightness, nextValue) {
+	if p.penObj != nil && nearlyEqualPenValue(p.penBrightness, nextValue) {
 		return
 	}
 	p.checkOrCreatePen()
@@ -220,7 +219,7 @@ func (p *penComponent) changePenBrightness(delta float64) {
 
 func (p *penComponent) setPenTransparency(value float64) {
 	nextValue := mathf.Clamp(value, 0, 100)
-	if nearlyEqualPenValue(p.penTransparency, nextValue) {
+	if p.penObj != nil && nearlyEqualPenValue(p.penTransparency, nextValue) {
 		return
 	}
 	p.checkOrCreatePen()

--- a/component_pen_test.go
+++ b/component_pen_test.go
@@ -163,6 +163,49 @@ func TestPenComponentIgnoresRepeatedPenStyleValues(t *testing.T) {
 	}
 }
 
+func TestPenComponentDefaultPenSizeStillMaterializesPen(t *testing.T) {
+	spy := setupSpyPenMgr(t)
+	sprite := newPenTestSprite()
+
+	sprite.pen().SetPenSize(1)
+
+	if spy.createCalls != 1 {
+		t.Fatalf("CreatePen calls = %d, want 1", spy.createCalls)
+	}
+	if spy.setSizeCalls != 1 {
+		t.Fatalf("SetPenSizeTo calls = %d, want 1", spy.setSizeCalls)
+	}
+}
+
+func TestPenComponentDefaultPenColorStillMaterializesPen(t *testing.T) {
+	spy := setupSpyPenMgr(t)
+	sprite := newPenTestSprite()
+
+	defaultColor := toSpxColor(sprite.pen().penColor)
+	sprite.pen().SetPenColor(defaultColor)
+
+	if spy.createCalls != 1 {
+		t.Fatalf("CreatePen calls = %d, want 1", spy.createCalls)
+	}
+	if spy.setColorCalls != 1 {
+		t.Fatalf("SetPenColorTo calls = %d, want 1", spy.setColorCalls)
+	}
+}
+
+func TestPenComponentDefaultHSVStillMaterializesPen(t *testing.T) {
+	spy := setupSpyPenMgr(t)
+	sprite := newPenTestSprite()
+
+	sprite.pen().SetPenColorParam(PenHue, sprite.pen().penHue)
+
+	if spy.createCalls != 1 {
+		t.Fatalf("CreatePen calls = %d, want 1", spy.createCalls)
+	}
+	if spy.setColorCalls != 1 {
+		t.Fatalf("SetPenColorTo calls = %d, want 1", spy.setColorCalls)
+	}
+}
+
 func TestPenComponentPenDownUsesLogicalPosition(t *testing.T) {
 	spy := setupSpyPenMgr(t)
 	sprite := newPenTestSprite()

--- a/component_pen_test.go
+++ b/component_pen_test.go
@@ -1,0 +1,190 @@
+package spx
+
+import (
+	"testing"
+
+	"github.com/goplus/spbase/mathf"
+	coreproject "github.com/goplus/spx/v2/internal/core/project"
+	"github.com/goplus/spx/v2/internal/enginewrap"
+	"github.com/goplus/spx/v2/pkg/spx/pkg/engine"
+)
+
+type spyPenMgr struct {
+	createCalls   int
+	moveCalls     int
+	penDownCalls  int
+	penUpCalls    int
+	setColorCalls int
+	setSizeCalls  int
+	lastMove      mathf.Vec2
+}
+
+type penTestSprite struct {
+	SpriteImpl
+}
+
+func (*penTestSprite) Main() {}
+
+func (s *spyPenMgr) DestroyAllPens() {}
+
+func (s *spyPenMgr) CreatePen() engine.Object {
+	s.createCalls++
+	return engine.Object(s.createCalls)
+}
+
+func (s *spyPenMgr) DestroyPen(obj engine.Object) {}
+
+func (s *spyPenMgr) PenStamp(obj engine.Object) {}
+
+func (s *spyPenMgr) MovePenTo(obj engine.Object, position mathf.Vec2) {
+	s.moveCalls++
+	s.lastMove = position
+}
+
+func (s *spyPenMgr) PenDown(obj engine.Object, moveByMouse bool) {
+	s.penDownCalls++
+}
+
+func (s *spyPenMgr) PenUp(obj engine.Object) {
+	s.penUpCalls++
+}
+
+func (s *spyPenMgr) SetPenColorTo(obj engine.Object, color mathf.Color) {
+	s.setColorCalls++
+}
+
+func (s *spyPenMgr) ChangePenBy(obj engine.Object, property int64, amount float64) {}
+
+func (s *spyPenMgr) SetPenTo(obj engine.Object, property int64, value float64) {}
+
+func (s *spyPenMgr) ChangePenSizeBy(obj engine.Object, amount float64) {}
+
+func (s *spyPenMgr) SetPenSizeTo(obj engine.Object, size float64) {
+	s.setSizeCalls++
+}
+
+func (s *spyPenMgr) SetPenStampTexture(obj engine.Object, texturePath string) {}
+
+func newPenTestSprite() *penTestSprite {
+	game := &Game{}
+	sprite := &penTestSprite{}
+	sprite.g = game
+	sprite.name = "PenTest"
+	sprite.sprite = sprite
+	sprite.scriptEventBindings.init(&game.scriptEvents, &sprite.SpriteImpl)
+	sprite.components.initComponents(&sprite.SpriteImpl, &coreproject.SpriteConfig{})
+	return sprite
+}
+
+func configurePenRenderOffsetSprite(sprite *penTestSprite) {
+	sprite.runtimeState.Scale = 1
+	sprite.transform().x = 50
+	sprite.transform().y = 60
+	sprite.transform().pivot = mathf.NewVec2(3, 4)
+	sprite.costumes = []*costume{{
+		path:             "sprites/PenTest/costume1.svg",
+		center:           mathf.NewVec2(10, 20),
+		bitmapResolution: 1,
+		width:            100,
+		height:           80,
+	}}
+	sprite.costumeIndex = 0
+}
+
+func setupSpyPenMgr(t *testing.T) *spyPenMgr {
+	t.Helper()
+
+	enginewrap.Init(func(call func()) {
+		call()
+	})
+
+	spy := &spyPenMgr{}
+	original := engine.PenMgr
+	engine.PenMgr = spy
+	t.Cleanup(func() {
+		engine.PenMgr = original
+	})
+	return spy
+}
+
+func TestPenComponentPenDownIsIdempotent(t *testing.T) {
+	spy := setupSpyPenMgr(t)
+	sprite := newPenTestSprite()
+
+	sprite.pen().PenDown()
+	sprite.pen().PenDown()
+
+	if spy.createCalls != 1 {
+		t.Fatalf("CreatePen calls = %d, want 1", spy.createCalls)
+	}
+	if spy.penDownCalls != 1 {
+		t.Fatalf("PenDown calls = %d, want 1", spy.penDownCalls)
+	}
+	if spy.moveCalls != 1 {
+		t.Fatalf("MovePenTo calls = %d, want 1", spy.moveCalls)
+	}
+}
+
+func TestPenComponentPenUpDoesNotAllocateOrRepeat(t *testing.T) {
+	spy := setupSpyPenMgr(t)
+	sprite := newPenTestSprite()
+
+	sprite.pen().PenUp()
+	if spy.createCalls != 0 {
+		t.Fatalf("CreatePen calls after idle PenUp = %d, want 0", spy.createCalls)
+	}
+	if spy.penUpCalls != 0 {
+		t.Fatalf("PenUp calls after idle PenUp = %d, want 0", spy.penUpCalls)
+	}
+
+	sprite.pen().PenDown()
+	sprite.pen().PenUp()
+	sprite.pen().PenUp()
+
+	if spy.penUpCalls != 1 {
+		t.Fatalf("PenUp calls after repeated PenUp = %d, want 1", spy.penUpCalls)
+	}
+}
+
+func TestPenComponentIgnoresRepeatedPenStyleValues(t *testing.T) {
+	spy := setupSpyPenMgr(t)
+	sprite := newPenTestSprite()
+
+	sprite.pen().SetPenSize(10)
+	sprite.pen().SetPenSize(10)
+	sprite.pen().SetPenColor(HSB(85, 33, 100))
+	sprite.pen().SetPenColor(HSB(85, 33, 100))
+
+	if spy.setSizeCalls != 1 {
+		t.Fatalf("SetPenSizeTo calls = %d, want 1", spy.setSizeCalls)
+	}
+	if spy.setColorCalls != 1 {
+		t.Fatalf("SetPenColorTo calls = %d, want 1", spy.setColorCalls)
+	}
+}
+
+func TestPenComponentPenDownUsesLogicalPosition(t *testing.T) {
+	spy := setupSpyPenMgr(t)
+	sprite := newPenTestSprite()
+	configurePenRenderOffsetSprite(sprite)
+
+	sprite.pen().PenDown()
+
+	want := mathf.NewVec2(50, -60)
+	if spy.lastMove != want {
+		t.Fatalf("MovePenTo position = %v, want %v", spy.lastMove, want)
+	}
+}
+
+func TestPenComponentStampUsesRenderedPosition(t *testing.T) {
+	spy := setupSpyPenMgr(t)
+	sprite := newPenTestSprite()
+	configurePenRenderOffsetSprite(sprite)
+
+	sprite.pen().Stamp()
+
+	want := mathf.NewVec2(87, -36)
+	if spy.lastMove != want {
+		t.Fatalf("MovePenTo position = %v, want %v", spy.lastMove, want)
+	}
+}


### PR DESCRIPTION
## Summary

This PR makes pen commands idempotent to better match Scratch-style scripts that may repeatedly issue the same pen operations every frame.

## Changes

- make repeated `penDown` calls a no-op once the pen is already down
- make repeated `penUp` calls a no-op when the pen is already up
- skip redundant pen size updates when the requested size is unchanged
- skip redundant pen color and HSV parameter updates when the effective value is unchanged
- add regression tests covering pen down/up idempotency and repeated style updates

## Why

Scratch projects often call `penDown`, `setPenSize`, and `setPenColor` inside tight loops.
Without idempotent handling, repeated identical calls can continuously restart pen state and break drawing behavior.

## Testing

- go test .