### PR TITLE
fix: align click picking with Scratch ghost behavior

### DIFF
--- a/internal/core/event/manager.go
+++ b/internal/core/event/manager.go
@@ -117,15 +117,6 @@ func deleteOwnerCopy(sinks []Sink, owner any) []Sink {
 	return out
 }
 
-func HasOwner(sinks []Sink, owner any) bool {
-	for _, sink := range sinks {
-		if sink.Owner == owner {
-			return true
-		}
-	}
-	return false
-}
-
 func (m *Manager) Add(bucket Bucket, sink Sink) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/internal/core/event/manager_test.go
+++ b/internal/core/event/manager_test.go
@@ -119,20 +119,6 @@ func TestManagerConvenienceMethods(t *testing.T) {
 	}
 }
 
-func TestHasOwner(t *testing.T) {
-	sinks := []Sink{
-		{Owner: "keep", Handler: func() {}},
-		{Owner: "click", Handler: func() {}},
-	}
-
-	if !HasOwner(sinks, "click") {
-		t.Fatal("HasOwner should find matching owner")
-	}
-	if HasOwner(sinks, "missing") {
-		t.Fatal("HasOwner should return false for missing owner")
-	}
-}
-
 func TestManagerStartLifecycle(t *testing.T) {
 	var mgr Manager
 	if !mgr.TryAddStart(Sink{Owner: "first", Handler: func() {}}) {

--- a/runtime_events.go
+++ b/runtime_events.go
@@ -200,7 +200,6 @@ type clicker interface {
 }
 
 func (p *Game) findClickTarget(point mathf.Vec2) (coreruntime.ClickSelection[clicker, *SpriteImpl], bool) {
-	clickSinks := p.scriptEvents.manager.SnapshotClick()
 	return coreruntime.FindClickTarget(p.getTempShapes(), func(item Shape) (coreruntime.ClickSelection[clicker, *SpriteImpl], bool) {
 		o, ok := item.(clicker)
 		if !ok {
@@ -210,10 +209,10 @@ func (p *Game) findClickTarget(point mathf.Vec2) (coreruntime.ClickSelection[cli
 		if syncSprite == nil || !o.Visible() {
 			return coreruntime.ClickSelection[clicker, *SpriteImpl]{}, false
 		}
-		if !p.engine().SpriteMgr.CheckCollisionWithPoint(syncSprite.GetId(), point, true) {
+		if sprite, ok := o.(*SpriteImpl); ok && sprite.isFullyGhosted() {
 			return coreruntime.ClickSelection[clicker, *SpriteImpl]{}, false
 		}
-		if !coreevent.HasOwner(clickSinks, o) {
+		if !p.engine().SpriteMgr.CheckCollisionWithPoint(syncSprite.GetId(), point, true) {
 			return coreruntime.ClickSelection[clicker, *SpriteImpl]{}, false
 		}
 		if sprite, ok := o.(*SpriteImpl); ok {

--- a/runtime_events_test.go
+++ b/runtime_events_test.go
@@ -83,7 +83,7 @@ func newClickTestSprite(g *Game, name string, id pkgengine.Object, registerClick
 	return sprite
 }
 
-func TestFindClickTargetSkipsCoveredSpriteWithoutClickHandler(t *testing.T) {
+func TestFindClickTargetKeepsTopmostSpriteWithoutClickHandler(t *testing.T) {
 	setupClickThroughSpriteMgr(t, map[pkgengine.Object]bool{
 		1: true,
 		2: true,
@@ -101,11 +101,11 @@ func TestFindClickTargetSkipsCoveredSpriteWithoutClickHandler(t *testing.T) {
 	if !ok {
 		t.Fatal("expected click target")
 	}
-	if selection.Target != bottom {
-		t.Fatalf("target = %p, want bottom %p", selection.Target, bottom)
+	if selection.Target != top {
+		t.Fatalf("target = %p, want top %p", selection.Target, top)
 	}
-	if selection.SwipeTarget != bottom {
-		t.Fatalf("swipe target = %p, want bottom %p", selection.SwipeTarget, bottom)
+	if selection.SwipeTarget != top {
+		t.Fatalf("swipe target = %p, want top %p", selection.SwipeTarget, top)
 	}
 }
 
@@ -132,5 +132,32 @@ func TestFindClickTargetKeepsTopmostClickableSprite(t *testing.T) {
 	}
 	if selection.SwipeTarget != top {
 		t.Fatalf("swipe target = %p, want top %p", selection.SwipeTarget, top)
+	}
+}
+
+func TestFindClickTargetSkipsFullyGhostedSpriteEvenWithClickHandler(t *testing.T) {
+	setupClickThroughSpriteMgr(t, map[pkgengine.Object]bool{
+		1: true,
+		2: true,
+	})
+
+	var g Game
+	g.initShapeMgr()
+
+	bottom := newClickTestSprite(&g, "bottom", 1, true)
+	top := newClickTestSprite(&g, "top", 2, true)
+	top.greffUniforms = map[EffectKind]float64{GhostEffect: 100}
+	g.addShape(bottom)
+	g.addShape(top)
+
+	selection, ok := g.findClickTarget(mathf.NewVec2(0, 0))
+	if !ok {
+		t.Fatal("expected click target")
+	}
+	if selection.Target != bottom {
+		t.Fatalf("target = %p, want bottom %p", selection.Target, bottom)
+	}
+	if selection.SwipeTarget != bottom {
+		t.Fatalf("swipe target = %p, want bottom %p", selection.SwipeTarget, bottom)
 	}
 }

--- a/sprite_render.go
+++ b/sprite_render.go
@@ -104,6 +104,14 @@ func (p *SpriteImpl) ClearGraphicEffects() {
 	p.clearGraphicEffects()
 }
 
+func (p *SpriteImpl) isFullyGhosted() bool {
+	if p.greffUniforms == nil {
+		return false
+	}
+	val, ok := p.greffUniforms[GhostEffect]
+	return ok && normalizeEffectValue(GhostEffect, val) >= 1
+}
+
 // -----------------------------------------------------------------------------
 // Layer
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Align sprite click picking with Scratch behavior.

This change removes the previous "click through covered sprites without handlers" behavior and instead matches Scratch more closely:

- the topmost hit sprite remains the click target even if it does not register `onClick`
- fully ghosted sprites (`GhostEffect = 100`) are excluded from click picking
- hidden sprites continue to be excluded from click picking

## Background

The previous implementation allowed clicks to pass through a covered sprite when that sprite had no registered click handler.

After checking Scratch's runtime and renderer behavior, that is not how Scratch handles sprite clicks:
- Scratch picks a single topmost target
- it does not continue searching downward based on whether a click hat exists
- fully ghosted sprites are not pickable, so clicks can pass through them naturally

This update changes SPX to follow that model.

## Changes

- remove click target filtering based on registered `onClick` handlers
- add a fully-ghosted check before point collision testing
- keep topmost-hit selection behavior intact
- remove the no-longer-needed event sink owner helper
- update click-picking tests to match the new behavior

## Behavior After This Change

- covered sprites without `onClick` still block clicks, as long as they are pickable
- sprites with `GhostEffect = 100` do not receive clicks
- clicks can pass through fully ghosted sprites to pick targets underneath
- topmost clickable sprites still win over lower sprites

## Tests

```bash
go test . -run 'TestFindClickTargetKeepsTopmostSpriteWithoutClickHandler|TestFindClickTargetKeepsTopmostClickableSprite|TestFindClickTargetSkipsFullyGhostedSpriteEvenWithClickHandler' -count=1
go test ./internal/core/runtime -run 'TestFindClickTarget|TestHandleLeftButtonDown'
go test ./internal/core/event -run 'TestManagerConvenienceMethods'