### PR TITLE
fix: allow click through covered sprites without handlers

### DIFF
--- a/internal/core/event/manager.go
+++ b/internal/core/event/manager.go
@@ -117,6 +117,15 @@ func deleteOwnerCopy(sinks []Sink, owner any) []Sink {
 	return out
 }
 
+func HasOwner(sinks []Sink, owner any) bool {
+	for _, sink := range sinks {
+		if sink.Owner == owner {
+			return true
+		}
+	}
+	return false
+}
+
 func (m *Manager) Add(bucket Bucket, sink Sink) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/internal/core/event/manager_test.go
+++ b/internal/core/event/manager_test.go
@@ -119,6 +119,20 @@ func TestManagerConvenienceMethods(t *testing.T) {
 	}
 }
 
+func TestHasOwner(t *testing.T) {
+	sinks := []Sink{
+		{Owner: "keep", Handler: func() {}},
+		{Owner: "click", Handler: func() {}},
+	}
+
+	if !HasOwner(sinks, "click") {
+		t.Fatal("HasOwner should find matching owner")
+	}
+	if HasOwner(sinks, "missing") {
+		t.Fatal("HasOwner should return false for missing owner")
+	}
+}
+
 func TestManagerStartLifecycle(t *testing.T) {
 	var mgr Manager
 	if !mgr.TryAddStart(Sink{Owner: "first", Handler: func() {}}) {

--- a/runtime_events.go
+++ b/runtime_events.go
@@ -200,6 +200,7 @@ type clicker interface {
 }
 
 func (p *Game) findClickTarget(point mathf.Vec2) (coreruntime.ClickSelection[clicker, *SpriteImpl], bool) {
+	clickSinks := p.scriptEvents.manager.SnapshotClick()
 	return coreruntime.FindClickTarget(p.getTempShapes(), func(item Shape) (coreruntime.ClickSelection[clicker, *SpriteImpl], bool) {
 		o, ok := item.(clicker)
 		if !ok {
@@ -210,6 +211,9 @@ func (p *Game) findClickTarget(point mathf.Vec2) (coreruntime.ClickSelection[cli
 			return coreruntime.ClickSelection[clicker, *SpriteImpl]{}, false
 		}
 		if !p.engine().SpriteMgr.CheckCollisionWithPoint(syncSprite.GetId(), point, true) {
+			return coreruntime.ClickSelection[clicker, *SpriteImpl]{}, false
+		}
+		if !coreevent.HasOwner(clickSinks, o) {
 			return coreruntime.ClickSelection[clicker, *SpriteImpl]{}, false
 		}
 		if sprite, ok := o.(*SpriteImpl); ok {

--- a/runtime_events_test.go
+++ b/runtime_events_test.go
@@ -19,6 +19,11 @@ package spx
 import (
 	"reflect"
 	"testing"
+
+	"github.com/goplus/spbase/mathf"
+	"github.com/goplus/spx/v2/internal/engine"
+	"github.com/goplus/spx/v2/internal/enginewrap"
+	pkgengine "github.com/goplus/spx/v2/pkg/spx/pkg/engine"
 )
 
 func TestGameRunBootstrapTasksExecutesQueuedHooksOnce(t *testing.T) {
@@ -38,5 +43,94 @@ func TestGameRunBootstrapTasksExecutesQueuedHooksOnce(t *testing.T) {
 	want := []string{"first", "second"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("runBootstrapTasks got %v, want %v", got, want)
+	}
+}
+
+type clickThroughSpriteMgr struct {
+	enginewrap.SpriteMgrImpl
+	hits map[pkgengine.Object]bool
+}
+
+func (s *clickThroughSpriteMgr) CheckCollisionWithPoint(obj pkgengine.Object, point mathf.Vec2, isTrigger bool) bool {
+	return s.hits[obj]
+}
+
+func setupClickThroughSpriteMgr(t *testing.T, hits map[pkgengine.Object]bool) {
+	t.Helper()
+
+	enginewrap.Init(func(call func()) {
+		call()
+	})
+
+	original := pkgengine.SpriteMgr
+	pkgengine.SpriteMgr = &clickThroughSpriteMgr{hits: hits}
+	t.Cleanup(func() {
+		pkgengine.SpriteMgr = original
+	})
+}
+
+func newClickTestSprite(g *Game, name string, id pkgengine.Object, registerClick bool) *SpriteImpl {
+	sprite := &SpriteImpl{}
+	sprite.g = g
+	sprite.name = name
+	sprite.spriteState.IsVisible = true
+	sprite.runtimeState.SyncSprite = &engine.Sprite{}
+	sprite.runtimeState.SyncSprite.SetId(id)
+	sprite.scriptEventBindings.init(&g.scriptEvents, sprite)
+	if registerClick {
+		sprite.OnClick(func() {})
+	}
+	return sprite
+}
+
+func TestFindClickTargetSkipsCoveredSpriteWithoutClickHandler(t *testing.T) {
+	setupClickThroughSpriteMgr(t, map[pkgengine.Object]bool{
+		1: true,
+		2: true,
+	})
+
+	var g Game
+	g.initShapeMgr()
+
+	bottom := newClickTestSprite(&g, "bottom", 1, true)
+	top := newClickTestSprite(&g, "top", 2, false)
+	g.addShape(bottom)
+	g.addShape(top)
+
+	selection, ok := g.findClickTarget(mathf.NewVec2(0, 0))
+	if !ok {
+		t.Fatal("expected click target")
+	}
+	if selection.Target != bottom {
+		t.Fatalf("target = %p, want bottom %p", selection.Target, bottom)
+	}
+	if selection.SwipeTarget != bottom {
+		t.Fatalf("swipe target = %p, want bottom %p", selection.SwipeTarget, bottom)
+	}
+}
+
+func TestFindClickTargetKeepsTopmostClickableSprite(t *testing.T) {
+	setupClickThroughSpriteMgr(t, map[pkgengine.Object]bool{
+		1: true,
+		2: true,
+	})
+
+	var g Game
+	g.initShapeMgr()
+
+	bottom := newClickTestSprite(&g, "bottom", 1, true)
+	top := newClickTestSprite(&g, "top", 2, true)
+	g.addShape(bottom)
+	g.addShape(top)
+
+	selection, ok := g.findClickTarget(mathf.NewVec2(0, 0))
+	if !ok {
+		t.Fatal("expected click target")
+	}
+	if selection.Target != top {
+		t.Fatalf("target = %p, want top %p", selection.Target, top)
+	}
+	if selection.SwipeTarget != top {
+		t.Fatalf("swipe target = %p, want top %p", selection.SwipeTarget, top)
 	}
 }


### PR DESCRIPTION
## Summary

Fix click target resolution so covered sprites without registered `onClick` handlers no longer block clicks on clickable sprites underneath.

## Background

The current click flow resolves the top-most visible sprite whose collision area matches the pointer position.

This causes a problem when an upper sprite is visible to hit testing but does not actually handle clicks, for example:
- a sprite covered by another sprite
- a sprite made visually transparent via `GhostEffect`
- an overlay sprite without an `onClick` handler

In these cases, the upper sprite could still intercept hit testing and prevent the lower sprite's `onClick` from firing.

## Changes

- Update `Game.findClickTarget` to snapshot click sinks before resolving the click target
- Skip matched sprites that do not have a registered click sink, and continue searching lower layers
- Add `coreevent.HasOwner` to query whether a sink snapshot contains a specific owner
- Add tests for:
  - clicking through a covered sprite without a click handler
  - preserving top-most priority when the covered sprite does have a click handler

## Behavior After This Change

- If the top-most matched sprite does not register `onClick`, the engine continues searching below it
- If the top-most matched sprite does register `onClick`, it still receives the click first
- Stage click behavior remains unchanged when no clickable target is found

## Tests

```bash
go test ./... -run 'TestHasOwner|TestFindClickTargetSkipsCoveredSpriteWithoutClickHandler|TestFindClickTargetKeepsTopmostClickableSprite|TestFindClickTarget|TestHandleLeftButtonDown'