### PR TITLE
refactor(font): use explicit svg font face registration

### DIFF
--- a/game_build.go
+++ b/game_build.go
@@ -28,18 +28,6 @@ import (
 	spxlog "github.com/goplus/spx/v2/internal/log"
 )
 
-const defaultEngineFontPath = "res://engine/fonts/CnFont.ttf"
-
-var scratchSVGFontRegistrations = []string{
-	"res://engine/fonts/scratch/NotoSans-Medium.ttf#spx-family=Sans Serif&spx-register-only=1",
-	"res://engine/fonts/scratch/SourceSerifPro-Regular.otf#spx-family=Serif&spx-register-only=1",
-	"res://engine/fonts/scratch/handlee-regular.ttf#spx-family=Handwriting&spx-register-only=1",
-	"res://engine/fonts/scratch/Knewave.ttf#spx-family=Marker&spx-register-only=1",
-	"res://engine/fonts/scratch/Griffy-Regular.ttf#spx-family=Curly&spx-register-only=1",
-	"res://engine/fonts/scratch/Grand9K-Pixel.ttf#spx-family=Pixel&spx-register-only=1",
-	"res://engine/fonts/scratch/Scratch.ttf#spx-family=Scratch&spx-register-only=1",
-}
-
 type gameBuilder struct {
 	gamer    Gamer
 	resource any
@@ -89,10 +77,8 @@ func (b *gameBuilder) loadResources() *gameBuilder {
 	b.proj = opened.Project
 
 	resMgr := b.game.engine().ResMgr
-	resMgr.SetDefaultFont(defaultEngineFontPath)
-	for _, fontPath := range scratchSVGFontRegistrations {
-		resMgr.SetDefaultFont(fontPath)
-	}
+	display := coreproject.ResolveDisplaySettings(&b.proj)
+	coreproject.RegisterDisplayFonts(display, resMgr.SetDefaultFont, resMgr.RegisterSvgFontFace)
 	return b
 }
 

--- a/internal/cmd/codegen/generate/webffi/gdspx.js.tmpl
+++ b/internal/cmd/codegen/generate/webffi/gdspx.js.tmpl
@@ -7,114 +7,6 @@
 //   code.
 //----------------------------------------------------------------------------*/
 {{ $view := . -}}
-const SPX_DEFAULT_FONT_RESOURCE_PATH = "res://engine/fonts/CnFont.ttf";
-const SPX_SCRATCH_FONT_RESOURCE_ROOT = "res://engine/fonts/scratch/";
-const SPX_SCRATCH_PACKAGED_FONT_DEFS = [
-	{ family: "Sans Serif", path: SPX_SCRATCH_FONT_RESOURCE_ROOT + "NotoSans-Medium.ttf" },
-	{ family: "Serif", path: SPX_SCRATCH_FONT_RESOURCE_ROOT + "SourceSerifPro-Regular.otf" },
-	{ family: "Handwriting", path: SPX_SCRATCH_FONT_RESOURCE_ROOT + "handlee-regular.ttf" },
-	{ family: "Marker", path: SPX_SCRATCH_FONT_RESOURCE_ROOT + "Knewave.ttf" },
-	{ family: "Curly", path: SPX_SCRATCH_FONT_RESOURCE_ROOT + "Griffy-Regular.ttf" },
-	{ family: "Pixel", path: SPX_SCRATCH_FONT_RESOURCE_ROOT + "Grand9K-Pixel.ttf" },
-	{ family: "Scratch", path: SPX_SCRATCH_FONT_RESOURCE_ROOT + "Scratch.ttf" },
-];
-const SPX_SCRATCH_CJK_FONT_STACKS = [
-	{ label: "中文", stack: '"Microsoft YaHei", "微软雅黑", STXihei, "华文细黑"' },
-	{ label: "日本語", stack: '"ヒラギノ角ゴ Pro W3", "Hiragino Kaku Gothic Pro", Osaka, "メイリオ", Meiryo, "ＭＳ Ｐゴシック", "MS PGothic"' },
-	{ label: "한국어", stack: "Malgun Gothic" },
-];
-const SPX_SCRATCH_FONT_FACE_STATE = globalThis.__spxScratchFontFaceState || (globalThis.__spxScratchFontFaceState = {
-	registered: false,
-	moduleRef: null,
-});
-
-function spxNormalizeFontRequestName(value) {
-	return String(value || "")
-		.toLowerCase()
-		.replace(/["',]/g, "")
-		.replace(/[\s_-]+/g, "")
-		.trim();
-}
-
-const SPX_SCRATCH_FONT_ALIAS_MAP = (function () {
-	var _map = Object.create(null);
-	function _registerAlias(alias, resolvedPath, svgFamily) {
-		var _key = spxNormalizeFontRequestName(alias);
-		if (_key === "") {
-			return;
-		}
-		_map[_key] = {
-			resolvedPath: resolvedPath,
-			svgFamily: svgFamily || "",
-		};
-	}
-
-	for (var _i = 0; _i < SPX_SCRATCH_PACKAGED_FONT_DEFS.length; _i++) {
-		var _fontDef = SPX_SCRATCH_PACKAGED_FONT_DEFS[_i];
-		_registerAlias(_fontDef.family, _fontDef.path, _fontDef.family);
-		_registerAlias(_fontDef.path, _fontDef.path, _fontDef.family);
-	}
-
-	for (var _j = 0; _j < SPX_SCRATCH_CJK_FONT_STACKS.length; _j++) {
-		var _cjkDef = SPX_SCRATCH_CJK_FONT_STACKS[_j];
-		_registerAlias(_cjkDef.label, SPX_DEFAULT_FONT_RESOURCE_PATH, "");
-		_registerAlias(_cjkDef.stack, SPX_DEFAULT_FONT_RESOURCE_PATH, "");
-	}
-
-	return _map;
-})();
-
-function spxBuildManagedFontPath(fontPath, options) {
-	var _metadata = [];
-	if (options != null && options.family) {
-		_metadata.push("spx-family=" + String(options.family));
-	}
-	if (options != null && options.registerOnly) {
-		_metadata.push("spx-register-only=1");
-	}
-	if (_metadata.length === 0) {
-		return String(fontPath || "");
-	}
-	return String(fontPath || "") + "#" + _metadata.join("&");
-}
-
-function spxResolveFontRequest(fontPath) {
-	var _requestedPath = String(fontPath || "");
-	var _aliasKey = spxNormalizeFontRequestName(_requestedPath);
-	var _matched = _aliasKey === "" ? null : SPX_SCRATCH_FONT_ALIAS_MAP[_aliasKey];
-	if (_matched != null) {
-		return {
-			requestedPath: _requestedPath,
-			resolvedPath: _matched.resolvedPath,
-			svgFamily: _matched.svgFamily,
-		};
-	}
-	return {
-		requestedPath: _requestedPath,
-		resolvedPath: _requestedPath,
-		svgFamily: "",
-	};
-}
-
-function spxEnsureScratchFontFacesRegistered(runtimeModule, registerFontFace) {
-	var _state = SPX_SCRATCH_FONT_FACE_STATE;
-	if (_state.moduleRef !== runtimeModule) {
-		_state.registered = false;
-		_state.moduleRef = runtimeModule;
-	}
-	if (_state.registered || typeof registerFontFace !== "function") {
-		return;
-	}
-	for (var _i = 0; _i < SPX_SCRATCH_PACKAGED_FONT_DEFS.length; _i++) {
-		var _fontDef = SPX_SCRATCH_PACKAGED_FONT_DEFS[_i];
-		registerFontFace(spxBuildManagedFontPath(_fontDef.path, {
-			family: _fontDef.family,
-			registerOnly: true,
-		}));
-	}
-	_state.registered = true;
-}
-
 class GdspxFuncs {
 constructor() {
 	this._inputMousePosScratch = null;
@@ -155,12 +47,6 @@ _readGdIntLike(ptr, scratch) {
 	return scratch;
 }
 
-_invokeResSetDefaultFont(gdFuncPtr, fontPath) {
-	var _arg0 = ToGdString(fontPath);
-	gdFuncPtr(_arg0);
-	FreeGdString(_arg0);
-}
-
 {{- range $i, $f := $view.CollectGDExtensionInterfaceFunctions -}}
 {{ $rt := goReturnType .ReturnType }}
 gd{{ loadProcAddressName $f.Name }}(
@@ -171,18 +57,7 @@ gd{{ loadProcAddressName $f.Name }}(
 	{{ end -}}
 ) {
 	var _gdFuncPtr = Module._gd{{ loadProcAddressName $f.Name }}; 
-	{{- if eq (loadProcAddressName $f.Name) "spx_res_set_default_font" }}
-	var _module = Module;
-	var _fontRequest = spxResolveFontRequest(font_path);
-	spxEnsureScratchFontFacesRegistered(_module, function (managedFontPath) {
-		this._invokeResSetDefaultFont(_gdFuncPtr, managedFontPath);
-	}.bind(this));
-	this._invokeResSetDefaultFont(_gdFuncPtr, spxBuildManagedFontPath(_fontRequest.resolvedPath, {
-		family: _fontRequest.svgFamily,
-	}));
-	{{- else }}
 	{{ getJsFuncBody $f }}
-	{{- end }}
 }
 {{- end -}}
 }

--- a/internal/cmd/codegen/generate/webffi/generate_test.go
+++ b/internal/cmd/codegen/generate/webffi/generate_test.go
@@ -170,23 +170,14 @@ func TestGetJsFuncBodyUsesInstanceScratchForMousePos(t *testing.T) {
 	require.NotContains(t, body, "GdspxFuncs._inputMousePosScratch")
 }
 
-func TestJsTemplateDeclaresScratchFontCompatibilityMap(t *testing.T) {
-	require.Contains(t, jsEngineJsFileText, `const SPX_SCRATCH_PACKAGED_FONT_DEFS = [`)
-	require.Contains(t, jsEngineJsFileText, `SPX_SCRATCH_FONT_RESOURCE_ROOT + "Knewave.ttf"`)
-	require.Contains(t, jsEngineJsFileText, `SPX_SCRATCH_FONT_RESOURCE_ROOT + "Scratch.ttf"`)
-	require.Contains(t, jsEngineJsFileText, `const SPX_SCRATCH_CJK_FONT_STACKS = [`)
-}
-
-func TestJsTemplatePreloadsScratchSvgFontFaces(t *testing.T) {
-	require.Contains(t, jsEngineJsFileText, "function spxEnsureScratchFontFacesRegistered(runtimeModule, registerFontFace)")
-	require.Contains(t, jsEngineJsFileText, `registerOnly: true,`)
-	require.Contains(t, jsEngineJsFileText, `spx-family=`)
-}
-
-func TestJsTemplateUsesPackagedDefaultFontForScratchCjkAliases(t *testing.T) {
-	require.Contains(t, jsEngineJsFileText, "var _fontRequest = spxResolveFontRequest(font_path);")
-	require.Contains(t, jsEngineJsFileText, `_registerAlias(_cjkDef.label, SPX_DEFAULT_FONT_RESOURCE_PATH, "");`)
-	require.Contains(t, jsEngineJsFileText, `_registerAlias(_cjkDef.stack, SPX_DEFAULT_FONT_RESOURCE_PATH, "");`)
+func TestJsTemplateDoesNotCarryScratchFontAliasCompat(t *testing.T) {
+	require.NotContains(t, jsEngineJsFileText, "SPX_SCRATCH_PACKAGED_FONT_DEFS")
+	require.NotContains(t, jsEngineJsFileText, "SPX_SCRATCH_CJK_FONT_STACKS")
+	require.NotContains(t, jsEngineJsFileText, "spxResolveFontRequest")
+	require.NotContains(t, jsEngineJsFileText, "_invokeResRegisterSvgFontFace")
+	require.NotContains(t, jsEngineJsFileText, "_invokeResSetDefaultFont")
+	require.NotContains(t, jsEngineJsFileText, "spx-register-only=1")
+	require.NotContains(t, jsEngineJsFileText, `spx-family=`)
 	require.NotContains(t, jsEngineJsFileText, "queryLocalFonts")
 	require.NotContains(t, jsEngineJsFileText, "useLocalFontAccess")
 }

--- a/internal/core/project/display.go
+++ b/internal/core/project/display.go
@@ -24,9 +24,28 @@ import (
 )
 
 type DisplaySettings struct {
-	WindowScale float64
-	StretchMode bool
-	Debug       bool
+	WindowScale              float64
+	StretchMode              bool
+	Debug                    bool
+	DefaultFontPath          string
+	SVGFontFaceRegistrations []SVGFontFaceRegistration
+}
+
+const defaultDisplayFontPath = "res://engine/fonts/CnFont.ttf"
+
+type SVGFontFaceRegistration struct {
+	Path   string
+	Family string
+}
+
+var scratchSVGFontRegistrations = []SVGFontFaceRegistration{
+	{Path: "res://engine/fonts/scratch/NotoSans-Medium.ttf", Family: "Sans Serif"},
+	{Path: "res://engine/fonts/scratch/SourceSerifPro-Regular.otf", Family: "Serif"},
+	{Path: "res://engine/fonts/scratch/handlee-regular.ttf", Family: "Handwriting"},
+	{Path: "res://engine/fonts/scratch/Knewave.ttf", Family: "Marker"},
+	{Path: "res://engine/fonts/scratch/Griffy-Regular.ttf", Family: "Curly"},
+	{Path: "res://engine/fonts/scratch/Grand9K-Pixel.ttf", Family: "Pixel"},
+	{Path: "res://engine/fonts/scratch/Scratch.ttf", Family: "Scratch"},
 }
 
 func ResolveDisplaySettings(proj *ProjectConfig) DisplaySettings {
@@ -35,9 +54,30 @@ func ResolveDisplaySettings(proj *ProjectConfig) DisplaySettings {
 		windowScale = proj.WindowScale
 	}
 	return DisplaySettings{
-		WindowScale: windowScale,
-		StretchMode: proj.StretchMode == nil || *proj.StretchMode,
-		Debug:       proj.Debug,
+		WindowScale:              windowScale,
+		StretchMode:              proj.StretchMode == nil || *proj.StretchMode,
+		Debug:                    proj.Debug,
+		DefaultFontPath:          defaultDisplayFontPath,
+		SVGFontFaceRegistrations: append([]SVGFontFaceRegistration(nil), scratchSVGFontRegistrations...),
+	}
+}
+
+func RegisterDisplayFonts(
+	settings DisplaySettings,
+	setDefaultFont func(string),
+	registerSVGFontFace func(string, string),
+) {
+	if setDefaultFont != nil && settings.DefaultFontPath != "" {
+		setDefaultFont(settings.DefaultFontPath)
+	}
+	if registerSVGFontFace == nil {
+		return
+	}
+	for _, font := range settings.SVGFontFaceRegistrations {
+		if font.Path == "" || font.Family == "" {
+			continue
+		}
+		registerSVGFontFace(font.Path, font.Family)
 	}
 }
 

--- a/internal/core/project/display.go
+++ b/internal/core/project/display.go
@@ -49,6 +49,9 @@ var scratchSVGFontRegistrations = []SVGFontFaceRegistration{
 }
 
 func ResolveDisplaySettings(proj *ProjectConfig) DisplaySettings {
+	if proj == nil {
+		proj = &ProjectConfig{}
+	}
 	windowScale := 1.0
 	if proj.WindowScale >= 0.001 {
 		windowScale = proj.WindowScale

--- a/internal/core/project/project_test.go
+++ b/internal/core/project/project_test.go
@@ -266,6 +266,14 @@ func TestResolveDisplaySettings(t *testing.T) {
 	if fresh.SVGFontFaceRegistrations[0].Path == "mutated" {
 		t.Fatal("font registrations should be copied per call")
 	}
+
+	nilSettings := ResolveDisplaySettings(nil)
+	if nilSettings.WindowScale != 1 || !nilSettings.StretchMode || nilSettings.Debug {
+		t.Fatalf("unexpected nil settings defaults: %+v", nilSettings)
+	}
+	if nilSettings.DefaultFontPath != defaultDisplayFontPath {
+		t.Fatalf("nil default font path = %q", nilSettings.DefaultFontPath)
+	}
 }
 
 func TestRegisterDisplayFonts(t *testing.T) {

--- a/internal/core/project/project_test.go
+++ b/internal/core/project/project_test.go
@@ -243,10 +243,50 @@ func TestResolveDisplaySettings(t *testing.T) {
 	if settings.WindowScale != 2 || settings.StretchMode || !settings.Debug {
 		t.Fatalf("unexpected settings: %+v", settings)
 	}
+	if settings.DefaultFontPath != "res://engine/fonts/CnFont.ttf" {
+		t.Fatalf("default font path = %q", settings.DefaultFontPath)
+	}
+	if len(settings.SVGFontFaceRegistrations) == 0 {
+		t.Fatalf("expected scratch font registrations: %+v", settings)
+	}
+	if got := settings.SVGFontFaceRegistrations[0]; got != (SVGFontFaceRegistration{
+		Path:   "res://engine/fonts/scratch/NotoSans-Medium.ttf",
+		Family: "Sans Serif",
+	}) {
+		t.Fatalf("first font registration = %+v", got)
+	}
 
 	settings = ResolveDisplaySettings(&ProjectConfig{})
 	if settings.WindowScale != 1 || !settings.StretchMode || settings.Debug {
 		t.Fatalf("unexpected default settings: %+v", settings)
+	}
+
+	settings.SVGFontFaceRegistrations[0].Path = "mutated"
+	fresh := ResolveDisplaySettings(&ProjectConfig{})
+	if fresh.SVGFontFaceRegistrations[0].Path == "mutated" {
+		t.Fatal("font registrations should be copied per call")
+	}
+}
+
+func TestRegisterDisplayFonts(t *testing.T) {
+	settings := ResolveDisplaySettings(&ProjectConfig{})
+	var defaultFonts []string
+	var fontFaces []SVGFontFaceRegistration
+	RegisterDisplayFonts(
+		settings,
+		func(path string) {
+			defaultFonts = append(defaultFonts, path)
+		},
+		func(path, family string) {
+			fontFaces = append(fontFaces, SVGFontFaceRegistration{Path: path, Family: family})
+		},
+	)
+
+	if !reflect.DeepEqual(defaultFonts, []string{settings.DefaultFontPath}) {
+		t.Fatalf("default fonts = %#v, want %#v", defaultFonts, []string{settings.DefaultFontPath})
+	}
+	if !reflect.DeepEqual(fontFaces, settings.SVGFontFaceRegistrations) {
+		t.Fatalf("registered svg font faces = %#v, want %#v", fontFaces, settings.SVGFontFaceRegistrations)
 	}
 }
 

--- a/internal/enginewrap/sync.gen.go
+++ b/internal/enginewrap/sync.gen.go
@@ -838,6 +838,11 @@ func (*resMgrImpl) SetDefaultFont(font_path string) {
 		gdx.ResMgr.SetDefaultFont(font_path)
 	})
 }
+func (*resMgrImpl) RegisterSvgFontFace(font_path string, family string) {
+	callInMainThread(func() {
+		gdx.ResMgr.RegisterSvgFontFace(font_path, family)
+	})
+}
 
 // ISceneMgr
 func (*sceneMgrImpl) ChangeSceneToFile(path string) {

--- a/internal/enginewrap/sync_pure.gen.go
+++ b/internal/enginewrap/sync_pure.gen.go
@@ -385,9 +385,10 @@ func (*resMgrImpl) ReadAllText(p_path string) string {
 func (*resMgrImpl) HasFile(p_path string) bool {
 	return false
 }
-func (*resMgrImpl) ReloadTexture(path string)       {}
-func (*resMgrImpl) FreeStr(str string)              {}
-func (*resMgrImpl) SetDefaultFont(font_path string) {}
+func (*resMgrImpl) ReloadTexture(path string)                           {}
+func (*resMgrImpl) FreeStr(str string)                                  {}
+func (*resMgrImpl) SetDefaultFont(font_path string)                     {}
+func (*resMgrImpl) RegisterSvgFontFace(font_path string, family string) {}
 
 // ISceneMgr
 func (*sceneMgrImpl) ChangeSceneToFile(path string) {}

--- a/internal/gdengine/binding/native/ffi.gen.go
+++ b/internal/gdengine/binding/native/ffi.gen.go
@@ -149,6 +149,7 @@ type GDExtensionInterface struct {
 	SpxResReloadTexture                         GDExtensionSpxResReloadTexture
 	SpxResFreeStr                               GDExtensionSpxResFreeStr
 	SpxResSetDefaultFont                        GDExtensionSpxResSetDefaultFont
+	SpxResRegisterSvgFontFace                   GDExtensionSpxResRegisterSvgFontFace
 	SpxSceneChangeSceneToFile                   GDExtensionSpxSceneChangeSceneToFile
 	SpxSceneDestroyAllSprites                   GDExtensionSpxSceneDestroyAllSprites
 	SpxSceneReloadCurrentScene                  GDExtensionSpxSceneReloadCurrentScene
@@ -468,6 +469,7 @@ func (x *GDExtensionInterface) resolveAPIFunctions() {
 	x.SpxResReloadTexture = (GDExtensionSpxResReloadTexture)(resolveCFunc("spx_res_reload_texture"))
 	x.SpxResFreeStr = (GDExtensionSpxResFreeStr)(resolveCFunc("spx_res_free_str"))
 	x.SpxResSetDefaultFont = (GDExtensionSpxResSetDefaultFont)(resolveCFunc("spx_res_set_default_font"))
+	x.SpxResRegisterSvgFontFace = (GDExtensionSpxResRegisterSvgFontFace)(resolveCFunc("spx_res_register_svg_font_face"))
 	x.SpxSceneChangeSceneToFile = (GDExtensionSpxSceneChangeSceneToFile)(resolveCFunc("spx_scene_change_scene_to_file"))
 	x.SpxSceneDestroyAllSprites = (GDExtensionSpxSceneDestroyAllSprites)(resolveCFunc("spx_scene_destroy_all_sprites"))
 	x.SpxSceneReloadCurrentScene = (GDExtensionSpxSceneReloadCurrentScene)(resolveCFunc("spx_scene_reload_current_scene"))

--- a/internal/gdengine/binding/native/ffi_wrapper.gen.go
+++ b/internal/gdengine/binding/native/ffi_wrapper.gen.go
@@ -214,6 +214,7 @@ type GDExtensionSpxResHasFile C.GDExtensionSpxResHasFile
 type GDExtensionSpxResReloadTexture C.GDExtensionSpxResReloadTexture
 type GDExtensionSpxResFreeStr C.GDExtensionSpxResFreeStr
 type GDExtensionSpxResSetDefaultFont C.GDExtensionSpxResSetDefaultFont
+type GDExtensionSpxResRegisterSvgFontFace C.GDExtensionSpxResRegisterSvgFontFace
 type GDExtensionSpxSceneChangeSceneToFile C.GDExtensionSpxSceneChangeSceneToFile
 type GDExtensionSpxSceneDestroyAllSprites C.GDExtensionSpxSceneDestroyAllSprites
 type GDExtensionSpxSceneReloadCurrentScene C.GDExtensionSpxSceneReloadCurrentScene
@@ -1495,6 +1496,17 @@ func CallResSetDefaultFont(
 	arg1 := (C.GdString)(font_path)
 
 	C.cgo_callfn_GDExtensionSpxResSetDefaultFont(arg0, arg1)
+
+}
+func CallResRegisterSvgFontFace(
+	font_path GdString,
+	family GdString,
+) {
+	arg0 := (C.GDExtensionSpxResRegisterSvgFontFace)(api.SpxResRegisterSvgFontFace)
+	arg1 := (C.GdString)(font_path)
+	arg2 := (C.GdString)(family)
+
+	C.cgo_callfn_GDExtensionSpxResRegisterSvgFontFace(arg0, arg1, arg2)
 
 }
 func CallSceneChangeSceneToFile(

--- a/internal/gdengine/binding/native/ffi_wrapper.gen.h
+++ b/internal/gdengine/binding/native/ffi_wrapper.gen.h
@@ -690,6 +690,12 @@ void cgo_callfn_GDExtensionSpxResSetDefaultFont(const GDExtensionSpxResSetDefaul
 	}
 	fn(font_path);
 }
+void cgo_callfn_GDExtensionSpxResRegisterSvgFontFace(const GDExtensionSpxResRegisterSvgFontFace fn, GdString font_path, GdString family) {
+	if (!fn) {
+		return;
+	}
+	fn(font_path, family);
+}
 void cgo_callfn_GDExtensionSpxSceneChangeSceneToFile(const GDExtensionSpxSceneChangeSceneToFile fn, GdString path) {
 	if (!fn) {
 		return;

--- a/internal/gdengine/binding/native/gdextension_spx_ext.h
+++ b/internal/gdengine/binding/native/gdextension_spx_ext.h
@@ -339,6 +339,7 @@ typedef void (*GDExtensionSpxResHasFile)(GdString p_path, GdBool *ret_value);
 typedef void (*GDExtensionSpxResReloadTexture)(GdString path);
 typedef void (*GDExtensionSpxResFreeStr)(GdString str);
 typedef void (*GDExtensionSpxResSetDefaultFont)(GdString font_path);
+typedef void (*GDExtensionSpxResRegisterSvgFontFace)(GdString font_path, GdString family);
 // SpxScene
 typedef void (*GDExtensionSpxSceneChangeSceneToFile)(GdString path);
 typedef void (*GDExtensionSpxSceneDestroyAllSprites)();

--- a/internal/gdengine/binding/web/ffi.gen.go
+++ b/internal/gdengine/binding/web/ffi.gen.go
@@ -153,6 +153,7 @@ type GDExtensionInterface struct {
 	SpxResReloadTexture                         js.Value
 	SpxResFreeStr                               js.Value
 	SpxResSetDefaultFont                        js.Value
+	SpxResRegisterSvgFontFace                   js.Value
 	SpxSceneChangeSceneToFile                   js.Value
 	SpxSceneDestroyAllSprites                   js.Value
 	SpxSceneReloadCurrentScene                  js.Value
@@ -472,6 +473,7 @@ func (x *GDExtensionInterface) resolveAPIFunctions() {
 	x.SpxResReloadTexture = resolveJSFunc("gdspx_res_reload_texture")
 	x.SpxResFreeStr = resolveJSFunc("gdspx_res_free_str")
 	x.SpxResSetDefaultFont = resolveJSFunc("gdspx_res_set_default_font")
+	x.SpxResRegisterSvgFontFace = resolveJSFunc("gdspx_res_register_svg_font_face")
 	x.SpxSceneChangeSceneToFile = resolveJSFunc("gdspx_scene_change_scene_to_file")
 	x.SpxSceneDestroyAllSprites = resolveJSFunc("gdspx_scene_destroy_all_sprites")
 	x.SpxSceneReloadCurrentScene = resolveJSFunc("gdspx_scene_reload_current_scene")

--- a/internal/gdengine/impl/manager_native.gen.go
+++ b/internal/gdengine/impl/manager_native.gen.go
@@ -752,6 +752,15 @@ func (pself *resMgr) SetDefaultFont(font_path string) {
 	defer C.free(unsafe.Pointer(arg0Str))
 	CallResSetDefaultFont(arg0)
 }
+func (pself *resMgr) RegisterSvgFontFace(font_path string, family string) {
+	arg0Str := C.CString(font_path)
+	arg0 := (GdString)(arg0Str)
+	defer C.free(unsafe.Pointer(arg0Str))
+	arg1Str := C.CString(family)
+	arg1 := (GdString)(arg1Str)
+	defer C.free(unsafe.Pointer(arg1Str))
+	CallResRegisterSvgFontFace(arg0, arg1)
+}
 func (pself *sceneMgr) ChangeSceneToFile(path string) {
 	arg0Str := C.CString(path)
 	arg0 := (GdString)(arg0Str)

--- a/internal/gdengine/impl/manager_web.gen.go
+++ b/internal/gdengine/impl/manager_web.gen.go
@@ -696,6 +696,11 @@ func (pself *resMgr) SetDefaultFont(font_path string) {
 	arg0 := JsFromGdString(font_path)
 	API.SpxResSetDefaultFont.Invoke(arg0)
 }
+func (pself *resMgr) RegisterSvgFontFace(font_path string, family string) {
+	arg0 := JsFromGdString(font_path)
+	arg1 := JsFromGdString(family)
+	API.SpxResRegisterSvgFontFace.Invoke(arg0, arg1)
+}
 func (pself *sceneMgr) ChangeSceneToFile(path string) {
 	arg0 := JsFromGdString(path)
 	API.SpxSceneChangeSceneToFile.Invoke(arg0)

--- a/pkg/spx/pkg/engine/interface.gen.go
+++ b/pkg/spx/pkg/engine/interface.gen.go
@@ -189,6 +189,7 @@ type IResMgr interface {
 	ReloadTexture(path string)
 	FreeStr(str string)
 	SetDefaultFont(font_path string)
+	RegisterSvgFontFace(font_path string, family string)
 }
 
 type ISceneMgr interface {


### PR DESCRIPTION
## Summary

- switch display font bootstrap config to typed SVG font-face registrations
- register the default font and Scratch SVG font families explicitly during game startup
- regenerate native/web bindings for the new engine API
- remove the web-side Scratch font alias compatibility layer so web now matches native behavior

## Why

The old flow relied on packing SVG font registration metadata into font-path strings.
Now that the engine exposes an explicit `RegisterSvgFontFace` API, SPX can pass structured font
registration data directly instead of encoding behavior into paths.

## Testing

- `make generate-bindings`
- `cd internal/cmd/codegen && go test ./...`
- `go test ./...`

## Notes

- this PR depends on the paired Godot change that adds `register_svg_font_face`
- web no longer performs extra alias/path rewriting for Scratch font registration; startup now relies
  on the explicit registration flow