### PR TITLE
refactor: unify costume asset path helpers

### DIFF
--- a/baseobj.go
+++ b/baseobj.go
@@ -274,19 +274,24 @@ func (p *baseObj) getCostumeIndex() int {
 	return p.costumeIndex
 }
 
+// currentCostume returns the currently selected costume.
+func (p *baseObj) currentCostume() *costume {
+	return p.costumes[p.costumeIndex]
+}
+
 // getCostumeName returns the name of the current costume.
 func (p *baseObj) getCostumeName() SpriteCostumeName {
-	return p.costumes[p.costumeIndex].name
+	return p.currentCostume().name
 }
 
 // getCostumePath returns the file path of the current costume.
 func (p *baseObj) getCostumePath() string {
-	return p.costumes[p.costumeIndex].path
+	return p.currentCostume().path
 }
 
 // getCostumeAssetPath returns the engine-ready asset path of the current costume.
 func (p *baseObj) getCostumeAssetPath() string {
-	return p.costumes[p.costumeIndex].getAssetPath()
+	return p.currentCostume().getAssetPath()
 }
 
 // getCostumeRenderScale returns the render scale for the current costume.
@@ -301,23 +306,23 @@ func (p *baseObj) getAnimRenderScale(bitmapResolution int) float64 {
 
 // getCurrentBitmapResolution returns the bitmap resolution of the current costume.
 func (p *baseObj) getCurrentBitmapResolution() int {
-	return p.costumes[p.costumeIndex].bitmapResolution
+	return p.currentCostume().bitmapResolution
 }
 
 // getCostumeSize returns the size of the current costume.
 func (p *baseObj) getCostumeSize() (float64, float64) {
-	x, y := p.costumes[p.costumeIndex].getSize()
+	x, y := p.currentCostume().getSize()
 	return float64(x), float64(y)
 }
 
 // isCostumeAtlas returns true if the current costume is part of an atlas.
 func (p *baseObj) isCostumeAtlas() bool {
-	return p.costumes[p.costumeIndex].isAtlas()
+	return p.currentCostume().isAtlas()
 }
 
 // getCostumeAtlasUvRemap returns the UV remap coordinates for the current costume.
 func (p *baseObj) getCostumeAtlasUvRemap() mathf.Rect2 {
-	costume := p.costumes[p.costumeIndex]
+	costume := p.currentCostume()
 	return mathf.NewRect2(
 		costume.atlasUVRect.X,
 		costume.atlasUVRect.Y,
@@ -328,7 +333,7 @@ func (p *baseObj) getCostumeAtlasUvRemap() mathf.Rect2 {
 
 // getCostumeAtlasRegion returns the pixel region of the current costume in the atlas.
 func (p *baseObj) getCostumeAtlasRegion() mathf.Rect2 {
-	costume := p.costumes[p.costumeIndex]
+	costume := p.currentCostume()
 	return mathf.NewRect2(
 		float64(costume.posX),
 		float64(costume.posY),

--- a/baseobj.go
+++ b/baseobj.go
@@ -286,7 +286,7 @@ func (p *baseObj) getCostumePath() string {
 
 // getCostumeAssetPath returns the engine-ready asset path of the current costume.
 func (p *baseObj) getCostumeAssetPath() string {
-	return engine.ToAssetPath(p.getCostumePath())
+	return p.costumes[p.costumeIndex].getAssetPath()
 }
 
 // getCostumeRenderScale returns the render scale for the current costume.

--- a/component_pen.go
+++ b/component_pen.go
@@ -280,6 +280,10 @@ func (p *penComponent) applyPenHsvProperty() {
 	p.updatePenColor()
 }
 
+func (p *penComponent) updatePenColor() {
+	p.engine().PenMgr.SetPenColorTo(*p.penObj, p.penColor)
+}
+
 func hueToPercent(hue float64) float64 {
 	return (hue / 360) * 100
 }
@@ -294,10 +298,6 @@ func normalizedToPercent(normalized float64) float64 {
 
 func percentToNormalized(percent float64) float64 {
 	return percent / 100
-}
-
-func (p *penComponent) updatePenColor() {
-	p.engine().PenMgr.SetPenColorTo(*p.penObj, p.penColor)
 }
 
 func nearlyEqualPenValue(a, b float64) bool {

--- a/costume.go
+++ b/costume.go
@@ -122,6 +122,14 @@ func newCostume(config *coreproject.CostumeConfig) *costume {
 	}
 }
 
+func costumeAssetPath(path string) string {
+	return engine.ToAssetPath(path)
+}
+
+func (c *costume) getAssetPath() string {
+	return costumeAssetPath(c.path)
+}
+
 // getImageSizeCached retrieves image size from cache or loads it.
 func getImageSizeCached(imagePath string) mathf.Vec2 {
 	cache := imageSizeCacheRef()
@@ -135,7 +143,7 @@ func getImageSizeCached(imagePath string) mathf.Vec2 {
 
 // getCostumeAssetSize loads the actual image size from the asset.
 func getCostumeAssetSize(imagePath string) mathf.Vec2 {
-	assetPath := engine.ToAssetPath(imagePath)
+	assetPath := costumeAssetPath(imagePath)
 	if game, ok := engine.GetGame().(*Game); ok && game != nil {
 		return game.engine().ResMgr.GetImageSize(assetPath)
 	}

--- a/sprite_render_util.go
+++ b/sprite_render_util.go
@@ -86,7 +86,7 @@ func getCostumeBoundByAlpha(p *SpriteImpl, isSync bool) (mathf.Vec2, mathf.Vec2)
 		if cache, ok := cachedBounds[cs.path]; ok {
 			rect = cache
 		} else {
-			assetPath := engine.ToAssetPath(cs.path)
+			assetPath := cs.getAssetPath()
 			if isSync {
 				rect = engine.Managers().ResMgr.GetBoundFromAlpha(assetPath)
 			} else {


### PR DESCRIPTION
## Summary

This PR unifies costume asset path handling and slightly cleans up current costume access in `baseObj`.

## Changes

- Add shared helpers for costume asset path resolution.
- Update `baseObj`, costume size lookup, and sprite alpha-bound lookup to reuse the same helper.
- Extract `currentCostume()` in `baseObj` to simplify repeated current-costume access.

## Validation

- `go test .`