### PR TITLE
fix: install updated spx after build-dev exports

### DIFF
--- a/internal/cmd/buildctl/prepare_test.go
+++ b/internal/cmd/buildctl/prepare_test.go
@@ -97,19 +97,20 @@ func newRuntimeFixtureRunner(t *testing.T) *recordingRunner {
 }
 
 func simulateRuntimeCommandOutputs(workdir string, name string, args ...string) error {
-	if name != "spx" || len(args) == 0 {
+	projectDir, spxArgs, ok := simulatedSPXInvocation(workdir, name, args...)
+	if !ok || len(spxArgs) == 0 {
 		return nil
 	}
 
-	switch args[0] {
+	switch spxArgs[0] {
 	case "export":
-		dst := filepath.Join(workdir, "project", ".builds", "pc", "gdexport.pck")
+		dst := filepath.Join(projectDir, "project", ".builds", "pc", "gdexport.pck")
 		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
 			return err
 		}
 		return os.WriteFile(dst, []byte("runtime-pack"), 0o644)
 	case "exporttemplateweb":
-		dstDir := filepath.Join(workdir, "project", ".builds", "webi")
+		dstDir := filepath.Join(projectDir, "project", ".builds", "webi")
 		if err := os.MkdirAll(dstDir, 0o755); err != nil {
 			return err
 		}
@@ -118,16 +119,39 @@ func simulateRuntimeCommandOutputs(workdir string, name string, args ...string) 
 		}
 		return os.WriteFile(filepath.Join(dstDir, "engine.js"), []byte("console.log('engine');\n"), 0o644)
 	case "exportweb", "exportwebworker", "exportminigame", "exportminiprogram":
-		dstDir := filepath.Join(workdir, "project", ".builds", "web", "subdir")
+		dstDir := filepath.Join(projectDir, "project", ".builds", "web", "subdir")
 		if err := os.MkdirAll(dstDir, 0o755); err != nil {
 			return err
 		}
-		if err := os.WriteFile(filepath.Join(workdir, "project", ".builds", "web", "index.html"), []byte("<html></html>"), 0o644); err != nil {
+		if err := os.WriteFile(filepath.Join(projectDir, "project", ".builds", "web", "index.html"), []byte("<html></html>"), 0o644); err != nil {
 			return err
 		}
 		return os.WriteFile(filepath.Join(dstDir, "game.js"), []byte("console.log('game');\n"), 0o644)
 	default:
 		return nil
+	}
+}
+
+func simulatedSPXInvocation(workdir string, name string, args ...string) (string, []string, bool) {
+	switch name {
+	case "spx":
+		return workdir, append([]string(nil), args...), len(args) > 0
+	case "go":
+		if len(args) < 4 || args[0] != "run" || args[1] != "./cmd/spx" {
+			return "", nil, false
+		}
+		spxArgs := append([]string(nil), args[2:]...)
+		projectDir := workdir
+		for i := 0; i+1 < len(spxArgs); i++ {
+			if spxArgs[i] == "--path" {
+				projectDir = spxArgs[i+1]
+				spxArgs = append(spxArgs[:i], spxArgs[i+2:]...)
+				break
+			}
+		}
+		return projectDir, spxArgs, len(spxArgs) > 0
+	default:
+		return "", nil, false
 	}
 }
 
@@ -351,6 +375,17 @@ func assertRuntimeWorkspaceCommands(t *testing.T, got []recordedCommand, repoRoo
 		t.Fatalf("unexpected commands: %#v", got)
 	}
 	for i := range want {
+		if want[i].name == "spx" {
+			projectDir, spxArgs, ok := simulatedSPXInvocation(got[i].dir, got[i].name, got[i].args...)
+			if !ok || !reflect.DeepEqual(spxArgs, want[i].args) {
+				t.Fatalf("unexpected command[%d]: %#v", i, got[i])
+			}
+			prefix := filepath.Join(repoRoot, ".tmp", "runtime-")
+			if !strings.HasPrefix(projectDir, prefix) {
+				t.Fatalf("unexpected runtime workspace dir[%d]: %s", i, projectDir)
+			}
+			continue
+		}
 		if got[i].name != want[i].name || !reflect.DeepEqual(got[i].args, want[i].args) {
 			t.Fatalf("unexpected command[%d]: %#v", i, got[i])
 		}

--- a/internal/cmd/buildctl/runtimecmd/assets.go
+++ b/internal/cmd/buildctl/runtimecmd/assets.go
@@ -42,7 +42,7 @@ func exportPackRuntime(runner scriptRunner) error {
 	}
 	defer cleanup()
 
-	if err := runner.runCommand(workspace.workDir, "spx", "export"); err != nil {
+	if err := runRepoSPXCommand(runner, workspace.workDir, "export"); err != nil {
 		return err
 	}
 
@@ -86,7 +86,7 @@ func exportWebRuntime(cfg runtimeExportWebConfig, runner scriptRunner) error {
 	}
 	defer cleanup()
 
-	if err := runner.runCommand(workspace.workDir, "spx", spxCommand); err != nil {
+	if err := runRepoSPXCommand(runner, workspace.workDir, spxCommand); err != nil {
 		return err
 	}
 
@@ -104,7 +104,7 @@ func exportWebTemplateRuntime(mode string, runner scriptRunner) error {
 	}
 	defer cleanup()
 
-	if err := runner.runCommand(workspace.workDir, "spx", "exporttemplateweb"); err != nil {
+	if err := runRepoSPXCommand(runner, workspace.workDir, "exporttemplateweb"); err != nil {
 		return err
 	}
 
@@ -133,6 +133,13 @@ func exportWebTemplateRuntime(mode string, runner scriptRunner) error {
 	}
 	prefix := fmt.Sprintf("var EnginePackMode = '%s';\n", mode)
 	return os.WriteFile(engineJS, append([]byte(prefix), content...), 0o644)
+}
+
+func runRepoSPXCommand(runner scriptRunner, projectDir string, args ...string) error {
+	commandArgs := []string{"run", "./cmd/spx"}
+	commandArgs = append(commandArgs, args...)
+	commandArgs = append(commandArgs, "--path", projectDir)
+	return runner.runCommand(runner.repoRootDir(), "go", commandArgs...)
 }
 
 func prepareRuntimeWorkspace(repoRoot string, includeRuntimeExtension bool) (runtimeWorkspace, func(), error) {

--- a/internal/cmd/buildctl/runtimecmd/cmd_test.go
+++ b/internal/cmd/buildctl/runtimecmd/cmd_test.go
@@ -176,11 +176,18 @@ func assertSingleRuntimeWorkspaceCommand(t *testing.T, runner *recordingRunner, 
 		t.Fatalf("unexpected commands: %#v", runner.commands)
 	}
 	got := runner.commands[0]
-	if got.name != name || !reflect.DeepEqual(got.args, args) {
+	if name != "spx" {
+		if got.name != name || !reflect.DeepEqual(got.args, args) {
+			t.Fatalf("unexpected command: %#v", got)
+		}
+		return
+	}
+	projectDir, spxArgs, ok := simulatedSPXInvocation(got.dir, got.name, got.args...)
+	if !ok || !reflect.DeepEqual(spxArgs, args) {
 		t.Fatalf("unexpected command: %#v", got)
 	}
 	prefix := filepath.Join(runner.repoRoot, ".tmp", "runtime-")
-	if !strings.HasPrefix(got.dir, prefix) {
-		t.Fatalf("unexpected runtime workspace dir: %s", got.dir)
+	if !strings.HasPrefix(projectDir, prefix) {
+		t.Fatalf("unexpected runtime workspace dir: %s", projectDir)
 	}
 }

--- a/internal/cmd/buildctl/runtimecmd/test_helpers_test.go
+++ b/internal/cmd/buildctl/runtimecmd/test_helpers_test.go
@@ -88,19 +88,20 @@ func newRuntimeFixtureRunner(t *testing.T) *recordingRunner {
 }
 
 func simulateRuntimeCommandOutputs(workdir string, name string, args ...string) error {
-	if name != "spx" || len(args) == 0 {
+	projectDir, spxArgs, ok := simulatedSPXInvocation(workdir, name, args...)
+	if !ok || len(spxArgs) == 0 {
 		return nil
 	}
 
-	switch args[0] {
+	switch spxArgs[0] {
 	case "export":
-		dst := filepath.Join(workdir, "project", ".builds", "pc", "gdexport.pck")
+		dst := filepath.Join(projectDir, "project", ".builds", "pc", "gdexport.pck")
 		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
 			return err
 		}
 		return os.WriteFile(dst, []byte("runtime-pack"), 0o644)
 	case "exporttemplateweb":
-		dstDir := filepath.Join(workdir, "project", ".builds", "webi")
+		dstDir := filepath.Join(projectDir, "project", ".builds", "webi")
 		if err := os.MkdirAll(dstDir, 0o755); err != nil {
 			return err
 		}
@@ -109,16 +110,39 @@ func simulateRuntimeCommandOutputs(workdir string, name string, args ...string) 
 		}
 		return os.WriteFile(filepath.Join(dstDir, "engine.js"), []byte("console.log('engine');\n"), 0o644)
 	case "exportweb", "exportwebworker", "exportminigame", "exportminiprogram":
-		dstDir := filepath.Join(workdir, "project", ".builds", "web", "subdir")
+		dstDir := filepath.Join(projectDir, "project", ".builds", "web", "subdir")
 		if err := os.MkdirAll(dstDir, 0o755); err != nil {
 			return err
 		}
-		if err := os.WriteFile(filepath.Join(workdir, "project", ".builds", "web", "index.html"), []byte("<html></html>"), 0o644); err != nil {
+		if err := os.WriteFile(filepath.Join(projectDir, "project", ".builds", "web", "index.html"), []byte("<html></html>"), 0o644); err != nil {
 			return err
 		}
 		return os.WriteFile(filepath.Join(dstDir, "game.js"), []byte("console.log('game');\n"), 0o644)
 	default:
 		return nil
+	}
+}
+
+func simulatedSPXInvocation(workdir string, name string, args ...string) (string, []string, bool) {
+	switch name {
+	case "spx":
+		return workdir, append([]string(nil), args...), len(args) > 0
+	case "go":
+		if len(args) < 4 || args[0] != "run" || args[1] != "./cmd/spx" {
+			return "", nil, false
+		}
+		spxArgs := append([]string(nil), args[2:]...)
+		projectDir := workdir
+		for i := 0; i+1 < len(spxArgs); i++ {
+			if spxArgs[i] == "--path" {
+				projectDir = spxArgs[i+1]
+				spxArgs = append(spxArgs[:i], spxArgs[i+2:]...)
+				break
+			}
+		}
+		return projectDir, spxArgs, len(spxArgs) > 0
+	default:
+		return "", nil, false
 	}
 }
 

--- a/internal/cmd/buildctl/workflow/cmd.go
+++ b/internal/cmd/buildctl/workflow/cmd.go
@@ -417,23 +417,23 @@ func buildHostRuntimeWorkflow(runner scriptRunner) error {
 }
 
 func buildDevWorkflow(cfg workflowBuildDevConfig, runner scriptRunner) error {
-	printWorkflowStep(1, 4, "Install spx toolchain and web runtime")
-	if err := installTools(toolInstallConfig{web: true}, runner); err != nil {
-		return err
-	}
-
-	printWorkflowStep(2, 4, "Build host editor")
+	printWorkflowStep(1, 4, "Build host editor")
 	if err := runEngineBuildWorkflow(runner, engineBuildConfig{target: "editor"}); err != nil {
 		return err
 	}
 
-	printWorkflowStep(3, 4, "Build host runtime template and export pack")
+	printWorkflowStep(2, 4, "Build host runtime template and export pack")
 	if err := buildHostRuntimeWorkflow(runner); err != nil {
 		return err
 	}
 
-	printWorkflowStep(4, 4, "Build web template and export assets")
+	printWorkflowStep(3, 4, "Build web template and export assets")
 	if err := buildWebWorkflow(workflowBuildWebConfig{mode: cfg.webMode, skipToolInstall: true}, runner); err != nil {
+		return err
+	}
+
+	printWorkflowStep(4, 4, "Install spx toolchain and web runtime")
+	if err := installTools(toolInstallConfig{web: true}, runner); err != nil {
 		return err
 	}
 

--- a/internal/cmd/buildctl/workflow/cmd_test.go
+++ b/internal/cmd/buildctl/workflow/cmd_test.go
@@ -345,6 +345,17 @@ func assertWorkflowRuntimeWorkspaceCommands(t *testing.T, got []recordedCommand,
 		t.Fatalf("unexpected commands: %#v", got)
 	}
 	for i := range want {
+		if want[i].name == "spx" {
+			projectDir, spxArgs, ok := simulatedSPXInvocation(got[i].dir, got[i].name, got[i].args...)
+			if !ok || !reflect.DeepEqual(want[i].args, spxArgs) {
+				t.Fatalf("unexpected command[%d]: %#v", i, got[i])
+			}
+			prefix := filepath.Join(repoRoot, ".tmp", "runtime-")
+			if !strings.HasPrefix(projectDir, prefix) {
+				t.Fatalf("unexpected runtime workspace dir[%d]: %s", i, projectDir)
+			}
+			continue
+		}
 		if want[i].name != got[i].name || !reflect.DeepEqual(want[i].args, got[i].args) {
 			t.Fatalf("unexpected command[%d]: %#v", i, got[i])
 		}

--- a/internal/cmd/buildctl/workflow/test_helpers_test.go
+++ b/internal/cmd/buildctl/workflow/test_helpers_test.go
@@ -82,19 +82,20 @@ func newRuntimeFixtureRunner(t *testing.T) *recordingRunner {
 }
 
 func simulateRuntimeCommandOutputs(workdir string, name string, args ...string) error {
-	if name != "spx" || len(args) == 0 {
+	projectDir, spxArgs, ok := simulatedSPXInvocation(workdir, name, args...)
+	if !ok || len(spxArgs) == 0 {
 		return nil
 	}
 
-	switch args[0] {
+	switch spxArgs[0] {
 	case "export":
-		dst := filepath.Join(workdir, "project", ".builds", "pc", "gdexport.pck")
+		dst := filepath.Join(projectDir, "project", ".builds", "pc", "gdexport.pck")
 		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
 			return err
 		}
 		return os.WriteFile(dst, []byte("runtime-pack"), 0o644)
 	case "exporttemplateweb":
-		dstDir := filepath.Join(workdir, "project", ".builds", "webi")
+		dstDir := filepath.Join(projectDir, "project", ".builds", "webi")
 		if err := os.MkdirAll(dstDir, 0o755); err != nil {
 			return err
 		}
@@ -103,16 +104,39 @@ func simulateRuntimeCommandOutputs(workdir string, name string, args ...string) 
 		}
 		return os.WriteFile(filepath.Join(dstDir, "engine.js"), []byte("console.log('engine');\n"), 0o644)
 	case "exportweb", "exportwebworker", "exportminigame", "exportminiprogram":
-		dstDir := filepath.Join(workdir, "project", ".builds", "web", "subdir")
+		dstDir := filepath.Join(projectDir, "project", ".builds", "web", "subdir")
 		if err := os.MkdirAll(dstDir, 0o755); err != nil {
 			return err
 		}
-		if err := os.WriteFile(filepath.Join(workdir, "project", ".builds", "web", "index.html"), []byte("<html></html>"), 0o644); err != nil {
+		if err := os.WriteFile(filepath.Join(projectDir, "project", ".builds", "web", "index.html"), []byte("<html></html>"), 0o644); err != nil {
 			return err
 		}
 		return os.WriteFile(filepath.Join(dstDir, "game.js"), []byte("console.log('game');\n"), 0o644)
 	default:
 		return nil
+	}
+}
+
+func simulatedSPXInvocation(workdir string, name string, args ...string) (string, []string, bool) {
+	switch name {
+	case "spx":
+		return workdir, append([]string(nil), args...), len(args) > 0
+	case "go":
+		if len(args) < 4 || args[0] != "run" || args[1] != "./cmd/spx" {
+			return "", nil, false
+		}
+		spxArgs := append([]string(nil), args[2:]...)
+		projectDir := workdir
+		for i := 0; i+1 < len(spxArgs); i++ {
+			if spxArgs[i] == "--path" {
+				projectDir = spxArgs[i+1]
+				spxArgs = append(spxArgs[:i], spxArgs[i+2:]...)
+				break
+			}
+		}
+		return projectDir, spxArgs, len(spxArgs) > 0
+	default:
+		return "", nil, false
 	}
 }
 


### PR DESCRIPTION
## Summary

- move the `build-dev` install step to the end of the workflow so the final installed `spx` is rebuilt from the latest artifacts
- run runtime export commands from the current repo via `go run ./cmd/spx --path ...` instead of depending on an already-installed `spx` binary
- update buildctl runtime/workflow tests to cover the repo-driven `spx` invocation path

## Why

`build-dev` previously installed `spx` before the host and web export assets were rebuilt. That could leave the final binary in `GOPATH/bin` behind the freshly built runtime/template outputs.

## Testing

- `go test ./internal/cmd/buildctl/runtimecmd ./internal/cmd/buildctl/workflow ./internal/cmd/buildctl`