### PR TITLE
fix: support stepTo Random targets

### DIFF
--- a/sprite.go
+++ b/sprite.go
@@ -208,6 +208,9 @@ type Sprite interface {
 	StepTo__9(sprite SpriteName, speed Speed, animation SpriteAnimationName)
 	StepTo__a(obj specialObj, speed Speed, animation SpriteAnimationName)
 	StepTo__b(x, y, speed Speed, animation SpriteAnimationName)
+	StepTo__c(pos Pos)
+	StepTo__d(pos Pos, speed Speed)
+	StepTo__e(pos Pos, speed Speed, animation SpriteAnimationName)
 
 	StepToTarget(target Target, __xgo_optional_opts *MotionOptions)
 	StepToXYpos(x, y float64, __xgo_optional_opts *MotionOptions)

--- a/sprite_transform.go
+++ b/sprite_transform.go
@@ -173,6 +173,18 @@ func (p *SpriteImpl) StepTo__b(x, y, speed float64, animation SpriteAnimationNam
 	p.transform().StepToPos(x, y, speed, animation)
 }
 
+func (p *SpriteImpl) StepTo__c(pos Pos) {
+	p.doStepTo(pos, 1, "")
+}
+
+func (p *SpriteImpl) StepTo__d(pos Pos, speed float64) {
+	p.doStepTo(pos, speed, "")
+}
+
+func (p *SpriteImpl) StepTo__e(pos Pos, speed float64, animation SpriteAnimationName) {
+	p.doStepTo(pos, speed, animation)
+}
+
 func (p *SpriteImpl) StepToTarget(target Target, __xgo_optional_opts *MotionOptions) {
 	speed, animation := motionOptions(__xgo_optional_opts)
 	p.doStepTo(target, speed, animation)

--- a/sprite_transform_motion_test.go
+++ b/sprite_transform_motion_test.go
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2021 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package spx
+
+import (
+	"math/rand"
+	"testing"
+)
+
+func TestSpriteStepToRandomUsesRandomPositionTarget(t *testing.T) {
+	sprite := newTestTransformSprite(1000, 1000)
+	sprite.g.displayState.WorldWidth = 480
+	sprite.g.displayState.WorldHeight = 360
+
+	rand.Seed(1)
+	sprite.StepTo__c(Random)
+
+	gotX, gotY := sprite.getXY()
+	if gotX == 1000 && gotY == 1000 {
+		t.Fatal("StepTo__c(Random) did not move the sprite")
+	}
+
+	minX := float64(-(sprite.g.displayState.WorldWidth >> 1))
+	maxX := float64(sprite.g.displayState.WorldWidth - (sprite.g.displayState.WorldWidth >> 1) - 1)
+	minY := float64((sprite.g.displayState.WorldHeight >> 1) - (sprite.g.displayState.WorldHeight - 1))
+	maxY := float64(sprite.g.displayState.WorldHeight >> 1)
+	if gotX < minX || gotX > maxX || gotY < minY || gotY > maxY {
+		t.Fatalf(
+			"StepTo__c(Random) moved to (%v, %v), want x in [%v, %v], y in [%v, %v]",
+			gotX,
+			gotY,
+			minX,
+			maxX,
+			minY,
+			maxY,
+		)
+	}
+}


### PR DESCRIPTION
## Summary

- add `StepTo` overloads for `Pos` targets so `stepTo Random` resolves correctly
- route the new overloads through the existing random-position target handling
- add a regression test covering `StepTo(Random)`

## Testing

- `go test ./...`

## Related

Closes goplus/sb2xbp#392
Fixes goplus/sb2xbp#396
Resolves goplus/sb2xbp#401