### PR TITLE
refactor: streamline world/window metrics setup

### DIFF
--- a/game_load.go
+++ b/game_load.go
@@ -71,6 +71,16 @@ func (p *Game) setupDisplayConfig(proj *coreproject.ProjectConfig) {
 	engine.SetDebugMode(p.debugState.Debug)
 }
 
+func (p *Game) applyWorldWindowMetrics(metrics coreproject.WorldWindowMetrics) {
+	p.displayState.WorldWidth = metrics.WorldWidth
+	p.displayState.WorldHeight = metrics.WorldHeight
+	p.displayState.MinWorldX = metrics.MinWorldX
+	p.displayState.MinWorldY = metrics.MinWorldY
+	p.displayState.MapMode = metrics.MapMode
+	p.displayState.WindowWidth = metrics.WindowWidth
+	p.displayState.WindowHeight = metrics.WindowHeight
+}
+
 func (p *Game) setupWorldAndWindow(proj *coreproject.ProjectConfig) {
 	proj.Map = coreproject.ResolveMapConfig(proj.Map, p.tilemapMgr.hasData(), baseScreenWidth, baseScreenHeight)
 	backdrops := proj.GetBackdrops()
@@ -97,13 +107,7 @@ func (p *Game) setupWorldAndWindow(proj *coreproject.ProjectConfig) {
 		p.displayState.WindowHeight,
 		coreproject.ToMapMode(proj.Map.Mode),
 	)
-	p.displayState.WorldWidth = metrics.WorldWidth
-	p.displayState.WorldHeight = metrics.WorldHeight
-	p.displayState.MinWorldX = metrics.MinWorldX
-	p.displayState.MinWorldY = metrics.MinWorldY
-	p.displayState.MapMode = metrics.MapMode
-	p.displayState.WindowWidth = metrics.WindowWidth
-	p.displayState.WindowHeight = metrics.WindowHeight
+	p.applyWorldWindowMetrics(metrics)
 	spxlog.Debug("SetWindowSize: %d, %d", p.displayState.WindowWidth, p.displayState.WindowHeight)
 }
 

--- a/game_load.go
+++ b/game_load.go
@@ -89,6 +89,7 @@ func (p *Game) setupWorldAndWindow(proj *coreproject.ProjectConfig) {
 	}
 	spxlog.Debug("SetWorldSize: %d, %d", p.displayState.WorldWidth, p.displayState.WorldHeight)
 
+	p.doWindowSize()
 	metrics := coreproject.ResolveWorldWindowMetrics(
 		p.displayState.WorldWidth,
 		p.displayState.WorldHeight,
@@ -101,18 +102,9 @@ func (p *Game) setupWorldAndWindow(proj *coreproject.ProjectConfig) {
 	p.displayState.MinWorldX = metrics.MinWorldX
 	p.displayState.MinWorldY = metrics.MinWorldY
 	p.displayState.MapMode = metrics.MapMode
-	p.doWindowSize()
-	spxlog.Debug("SetWindowSize: %d, %d", p.displayState.WindowWidth, p.displayState.WindowHeight)
-
-	metrics = coreproject.ResolveWorldWindowMetrics(
-		p.displayState.WorldWidth,
-		p.displayState.WorldHeight,
-		p.displayState.WindowWidth,
-		p.displayState.WindowHeight,
-		p.displayState.MapMode,
-	)
 	p.displayState.WindowWidth = metrics.WindowWidth
 	p.displayState.WindowHeight = metrics.WindowHeight
+	spxlog.Debug("SetWindowSize: %d, %d", p.displayState.WindowWidth, p.displayState.WindowHeight)
 }
 
 func (p *Game) setupPlatformAndCamera(proj *coreproject.ProjectConfig) {

--- a/game_load_window_test.go
+++ b/game_load_window_test.go
@@ -1,0 +1,42 @@
+package spx
+
+import (
+	"testing"
+
+	coreproject "github.com/goplus/spx/v2/internal/core/project"
+)
+
+func TestSetupWorldAndWindowClampsBackdropWindowToWorld(t *testing.T) {
+	game := &Game{}
+	proj := &coreproject.ProjectConfig{
+		Map: coreproject.MapConfig{
+			Width:  320,
+			Height: 180,
+			Mode:   "repeat",
+		},
+		Backdrops: []*coreproject.BackdropConfig{
+			{
+				CostumeConfig: coreproject.CostumeConfig{
+					Path:        "bg.png",
+					ImageWidth:  640,
+					ImageHeight: 480,
+				},
+			},
+		},
+	}
+
+	game.setupWorldAndWindow(proj)
+
+	if game.displayState.WorldWidth != 320 || game.displayState.WorldHeight != 180 {
+		t.Fatalf("world size = %dx%d, want 320x180", game.displayState.WorldWidth, game.displayState.WorldHeight)
+	}
+	if game.displayState.WindowWidth != 320 || game.displayState.WindowHeight != 180 {
+		t.Fatalf("window size = %dx%d, want 320x180", game.displayState.WindowWidth, game.displayState.WindowHeight)
+	}
+	if game.displayState.MinWorldX != -160 || game.displayState.MinWorldY != -90 {
+		t.Fatalf("world min = (%d, %d), want (-160, -90)", game.displayState.MinWorldX, game.displayState.MinWorldY)
+	}
+	if game.displayState.MapMode != coreproject.MapModeRepeat {
+		t.Fatalf("map mode = %d, want %d", game.displayState.MapMode, coreproject.MapModeRepeat)
+	}
+}


### PR DESCRIPTION
## Summary
- move `doWindowSize()` before resolving world/window metrics so setup uses the final window input in a single pass
- remove the redundant second `ResolveWorldWindowMetrics` call in `setupWorldAndWindow`
- extract display-state updates into `applyWorldWindowMetrics` to keep metric calculation pure and centralize runtime state writes
- add a regression test covering the case where a backdrop is larger than the configured world and the window still needs to be clamped to world size

## Testing
- go test ./...