### PR TITLE
fix(ci): bootstrap runtime assets before release builds

### DIFF
--- a/.github/actions/prepare-standalone-release/action.yml
+++ b/.github/actions/prepare-standalone-release/action.yml
@@ -45,8 +45,8 @@ runs:
         cat "$FILE"
         log_success "Updated $FILE with version $VERSION"
 
-        log_info "Reinstalling spx with default embedded runtime assets"
-        "$BUILDCTL" tool install
+        log_info "Preparing runtime assets and reinstalling spx"
+        "$BUILDCTL" prepare --setup-mode runtime
 
         GOEXE="$(go_env_goexe)"
         SPX_BIN_PATH="$(go_env_spx_path "$GOEXE")"

--- a/.github/workflows/release_runtime_assets.yml
+++ b/.github/workflows/release_runtime_assets.yml
@@ -30,7 +30,11 @@ jobs:
       - name: Set up toolchain and engine assets
         uses: ./.github/actions/deps
         with:
-          setup-mode: runtime
+          setup-mode: none
+
+      - name: Prepare host export assets
+        run: |
+          "$BUILDCTL" engine download --runtime --skip-runtime-pack
 
       - name: Build runtime asset bundle
         id: build_runtime_assets

--- a/internal/cmd/buildctl/engine/api.go
+++ b/internal/cmd/buildctl/engine/api.go
@@ -19,9 +19,10 @@ package engine
 import "net/http"
 
 type DownloadConfig struct {
-	Runtime  bool
-	Platform string
-	Mode     string
+	Runtime         bool
+	SkipRuntimePack bool
+	Platform        string
+	Mode            string
 }
 
 type DownloadEnv struct {
@@ -62,7 +63,7 @@ func Run(args []string) error {
 
 func ParseEngineDownloadArgs(args []string) (DownloadConfig, error) {
 	cfg, err := parseEngineDownloadArgs(args)
-	return DownloadConfig{Runtime: cfg.runtime, Platform: cfg.platform, Mode: cfg.mode}, err
+	return DownloadConfig{Runtime: cfg.runtime, SkipRuntimePack: cfg.skipRuntimePack, Platform: cfg.platform, Mode: cfg.mode}, err
 }
 
 func ParseEngineBuildArgs(args []string) (BuildConfig, error) {
@@ -89,7 +90,7 @@ func (plan BuildShellPlan) ShellExports() string {
 }
 
 func DownloadEngineAssets(cfg DownloadConfig, repoRoot string) error {
-	return downloadEngineAssets(engineDownloadConfig{runtime: cfg.Runtime, platform: cfg.Platform, mode: cfg.Mode}, repoRoot)
+	return downloadEngineAssets(engineDownloadConfig{runtime: cfg.Runtime, skipRuntimePack: cfg.SkipRuntimePack, platform: cfg.Platform, mode: cfg.Mode}, repoRoot)
 }
 
 func BuildEngine(cfg BuildConfig, repoRoot string) error {

--- a/internal/cmd/buildctl/engine/cmd.go
+++ b/internal/cmd/buildctl/engine/cmd.go
@@ -23,9 +23,10 @@ import (
 )
 
 type engineDownloadConfig struct {
-	runtime  bool
-	platform string
-	mode     string
+	runtime         bool
+	skipRuntimePack bool
+	platform        string
+	mode            string
 }
 
 type engineBuildConfig struct {
@@ -88,10 +89,11 @@ func parseEngineDownloadArgs(args []string) (engineDownloadConfig, error) {
 	fs := flag.NewFlagSet("engine download", flag.ContinueOnError)
 	fs.SetOutput(osStderr)
 	fs.BoolVar(&cfg.runtime, "runtime", false, "download runtime assets for the current host platform")
+	fs.BoolVar(&cfg.skipRuntimePack, "skip-runtime-pack", false, "skip downloading the published runtime asset bundle")
 	fs.StringVar(&cfg.platform, "platform", "", "download templates for android, ios, web, linux, windows, or macos")
 	fs.StringVar(&cfg.mode, "mode", "", "web mode: normal, worker, minigame, or miniprogram")
 	fs.Usage = func() {
-		fmt.Fprintln(osStderr, "Usage: buildctl engine download [--runtime] [--platform android|ios|web|linux|windows|macos] [--mode normal|worker|minigame|miniprogram]")
+		fmt.Fprintln(osStderr, "Usage: buildctl engine download [--runtime] [--skip-runtime-pack] [--platform android|ios|web|linux|windows|macos] [--mode normal|worker|minigame|miniprogram]")
 	}
 
 	if err := fs.Parse(args); err != nil {
@@ -108,6 +110,9 @@ func parseEngineDownloadArgs(args []string) (engineDownloadConfig, error) {
 }
 
 func (cfg *engineDownloadConfig) validate() error {
+	if cfg.skipRuntimePack && !cfg.runtime {
+		return errors.New("--skip-runtime-pack requires --runtime")
+	}
 	if cfg.runtime && cfg.platform != "" {
 		return errors.New("--runtime cannot be combined with --platform")
 	}

--- a/internal/cmd/buildctl/engine/cmd_test.go
+++ b/internal/cmd/buildctl/engine/cmd_test.go
@@ -43,6 +43,26 @@ func TestParseEngineDownloadArgsDefault(t *testing.T) {
 	}
 }
 
+func TestParseEngineDownloadArgsRuntimeSkipsPack(t *testing.T) {
+	cfg, err := parseEngineDownloadArgs([]string{"--runtime", "--skip-runtime-pack"})
+	if err != nil {
+		t.Fatalf("parseEngineDownloadArgs returned error: %v", err)
+	}
+
+	if !cfg.runtime {
+		t.Fatal("runtime should be true")
+	}
+	if !cfg.skipRuntimePack {
+		t.Fatal("skipRuntimePack should be true")
+	}
+}
+
+func TestParseEngineDownloadArgsRejectsSkipPackWithoutRuntime(t *testing.T) {
+	if _, err := parseEngineDownloadArgs([]string{"--skip-runtime-pack"}); err == nil {
+		t.Fatal("expected --skip-runtime-pack without --runtime to fail")
+	}
+}
+
 func TestParseEngineDownloadArgsWebDefaultMode(t *testing.T) {
 	cfg, err := parseEngineDownloadArgs([]string{"--platform", "web"})
 	if err != nil {
@@ -86,6 +106,36 @@ func TestDownloadEngineAssetsRuntime(t *testing.T) {
 	}
 	if !fileExists(filepath.Join(runner.repoRoot, "templates", "linux_release.x86_64")) {
 		t.Fatalf("expected linux template fanout to exist")
+	}
+}
+
+func TestDownloadEngineAssetsRuntimeSkipsPack(t *testing.T) {
+	runner := newRuntimeFixtureRunner(t)
+	installFakeEngineDownload(t, runner.repoRoot, "linux", "x86_64")
+	version := mustDefaultRuntimeVersion(t)
+
+	oldFetcher := EngineDownloadFetcher
+	EngineDownloadFetcher = func(url, dst string) error {
+		if filepath.Base(url) == release.RuntimeAssetZipName {
+			return errors.New("runtime pack should not be downloaded")
+		}
+		return oldFetcher(url, dst)
+	}
+	t.Cleanup(func() { EngineDownloadFetcher = oldFetcher })
+
+	if err := downloadEngineAssets(engineDownloadConfig{runtime: true, skipRuntimePack: true}, runner.repoRoot); err != nil {
+		t.Fatalf("downloadEngineAssets returned error: %v", err)
+	}
+
+	gopathBin := filepath.Join(os.Getenv("GOPATH"), "bin")
+	if !fileExists(filepath.Join(gopathBin, "gdspx"+version)) {
+		t.Fatalf("expected host editor binary to exist")
+	}
+	if !fileExists(filepath.Join(gopathBin, "gdspxrt"+version)) {
+		t.Fatalf("expected host template binary to exist")
+	}
+	if fileExists(filepath.Join(gopathBin, "gdspxrt"+version+".pck")) {
+		t.Fatalf("expected runtime pck not to exist")
 	}
 }
 

--- a/internal/cmd/buildctl/engine/download.go
+++ b/internal/cmd/buildctl/engine/download.go
@@ -58,6 +58,9 @@ func downloadEngineAssets(cfg engineDownloadConfig, repoRoot string) error {
 		if err := downloadHostRuntimeAssets(env); err != nil {
 			return err
 		}
+		if cfg.skipRuntimePack {
+			return nil
+		}
 		if err := downloadRuntimePack(env); err != nil {
 			fmt.Fprintf(osStderr, "Warning: failed to download runtime asset bundle: %v\n", err)
 		}

--- a/internal/cmd/buildctl/prepare.go
+++ b/internal/cmd/buildctl/prepare.go
@@ -96,38 +96,61 @@ func prepareAssets(cfg prepareConfig, runner shared.ScriptRunner) error {
 	case "none":
 		return nil
 	case "runtime":
-		if err := runner.RunScript(filepath.Join("cmd", "spx", "install.sh")); err != nil {
+		if err := prepareRuntimeAssets(runner); err != nil {
 			return err
 		}
-		return prepareRuntimeAssets(runner)
+		return runner.RunScript(filepath.Join("cmd", "spx", "install.sh"))
 	case "web":
 		if err := prepareHostEditorAsset(runner.RepoRootDir()); err != nil {
 			return err
 		}
-		return prepareWebAssets(cfg.webMode, runner)
+		return prepareWebAssets(cfg.webMode, runner, false)
 	case "full":
 		if err := prepareRuntimeAssets(runner); err != nil {
 			return err
 		}
-		return prepareWebAssets(cfg.webMode, runner)
+		return prepareWebAssets(cfg.webMode, runner, true)
 	default:
 		return fmt.Errorf("unsupported setup-mode: %s", cfg.setupMode)
 	}
 }
 
 func prepareRuntimeAssets(runner shared.ScriptRunner) error {
-	return engine.DownloadEngineAssets(engine.DownloadConfig{Runtime: true}, runner.RepoRootDir())
+	if err := engine.DownloadEngineAssets(engine.DownloadConfig{Runtime: true, SkipRuntimePack: true}, runner.RepoRootDir()); err != nil {
+		return err
+	}
+	return ensureRuntimePack(runner)
+}
+
+func ensureRuntimePack(runner shared.ScriptRunner) error {
+	goPath, err := shared.EnsureGoPath()
+	if err != nil {
+		return err
+	}
+	version, err := shared.DefaultRuntimeVersion()
+	if err != nil {
+		return err
+	}
+	packPath := filepath.Join(goPath, "bin", fmt.Sprintf("gdspxrt%s.pck", version))
+	if !engine.ShouldRefreshPreparedAssets() && shared.FileExists(packPath) {
+		return nil
+	}
+	return runtimecmd.ExportPackRuntime(runner)
 }
 
 func prepareHostEditorAsset(repoRoot string) error {
 	return engine.PrepareHostEditorAsset(repoRoot)
 }
 
-func prepareWebAssets(webMode string, runner shared.ScriptRunner) error {
+func prepareWebAssets(webMode string, runner shared.ScriptRunner, embedRuntime bool) error {
 	if err := engine.DownloadEngineAssets(engine.DownloadConfig{Platform: "web", Mode: webMode}, runner.RepoRootDir()); err != nil {
 		return err
 	}
-	if err := runner.RunScript(filepath.Join("cmd", "spx", "install.sh"), "--web"); err != nil {
+	args := []string{"--web"}
+	if !embedRuntime {
+		args = append(args, "--no-embed-runtime")
+	}
+	if err := runner.RunScript(filepath.Join("cmd", "spx", "install.sh"), args...); err != nil {
 		return err
 	}
 	return runtimecmd.ExportWebTemplateRuntime(webMode, runner)

--- a/internal/cmd/buildctl/prepare_test.go
+++ b/internal/cmd/buildctl/prepare_test.go
@@ -208,8 +208,15 @@ func TestPrepareAssetsRuntime(t *testing.T) {
 		t.Fatalf("unexpected calls: %#v", runner.calls)
 	}
 
+	assertRuntimeWorkspaceCommands(t, runner.commands, runner.repoRoot, []recordedCommand{
+		{name: "spx", args: []string{"export"}},
+	})
+
 	if !shared.FileExists(filepath.Join(os.Getenv("GOPATH"), "bin", "gdspx"+version)) {
 		t.Fatalf("expected host editor binary to exist")
+	}
+	if !shared.FileExists(filepath.Join(os.Getenv("GOPATH"), "bin", "gdspxrt"+version+".pck")) {
+		t.Fatalf("expected runtime pck to exist")
 	}
 }
 
@@ -239,7 +246,7 @@ func TestPrepareAssetsWeb(t *testing.T) {
 		t.Fatalf("prepareAssets returned error: %v", err)
 	}
 
-	expectedCalls := []recordedCall{{script: "cmd/spx/install.sh", args: []string{"--web"}}}
+	expectedCalls := []recordedCall{{script: "cmd/spx/install.sh", args: []string{"--web", "--no-embed-runtime"}}}
 	if !reflect.DeepEqual(runner.calls, expectedCalls) {
 		t.Fatalf("unexpected calls: %#v", runner.calls)
 	}
@@ -275,6 +282,7 @@ func TestPrepareAssetsFull(t *testing.T) {
 	}
 
 	assertRuntimeWorkspaceCommands(t, runner.commands, runner.repoRoot, []recordedCommand{
+		{name: "spx", args: []string{"export"}},
 		{name: "spx", args: []string{"exporttemplateweb"}},
 	})
 }

--- a/internal/cmd/buildctl/runtimecmd/assets.go
+++ b/internal/cmd/buildctl/runtimecmd/assets.go
@@ -67,7 +67,7 @@ func exportPackRuntime(runner scriptRunner) error {
 }
 
 func exportWebRuntime(cfg runtimeExportWebConfig, runner scriptRunner) error {
-	if err := installTools(toolInstallConfig{web: true, opt: true}, runner); err != nil {
+	if err := installTools(toolInstallConfig{web: true, opt: true, noEmbedRuntime: true}, runner); err != nil {
 		return err
 	}
 

--- a/internal/cmd/buildctl/runtimecmd/cmd_test.go
+++ b/internal/cmd/buildctl/runtimecmd/cmd_test.go
@@ -50,7 +50,7 @@ func TestRuntimeBuildWasmSequence(t *testing.T) {
 	}
 
 	expected := []recordedCall{
-		{script: "cmd/spx/install.sh", args: []string{"--web"}},
+		{script: "cmd/spx/install.sh", args: []string{"--web", "--no-embed-runtime"}},
 	}
 	if !reflect.DeepEqual(runner.calls, expected) {
 		t.Fatalf("unexpected calls: %#v", runner.calls)
@@ -70,7 +70,7 @@ func TestRuntimeBuildWasmOptSequence(t *testing.T) {
 	}
 
 	expected := []recordedCall{
-		{script: "cmd/spx/install.sh", args: []string{"--web", "--opt"}},
+		{script: "cmd/spx/install.sh", args: []string{"--web", "--opt", "--no-embed-runtime"}},
 	}
 	if !reflect.DeepEqual(runner.calls, expected) {
 		t.Fatalf("unexpected calls: %#v", runner.calls)
@@ -102,7 +102,7 @@ func TestRuntimeExportWebSequence(t *testing.T) {
 	}
 
 	expectedCalls := []recordedCall{
-		{script: "cmd/spx/install.sh", args: []string{"--web", "--opt"}},
+		{script: "cmd/spx/install.sh", args: []string{"--web", "--opt", "--no-embed-runtime"}},
 	}
 	if !reflect.DeepEqual(runner.calls, expectedCalls) {
 		t.Fatalf("unexpected calls: %#v", runner.calls)

--- a/internal/cmd/buildctl/runtimecmd/common.go
+++ b/internal/cmd/buildctl/runtimecmd/common.go
@@ -82,12 +82,13 @@ func zipDirectory(srcDir, dstZip string) error {
 }
 
 type toolInstallConfig struct {
-	web bool
-	opt bool
+	web            bool
+	opt            bool
+	noEmbedRuntime bool
 }
 
 func installTools(cfg toolInstallConfig, runner scriptRunner) error {
-	return toolpkg.InstallTools(toolpkg.InstallConfig{Web: cfg.web, Opt: cfg.opt}, runnerAdapter{inner: runner})
+	return toolpkg.InstallTools(toolpkg.InstallConfig{Web: cfg.web, Opt: cfg.opt, NoEmbedRuntime: cfg.noEmbedRuntime}, runnerAdapter{inner: runner})
 }
 
 type runnerAdapter struct {
@@ -107,7 +108,7 @@ func (a runnerAdapter) RepoRootDir() string {
 }
 
 func buildWasmRuntime(cfg runtimeBuildWasmConfig, runner scriptRunner) error {
-	if err := installTools(toolInstallConfig{web: true, opt: cfg.opt}, runner); err != nil {
+	if err := installTools(toolInstallConfig{web: true, opt: cfg.opt, noEmbedRuntime: true}, runner); err != nil {
 		return err
 	}
 	if !cfg.opt {

--- a/internal/cmd/buildctl/shared/runner.go
+++ b/internal/cmd/buildctl/shared/runner.go
@@ -121,7 +121,11 @@ func buildctlCommandEnv() (map[string]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	env["PATH"] = prependToPath(env["PATH"], filepath.Join(goPath, "bin"))
+	pathDirs := []string{filepath.Join(goPath, "bin")}
+	if goRoot := runtime.GOROOT(); goRoot != "" {
+		pathDirs = append(pathDirs, filepath.Join(goRoot, "bin"))
+	}
+	setPathEnv(env, prependToPath(pathEnvValue(env), pathDirs...))
 	return env, nil
 }
 
@@ -129,19 +133,19 @@ func resolveCommandPath(name string, env map[string]string) (string, error) {
 	if filepath.IsAbs(name) || strings.ContainsRune(name, filepath.Separator) {
 		return name, nil
 	}
-	for _, dir := range filepath.SplitList(env["PATH"]) {
+	for _, dir := range filepath.SplitList(pathEnvValue(env)) {
 		if dir == "" {
 			continue
 		}
 		candidate := filepath.Join(dir, name)
 		info, err := os.Stat(candidate)
-		if err == nil && !info.IsDir() && info.Mode()&0o111 != 0 {
+		if err == nil && isCommandFile(info) {
 			return candidate, nil
 		}
 		for _, ext := range executableExtensions(env) {
 			candidateWithExt := candidate + ext
 			info, err := os.Stat(candidateWithExt)
-			if err == nil && !info.IsDir() && info.Mode()&0o111 != 0 {
+			if err == nil && isCommandFile(info) {
 				return candidateWithExt, nil
 			}
 		}
@@ -149,11 +153,25 @@ func resolveCommandPath(name string, env map[string]string) (string, error) {
 	return "", fmt.Errorf("%s not found in PATH", name)
 }
 
+func isCommandFile(info os.FileInfo) bool {
+	return isCommandFileForOS(info, runtime.GOOS)
+}
+
+func isCommandFileForOS(info os.FileInfo, goos string) bool {
+	if info.IsDir() {
+		return false
+	}
+	if goos == "windows" {
+		return true
+	}
+	return info.Mode()&0o111 != 0
+}
+
 func executableExtensions(env map[string]string) []string {
 	if runtime.GOOS != "windows" {
 		return nil
 	}
-	pathExt := env["PATHEXT"]
+	pathExt := envValue(env, "PATHEXT")
 	if pathExt == "" {
 		return []string{".com", ".exe", ".bat", ".cmd"}
 	}
@@ -172,6 +190,33 @@ func executableExtensions(env map[string]string) []string {
 		return []string{".com", ".exe", ".bat", ".cmd"}
 	}
 	return exts
+}
+
+func pathEnvValue(env map[string]string) string {
+	return envValue(env, "PATH")
+}
+
+func envValue(env map[string]string, key string) string {
+	if value, ok := env[key]; ok {
+		return value
+	}
+	for envKey, value := range env {
+		if strings.EqualFold(envKey, key) {
+			return value
+		}
+	}
+	return ""
+}
+
+func setPathEnv(env map[string]string, value string) {
+	if runtime.GOOS == "windows" {
+		for key := range env {
+			if key != "PATH" && strings.EqualFold(key, "PATH") {
+				delete(env, key)
+			}
+		}
+	}
+	env["PATH"] = value
 }
 
 func currentEnvMap() map[string]string {

--- a/internal/cmd/buildctl/shared/runner_test.go
+++ b/internal/cmd/buildctl/shared/runner_test.go
@@ -19,6 +19,7 @@ package shared
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -48,6 +49,71 @@ func TestCommandRunnerRunCommandUsesGoPathBin(t *testing.T) {
 
 	if !fileExists(outPath) {
 		t.Fatalf("expected fake command output at %s", outPath)
+	}
+}
+
+func TestBuildctlCommandEnvPrependsGoBinDirs(t *testing.T) {
+	root := t.TempDir()
+	gopath := filepath.Join(root, "gopath")
+	t.Setenv("GOPATH", gopath)
+
+	env, err := buildctlCommandEnv()
+	if err != nil {
+		t.Fatalf("buildctlCommandEnv returned error: %v", err)
+	}
+
+	pathDirs := filepath.SplitList(pathEnvValue(env))
+	wantDirs := []string{filepath.Join(gopath, "bin")}
+	if goRoot := runtime.GOROOT(); goRoot != "" {
+		wantDirs = append(wantDirs, filepath.Join(goRoot, "bin"))
+	}
+	if len(pathDirs) < len(wantDirs) {
+		t.Fatalf("PATH dirs = %v, want prefix %v", pathDirs, wantDirs)
+	}
+	for i, want := range wantDirs {
+		if pathDirs[i] != want {
+			t.Fatalf("PATH dirs = %v, want prefix %v", pathDirs, wantDirs)
+		}
+	}
+}
+
+func TestResolveCommandPathUsesCaseInsensitivePathFallback(t *testing.T) {
+	root := t.TempDir()
+	binDir := filepath.Join(root, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll returned error: %v", err)
+	}
+
+	cmdPath := filepath.Join(binDir, "fakecmd")
+	if err := os.WriteFile(cmdPath, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+
+	got, err := resolveCommandPath("fakecmd", map[string]string{"Path": binDir})
+	if err != nil {
+		t.Fatalf("resolveCommandPath returned error: %v", err)
+	}
+	if got != cmdPath {
+		t.Fatalf("resolveCommandPath = %q, want %q", got, cmdPath)
+	}
+}
+
+func TestIsCommandFileForOSAllowsWindowsFilesWithoutUnixExecBit(t *testing.T) {
+	root := t.TempDir()
+	cmdPath := filepath.Join(root, "fakecmd.exe")
+	if err := os.WriteFile(cmdPath, []byte("fake"), 0o644); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+	info, err := os.Stat(cmdPath)
+	if err != nil {
+		t.Fatalf("Stat returned error: %v", err)
+	}
+
+	if !isCommandFileForOS(info, "windows") {
+		t.Fatal("expected regular Windows command file to be accepted without Unix exec bit")
+	}
+	if isCommandFileForOS(info, "linux") {
+		t.Fatal("expected non-executable Unix command file to be rejected")
 	}
 }
 

--- a/internal/cmd/buildctl/tool/api.go
+++ b/internal/cmd/buildctl/tool/api.go
@@ -19,8 +19,9 @@ package tool
 import "github.com/goplus/spx/v2/internal/cmd/buildctl/shared"
 
 type InstallConfig struct {
-	Web bool
-	Opt bool
+	Web            bool
+	Opt            bool
+	NoEmbedRuntime bool
 }
 
 type SetupNDKConfig struct {
@@ -57,7 +58,7 @@ func ParseToolCleanAssetsArgs(args []string) error {
 
 func ParseToolInstallArgs(args []string) (InstallConfig, error) {
 	cfg, err := parseToolInstallArgs(args)
-	return InstallConfig{Web: cfg.web, Opt: cfg.opt}, err
+	return InstallConfig{Web: cfg.web, Opt: cfg.opt, NoEmbedRuntime: cfg.noEmbedRuntime}, err
 }
 
 func ParseToolSetupNDKArgs(args []string) (SetupNDKConfig, error) {
@@ -85,7 +86,7 @@ func ParseToolSetupEMSDKArgs(args []string) (SetupEMSDKConfig, error) {
 }
 
 func InstallTools(cfg InstallConfig, runner shared.ScriptRunner) error {
-	return installTools(toolInstallConfig{web: cfg.Web, opt: cfg.Opt}, scriptRunnerAdapter{inner: runner})
+	return installTools(toolInstallConfig{web: cfg.Web, opt: cfg.Opt, noEmbedRuntime: cfg.NoEmbedRuntime}, scriptRunnerAdapter{inner: runner})
 }
 
 func CleanInstalledAssets() error {

--- a/internal/cmd/buildctl/workflow/cmd_test.go
+++ b/internal/cmd/buildctl/workflow/cmd_test.go
@@ -289,7 +289,7 @@ func TestRunDemoWorkflowWebWorker(t *testing.T) {
 	}
 
 	expectedScripts := []recordedCall{
-		{script: "cmd/spx/install.sh", args: []string{"--web"}},
+		{script: "cmd/spx/install.sh", args: []string{"--web", "--no-embed-runtime"}},
 	}
 	if !reflect.DeepEqual(runner.calls, expectedScripts) {
 		t.Fatalf("unexpected script calls: %#v", runner.calls)
@@ -322,7 +322,7 @@ func TestRunDemoWorkflowWeb(t *testing.T) {
 	}
 
 	expectedScripts := []recordedCall{
-		{script: "cmd/spx/install.sh", args: []string{"--web"}},
+		{script: "cmd/spx/install.sh", args: []string{"--web", "--no-embed-runtime"}},
 	}
 	if !reflect.DeepEqual(runner.calls, expectedScripts) {
 		t.Fatalf("unexpected script calls: %#v", runner.calls)

--- a/internal/release/release_meta.go
+++ b/internal/release/release_meta.go
@@ -52,6 +52,7 @@ type releaseVersionMapping struct {
 var releaseVersionMappings = []releaseVersionMapping{
 	{"v2.0.0", "2.2.0"},
 	{"v2.0.1", "2.2.1"},
+	{"v2.0.2", "2.2.2"},
 }
 
 func newReleaseMeta(mapping releaseVersionMapping) ReleaseMeta {

--- a/internal/release/release_meta_test.go
+++ b/internal/release/release_meta_test.go
@@ -40,14 +40,14 @@ func TestReleaseMetaForRuntimeVersionMapped(t *testing.T) {
 
 func TestDefaultReleaseMetaUsesLatestSPXVersionForRuntimeAssets(t *testing.T) {
 	meta := DefaultReleaseMeta()
-	if meta.SPXVersion != "v2.0.1" {
-		t.Fatalf("spx version = %q, want %q", meta.SPXVersion, "v2.0.1")
+	if meta.SPXVersion != "v2.0.2" {
+		t.Fatalf("spx version = %q, want %q", meta.SPXVersion, "v2.0.2")
 	}
-	if meta.Runtime.Version != "2.2.1" {
-		t.Fatalf("runtime version = %q, want %q", meta.Runtime.Version, "2.2.1")
+	if meta.Runtime.Version != "2.2.2" {
+		t.Fatalf("runtime version = %q, want %q", meta.Runtime.Version, "2.2.2")
 	}
-	if got := meta.RuntimeAssetDownloadURL(RuntimeAssetZipName); got != SpxReleaseURLBase+"v2.0.1/"+RuntimeAssetZipName {
-		t.Fatalf("runtime asset download url = %q, want %q", got, SpxReleaseURLBase+"v2.0.1/"+RuntimeAssetZipName)
+	if got := meta.RuntimeAssetDownloadURL(RuntimeAssetZipName); got != SpxReleaseURLBase+"v2.0.2/"+RuntimeAssetZipName {
+		t.Fatalf("runtime asset download url = %q, want %q", got, SpxReleaseURLBase+"v2.0.2/"+RuntimeAssetZipName)
 	}
 }
 


### PR DESCRIPTION
## Summary

- avoid downloading the runtime asset bundle before it is built for a new SPX/runtime release
- add `--skip-runtime-pack` for `buildctl engine download --runtime`
- make `buildctl prepare` bootstrap the local runtime pack before running `install.sh`
- update runtime asset and standalone release workflows to use the bootstrap flow
- fix YAML quoting for the runtime asset prepare command

## Testing

- `go test ./internal/cmd/buildctl`
- `go test ./internal/cmd/buildctl/engine ./internal/cmd/buildctl/runtimecmd`
- `go test ./internal/cmd/buildctl/...`
- verified release workflow/action YAML parses successfully