### PR TITLE
template: default generated runners to white background

### DIFF
--- a/cmd/ispx/web/runner.html
+++ b/cmd/ispx/web/runner.html
@@ -16,7 +16,6 @@
 			display: flex;
 			justify-content: center;
 			align-items: center;
-			background: #fff;
 			background-color: #fff;
 			overflow: hidden;
 		}

--- a/cmd/ispx/web/runner.html
+++ b/cmd/ispx/web/runner.html
@@ -16,8 +16,8 @@
 			display: flex;
 			justify-content: center;
 			align-items: center;
-			background: transparent;
-			background-color: transparent;
+			background: #fff;
+			background-color: #fff;
 			overflow: hidden;
 		}
 
@@ -25,6 +25,7 @@
 			display: block;
 			margin: 0;
 			outline: none;
+			background-color: #fff;
 		}
 	</style>
 </head>

--- a/cmd/spx/template/platform/webminiprogram/index.html
+++ b/cmd/spx/template/platform/webminiprogram/index.html
@@ -20,7 +20,7 @@
 			display: flex;
 			justify-content: center;
 			align-items: center;
-			background-color: #333;
+			background-color: #fff;
 			overflow: hidden;
 		}
 
@@ -28,6 +28,7 @@
 			display: block;
 			margin: 0;
 			outline: none;
+			background-color: #fff;
 		}
 
 

--- a/cmd/spx/template/project/project.godot
+++ b/cmd/spx/template/project/project.godot
@@ -30,4 +30,5 @@ realtime_mode=true
 
 [rendering]
 
+environment/defaults/default_clear_color=Color(1, 1, 1, 1)
 textures/vram_compression/import_etc2_astc=true


### PR DESCRIPTION
## Background

The current Web runner, mini program template, and project rendering defaults use inconsistent background colors. This can cause gray or transparent areas during loading or around the canvas.

## Changes

- Updated `cmd/ispx/web/runner.html` to use a white page background
- Updated `cmd/spx/template/platform/webminiprogram/index.html` to use a white page background and white canvas background
- Set the default clear color to white in `cmd/spx/template/project/project.godot`

## Impact

Newly generated projects will have a more consistent white background across Web and mini program runtimes, avoiding gray, dark, or transparent visual gaps.

## Validation

- Template-only changes, no new automated tests were added