### PR TITLE
feat(pen): add single-call stamp transform bridge

### DIFF
--- a/component_pen.go
+++ b/component_pen.go
@@ -109,12 +109,12 @@ func (p *penComponent) Stamp() {
 	p.checkOrCreatePen()
 	x, y := p.sprite.getXY()
 	applyRenderOffset(p.sprite, &x, &y)
-	rotation, scale := p.getPenStampTransform()
+	rotationRadians, scale := p.getPenStampTransform()
 	p.engine().PenMgr.PenStampWithTransform(
 		*p.penObj,
-		mathf.NewVec2(x, -y),
 		p.sprite.getCostumeAssetPath(),
-		rotation,
+		mathf.NewVec2(x, -y),
+		rotationRadians,
 		scale,
 	)
 }
@@ -269,7 +269,7 @@ func (p *penComponent) syncPenPosition(x, y float64) {
 	p.engine().PenMgr.MovePenTo(*p.penObj, mathf.NewVec2(x, -y))
 }
 
-func (p *penComponent) getPenStampTransform() (rotation float64, scale mathf.Vec2) {
+func (p *penComponent) getPenStampTransform() (rotationRadians float64, scale mathf.Vec2) {
 	rotation, scaleX, scaleY := getRenderRotationAndScale(p.sprite)
 	renderScale := p.sprite.getCostumeRenderScale()
 	return engine.DegToRad(rotation), mathf.NewVec2(scaleX*renderScale, scaleY*renderScale)

--- a/component_pen.go
+++ b/component_pen.go
@@ -109,9 +109,14 @@ func (p *penComponent) Stamp() {
 	p.checkOrCreatePen()
 	x, y := p.sprite.getXY()
 	applyRenderOffset(p.sprite, &x, &y)
-	p.syncPenPosition(x, y)
-	p.engine().PenMgr.SetPenStampTexture(*p.penObj, p.sprite.getCostumeAssetPath())
-	p.engine().PenMgr.PenStamp(*p.penObj)
+	rotation, scale := p.getPenStampTransform()
+	p.engine().PenMgr.PenStampWithTransform(
+		*p.penObj,
+		mathf.NewVec2(x, -y),
+		p.sprite.getCostumeAssetPath(),
+		rotation,
+		scale,
+	)
 }
 
 // ============================================================================
@@ -262,6 +267,12 @@ func (p *penComponent) syncPenPosition(x, y float64) {
 		return
 	}
 	p.engine().PenMgr.MovePenTo(*p.penObj, mathf.NewVec2(x, -y))
+}
+
+func (p *penComponent) getPenStampTransform() (rotation float64, scale mathf.Vec2) {
+	rotation, scaleX, scaleY := getRenderRotationAndScale(p.sprite)
+	renderScale := p.sprite.getCostumeRenderScale()
+	return engine.DegToRad(rotation), mathf.NewVec2(scaleX*renderScale, scaleY*renderScale)
 }
 
 func (p *penComponent) applyPenColorProperty() {

--- a/component_pen_test.go
+++ b/component_pen_test.go
@@ -70,11 +70,11 @@ func (s *spyPenMgr) SetPenSizeTo(obj engine.Object, size float64) {
 
 func (s *spyPenMgr) SetPenStampTexture(obj engine.Object, texturePath string) {}
 
-func (s *spyPenMgr) PenStampWithTransform(obj engine.Object, position mathf.Vec2, texturePath string, rotation float64, scale mathf.Vec2) {
+func (s *spyPenMgr) PenStampWithTransform(obj engine.Object, texturePath string, position mathf.Vec2, rotationRadians float64, scale mathf.Vec2) {
 	s.stampWithCalls++
-	s.lastStampPosition = position
 	s.lastStampTexturePath = texturePath
-	s.lastStampRotation = rotation
+	s.lastStampPosition = position
+	s.lastStampRotation = rotationRadians
 	s.lastStampScale = scale
 }
 
@@ -249,7 +249,7 @@ func TestPenComponentStampUsesRenderedPosition(t *testing.T) {
 }
 
 func TestPenComponentStampSyncsRenderedTransform(t *testing.T) {
-	penSpy := setupSpyPenMgr(t)
+	spy := setupSpyPenMgr(t)
 	sprite := newPenTestSprite()
 	configurePenRenderOffsetSprite(sprite)
 	sprite.runtimeState.Scale = 2
@@ -258,30 +258,31 @@ func TestPenComponentStampSyncsRenderedTransform(t *testing.T) {
 
 	sprite.pen().Stamp()
 
-	if penSpy.createCalls != 1 {
-		t.Fatalf("CreatePen calls = %d, want 1", penSpy.createCalls)
+	if spy.createCalls != 1 {
+		t.Fatalf("CreatePen calls = %d, want 1", spy.createCalls)
 	}
-	if penSpy.stampWithCalls != 1 {
-		t.Fatalf("PenStampWithTransform calls = %d, want 1", penSpy.stampWithCalls)
+	if spy.stampWithCalls != 1 {
+		t.Fatalf("PenStampWithTransform calls = %d, want 1", spy.stampWithCalls)
 	}
 
 	wantRotation := 0.0
-	if penSpy.lastStampRotation != wantRotation {
-		t.Fatalf("PenStampWithTransform rotation = %v, want %v", penSpy.lastStampRotation, wantRotation)
+	if spy.lastStampRotation != wantRotation {
+		t.Fatalf("PenStampWithTransform rotation = %v, want %v", spy.lastStampRotation, wantRotation)
 	}
 
 	wantScale := mathf.NewVec2(-2, 2)
-	if penSpy.lastStampScale != wantScale {
-		t.Fatalf("PenStampWithTransform scale = %v, want %v", penSpy.lastStampScale, wantScale)
+	if spy.lastStampScale != wantScale {
+		t.Fatalf("PenStampWithTransform scale = %v, want %v", spy.lastStampScale, wantScale)
 	}
+
 	wantTexturePath := sprite.getCostumeAssetPath()
-	if penSpy.lastStampTexturePath != wantTexturePath {
-		t.Fatalf("PenStampWithTransform texturePath = %q, want %q", penSpy.lastStampTexturePath, wantTexturePath)
+	if spy.lastStampTexturePath != wantTexturePath {
+		t.Fatalf("PenStampWithTransform texturePath = %q, want %q", spy.lastStampTexturePath, wantTexturePath)
 	}
 }
 
 func TestPenComponentStampSyncsNormalRotation(t *testing.T) {
-	penSpy := setupSpyPenMgr(t)
+	spy := setupSpyPenMgr(t)
 	sprite := newPenTestSprite()
 	configurePenRenderOffsetSprite(sprite)
 	sprite.transform().direction = 45
@@ -290,7 +291,7 @@ func TestPenComponentStampSyncsNormalRotation(t *testing.T) {
 	sprite.pen().Stamp()
 
 	wantRotation := engine.DegToRad(-45)
-	if penSpy.lastStampRotation != wantRotation {
-		t.Fatalf("PenStampWithTransform rotation = %v, want %v", penSpy.lastStampRotation, wantRotation)
+	if spy.lastStampRotation != wantRotation {
+		t.Fatalf("PenStampWithTransform rotation = %v, want %v", spy.lastStampRotation, wantRotation)
 	}
 }

--- a/component_pen_test.go
+++ b/component_pen_test.go
@@ -10,13 +10,18 @@ import (
 )
 
 type spyPenMgr struct {
-	createCalls   int
-	moveCalls     int
-	penDownCalls  int
-	penUpCalls    int
-	setColorCalls int
-	setSizeCalls  int
-	lastMove      mathf.Vec2
+	createCalls          int
+	moveCalls            int
+	penDownCalls         int
+	penUpCalls           int
+	setColorCalls        int
+	setSizeCalls         int
+	stampWithCalls       int
+	lastMove             mathf.Vec2
+	lastStampPosition    mathf.Vec2
+	lastStampTexturePath string
+	lastStampRotation    float64
+	lastStampScale       mathf.Vec2
 }
 
 type penTestSprite struct {
@@ -64,6 +69,14 @@ func (s *spyPenMgr) SetPenSizeTo(obj engine.Object, size float64) {
 }
 
 func (s *spyPenMgr) SetPenStampTexture(obj engine.Object, texturePath string) {}
+
+func (s *spyPenMgr) PenStampWithTransform(obj engine.Object, position mathf.Vec2, texturePath string, rotation float64, scale mathf.Vec2) {
+	s.stampWithCalls++
+	s.lastStampPosition = position
+	s.lastStampTexturePath = texturePath
+	s.lastStampRotation = rotation
+	s.lastStampScale = scale
+}
 
 func newPenTestSprite() *penTestSprite {
 	game := &Game{}
@@ -227,7 +240,57 @@ func TestPenComponentStampUsesRenderedPosition(t *testing.T) {
 	sprite.pen().Stamp()
 
 	want := mathf.NewVec2(87, -36)
-	if spy.lastMove != want {
-		t.Fatalf("MovePenTo position = %v, want %v", spy.lastMove, want)
+	if spy.stampWithCalls != 1 {
+		t.Fatalf("PenStampWithTransform calls = %d, want 1", spy.stampWithCalls)
+	}
+	if spy.lastStampPosition != want {
+		t.Fatalf("PenStampWithTransform position = %v, want %v", spy.lastStampPosition, want)
+	}
+}
+
+func TestPenComponentStampSyncsRenderedTransform(t *testing.T) {
+	penSpy := setupSpyPenMgr(t)
+	sprite := newPenTestSprite()
+	configurePenRenderOffsetSprite(sprite)
+	sprite.runtimeState.Scale = 2
+	sprite.transform().direction = -30
+	sprite.transform().rotationStyle = LeftRight
+
+	sprite.pen().Stamp()
+
+	if penSpy.createCalls != 1 {
+		t.Fatalf("CreatePen calls = %d, want 1", penSpy.createCalls)
+	}
+	if penSpy.stampWithCalls != 1 {
+		t.Fatalf("PenStampWithTransform calls = %d, want 1", penSpy.stampWithCalls)
+	}
+
+	wantRotation := 0.0
+	if penSpy.lastStampRotation != wantRotation {
+		t.Fatalf("PenStampWithTransform rotation = %v, want %v", penSpy.lastStampRotation, wantRotation)
+	}
+
+	wantScale := mathf.NewVec2(-2, 2)
+	if penSpy.lastStampScale != wantScale {
+		t.Fatalf("PenStampWithTransform scale = %v, want %v", penSpy.lastStampScale, wantScale)
+	}
+	wantTexturePath := sprite.getCostumeAssetPath()
+	if penSpy.lastStampTexturePath != wantTexturePath {
+		t.Fatalf("PenStampWithTransform texturePath = %q, want %q", penSpy.lastStampTexturePath, wantTexturePath)
+	}
+}
+
+func TestPenComponentStampSyncsNormalRotation(t *testing.T) {
+	penSpy := setupSpyPenMgr(t)
+	sprite := newPenTestSprite()
+	configurePenRenderOffsetSprite(sprite)
+	sprite.transform().direction = 45
+	sprite.transform().rotationStyle = Normal
+
+	sprite.pen().Stamp()
+
+	wantRotation := engine.DegToRad(-45)
+	if penSpy.lastStampRotation != wantRotation {
+		t.Fatalf("PenStampWithTransform rotation = %v, want %v", penSpy.lastStampRotation, wantRotation)
 	}
 }

--- a/internal/enginewrap/sync.gen.go
+++ b/internal/enginewrap/sync.gen.go
@@ -543,6 +543,11 @@ func (*penMgrImpl) SetPenStampTexture(obj gdx.Object, texture_path string) {
 		gdx.PenMgr.SetPenStampTexture(obj, texture_path)
 	})
 }
+func (*penMgrImpl) PenStampWithTransform(obj gdx.Object, position Vec2, texture_path string, rotation float64, scale Vec2) {
+	callInMainThread(func() {
+		gdx.PenMgr.PenStampWithTransform(obj, position, texture_path, rotation, scale)
+	})
+}
 
 // IPhysicsMgr
 func (*physicsMgrImpl) Raycast(from Vec2, to Vec2, collision_mask int64) gdx.Object {

--- a/internal/enginewrap/sync.gen.go
+++ b/internal/enginewrap/sync.gen.go
@@ -543,9 +543,9 @@ func (*penMgrImpl) SetPenStampTexture(obj gdx.Object, texture_path string) {
 		gdx.PenMgr.SetPenStampTexture(obj, texture_path)
 	})
 }
-func (*penMgrImpl) PenStampWithTransform(obj gdx.Object, position Vec2, texture_path string, rotation float64, scale Vec2) {
+func (*penMgrImpl) PenStampWithTransform(obj gdx.Object, texture_path string, position Vec2, rotation_radians float64, scale Vec2) {
 	callInMainThread(func() {
-		gdx.PenMgr.PenStampWithTransform(obj, position, texture_path, rotation, scale)
+		gdx.PenMgr.PenStampWithTransform(obj, texture_path, position, rotation_radians, scale)
 	})
 }
 

--- a/internal/enginewrap/sync_pure.gen.go
+++ b/internal/enginewrap/sync_pure.gen.go
@@ -280,7 +280,7 @@ func (*penMgrImpl) SetPenTo(obj gdx.Object, property int64, value float64)     {
 func (*penMgrImpl) ChangePenSizeBy(obj gdx.Object, amount float64)             {}
 func (*penMgrImpl) SetPenSizeTo(obj gdx.Object, size float64)                  {}
 func (*penMgrImpl) SetPenStampTexture(obj gdx.Object, texture_path string)     {}
-func (*penMgrImpl) PenStampWithTransform(obj gdx.Object, position Vec2, texture_path string, rotation float64, scale Vec2) {
+func (*penMgrImpl) PenStampWithTransform(obj gdx.Object, texture_path string, position Vec2, rotation_radians float64, scale Vec2) {
 }
 
 // IPhysicsMgr

--- a/internal/enginewrap/sync_pure.gen.go
+++ b/internal/enginewrap/sync_pure.gen.go
@@ -280,6 +280,8 @@ func (*penMgrImpl) SetPenTo(obj gdx.Object, property int64, value float64)     {
 func (*penMgrImpl) ChangePenSizeBy(obj gdx.Object, amount float64)             {}
 func (*penMgrImpl) SetPenSizeTo(obj gdx.Object, size float64)                  {}
 func (*penMgrImpl) SetPenStampTexture(obj gdx.Object, texture_path string)     {}
+func (*penMgrImpl) PenStampWithTransform(obj gdx.Object, position Vec2, texture_path string, rotation float64, scale Vec2) {
+}
 
 // IPhysicsMgr
 func (*physicsMgrImpl) Raycast(from Vec2, to Vec2, collision_mask int64) gdx.Object {

--- a/internal/gdengine/binding/native/ffi.gen.go
+++ b/internal/gdengine/binding/native/ffi.gen.go
@@ -102,6 +102,7 @@ type GDExtensionInterface struct {
 	SpxPenChangePenSizeBy                       GDExtensionSpxPenChangePenSizeBy
 	SpxPenSetPenSizeTo                          GDExtensionSpxPenSetPenSizeTo
 	SpxPenSetPenStampTexture                    GDExtensionSpxPenSetPenStampTexture
+	SpxPenPenStampWithTransform                 GDExtensionSpxPenPenStampWithTransform
 	SpxPhysicsRaycast                           GDExtensionSpxPhysicsRaycast
 	SpxPhysicsCheckCollision                    GDExtensionSpxPhysicsCheckCollision
 	SpxPhysicsCheckTouchedCameraBoundaries      GDExtensionSpxPhysicsCheckTouchedCameraBoundaries
@@ -423,6 +424,7 @@ func (x *GDExtensionInterface) resolveAPIFunctions() {
 	x.SpxPenChangePenSizeBy = (GDExtensionSpxPenChangePenSizeBy)(resolveCFunc("spx_pen_change_pen_size_by"))
 	x.SpxPenSetPenSizeTo = (GDExtensionSpxPenSetPenSizeTo)(resolveCFunc("spx_pen_set_pen_size_to"))
 	x.SpxPenSetPenStampTexture = (GDExtensionSpxPenSetPenStampTexture)(resolveCFunc("spx_pen_set_pen_stamp_texture"))
+	x.SpxPenPenStampWithTransform = (GDExtensionSpxPenPenStampWithTransform)(resolveCFunc("spx_pen_pen_stamp_with_transform"))
 	x.SpxPhysicsRaycast = (GDExtensionSpxPhysicsRaycast)(resolveCFunc("spx_physics_raycast"))
 	x.SpxPhysicsCheckCollision = (GDExtensionSpxPhysicsCheckCollision)(resolveCFunc("spx_physics_check_collision"))
 	x.SpxPhysicsCheckTouchedCameraBoundaries = (GDExtensionSpxPhysicsCheckTouchedCameraBoundaries)(resolveCFunc("spx_physics_check_touched_camera_boundaries"))

--- a/internal/gdengine/binding/native/ffi_wrapper.gen.go
+++ b/internal/gdengine/binding/native/ffi_wrapper.gen.go
@@ -167,6 +167,7 @@ type GDExtensionSpxPenSetPenTo C.GDExtensionSpxPenSetPenTo
 type GDExtensionSpxPenChangePenSizeBy C.GDExtensionSpxPenChangePenSizeBy
 type GDExtensionSpxPenSetPenSizeTo C.GDExtensionSpxPenSetPenSizeTo
 type GDExtensionSpxPenSetPenStampTexture C.GDExtensionSpxPenSetPenStampTexture
+type GDExtensionSpxPenPenStampWithTransform C.GDExtensionSpxPenPenStampWithTransform
 type GDExtensionSpxPhysicsRaycast C.GDExtensionSpxPhysicsRaycast
 type GDExtensionSpxPhysicsCheckCollision C.GDExtensionSpxPhysicsCheckCollision
 type GDExtensionSpxPhysicsCheckTouchedCameraBoundaries C.GDExtensionSpxPhysicsCheckTouchedCameraBoundaries
@@ -1047,6 +1048,23 @@ func CallPenSetPenStampTexture(
 	arg2 := (C.GdString)(texture_path)
 
 	C.cgo_callfn_GDExtensionSpxPenSetPenStampTexture(arg0, arg1, arg2)
+
+}
+func CallPenPenStampWithTransform(
+	obj GdObj,
+	position GdVec2,
+	texture_path GdString,
+	rotation GdFloat,
+	scale GdVec2,
+) {
+	arg0 := (C.GDExtensionSpxPenPenStampWithTransform)(api.SpxPenPenStampWithTransform)
+	arg1 := (C.GdObj)(obj)
+	arg2 := (C.GdVec2)(position)
+	arg3 := (C.GdString)(texture_path)
+	arg4 := (C.GdFloat)(rotation)
+	arg5 := (C.GdVec2)(scale)
+
+	C.cgo_callfn_GDExtensionSpxPenPenStampWithTransform(arg0, arg1, arg2, arg3, arg4, arg5)
 
 }
 func CallPhysicsRaycast(

--- a/internal/gdengine/binding/native/ffi_wrapper.gen.go
+++ b/internal/gdengine/binding/native/ffi_wrapper.gen.go
@@ -1052,16 +1052,16 @@ func CallPenSetPenStampTexture(
 }
 func CallPenPenStampWithTransform(
 	obj GdObj,
-	position GdVec2,
 	texture_path GdString,
-	rotation GdFloat,
+	position GdVec2,
+	rotation_radians GdFloat,
 	scale GdVec2,
 ) {
 	arg0 := (C.GDExtensionSpxPenPenStampWithTransform)(api.SpxPenPenStampWithTransform)
 	arg1 := (C.GdObj)(obj)
-	arg2 := (C.GdVec2)(position)
-	arg3 := (C.GdString)(texture_path)
-	arg4 := (C.GdFloat)(rotation)
+	arg2 := (C.GdString)(texture_path)
+	arg3 := (C.GdVec2)(position)
+	arg4 := (C.GdFloat)(rotation_radians)
 	arg5 := (C.GdVec2)(scale)
 
 	C.cgo_callfn_GDExtensionSpxPenPenStampWithTransform(arg0, arg1, arg2, arg3, arg4, arg5)

--- a/internal/gdengine/binding/native/ffi_wrapper.gen.h
+++ b/internal/gdengine/binding/native/ffi_wrapper.gen.h
@@ -408,11 +408,11 @@ void cgo_callfn_GDExtensionSpxPenSetPenStampTexture(const GDExtensionSpxPenSetPe
 	}
 	fn(obj, texture_path);
 }
-void cgo_callfn_GDExtensionSpxPenPenStampWithTransform(const GDExtensionSpxPenPenStampWithTransform fn, GdObj obj, GdVec2 position, GdString texture_path, GdFloat rotation, GdVec2 scale) {
+void cgo_callfn_GDExtensionSpxPenPenStampWithTransform(const GDExtensionSpxPenPenStampWithTransform fn, GdObj obj, GdString texture_path, GdVec2 position, GdFloat rotation_radians, GdVec2 scale) {
 	if (!fn) {
 		return;
 	}
-	fn(obj, position, texture_path, rotation, scale);
+	fn(obj, texture_path, position, rotation_radians, scale);
 }
 void cgo_callfn_GDExtensionSpxPhysicsRaycast(const GDExtensionSpxPhysicsRaycast fn, GdVec2 from, GdVec2 to, GdInt collision_mask, GdObj* ret_val) {
 	if (!fn) {

--- a/internal/gdengine/binding/native/ffi_wrapper.gen.h
+++ b/internal/gdengine/binding/native/ffi_wrapper.gen.h
@@ -408,6 +408,12 @@ void cgo_callfn_GDExtensionSpxPenSetPenStampTexture(const GDExtensionSpxPenSetPe
 	}
 	fn(obj, texture_path);
 }
+void cgo_callfn_GDExtensionSpxPenPenStampWithTransform(const GDExtensionSpxPenPenStampWithTransform fn, GdObj obj, GdVec2 position, GdString texture_path, GdFloat rotation, GdVec2 scale) {
+	if (!fn) {
+		return;
+	}
+	fn(obj, position, texture_path, rotation, scale);
+}
 void cgo_callfn_GDExtensionSpxPhysicsRaycast(const GDExtensionSpxPhysicsRaycast fn, GdVec2 from, GdVec2 to, GdInt collision_mask, GdObj* ret_val) {
 	if (!fn) {
 		return;

--- a/internal/gdengine/binding/native/gdextension_spx_ext.h
+++ b/internal/gdengine/binding/native/gdextension_spx_ext.h
@@ -289,6 +289,7 @@ typedef void (*GDExtensionSpxPenSetPenTo)(GdObj obj, GdInt property, GdFloat val
 typedef void (*GDExtensionSpxPenChangePenSizeBy)(GdObj obj, GdFloat amount);
 typedef void (*GDExtensionSpxPenSetPenSizeTo)(GdObj obj, GdFloat size);
 typedef void (*GDExtensionSpxPenSetPenStampTexture)(GdObj obj, GdString texture_path);
+typedef void (*GDExtensionSpxPenPenStampWithTransform)(GdObj obj, GdVec2 position, GdString texture_path, GdFloat rotation, GdVec2 scale);
 // SpxPhysics
 typedef void (*GDExtensionSpxPhysicsRaycast)(GdVec2 from, GdVec2 to, GdInt collision_mask, GdObj *ret_value);
 typedef void (*GDExtensionSpxPhysicsCheckCollision)(GdVec2 from, GdVec2 to, GdInt collision_mask, GdBool collide_with_areas, GdBool collide_with_bodies, GdBool *ret_value);

--- a/internal/gdengine/binding/native/gdextension_spx_ext.h
+++ b/internal/gdengine/binding/native/gdextension_spx_ext.h
@@ -289,7 +289,7 @@ typedef void (*GDExtensionSpxPenSetPenTo)(GdObj obj, GdInt property, GdFloat val
 typedef void (*GDExtensionSpxPenChangePenSizeBy)(GdObj obj, GdFloat amount);
 typedef void (*GDExtensionSpxPenSetPenSizeTo)(GdObj obj, GdFloat size);
 typedef void (*GDExtensionSpxPenSetPenStampTexture)(GdObj obj, GdString texture_path);
-typedef void (*GDExtensionSpxPenPenStampWithTransform)(GdObj obj, GdVec2 position, GdString texture_path, GdFloat rotation, GdVec2 scale);
+typedef void (*GDExtensionSpxPenPenStampWithTransform)(GdObj obj, GdString texture_path, GdVec2 position, GdFloat rotation_radians, GdVec2 scale);
 // SpxPhysics
 typedef void (*GDExtensionSpxPhysicsRaycast)(GdVec2 from, GdVec2 to, GdInt collision_mask, GdObj *ret_value);
 typedef void (*GDExtensionSpxPhysicsCheckCollision)(GdVec2 from, GdVec2 to, GdInt collision_mask, GdBool collide_with_areas, GdBool collide_with_bodies, GdBool *ret_value);

--- a/internal/gdengine/binding/web/ffi.gen.go
+++ b/internal/gdengine/binding/web/ffi.gen.go
@@ -106,6 +106,7 @@ type GDExtensionInterface struct {
 	SpxPenChangePenSizeBy                       js.Value
 	SpxPenSetPenSizeTo                          js.Value
 	SpxPenSetPenStampTexture                    js.Value
+	SpxPenPenStampWithTransform                 js.Value
 	SpxPhysicsRaycast                           js.Value
 	SpxPhysicsCheckCollision                    js.Value
 	SpxPhysicsCheckTouchedCameraBoundaries      js.Value
@@ -427,6 +428,7 @@ func (x *GDExtensionInterface) resolveAPIFunctions() {
 	x.SpxPenChangePenSizeBy = resolveJSFunc("gdspx_pen_change_pen_size_by")
 	x.SpxPenSetPenSizeTo = resolveJSFunc("gdspx_pen_set_pen_size_to")
 	x.SpxPenSetPenStampTexture = resolveJSFunc("gdspx_pen_set_pen_stamp_texture")
+	x.SpxPenPenStampWithTransform = resolveJSFunc("gdspx_pen_pen_stamp_with_transform")
 	x.SpxPhysicsRaycast = resolveJSFunc("gdspx_physics_raycast")
 	x.SpxPhysicsCheckCollision = resolveJSFunc("gdspx_physics_check_collision")
 	x.SpxPhysicsCheckTouchedCameraBoundaries = resolveJSFunc("gdspx_physics_check_touched_camera_boundaries")

--- a/internal/gdengine/impl/manager_native.gen.go
+++ b/internal/gdengine/impl/manager_native.gen.go
@@ -492,6 +492,16 @@ func (pself *penMgr) SetPenStampTexture(obj Object, texture_path string) {
 	defer C.free(unsafe.Pointer(arg1Str))
 	CallPenSetPenStampTexture(arg0, arg1)
 }
+func (pself *penMgr) PenStampWithTransform(obj Object, position Vec2, texture_path string, rotation float64, scale Vec2) {
+	arg0 := ToGdObj(obj)
+	arg1 := ToGdVec2(position)
+	arg2Str := C.CString(texture_path)
+	arg2 := (GdString)(arg2Str)
+	defer C.free(unsafe.Pointer(arg2Str))
+	arg3 := ToGdFloat(rotation)
+	arg4 := ToGdVec2(scale)
+	CallPenPenStampWithTransform(arg0, arg1, arg2, arg3, arg4)
+}
 func (pself *physicsMgr) Raycast(from Vec2, to Vec2, collision_mask int64) Object {
 	arg0 := ToGdVec2(from)
 	arg1 := ToGdVec2(to)

--- a/internal/gdengine/impl/manager_native.gen.go
+++ b/internal/gdengine/impl/manager_native.gen.go
@@ -492,13 +492,13 @@ func (pself *penMgr) SetPenStampTexture(obj Object, texture_path string) {
 	defer C.free(unsafe.Pointer(arg1Str))
 	CallPenSetPenStampTexture(arg0, arg1)
 }
-func (pself *penMgr) PenStampWithTransform(obj Object, position Vec2, texture_path string, rotation float64, scale Vec2) {
+func (pself *penMgr) PenStampWithTransform(obj Object, texture_path string, position Vec2, rotation_radians float64, scale Vec2) {
 	arg0 := ToGdObj(obj)
-	arg1 := ToGdVec2(position)
-	arg2Str := C.CString(texture_path)
-	arg2 := (GdString)(arg2Str)
-	defer C.free(unsafe.Pointer(arg2Str))
-	arg3 := ToGdFloat(rotation)
+	arg1Str := C.CString(texture_path)
+	arg1 := (GdString)(arg1Str)
+	defer C.free(unsafe.Pointer(arg1Str))
+	arg2 := ToGdVec2(position)
+	arg3 := ToGdFloat(rotation_radians)
 	arg4 := ToGdVec2(scale)
 	CallPenPenStampWithTransform(arg0, arg1, arg2, arg3, arg4)
 }

--- a/internal/gdengine/impl/manager_web.gen.go
+++ b/internal/gdengine/impl/manager_web.gen.go
@@ -469,6 +469,14 @@ func (pself *penMgr) SetPenStampTexture(obj Object, texture_path string) {
 	arg1 := JsFromGdString(texture_path)
 	API.SpxPenSetPenStampTexture.Invoke(arg0Low, arg0High, arg1)
 }
+func (pself *penMgr) PenStampWithTransform(obj Object, position Vec2, texture_path string, rotation float64, scale Vec2) {
+	arg0Low, arg0High := JsSplitGdObj(obj)
+	arg1 := JsFromGdVec2(position)
+	arg2 := JsFromGdString(texture_path)
+	arg3 := JsFromGdFloat(rotation)
+	arg4 := JsFromGdVec2(scale)
+	API.SpxPenPenStampWithTransform.Invoke(arg0Low, arg0High, arg1, arg2, arg3, arg4)
+}
 func (pself *physicsMgr) Raycast(from Vec2, to Vec2, collision_mask int64) Object {
 	arg0 := JsFromGdVec2(from)
 	arg1 := JsFromGdVec2(to)

--- a/internal/gdengine/impl/manager_web.gen.go
+++ b/internal/gdengine/impl/manager_web.gen.go
@@ -469,11 +469,11 @@ func (pself *penMgr) SetPenStampTexture(obj Object, texture_path string) {
 	arg1 := JsFromGdString(texture_path)
 	API.SpxPenSetPenStampTexture.Invoke(arg0Low, arg0High, arg1)
 }
-func (pself *penMgr) PenStampWithTransform(obj Object, position Vec2, texture_path string, rotation float64, scale Vec2) {
+func (pself *penMgr) PenStampWithTransform(obj Object, texture_path string, position Vec2, rotation_radians float64, scale Vec2) {
 	arg0Low, arg0High := JsSplitGdObj(obj)
-	arg1 := JsFromGdVec2(position)
-	arg2 := JsFromGdString(texture_path)
-	arg3 := JsFromGdFloat(rotation)
+	arg1 := JsFromGdString(texture_path)
+	arg2 := JsFromGdVec2(position)
+	arg3 := JsFromGdFloat(rotation_radians)
 	arg4 := JsFromGdVec2(scale)
 	API.SpxPenPenStampWithTransform.Invoke(arg0Low, arg0High, arg1, arg2, arg3, arg4)
 }

--- a/pkg/spx/pkg/engine/interface.gen.go
+++ b/pkg/spx/pkg/engine/interface.gen.go
@@ -133,7 +133,7 @@ type IPenMgr interface {
 	ChangePenSizeBy(obj Object, amount float64)
 	SetPenSizeTo(obj Object, size float64)
 	SetPenStampTexture(obj Object, texture_path string)
-	PenStampWithTransform(obj Object, position Vec2, texture_path string, rotation float64, scale Vec2)
+	PenStampWithTransform(obj Object, texture_path string, position Vec2, rotation_radians float64, scale Vec2)
 }
 
 type IPhysicsMgr interface {

--- a/pkg/spx/pkg/engine/interface.gen.go
+++ b/pkg/spx/pkg/engine/interface.gen.go
@@ -133,6 +133,7 @@ type IPenMgr interface {
 	ChangePenSizeBy(obj Object, amount float64)
 	SetPenSizeTo(obj Object, size float64)
 	SetPenStampTexture(obj Object, texture_path string)
+	PenStampWithTransform(obj Object, position Vec2, texture_path string, rotation float64, scale Vec2)
 }
 
 type IPhysicsMgr interface {


### PR DESCRIPTION
## Summary
- switch pen stamp to a single `PenStampWithTransform` bridge call
- precompute the final stamp scale in Go before calling into the engine
- regenerate native/web binding code for the new pen manager API
- add pen stamp tests covering rendered position, rotation, texture path, and final scale

## Testing
- go test .