### PR TITLE
cmd/spx: overwrite synced project files during env setup

### DIFF
--- a/cmd/spx/internal/command/env.go
+++ b/cmd/spx/internal/command/env.go
@@ -96,7 +96,7 @@ func (cmd *CmdTool) SetupEnv(version string, fs embed.FS, fsRelDir string, proje
 
 // PrepareEnv syncs project files.
 func (cmd *CmdTool) PrepareEnv(fsRelDir, dstDir string) {
-	util.CopyDir(cmd.ProjectFS, fsRelDir, dstDir, false)
+	util.CopyDir(cmd.ProjectFS, fsRelDir, dstDir, true)
 
 	tempFile, _ := filepath.Abs(path.Join(cmd.TargetDir, "xgo_autogen.go"))
 	tmp := `

--- a/cmd/spx/internal/util/io_test.go
+++ b/cmd/spx/internal/util/io_test.go
@@ -1,0 +1,65 @@
+package util
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCopyDirPreservesExistingFileWhenOverrideDisabled(t *testing.T) {
+	srcRoot := t.TempDir()
+	dstRoot := t.TempDir()
+
+	srcDir := filepath.Join(srcRoot, "template")
+	if err := os.MkdirAll(srcDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s) returned error: %v", srcDir, err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "project.godot"), []byte("template"), 0o644); err != nil {
+		t.Fatalf("WriteFile(template project.godot) returned error: %v", err)
+	}
+	dstPath := filepath.Join(dstRoot, "project.godot")
+	if err := os.WriteFile(dstPath, []byte("existing"), 0o644); err != nil {
+		t.Fatalf("WriteFile(existing project.godot) returned error: %v", err)
+	}
+
+	if err := CopyDir(os.DirFS(srcRoot), "template", dstRoot, false); err != nil {
+		t.Fatalf("CopyDir(..., false) returned error: %v", err)
+	}
+
+	got, err := os.ReadFile(dstPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%s) returned error: %v", dstPath, err)
+	}
+	if string(got) != "existing" {
+		t.Fatalf("project.godot = %q, want existing", string(got))
+	}
+}
+
+func TestCopyDirOverwritesExistingFileWhenOverrideEnabled(t *testing.T) {
+	srcRoot := t.TempDir()
+	dstRoot := t.TempDir()
+
+	srcDir := filepath.Join(srcRoot, "template")
+	if err := os.MkdirAll(srcDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s) returned error: %v", srcDir, err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "project.godot"), []byte("template"), 0o644); err != nil {
+		t.Fatalf("WriteFile(template project.godot) returned error: %v", err)
+	}
+	dstPath := filepath.Join(dstRoot, "project.godot")
+	if err := os.WriteFile(dstPath, []byte("existing"), 0o644); err != nil {
+		t.Fatalf("WriteFile(existing project.godot) returned error: %v", err)
+	}
+
+	if err := CopyDir(os.DirFS(srcRoot), "template", dstRoot, true); err != nil {
+		t.Fatalf("CopyDir(..., true) returned error: %v", err)
+	}
+
+	got, err := os.ReadFile(dstPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%s) returned error: %v", dstPath, err)
+	}
+	if string(got) != "template" {
+		t.Fatalf("project.godot = %q, want template", string(got))
+	}
+}


### PR DESCRIPTION
## Background

`PrepareEnv` currently syncs template files without overwriting existing files in the target directory. This means template updates may not be propagated to already-generated project directories.

## Changes

- Switched `CopyDir` to overwrite mode in `PrepareEnv`
- Added unit tests for `CopyDir` covering:
- preserving existing files when overwrite is disabled
- replacing existing files when overwrite is enabled

## Impact

This ensures updated template files are correctly synced into the project directory when the environment is prepared again.

## Validation

- `go test ./cmd/spx/internal/...`