### PR TITLE
fix(runtime): run awake before sprite main

### DIFF
--- a/game_load.go
+++ b/game_load.go
@@ -203,7 +203,7 @@ func (p *Game) runSpriteCallbacks(inits []Sprite, proj *coreproject.ProjectConfi
 		BeforeMain: func(ini Sprite) {
 			spr := spriteOf(ini)
 			if spr != nil {
-				spr.onAwake(func() {
+				p.deferBootstrapFor(generation, func() {
 					spr.awake()
 				})
 			}

--- a/game_load_test.go
+++ b/game_load_test.go
@@ -19,9 +19,13 @@ package spx
 import (
 	"reflect"
 	"testing"
+	"time"
 
+	"github.com/goplus/spbase/mathf"
 	coreproject "github.com/goplus/spx/v2/internal/core/project"
 	"github.com/goplus/spx/v2/internal/engine/platform"
+	"github.com/goplus/spx/v2/internal/enginewrap"
+	pkgengine "github.com/goplus/spx/v2/pkg/spx/pkg/engine"
 )
 
 type cameraFollowOverrideGame struct {
@@ -42,6 +46,25 @@ type collisionLayerOrderSprite struct {
 	onMain func()
 }
 
+type bootstrapAwakeOrderSprite struct {
+	SpriteImpl
+	peer         *bootstrapAwakeOrderSprite
+	sawSelfAwake bool
+	sawPeerAwake bool
+}
+
+type cloneAwakeOrderSprite struct {
+	SpriteImpl
+	sawAwakeInMain bool
+	onClonedFired  bool
+	clonedDone     chan struct{}
+}
+
+type spyCloneSpriteMgr struct {
+	enginewrap.SpriteMgrImpl
+	nextID pkgengine.Object
+}
+
 func (s *cameraFollowOverrideSprite) Main() {
 	if s.followTarget != "" {
 		s.g.Camera.Follow__1(s.followTarget)
@@ -54,12 +77,58 @@ func (s *collisionLayerOrderSprite) Main() {
 	}
 }
 
+func (s *bootstrapAwakeOrderSprite) Main() {
+	s.sawSelfAwake = s.spriteState.IsAwakened
+	if s.peer != nil {
+		s.sawPeerAwake = s.peer.spriteState.IsAwakened
+	}
+}
+
+func (s *cloneAwakeOrderSprite) Main() {
+	if !s.IsCloned() {
+		return
+	}
+	s.sawAwakeInMain = s.spriteState.IsAwakened
+	s.OnCloned__0(func() {
+		s.onClonedFired = true
+		if s.clonedDone != nil {
+			close(s.clonedDone)
+		}
+	})
+}
+
+func (s *spyCloneSpriteMgr) CreateBareSprite(pos mathf.Vec2) pkgengine.Object {
+	s.nextID++
+	return s.nextID
+}
+
+func (s *spyCloneSpriteMgr) SetTypeName(obj pkgengine.Object, typeName string) {}
+
+func (s *spyCloneSpriteMgr) SetVisible(obj pkgengine.Object, visible bool) {}
+
+func (s *spyCloneSpriteMgr) SetTriggerLayer(obj pkgengine.Object, layer int64) {}
+
+func (s *spyCloneSpriteMgr) SetTriggerMask(obj pkgengine.Object, mask int64) {}
+
+func (s *spyCloneSpriteMgr) SetCollisionLayer(obj pkgengine.Object, layer int64) {}
+
+func (s *spyCloneSpriteMgr) SetCollisionMask(obj pkgengine.Object, mask int64) {}
+
+func (s *spyCloneSpriteMgr) SetTriggerEnabled(obj pkgengine.Object, trigger bool) {}
+
+func (s *spyCloneSpriteMgr) SetCollisionEnabled(obj pkgengine.Object, enabled bool) {}
+
+func (s *spyCloneSpriteMgr) SetGravityScale(obj pkgengine.Object, scale float64) {}
+
+func (s *spyCloneSpriteMgr) SetPhysicsMode(obj pkgengine.Object, mode int64) {}
+
 func newCameraFollowOverrideSprite(g *Game, name string, followTarget SpriteName) *cameraFollowOverrideSprite {
 	sprite := &cameraFollowOverrideSprite{followTarget: followTarget}
 	sprite.g = g
 	sprite.name = name
 	sprite.sprite = sprite
 	sprite.scriptEventBindings.init(&g.scriptEvents, &sprite.SpriteImpl)
+	sprite.components.initComponents(&sprite.SpriteImpl, &coreproject.SpriteConfig{})
 	return sprite
 }
 
@@ -71,6 +140,45 @@ func newCollisionLayerOrderSprite(g *Game, name string, onMain func()) *collisio
 	sprite.scriptEventBindings.init(&g.scriptEvents, &sprite.SpriteImpl)
 	sprite.components.initComponents(&sprite.SpriteImpl, &coreproject.SpriteConfig{})
 	return sprite
+}
+
+func newBootstrapAwakeOrderSprite(g *Game, name string) *bootstrapAwakeOrderSprite {
+	sprite := &bootstrapAwakeOrderSprite{}
+	sprite.g = g
+	sprite.name = name
+	sprite.sprite = sprite
+	sprite.scriptEventBindings.init(&g.scriptEvents, &sprite.SpriteImpl)
+	sprite.components.initComponents(&sprite.SpriteImpl, &coreproject.SpriteConfig{})
+	return sprite
+}
+
+func newCloneAwakeOrderSprite(g *Game, name string) *cloneAwakeOrderSprite {
+	sprite := &cloneAwakeOrderSprite{
+		clonedDone: make(chan struct{}),
+	}
+	sprite.baseObj.initWithSize(1, 1)
+	sprite.g = g
+	sprite.name = name
+	sprite.sprite = sprite
+	sprite.scriptEventBindings.init(&g.scriptEvents, &sprite.SpriteImpl)
+	sprite.components.initComponents(&sprite.SpriteImpl, &coreproject.SpriteConfig{})
+	sprite.physics().collisionInfo.Type = physicsColliderNone
+	sprite.physics().triggerInfo.Type = physicsColliderNone
+	return sprite
+}
+
+func setupCloneSpriteMgr(t *testing.T) {
+	t.Helper()
+
+	enginewrap.Init(func(call func()) {
+		call()
+	})
+
+	original := pkgengine.SpriteMgr
+	pkgengine.SpriteMgr = &spyCloneSpriteMgr{}
+	t.Cleanup(func() {
+		pkgengine.SpriteMgr = original
+	})
 }
 
 func TestRunSpriteCallbacksKeepsManualCameraFollowLast(t *testing.T) {
@@ -176,6 +284,130 @@ func TestRunSpriteCallbacksRefreshesCollisionLayersRegisteredInMain(t *testing.T
 	}
 	if got := game.sprCollisionInfos["SpriteB"].Mask; got != 0 {
 		t.Fatalf("SpriteB collision mask = %d, want 0", got)
+	}
+}
+
+func TestRunSpriteCallbacksAwakesAllSpritesBeforeMain(t *testing.T) {
+	var game Game
+
+	spriteA := newBootstrapAwakeOrderSprite(&game, "SpriteA")
+	spriteB := newBootstrapAwakeOrderSprite(&game, "SpriteB")
+	spriteA.peer = spriteB
+	spriteB.peer = spriteA
+
+	generation := game.currentBootstrapGeneration()
+	game.runSpriteCallbacks(
+		[]Sprite{spriteA, spriteB},
+		&coreproject.ProjectConfig{},
+		reflect.ValueOf(&game).Elem(),
+		generation,
+	)
+	game.runBootstrapTasksFor(generation)
+
+	if !spriteA.sawSelfAwake || !spriteA.sawPeerAwake {
+		t.Fatalf("SpriteA main saw awake state self=%v peer=%v, want both true", spriteA.sawSelfAwake, spriteA.sawPeerAwake)
+	}
+	if !spriteB.sawSelfAwake || !spriteB.sawPeerAwake {
+		t.Fatalf("SpriteB main saw awake state self=%v peer=%v, want both true", spriteB.sawSelfAwake, spriteB.sawPeerAwake)
+	}
+	if got := game.scriptEvents.manager.SnapshotAwake(); len(got) != 0 {
+		t.Fatalf("SnapshotAwake len = %d, want 0 for initial sprites", len(got))
+	}
+}
+
+func TestInitRuntimeProxyAppliesCostumeBeforeAwake(t *testing.T) {
+	var game Game
+	setupCloneSpriteMgr(t)
+
+	sprite := newCloneAwakeOrderSprite(&game, "SpriteA")
+	sprite.spriteState.IsVisible = true
+
+	platform.RunOnMainThread(func() {
+		sprite.initRuntimeProxy()
+	})
+
+	if sprite.runtimeState.SyncSprite == nil {
+		t.Fatal("SyncSprite = nil, want initialized proxy")
+	}
+	if sprite.runtimeState.IsCostumeDirty {
+		t.Fatal("IsCostumeDirty = true, want false after initRuntimeProxy")
+	}
+}
+
+func TestApplySpritePropsBeforeInitRuntimeProxy(t *testing.T) {
+	var game Game
+	setupCloneSpriteMgr(t)
+
+	source := newCloneAwakeOrderSprite(&game, "SpriteA")
+	source.costumes = []*costume{newCostumeWithSize(1, 1), newCostumeWithSize(1, 1)}
+	source.costumeIndex = 0
+
+	out := reflect.New(reflect.TypeOf(source).Elem()).Elem()
+	shape := coreproject.StageShape{
+		"visible":      false,
+		"size":         2.0,
+		"costumeIndex": 1.0,
+	}
+
+	var dest *SpriteImpl
+	platform.RunOnMainThread(func() {
+		dest, _ = applySprite(out, source, shape)
+	})
+
+	if dest == nil {
+		t.Fatal("applySprite returned nil sprite")
+	}
+	if dest.runtimeState.SyncSprite == nil {
+		t.Fatal("SyncSprite = nil, want initialized proxy")
+	}
+	if dest.runtimeState.IsCostumeDirty {
+		t.Fatal("IsCostumeDirty = true, want false after applySprite")
+	}
+	if dest.costumeIndex != 1 {
+		t.Fatalf("costumeIndex = %d, want 1", dest.costumeIndex)
+	}
+	if dest.spriteState.IsVisible {
+		t.Fatal("IsVisible = true, want false from stage shape override")
+	}
+	if dest.runtimeState.Scale != 2 {
+		t.Fatalf("Scale = %v, want 2", dest.runtimeState.Scale)
+	}
+}
+
+func TestCloneSpriteAwakesBeforeMain(t *testing.T) {
+	var game Game
+	game.initShapeMgr()
+	setupCloneSpriteMgr(t)
+
+	source := newCloneAwakeOrderSprite(&game, "SpriteA")
+	game.addShape(spriteOf(source))
+
+	var cloned *cloneAwakeOrderSprite
+	platform.RunOnMainThread(func() {
+		doClone(source, nil, false, func(sprite *SpriteImpl) {
+			var ok bool
+			cloned, ok = sprite.sprite.(*cloneAwakeOrderSprite)
+			if !ok {
+				t.Fatalf("clone sprite type = %T, want *cloneAwakeOrderSprite", sprite.sprite)
+			}
+		})
+	})
+
+	if cloned == nil {
+		t.Fatal("clone callback did not capture cloned sprite")
+	}
+
+	select {
+	case <-cloned.clonedDone:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for clone onCloned handler")
+	}
+
+	if !cloned.sawAwakeInMain {
+		t.Fatal("clone Main ran before awake")
+	}
+	if !cloned.onClonedFired {
+		t.Fatal("clone onCloned did not fire after Main registration")
 	}
 }
 

--- a/internal/core/state/sprite.go
+++ b/internal/core/state/sprite.go
@@ -21,6 +21,7 @@ type SpriteRuntimeState struct {
 	Cloned              bool
 	IsDying             bool
 	IsDirty             bool
+	IsAwakened          bool
 	HasOnCloned         bool
 	HasOnTouchStart     bool
 	HasOnTouching       bool

--- a/runtime_events.go
+++ b/runtime_events.go
@@ -287,7 +287,6 @@ func (p *Game) handleEvent(ev event) {
 		// Note: key-up callbacks are not part of the current event sink API.
 		p.scriptEvents.doWhenKeyPressed(e.Key)
 	case *eventStart:
-		p.scriptEvents.doWhenAwake(nil)
 		p.scriptEvents.doWhenStart()
 		p.lifecycleState.StartDispatched.Store(true)
 	case *eventTimer:

--- a/runtime_sync.go
+++ b/runtime_sync.go
@@ -23,15 +23,16 @@ import (
 	spxlog "github.com/goplus/spx/v2/internal/log"
 )
 
-func (p *SpriteImpl) initEngineObjects() {
-	p.resetRuntimeProxy(false)
+func (p *SpriteImpl) initRuntimeProxy() {
+	p.rebuildRuntimeProxy(true)
 }
 
 func (p *SpriteImpl) awake() {
 	p.animation().playDefaultAnimIfIdle()
+	p.spriteState.IsAwakened = true
 }
 
-func (p *SpriteImpl) resetRuntimeProxy(applyCostume bool) {
+func (p *SpriteImpl) rebuildRuntimeProxy(applyCostume bool) {
 	p.runtimeState.SyncSprite = nil
 	engine.WaitMainThread(func() {
 		p.ensureProxyInitialized()

--- a/sprite_clone.go
+++ b/sprite_clone.go
@@ -76,19 +76,17 @@ func cloneSprite(out reflect.Value, outPtr Sprite, in reflect.Value, v coreproje
 
 	if v != nil {
 		applySpriteProps(dest, v)
+		dest.initRuntimeProxy()
 	} else {
-		dest.onAwake(func() {
-			dest.awake()
-		})
+		dest.initRuntimeProxy()
+		dest.awake()
 		runMain(outPtr.Main)
 	}
-	dest.resetRuntimeProxy(true)
 	return dest
 }
 
 func dispatchCloneLifecycle(dest *SpriteImpl, data any, isAsync bool) {
 	dispatch := func() {
-		dest.doWhenAwake(dest)
 		if dest.spriteState.HasOnCloned {
 			dest.doWhenCloned(dest, data)
 		}

--- a/sprite_core.go
+++ b/sprite_core.go
@@ -62,7 +62,7 @@ func (p *SpriteImpl) init(
 	p.initBaseObjects(spriteCfg, g)
 	p.initBasicProperties(g, name, sprite, gamer, spriteCfg)
 	p.initComponents(spriteCfg)
-	p.initEngineObjects()
+	p.initRuntimeProxy()
 }
 
 func (p *SpriteImpl) initBaseObjects(spriteCfg *coreproject.SpriteConfig, g *Game) {
@@ -80,6 +80,7 @@ func (p *SpriteImpl) initBasicProperties(g *Game, name string, sprite Sprite, ga
 	p.g, p.name, p.sprite = g, name, sprite
 	p.runtimeState.Scale = spriteCfg.Size
 	p.spriteState.IsVisible = spriteCfg.Visible
+	p.spriteState.IsAwakened = false
 }
 
 func (p *SpriteImpl) initComponents(spriteCfg *coreproject.SpriteConfig) {
@@ -96,6 +97,7 @@ func (p *SpriteImpl) InitFrom(src *SpriteImpl) {
 	p.spriteState.IsVisible = src.spriteState.IsVisible
 	p.spriteState.Cloned = true
 	p.spriteState.IsDying = false
+	p.spriteState.IsAwakened = false
 
 	p.spriteState.HasOnCloned = false
 	p.spriteState.HasOnTouchStart = false


### PR DESCRIPTION
## Summary

This PR fixes the startup ordering behind #1591 by making sprite top-level execution observe the same initialized state that was previously only guaranteed by `onStart`.

In practice, that means:

- initial sprites now run `awake()` before sprite `Main()`
- cloned sprites now initialize their runtime proxy and run `awake()` before clone `Main()`
- default animation and initial costume state are ready before top-level sprite code runs

## What changed

- Move initial sprite `awake()` into bootstrap before `Main()`
- Remove the old initial-sprite awake dispatch from the later start event
- For clones:
  - apply stage-shape overrides before runtime proxy initialization
  - initialize the runtime proxy before `awake()` and `Main()`
  - keep `onCloned` dispatch after clone `Main()`
- Rename `initEngineObjects` to `initRuntimeProxy` to better reflect its role
- Make runtime proxy initialization immediately apply the current costume
- Rename `resetRuntimeProxy` to `rebuildRuntimeProxy`

## Why

The issue came from startup ordering.

Previously, top-level sprite code could run before the sprite had entered its awakened/default-animation state, while `onStart` ran after that state was established. That made top-level behavior inconsistent with `onStart`, including cases where default animation did not reliably start.

This PR fixes the lifecycle and proxy initialization order directly instead of special-casing individual APIs.

## Tests

Added regression coverage for:

- all initial sprites being awake before any sprite `Main()`
- cloned sprites being awake before clone `Main()`
- runtime proxy initialization applying costume state before `awake()`
- stage-shape sprite overrides being applied before runtime proxy initialization

Validated with:

- `go test .`