### PR TITLE
fix: support random backdrop switching

### DIFF
--- a/runtime_display.go
+++ b/runtime_display.go
@@ -17,19 +17,53 @@
 package spx
 
 import (
+	"math/rand"
+
 	"github.com/goplus/spbase/mathf"
 	coreproject "github.com/goplus/spx/v2/internal/core/project"
+	spxlog "github.com/goplus/spx/v2/internal/log"
 )
 
 // -----------------------------------------------------------------------------
 // Backdrop
 // -----------------------------------------------------------------------------
 func (p *Game) setBackdrop(backdrop any, wait bool) {
-	if p.goSetCostume(backdrop) {
+	if p.goSetBackdrop(backdrop) {
 		p.setupBackdrop()
 		p.doWindowSize()
 		p.doWhenBackdropChanged(p.getCostumeName(), wait)
 	}
+}
+
+func (p *Game) goSetBackdrop(val any) bool {
+	switch v := val.(type) {
+	case int:
+		if Pos(v) == Random {
+			return p.setRandomBackdrop()
+		}
+	case float64:
+		if v == float64(Random) {
+			return p.setRandomBackdrop()
+		}
+	}
+	return p.goSetCostume(val)
+}
+
+func (p *Game) setRandomBackdrop() bool {
+	switch len(p.costumes) {
+	case 0:
+		spxlog.Error("setBackdrop: no backdrops available")
+		return false
+	case 1:
+		return true
+	}
+
+	nextIndex := rand.Intn(len(p.costumes) - 1)
+	if nextIndex >= p.costumeIndex {
+		nextIndex++
+	}
+	p.setCostumeIndex(nextIndex)
+	return true
 }
 
 func (p *Game) setupBackdrop() {

--- a/runtime_display_test.go
+++ b/runtime_display_test.go
@@ -1,6 +1,7 @@
 package spx
 
 import (
+	"math/rand"
 	"testing"
 
 	"github.com/goplus/spbase/mathf"
@@ -18,5 +19,74 @@ func TestGetCostumeRenderOffsetUsesPivot(t *testing.T) {
 	x, y := getCostumeRenderOffset(costume, costume.pivot, 1, 1)
 	if x != -10 || y != 5 {
 		t.Fatalf("getCostumeRenderOffset = (%v, %v), want (-10, 5)", x, y)
+	}
+}
+
+func TestGameGoSetBackdropRandomChoosesDifferentBackdrop(t *testing.T) {
+	game := &Game{
+		baseObj: baseObj{
+			costumes: []*costume{
+				{name: "backdrop1"},
+				{name: "backdrop2"},
+				{name: "backdrop3"},
+			},
+			costumeIndex: 1,
+		},
+	}
+
+	rand.Seed(1)
+	if ok := game.goSetBackdrop(Random); !ok {
+		t.Fatal("goSetBackdrop(Random) = false, want true")
+	}
+
+	if got := game.costumeIndex; got < 0 || got >= len(game.costumes) {
+		t.Fatalf("costumeIndex = %d, want in [0, %d)", got, len(game.costumes))
+	}
+	if got := game.costumeIndex; got == 1 {
+		t.Fatalf("costumeIndex = %d, want a different backdrop", got)
+	}
+}
+
+func TestGameGoSetBackdropRandomFloat64ChoosesDifferentBackdrop(t *testing.T) {
+	game := &Game{
+		baseObj: baseObj{
+			costumes: []*costume{
+				{name: "backdrop1"},
+				{name: "backdrop2"},
+			},
+			costumeIndex: 0,
+		},
+	}
+
+	rand.Seed(1)
+	if ok := game.goSetBackdrop(float64(Random)); !ok {
+		t.Fatal("goSetBackdrop(float64(Random)) = false, want true")
+	}
+
+	if got := game.costumeIndex; got != 1 {
+		t.Fatalf("costumeIndex = %d, want 1", got)
+	}
+}
+
+func TestGameSetRandomBackdropWithNoBackdropsFails(t *testing.T) {
+	var game Game
+	if ok := game.setRandomBackdrop(); ok {
+		t.Fatal("setRandomBackdrop() = true, want false")
+	}
+}
+
+func TestGameSetRandomBackdropWithSingleBackdropIsNoOp(t *testing.T) {
+	game := &Game{
+		baseObj: baseObj{
+			costumes:     []*costume{{name: "backdrop1"}},
+			costumeIndex: 0,
+		},
+	}
+
+	if ok := game.setRandomBackdrop(); !ok {
+		t.Fatal("setRandomBackdrop() = false, want true")
+	}
+	if got := game.costumeIndex; got != 0 {
+		t.Fatalf("costumeIndex = %d, want 0", got)
 	}
 }


### PR DESCRIPTION
## Summary

This change adds dedicated runtime support for random backdrop switching.

### What changed

- route `setBackdrop` through a backdrop-specific handler in `runtime_display.go`
- support `setBackdrop Random` for both `int` and `float64` random sentinel values
- avoid re-selecting the current backdrop when multiple backdrops are available
- keep the behavior safe for empty and single-backdrop projects
- add regression coverage for random backdrop switching scenarios

## Why

Scratch projects can use random backdrop switching semantics that are specific to stage backdrops.
Handling this in the backdrop runtime path keeps the behavior localized and avoids changing generic costume switching behavior.

## Testing

- `go test .`