### PR TITLE
refactor(runtime): deduplicate clone proxy init path

### DIFF
--- a/sprite_clone.go
+++ b/sprite_clone.go
@@ -76,9 +76,9 @@ func cloneSprite(out reflect.Value, outPtr Sprite, in reflect.Value, v coreproje
 
 	if v != nil {
 		applySpriteProps(dest, v)
-		dest.initRuntimeProxy()
-	} else {
-		dest.initRuntimeProxy()
+	}
+	dest.initRuntimeProxy()
+	if v == nil {
 		dest.awake()
 		runMain(outPtr.Main)
 	}


### PR DESCRIPTION
## Summary

This PR is a small follow-up refactor on top of the sprite startup ordering fix.

It removes the duplicated `initRuntimeProxy()` call in `cloneSprite()` while preserving the required execution order:

- apply stage-shape overrides first when `v != nil`
- initialize the runtime proxy once in a shared path
- only run `awake()` and `Main()` for the real clone path

## Why

The previous version was correct, but `initRuntimeProxy()` was called in both branches of the `v != nil` condition.

This refactor keeps the same behavior and makes the control flow easier to read:

- stage-shape path: props -> proxy init
- clone path: proxy init -> awake -> Main

## Testing

Behavior was verified with the existing regression tests covering:

- stage-shape props applied before runtime proxy initialization
- clone startup ordering
- initial sprite awake-before-main ordering