### PR TITLE
refactor(touching): inline stage edge default

### DIFF
--- a/sprite_edge_test.go
+++ b/sprite_edge_test.go
@@ -119,7 +119,7 @@ func newEdgeTestSprite(direction Direction) *SpriteImpl {
 	return sprite
 }
 
-func TestSpriteTouchingTargetUsesRequestedEdgeArea(t *testing.T) {
+func TestSpriteTouchingTargetDefaultsToStageArea(t *testing.T) {
 	installEdgePhysicsMgr(t, &fakeEdgePhysicsMgr{
 		stageTouching:  touchingScreenLeft,
 		cameraTouching: touchingScreenRight,
@@ -130,14 +130,11 @@ func TestSpriteTouchingTargetUsesRequestedEdgeArea(t *testing.T) {
 	if !sprite.Touching__2(EdgeLeft) {
 		t.Fatal("Touching__2(EdgeLeft) = false, want true for default stage area")
 	}
-	if sprite.touching(EdgeLeft, edgeAreaCamera) {
-		t.Fatal("touching(EdgeLeft, camera) = true, want false")
+	if sprite.Touching__2(EdgeRight) {
+		t.Fatal("Touching__2(EdgeRight) = true, want false when only camera boundary is touched")
 	}
-	if !sprite.touching(EdgeRight, edgeAreaViewport) {
-		t.Fatal("touching(EdgeRight, viewport) = false, want true")
-	}
-	if !sprite.touching(EdgeRight, "Camera") {
-		t.Fatal("touching(EdgeRight, Camera) = false, want true")
+	if sprite.checkTouchingScreen(touchingScreenRight, edgeAreaViewport) == 0 {
+		t.Fatal("checkTouchingScreen(EdgeRight, viewport) = 0, want non-zero")
 	}
 }
 

--- a/sprite_query.go
+++ b/sprite_query.go
@@ -62,22 +62,22 @@ func (p *SpriteImpl) TouchingColor__1(spriteColor, targetColor Color) bool {
 }
 
 func (p *SpriteImpl) Touching__0(sprite Sprite) bool {
-	return p.touching(sprite, edgeAreaStage)
+	return p.touching(sprite)
 }
 
 func (p *SpriteImpl) Touching__1(sprite SpriteName) bool {
-	return p.touching(sprite, edgeAreaStage)
+	return p.touching(sprite)
 }
 
 func (p *SpriteImpl) Touching__2(obj specialObj) bool {
-	return p.touching(obj, edgeAreaStage)
+	return p.touching(obj)
 }
 
 func (p *SpriteImpl) TouchingWith(target Target) bool {
-	return p.touching(target, edgeAreaStage)
+	return p.touching(target)
 }
 
-func (p *SpriteImpl) touching(obj Target, area string) bool {
+func (p *SpriteImpl) touching(obj Target) bool {
 	if p.spriteState.IsDying {
 		return false
 	}
@@ -86,7 +86,7 @@ func (p *SpriteImpl) touching(obj Target, area string) bool {
 		return p.g.touchingSpriteBy(p, v) != nil
 	case specialObj:
 		if v > 0 {
-			return p.checkTouchingScreen(int(v), area) != 0
+			return p.checkTouchingScreen(int(v), edgeAreaStage) != 0
 		}
 		if v == Mouse {
 			x, y := p.g.getMousePos()


### PR DESCRIPTION
## Summary

This PR simplifies the default edge-check path.

## Changes

- default edge checks inside `touching` to `edgeAreaStage`
- update edge-related tests to reflect the new default behavior while keeping explicit `checkTouchingScreen(..., area)` coverage

## Testing

- go test ./...