### PR TITLE
feat(backdrop): support the actualSize backdrop mode

### DIFF
--- a/baseobj.go
+++ b/baseobj.go
@@ -171,7 +171,7 @@ func (p *baseObj) addCostumeWith(name SpriteCostumeName, img *costumeSetImage, f
 func (p *baseObj) initBackdrops(configs []*coreproject.BackdropConfig, costumeIndex int) {
 	p.costumes = make([]*costume, len(configs))
 	for i, cfg := range configs {
-		p.costumes[i] = newCostume(&cfg.CostumeConfig)
+		p.costumes[i] = newBackdropCostume(cfg)
 	}
 	if costumeIndex >= len(configs) || costumeIndex < 0 {
 		costumeIndex = 0

--- a/costume.go
+++ b/costume.go
@@ -38,6 +38,7 @@ type costume struct {
 	width, height int
 	center        mathf.Vec2 // center point
 	imageSize     mathf.Vec2 // actual image dimensions
+	pivot         mathf.Vec2
 
 	faceRight        float64
 	bitmapResolution int
@@ -120,6 +121,12 @@ func newCostume(config *coreproject.CostumeConfig) *costume {
 		posY:             frame.PosY,
 		atlasUVRect:      frame.AtlasUVRect,
 	}
+}
+
+func newBackdropCostume(config *coreproject.BackdropConfig) *costume {
+	costume := newCostume(&config.CostumeConfig)
+	costume.pivot = config.Pivot
+	return costume
 }
 
 func costumeAssetPath(path string) string {

--- a/internal/core/project/config.go
+++ b/internal/core/project/config.go
@@ -49,12 +49,15 @@ const (
 	MapModeRepeat
 	MapModeFillRatio
 	MapModeFillCut
+	MapModeActualSize
 )
 
 func ToMapMode(mode string) int {
 	switch mode {
 	case "repeat":
 		return MapModeRepeat
+	case "actualSize":
+		return MapModeActualSize
 	case "fillCut":
 		return MapModeFillCut
 	case "fillRatio":
@@ -155,6 +158,7 @@ type CostumeConfig struct {
 
 type BackdropConfig struct {
 	CostumeConfig
+	Pivot mathf.Vec2 `json:"pivot"`
 }
 
 type AniType int8

--- a/internal/core/project/display.go
+++ b/internal/core/project/display.go
@@ -138,6 +138,9 @@ func ResolveBackdropLayout(imgW, imgH, dstW, dstH float64, mapMode int) Backdrop
 			X: dstW / imgW,
 			Y: dstH / imgH,
 		}
+	case MapModeActualSize:
+		dstW = imgW
+		dstH = imgH
 	case MapModeFillCut:
 		if isScaleHeight {
 			dstH = dstW / imgRatio

--- a/internal/core/project/project_test.go
+++ b/internal/core/project/project_test.go
@@ -225,6 +225,9 @@ func TestProjectConfigHelpers(t *testing.T) {
 	if got := ToMapMode("fillCut"); got != MapModeFillCut {
 		t.Fatalf("ToMapMode(fillCut) = %d, want %d", got, MapModeFillCut)
 	}
+	if got := ToMapMode("actualSize"); got != MapModeActualSize {
+		t.Fatalf("ToMapMode(actualSize) = %d, want %d", got, MapModeActualSize)
+	}
 	if got := ToMapMode("unknown"); got != MapModeFill {
 		t.Fatalf("ToMapMode(unknown) = %d, want %d", got, MapModeFill)
 	}
@@ -304,6 +307,11 @@ func TestResolveBackdropLayout(t *testing.T) {
 	fillCut := ResolveBackdropLayout(100, 50, 100, 100, MapModeFillCut)
 	if fillCut.ScaleX != 1 || fillCut.ScaleY != 1 {
 		t.Fatalf("unexpected fillCut layout: %+v", fillCut)
+	}
+
+	actualSize := ResolveBackdropLayout(100, 50, 400, 200, MapModeActualSize)
+	if actualSize.ScaleX != 1 || actualSize.ScaleY != 1 {
+		t.Fatalf("unexpected actualSize layout: %+v", actualSize)
 	}
 
 	fillRatio := ResolveBackdropLayout(100, 50, 100, 100, MapModeFillRatio)

--- a/runtime_display.go
+++ b/runtime_display.go
@@ -34,6 +34,7 @@ func (p *Game) setBackdrop(backdrop any, wait bool) {
 
 func (p *Game) setupBackdrop() {
 	imgW, imgH := p.getCostumeSize()
+	spriteMgr := p.engine().SpriteMgr
 	layout := coreproject.ResolveBackdropLayout(
 		imgW,
 		imgH,
@@ -46,7 +47,15 @@ func (p *Game) setupBackdrop() {
 	}
 	p.runtimeState.Scale = 1
 	p.baseObj.scheduleCostumeUpdate()
-	p.engine().SpriteMgr.SetScale(p.runtimeState.SyncSprite.GetId(), mathf.NewVec2(layout.ScaleX, layout.ScaleY))
+
+	if p.displayState.MapMode == coreproject.MapModeActualSize {
+		x, y := getCostumeRenderOffset(p.currentCostume(), p.currentCostume().pivot, layout.ScaleX, layout.ScaleY)
+		spriteMgr.SetPosition(
+			p.runtimeState.SyncSprite.GetId(),
+			mathf.NewVec2(x, y),
+		)
+	}
+	spriteMgr.SetScale(p.runtimeState.SyncSprite.GetId(), mathf.NewVec2(layout.ScaleX, layout.ScaleY))
 }
 
 // -----------------------------------------------------------------------------

--- a/runtime_display_test.go
+++ b/runtime_display_test.go
@@ -1,0 +1,22 @@
+package spx
+
+import (
+	"testing"
+
+	"github.com/goplus/spbase/mathf"
+)
+
+func TestGetCostumeRenderOffsetUsesPivot(t *testing.T) {
+	costume := &costume{
+		width:            200,
+		height:           120,
+		bitmapResolution: 2,
+		center:           mathf.NewVec2(100, 60),
+		pivot:            mathf.NewVec2(10, -5),
+	}
+
+	x, y := getCostumeRenderOffset(costume, costume.pivot, 1, 1)
+	if x != -10 || y != 5 {
+		t.Fatalf("getCostumeRenderOffset = (%v, %v), want (-10, 5)", x, y)
+	}
+}

--- a/sprite_render_util.go
+++ b/sprite_render_util.go
@@ -22,15 +22,16 @@ import (
 )
 
 func getRenderOffset(p *SpriteImpl) (float64, float64) {
-	cs := p.costumes[p.costumeIndex]
-	pivot := p.getPivot()
-	x, y := -((cs.center.X)/float64(cs.bitmapResolution)+pivot.X)*p.runtimeState.Scale,
-		((cs.center.Y)/float64(cs.bitmapResolution)-pivot.Y)*p.runtimeState.Scale
+	return getCostumeRenderOffset(p.currentCostume(), p.getPivot(), p.runtimeState.Scale, p.runtimeState.Scale)
+}
 
-	w, h := p.getCostumeSize()
-	x = x + float64(w)/2*p.runtimeState.Scale
-	y = y - float64(h)/2*p.runtimeState.Scale
+func getCostumeRenderOffset(c *costume, pivot mathf.Vec2, scaleX, scaleY float64) (float64, float64) {
+	w, h := c.getSize()
+	centerX := c.center.X / float64(c.bitmapResolution)
+	centerY := c.center.Y / float64(c.bitmapResolution)
 
+	x := -(centerX+pivot.X)*scaleX + float64(w)/2*scaleX
+	y := (centerY-pivot.Y)*scaleY - float64(h)/2*scaleY
 	return x, y
 }
 


### PR DESCRIPTION
## Summary

This PR adds support for the `actualSize` backdrop mode so a backdrop can be rendered using its original asset size instead of being scaled to fit the stage.

## Changes

- add `actualSize` to backdrop map mode parsing and layout resolution
- preserve backdrop-specific `pivot` data when initializing backdrop costumes
- apply pivot-based positioning when rendering backdrops in `actualSize` mode
- extract shared costume render offset logic for consistent sprite/backdrop placement
- add tests for map mode parsing, actual-size layout behavior, and pivot-based render offsets

## Why

Previously, backdrops were always laid out using fit/fill-style scaling, which made it difficult to render a backdrop at its true pixel size and align it precisely with a custom pivot. This change enables pixel-accurate backdrop placement for projects that rely on original asset dimensions.

## Testing

- `go test ./...`