### PR TITLE
fix: sync dirty proxy transforms before touching queries

### DIFF
--- a/component_transform.go
+++ b/component_transform.go
@@ -121,7 +121,7 @@ func (t *transformComponent) onDestroy() {
 // markDirty marks the transform as dirty, triggering an update.
 func (t *transformComponent) markDirty() {
 	t.isDirty = true
-	t.sprite.spriteState.IsDirty = true
+	t.sprite.markProxyDirty()
 }
 
 // getPivot returns the current pivot point.

--- a/internal/core/state/sprite.go
+++ b/internal/core/state/sprite.go
@@ -21,6 +21,8 @@ type SpriteRuntimeState struct {
 	Cloned              bool
 	IsDying             bool
 	IsDirty             bool
+	DirtyVersion        uint64
+	ProxySyncVersion    uint64
 	IsAwakened          bool
 	HasOnCloned         bool
 	HasOnTouchStart     bool

--- a/internal/enginewrap/sync.gen.go
+++ b/internal/enginewrap/sync.gen.go
@@ -1051,6 +1051,11 @@ func (*spriteMgrImpl) SetPosition(obj gdx.Object, pos Vec2) {
 		gdx.SpriteMgr.SetPosition(obj, pos)
 	})
 }
+func (*spriteMgrImpl) SetTransform(obj gdx.Object, pos Vec2, rot float64, scale Vec2, visible bool, pivot Vec2) {
+	callInMainThread(func() {
+		gdx.SpriteMgr.SetTransform(obj, pos, rot, scale, visible, pivot)
+	})
+}
 func (*spriteMgrImpl) GetPosition(obj gdx.Object) Vec2 {
 	var _ret1 Vec2
 	callInMainThread(func() {

--- a/internal/enginewrap/sync_pure.gen.go
+++ b/internal/enginewrap/sync_pure.gen.go
@@ -462,6 +462,8 @@ func (*spriteMgrImpl) IsSpriteAlive(obj gdx.Object) bool {
 	return false
 }
 func (*spriteMgrImpl) SetPosition(obj gdx.Object, pos Vec2) {}
+func (*spriteMgrImpl) SetTransform(obj gdx.Object, pos Vec2, rot float64, scale Vec2, visible bool, pivot Vec2) {
+}
 func (*spriteMgrImpl) GetPosition(obj gdx.Object) Vec2 {
 	return Vec2{}
 }

--- a/internal/gdengine/binding/native/ffi.gen.go
+++ b/internal/gdengine/binding/native/ffi.gen.go
@@ -184,6 +184,7 @@ type GDExtensionInterface struct {
 	SpxSpriteDestroySprite                      GDExtensionSpxSpriteDestroySprite
 	SpxSpriteIsSpriteAlive                      GDExtensionSpxSpriteIsSpriteAlive
 	SpxSpriteSetPosition                        GDExtensionSpxSpriteSetPosition
+	SpxSpriteSetTransform                       GDExtensionSpxSpriteSetTransform
 	SpxSpriteGetPosition                        GDExtensionSpxSpriteGetPosition
 	SpxSpriteSetRotation                        GDExtensionSpxSpriteSetRotation
 	SpxSpriteGetRotation                        GDExtensionSpxSpriteGetRotation
@@ -506,6 +507,7 @@ func (x *GDExtensionInterface) resolveAPIFunctions() {
 	x.SpxSpriteDestroySprite = (GDExtensionSpxSpriteDestroySprite)(resolveCFunc("spx_sprite_destroy_sprite"))
 	x.SpxSpriteIsSpriteAlive = (GDExtensionSpxSpriteIsSpriteAlive)(resolveCFunc("spx_sprite_is_sprite_alive"))
 	x.SpxSpriteSetPosition = (GDExtensionSpxSpriteSetPosition)(resolveCFunc("spx_sprite_set_position"))
+	x.SpxSpriteSetTransform = (GDExtensionSpxSpriteSetTransform)(resolveCFunc("spx_sprite_set_transform"))
 	x.SpxSpriteGetPosition = (GDExtensionSpxSpriteGetPosition)(resolveCFunc("spx_sprite_get_position"))
 	x.SpxSpriteSetRotation = (GDExtensionSpxSpriteSetRotation)(resolveCFunc("spx_sprite_set_rotation"))
 	x.SpxSpriteGetRotation = (GDExtensionSpxSpriteGetRotation)(resolveCFunc("spx_sprite_get_rotation"))

--- a/internal/gdengine/binding/native/ffi_wrapper.gen.go
+++ b/internal/gdengine/binding/native/ffi_wrapper.gen.go
@@ -249,6 +249,7 @@ type GDExtensionSpxSpriteCloneSprite C.GDExtensionSpxSpriteCloneSprite
 type GDExtensionSpxSpriteDestroySprite C.GDExtensionSpxSpriteDestroySprite
 type GDExtensionSpxSpriteIsSpriteAlive C.GDExtensionSpxSpriteIsSpriteAlive
 type GDExtensionSpxSpriteSetPosition C.GDExtensionSpxSpriteSetPosition
+type GDExtensionSpxSpriteSetTransform C.GDExtensionSpxSpriteSetTransform
 type GDExtensionSpxSpriteGetPosition C.GDExtensionSpxSpriteGetPosition
 type GDExtensionSpxSpriteSetRotation C.GDExtensionSpxSpriteSetRotation
 type GDExtensionSpxSpriteGetRotation C.GDExtensionSpxSpriteGetRotation
@@ -1896,6 +1897,25 @@ func CallSpriteSetPosition(
 	arg2 := (C.GdVec2)(pos)
 
 	C.cgo_callfn_GDExtensionSpxSpriteSetPosition(arg0, arg1, arg2)
+
+}
+func CallSpriteSetTransform(
+	obj GdObj,
+	pos GdVec2,
+	rot GdFloat,
+	scale GdVec2,
+	visible GdBool,
+	pivot GdVec2,
+) {
+	arg0 := (C.GDExtensionSpxSpriteSetTransform)(api.SpxSpriteSetTransform)
+	arg1 := (C.GdObj)(obj)
+	arg2 := (C.GdVec2)(pos)
+	arg3 := (C.GdFloat)(rot)
+	arg4 := (C.GdVec2)(scale)
+	arg5 := (C.GdBool)(visible)
+	arg6 := (C.GdVec2)(pivot)
+
+	C.cgo_callfn_GDExtensionSpxSpriteSetTransform(arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 
 }
 func CallSpriteGetPosition(

--- a/internal/gdengine/binding/native/ffi_wrapper.gen.h
+++ b/internal/gdengine/binding/native/ffi_wrapper.gen.h
@@ -900,6 +900,12 @@ void cgo_callfn_GDExtensionSpxSpriteSetPosition(const GDExtensionSpxSpriteSetPos
 	}
 	fn(obj, pos);
 }
+void cgo_callfn_GDExtensionSpxSpriteSetTransform(const GDExtensionSpxSpriteSetTransform fn, GdObj obj, GdVec2 pos, GdFloat rot, GdVec2 scale, GdBool visible, GdVec2 pivot) {
+	if (!fn) {
+		return;
+	}
+	fn(obj, pos, rot, scale, visible, pivot);
+}
 void cgo_callfn_GDExtensionSpxSpriteGetPosition(const GDExtensionSpxSpriteGetPosition fn, GdObj obj, GdVec2* ret_val) {
 	if (!fn) {
 		return;

--- a/internal/gdengine/binding/native/gdextension_spx_ext.h
+++ b/internal/gdengine/binding/native/gdextension_spx_ext.h
@@ -376,6 +376,7 @@ typedef void (*GDExtensionSpxSpriteCloneSprite)(GdObj obj, GdObj *ret_value);
 typedef void (*GDExtensionSpxSpriteDestroySprite)(GdObj obj, GdBool *ret_value);
 typedef void (*GDExtensionSpxSpriteIsSpriteAlive)(GdObj obj, GdBool *ret_value);
 typedef void (*GDExtensionSpxSpriteSetPosition)(GdObj obj, GdVec2 pos);
+typedef void (*GDExtensionSpxSpriteSetTransform)(GdObj obj, GdVec2 pos, GdFloat rot, GdVec2 scale, GdBool visible, GdVec2 pivot);
 typedef void (*GDExtensionSpxSpriteGetPosition)(GdObj obj, GdVec2 *ret_value);
 typedef void (*GDExtensionSpxSpriteSetRotation)(GdObj obj, GdFloat rot);
 typedef void (*GDExtensionSpxSpriteGetRotation)(GdObj obj, GdFloat *ret_value);

--- a/internal/gdengine/binding/web/ffi.gen.go
+++ b/internal/gdengine/binding/web/ffi.gen.go
@@ -188,6 +188,7 @@ type GDExtensionInterface struct {
 	SpxSpriteDestroySprite                      js.Value
 	SpxSpriteIsSpriteAlive                      js.Value
 	SpxSpriteSetPosition                        js.Value
+	SpxSpriteSetTransform                       js.Value
 	SpxSpriteGetPosition                        js.Value
 	SpxSpriteSetRotation                        js.Value
 	SpxSpriteGetRotation                        js.Value
@@ -510,6 +511,7 @@ func (x *GDExtensionInterface) resolveAPIFunctions() {
 	x.SpxSpriteDestroySprite = resolveJSFunc("gdspx_sprite_destroy_sprite")
 	x.SpxSpriteIsSpriteAlive = resolveJSFunc("gdspx_sprite_is_sprite_alive")
 	x.SpxSpriteSetPosition = resolveJSFunc("gdspx_sprite_set_position")
+	x.SpxSpriteSetTransform = resolveJSFunc("gdspx_sprite_set_transform")
 	x.SpxSpriteGetPosition = resolveJSFunc("gdspx_sprite_get_position")
 	x.SpxSpriteSetRotation = resolveJSFunc("gdspx_sprite_set_rotation")
 	x.SpxSpriteGetRotation = resolveJSFunc("gdspx_sprite_get_rotation")

--- a/internal/gdengine/impl/manager_native.gen.go
+++ b/internal/gdengine/impl/manager_native.gen.go
@@ -985,6 +985,15 @@ func (pself *spriteMgr) SetPosition(obj Object, pos Vec2) {
 	arg1 := ToGdVec2(pos)
 	CallSpriteSetPosition(arg0, arg1)
 }
+func (pself *spriteMgr) SetTransform(obj Object, pos Vec2, rot float64, scale Vec2, visible bool, pivot Vec2) {
+	arg0 := ToGdObj(obj)
+	arg1 := ToGdVec2(pos)
+	arg2 := ToGdFloat(rot)
+	arg3 := ToGdVec2(scale)
+	arg4 := ToGdBool(visible)
+	arg5 := ToGdVec2(pivot)
+	CallSpriteSetTransform(arg0, arg1, arg2, arg3, arg4, arg5)
+}
 func (pself *spriteMgr) GetPosition(obj Object) Vec2 {
 	arg0 := ToGdObj(obj)
 	retValue := CallSpriteGetPosition(arg0)

--- a/internal/gdengine/impl/manager_web.gen.go
+++ b/internal/gdengine/impl/manager_web.gen.go
@@ -890,6 +890,15 @@ func (pself *spriteMgr) SetPosition(obj Object, pos Vec2) {
 	arg1 := JsFromGdVec2(pos)
 	API.SpxSpriteSetPosition.Invoke(arg0Low, arg0High, arg1)
 }
+func (pself *spriteMgr) SetTransform(obj Object, pos Vec2, rot float64, scale Vec2, visible bool, pivot Vec2) {
+	arg0Low, arg0High := JsSplitGdObj(obj)
+	arg1 := JsFromGdVec2(pos)
+	arg2 := JsFromGdFloat(rot)
+	arg3 := JsFromGdVec2(scale)
+	arg4 := JsFromGdBool(visible)
+	arg5 := JsFromGdVec2(pivot)
+	API.SpxSpriteSetTransform.Invoke(arg0Low, arg0High, arg1, arg2, arg3, arg4, arg5)
+}
 func (pself *spriteMgr) GetPosition(obj Object) Vec2 {
 	arg0Low, arg0High := JsSplitGdObj(obj)
 	_retValue := API.SpxSpriteGetPosition.Invoke(arg0Low, arg0High)

--- a/pkg/spx/pkg/engine/interface.gen.go
+++ b/pkg/spx/pkg/engine/interface.gen.go
@@ -230,6 +230,7 @@ type ISpriteMgr interface {
 	DestroySprite(obj Object) bool
 	IsSpriteAlive(obj Object) bool
 	SetPosition(obj Object, pos Vec2)
+	SetTransform(obj Object, pos Vec2, rot float64, scale Vec2, visible bool, pivot Vec2)
 	GetPosition(obj Object) Vec2
 	SetRotation(obj Object, rot float64)
 	GetRotation(obj Object) float64

--- a/pkg/spx/pkg/engine/sprite.gen.go
+++ b/pkg/spx/pkg/engine/sprite.gen.go
@@ -502,6 +502,10 @@ func (pself *Sprite) SetTextureDirect(path string) {
 	SpriteMgr.SetTextureDirect(pself.Id, path)
 }
 
+func (pself *Sprite) SetTransform(pos Vec2, rot float64, scale Vec2, visible bool, pivot Vec2) {
+	SpriteMgr.SetTransform(pself.Id, pos, rot, scale, visible, pivot)
+}
+
 func (pself *Sprite) SetTriggerCapsule(center Vec2, size Vec2) {
 	SpriteMgr.SetTriggerCapsule(pself.Id, center, size)
 }

--- a/pkg/spx/pkg/engine/sprite_pure.gen.go
+++ b/pkg/spx/pkg/engine/sprite_pure.gen.go
@@ -451,6 +451,9 @@ func (pself *Sprite) SetTextureAtlasDirect(path string, rect2 Rect2) {
 func (pself *Sprite) SetTextureDirect(path string) {
 }
 
+func (pself *Sprite) SetTransform(pos Vec2, rot float64, scale Vec2, visible bool, pivot Vec2) {
+}
+
 func (pself *Sprite) SetTriggerCapsule(center Vec2, size Vec2) {
 }
 

--- a/runtime_sync.go
+++ b/runtime_sync.go
@@ -23,25 +23,9 @@ import (
 	spxlog "github.com/goplus/spx/v2/internal/log"
 )
 
-func (p *SpriteImpl) initRuntimeProxy() {
-	p.rebuildRuntimeProxy(true)
-}
-
-func (p *SpriteImpl) awake() {
-	p.animation().playDefaultAnimIfIdle()
-	p.spriteState.IsAwakened = true
-}
-
-func (p *SpriteImpl) rebuildRuntimeProxy(applyCostume bool) {
-	p.runtimeState.SyncSprite = nil
-	engine.WaitMainThread(func() {
-		p.ensureProxyInitialized()
-		if applyCostume {
-			p.baseObj.applyCostumeUpdate()
-		}
-	})
-}
-
+// -----------------------------------------------------------------------------
+// Game Sync Pipeline
+// -----------------------------------------------------------------------------
 // dispatchStartEventIfNeeded fires the start event once after bootstrap completes.
 func (p *Game) dispatchStartEventIfNeeded() {
 	coreruntime.SyncOnce(&p.lifecycleState.StartFlag, func() {
@@ -116,6 +100,9 @@ func isSpriteTouchable(sprite *SpriteImpl) bool {
 	return sprite.spriteState.IsVisible && !sprite.spriteState.IsDying
 }
 
+// -----------------------------------------------------------------------------
+// Base Object Visual Sync
+// -----------------------------------------------------------------------------
 // scheduleCostumeUpdate schedules a costume update on the main thread.
 func (p *baseObj) scheduleCostumeUpdate() {
 	engine.WaitMainThread(func() {
@@ -153,86 +140,136 @@ func (p *baseObj) applyAtlasUVRemap() {
 	p.setMaterialParamsVec4("atlas_uv_rect2", val, true)
 }
 
+// -----------------------------------------------------------------------------
+// Sprite Proxy Lifecycle
+// -----------------------------------------------------------------------------
+func (p *SpriteImpl) initRuntimeProxy() {
+	p.rebuildRuntimeProxy(true)
+}
+
+func (p *SpriteImpl) awake() {
+	p.animation().playDefaultAnimIfIdle()
+	p.spriteState.IsAwakened = true
+}
+
+func (p *SpriteImpl) rebuildRuntimeProxy(applyCostume bool) {
+	p.runtimeState.SyncSprite = nil
+	engine.WaitMainThread(func() {
+		p.ensureProxyInitialized()
+		if applyCostume {
+			p.baseObj.applyCostumeUpdate()
+		}
+	})
+}
+
 // ensureProxyInitialized initializes the sprite's engine proxy if it hasn't been created yet.
-func (sprite *SpriteImpl) ensureProxyInitialized() {
-	if sprite.runtimeState.SyncSprite != nil || sprite.isDestroyed() {
+func (p *SpriteImpl) ensureProxyInitialized() {
+	if p.runtimeState.SyncSprite != nil || p.isDestroyed() {
 		return
 	}
-	sprite.runtimeState.SyncSprite = engine.BridgeNewBareSprite(sprite, mathf.NewVec2(sprite.getXYWithRenderOffset()))
-	sprite.applyPhysicsProxyConfig()
-	sprite.runtimeState.SyncSprite.SetVisible(sprite.spriteState.IsVisible)
-	sprite.runtimeState.SyncSprite.Name = sprite.name
-	sprite.runtimeState.SyncSprite.SetTypeName(sprite.name)
-	sprite.applyGraphicEffects(true)
-	sprite.animation().registerOnAnimationLooped(sprite.handleAnimationLooped)
-	sprite.animation().registerOnAnimationFinished(sprite.handleAnimationFinished)
-	sprite.spriteState.IsDirty = true
+	p.runtimeState.SyncSprite = engine.BridgeNewBareSprite(p, mathf.NewVec2(p.getXYWithRenderOffset()))
+	p.applyPhysicsProxyConfig()
+	p.runtimeState.SyncSprite.SetVisible(p.spriteState.IsVisible)
+	p.runtimeState.SyncSprite.Name = p.name
+	p.runtimeState.SyncSprite.SetTypeName(p.name)
+	p.applyGraphicEffects(true)
+	p.animation().registerOnAnimationLooped(p.handleAnimationLooped)
+	p.animation().registerOnAnimationFinished(p.handleAnimationFinished)
+	p.markProxyDirty()
 }
 
 // handleAnimationFinished records completed animation events from the proxy.
-func (sprite *SpriteImpl) handleAnimationFinished() {
+func (p *SpriteImpl) handleAnimationFinished() {
 	engine.Lock()
 	defer engine.Unlock()
-	if sprite.isDestroyed() || sprite.runtimeState.SyncSprite == nil {
+	if p.isDestroyed() || p.runtimeState.SyncSprite == nil {
 		return
 	}
-	state := sprite.animation().getCurAnimState()
+	state := p.animation().getCurAnimState()
 	if state != nil && state.Name != "" {
-		sprite.animation().addDonedAnimation(state.Name)
+		p.animation().addDonedAnimation(state.Name)
 	}
 }
 
 // handleAnimationLooped records audio work for animation loop boundaries.
-func (sprite *SpriteImpl) handleAnimationLooped() {
+func (p *SpriteImpl) handleAnimationLooped() {
 	engine.Lock()
 	defer engine.Unlock()
-	if sprite.isDestroyed() || sprite.runtimeState.SyncSprite == nil {
+	if p.isDestroyed() || p.runtimeState.SyncSprite == nil {
 		return
 	}
-	sprite.queueAnimationLoopAudio(sprite.animation().getCurAnimState())
-	sprite.queueAnimationLoopAudio(sprite.animation().getCurTweenState())
+	p.queueAnimationLoopAudio(p.animation().getCurAnimState())
+	p.queueAnimationLoopAudio(p.animation().getCurTweenState())
 }
 
-func (sprite *SpriteImpl) applyPhysicsProxyConfig() {
-	if sprite.runtimeState.SyncSprite == nil {
+// -----------------------------------------------------------------------------
+// Sprite Sync Helpers
+// -----------------------------------------------------------------------------
+func (p *SpriteImpl) applyPhysicsProxyConfig() {
+	if p.runtimeState.SyncSprite == nil {
 		return
 	}
-	sprite.physics().applyPhysicsProxyConfig(sprite.runtimeState.SyncSprite)
+	p.physics().applyPhysicsProxyConfig(p.runtimeState.SyncSprite)
 }
 
-func (sprite *SpriteImpl) shouldPullPhysicsPosition() bool {
-	return sprite.runtimeState.SyncSprite != nil && sprite.PhysicsMode() != NoPhysics
+func (p *SpriteImpl) shouldPullPhysicsPosition() bool {
+	return p.runtimeState.SyncSprite != nil && p.PhysicsMode() != NoPhysics
 }
 
-func (sprite *SpriteImpl) applyPhysicsPosition(x, y float64) {
-	revertRenderOffset(sprite, &x, &y)
-	sprite.transform().setXY(x, y)
+func (p *SpriteImpl) applyPhysicsPosition(x, y float64) {
+	revertRenderOffset(p, &x, &y)
+	p.transform().setXY(x, y)
 }
 
-func (sprite *SpriteImpl) collectProxyUpdate(buffer *engine.SpriteSyncBuffer) {
-	if sprite.isDestroyed() || sprite.runtimeState.SyncSprite == nil {
+func (p *SpriteImpl) ensureProxyTransformSynced() {
+	if p.isDestroyed() || p.runtimeState.SyncSprite == nil || !p.spriteState.IsDirty {
 		return
 	}
-	if sprite.spriteState.IsVisible {
-		sprite.baseObj.applyCostumeUpdate()
-	}
-	if !sprite.spriteState.IsDirty {
+	if p.spriteState.ProxySyncVersion == p.spriteState.DirtyVersion {
 		return
 	}
-	sprite.appendTransformUpdate(buffer)
-	sprite.spriteState.IsDirty = false
+
+	x, y := p.getXY()
+	offsetX, offsetY := getRenderOffset(p)
+	rot, scaleX, scaleY := getRenderRotationAndScale(p)
+
+	p.getProxy().SetTransform(
+		mathf.NewVec2(x+offsetX, y+offsetY),
+		engine.DegToRad(rot),
+		mathf.NewVec2(scaleX, scaleY),
+		p.spriteState.IsVisible,
+		mathf.NewVec2(offsetX, offsetY),
+	)
+	p.spriteState.ProxySyncVersion = p.spriteState.DirtyVersion
 }
 
-func (sprite *SpriteImpl) appendTransformUpdate(buffer *engine.SpriteSyncBuffer) {
-	x, y := sprite.getXY()
-	offsetX, offsetY := getRenderOffset(sprite)
-	rot, scaleX, scaleY := getRenderRotationAndScale(sprite)
+func (p *SpriteImpl) collectProxyUpdate(buffer *engine.SpriteSyncBuffer) {
+	if p.isDestroyed() || p.runtimeState.SyncSprite == nil {
+		return
+	}
+	if p.spriteState.IsVisible {
+		p.baseObj.applyCostumeUpdate()
+	}
+	if !p.spriteState.IsDirty {
+		return
+	}
+	if p.spriteState.ProxySyncVersion != p.spriteState.DirtyVersion {
+		p.appendTransformUpdate(buffer)
+	}
+	p.spriteState.IsDirty = false
+}
+
+func (p *SpriteImpl) appendTransformUpdate(buffer *engine.SpriteSyncBuffer) {
+	x, y := p.getXY()
+	offsetX, offsetY := getRenderOffset(p)
+	rot, scaleX, scaleY := getRenderRotationAndScale(p)
 	buffer.Add(
-		int64(sprite.runtimeState.SyncSprite.Id),
+		int64(p.runtimeState.SyncSprite.Id),
 		x+offsetX, y+offsetY,
 		engine.DegToRad(rot),
 		scaleX, scaleY,
 		offsetX, offsetY,
-		sprite.spriteState.IsVisible,
+		p.spriteState.IsVisible,
 	)
+	p.spriteState.ProxySyncVersion = p.spriteState.DirtyVersion
 }

--- a/runtime_sync.go
+++ b/runtime_sync.go
@@ -221,8 +221,14 @@ func (p *SpriteImpl) applyPhysicsPosition(x, y float64) {
 	p.transform().setXY(x, y)
 }
 
-func (p *SpriteImpl) ensureProxyTransformSynced() {
-	if p.isDestroyed() || p.runtimeState.SyncSprite == nil || !p.spriteState.IsDirty {
+func (p *SpriteImpl) ensureProxyQueryStateSynced() {
+	if p.isDestroyed() || p.runtimeState.SyncSprite == nil {
+		return
+	}
+	if p.spriteState.IsVisible {
+		p.baseObj.applyCostumeUpdate()
+	}
+	if !p.spriteState.IsDirty {
 		return
 	}
 	if p.spriteState.ProxySyncVersion == p.spriteState.DirtyVersion {
@@ -233,7 +239,7 @@ func (p *SpriteImpl) ensureProxyTransformSynced() {
 	offsetX, offsetY := getRenderOffset(p)
 	rot, scaleX, scaleY := getRenderRotationAndScale(p)
 
-	p.getProxy().SetTransform(
+	p.runtimeState.SyncSprite.SetTransform(
 		mathf.NewVec2(x+offsetX, y+offsetY),
 		engine.DegToRad(rot),
 		mathf.NewVec2(scaleX, scaleY),

--- a/sprite_core.go
+++ b/sprite_core.go
@@ -54,6 +54,11 @@ func (p *SpriteImpl) setDying() {
 	p.spriteState.IsDying = true
 }
 
+func (p *SpriteImpl) markProxyDirty() {
+	p.spriteState.DirtyVersion++
+	p.spriteState.IsDirty = true
+}
+
 // -----------------------------------------------------------------------------
 // Initialization
 // -----------------------------------------------------------------------------
@@ -99,6 +104,8 @@ func (p *SpriteImpl) InitFrom(src *SpriteImpl) {
 	p.spriteState.IsDying = false
 	p.spriteState.IsAwakened = false
 
+	p.spriteState.DirtyVersion = 0
+	p.spriteState.ProxySyncVersion = 0
 	p.spriteState.HasOnCloned = false
 	p.spriteState.HasOnTouchStart = false
 	p.spriteState.HasOnTouching = false

--- a/sprite_query.go
+++ b/sprite_query.go
@@ -106,7 +106,7 @@ func (p *SpriteImpl) prepareSelfCollisionQuery() bool {
 	if p.runtimeState.SyncSprite == nil {
 		return false
 	}
-	p.ensureProxyTransformSynced()
+	p.ensureProxyQueryStateSynced()
 	return true
 }
 

--- a/sprite_query.go
+++ b/sprite_query.go
@@ -93,34 +93,39 @@ func (p *SpriteImpl) touching(obj Target) bool {
 			return p.g.touchingPoint(p, x, y)
 		}
 	case Sprite:
-		return touchingSprite(p, spriteOf(v))
+		src := spriteOf(v)
+		if src == nil || src.spriteState.IsDying {
+			return false
+		}
+		return src.touchingSprite(p)
 	}
 	panic("Touching: unexpected input")
 }
 
-func touchingSprite(dst, src *SpriteImpl) bool {
-	if src.spriteState.IsDying {
+func (p *SpriteImpl) prepareSelfCollisionQuery() bool {
+	if p.runtimeState.SyncSprite == nil {
 		return false
 	}
-	return src.touchingSprite(dst)
+	p.ensureProxyTransformSynced()
+	return true
 }
 
 func (p *SpriteImpl) touchPoint(x, y float64) bool {
-	if p.runtimeState.SyncSprite == nil {
+	if !p.prepareSelfCollisionQuery() {
 		return false
 	}
 	return p.engine().SpriteMgr.CheckCollisionWithPoint(p.runtimeState.SyncSprite.GetId(), mathf.NewVec2(x, y), true)
 }
 
 func (p *SpriteImpl) touchingColor(color mathf.Color) bool {
-	if p.runtimeState.SyncSprite == nil {
+	if !p.prepareSelfCollisionQuery() {
 		return false
 	}
 	return p.engine().SpriteMgr.CheckCollisionByColor(p.runtimeState.SyncSprite.GetId(), color, colorThreshold, alphaThreshold)
 }
 
 func (p *SpriteImpl) touchingColors(spriteColor, targetColor mathf.Color) bool {
-	if p.runtimeState.SyncSprite == nil {
+	if !p.prepareSelfCollisionQuery() {
 		return false
 	}
 	return p.engine().SpriteMgr.CheckCollisionByColors(
@@ -133,14 +138,14 @@ func (p *SpriteImpl) touchingColors(spriteColor, targetColor mathf.Color) bool {
 }
 
 func (p *SpriteImpl) touchingSprite(dst *SpriteImpl) bool {
-	if p.runtimeState.SyncSprite == nil || dst.runtimeState.SyncSprite == nil {
+	if !p.prepareSelfCollisionQuery() || !dst.prepareSelfCollisionQuery() {
 		return false
 	}
 	return p.engine().SpriteMgr.CheckCollisionWithSprite(p.runtimeState.SyncSprite.GetId(), dst.runtimeState.SyncSprite.GetId(), alphaThreshold, !isPhysicsEnabled())
 }
 
 func (p *SpriteImpl) checkTouchingScreen(where int, area string) (touching int) {
-	if p.runtimeState.SyncSprite == nil {
+	if !p.prepareSelfCollisionQuery() {
 		return 0
 	}
 	switch normalizeEdgeArea(area) {
@@ -153,7 +158,7 @@ func (p *SpriteImpl) checkTouchingScreen(where int, area string) (touching int) 
 }
 
 func (p *SpriteImpl) checkNearestTouchedBoundary(area string) int {
-	if p.runtimeState.SyncSprite == nil {
+	if !p.prepareSelfCollisionQuery() {
 		return 0
 	}
 	switch normalizeEdgeArea(area) {

--- a/sprite_query_test.go
+++ b/sprite_query_test.go
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2021 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package spx
+
+import (
+	"testing"
+
+	"github.com/goplus/spbase/mathf"
+	internalengine "github.com/goplus/spx/v2/internal/engine"
+	"github.com/goplus/spx/v2/internal/enginewrap"
+	pkgengine "github.com/goplus/spx/v2/pkg/spx/pkg/engine"
+)
+
+type touchingSyncSpriteMgr struct {
+	enginewrap.SpriteMgrImpl
+	positions         map[pkgengine.Object]mathf.Vec2
+	setTransformCalls map[pkgengine.Object]int
+	setPositionCalls  map[pkgengine.Object]int
+	setRotationCalls  map[pkgengine.Object]int
+	setScaleCalls     map[pkgengine.Object]int
+	setPivotCalls     map[pkgengine.Object]int
+	setVisibleCalls   map[pkgengine.Object]int
+}
+
+func (s *touchingSyncSpriteMgr) SetTransform(
+	obj pkgengine.Object,
+	pos mathf.Vec2,
+	rot float64,
+	scale mathf.Vec2,
+	visible bool,
+	pivot mathf.Vec2,
+) {
+	s.positions[obj] = pos
+	s.setTransformCalls[obj]++
+}
+
+func (s *touchingSyncSpriteMgr) SetPosition(obj pkgengine.Object, pos mathf.Vec2) {
+	s.positions[obj] = pos
+	s.setPositionCalls[obj]++
+}
+
+func (s *touchingSyncSpriteMgr) SetRotation(obj pkgengine.Object, rot float64) {
+	s.setRotationCalls[obj]++
+}
+
+func (s *touchingSyncSpriteMgr) SetScale(obj pkgengine.Object, scale mathf.Vec2) {
+	s.setScaleCalls[obj]++
+}
+
+func (s *touchingSyncSpriteMgr) SetPivot(obj pkgengine.Object, pivot mathf.Vec2) {
+	s.setPivotCalls[obj]++
+}
+
+func (s *touchingSyncSpriteMgr) SetVisible(obj pkgengine.Object, visible bool) {
+	s.setVisibleCalls[obj]++
+}
+
+func (s *touchingSyncSpriteMgr) CheckCollisionWithSprite(obj, objB pkgengine.Object, alphaThreshold float64, usePixelPerfect bool) bool {
+	return s.positions[obj] == s.positions[objB]
+}
+
+func installTouchingSyncSpriteMgr(t *testing.T, mgr *touchingSyncSpriteMgr) {
+	t.Helper()
+
+	enginewrap.Init(func(call func()) {
+		call()
+	})
+
+	original := pkgengine.SpriteMgr
+	pkgengine.SpriteMgr = mgr
+	t.Cleanup(func() {
+		pkgengine.SpriteMgr = original
+	})
+}
+
+func newTouchingTestSprite(name string, x, y float64, id pkgengine.Object) *SpriteImpl {
+	sprite := newTestTransformSprite(x, y)
+	sprite.name = name
+	sprite.g.displayState.WorldWidth = 480
+	sprite.g.displayState.WorldHeight = 360
+	sprite.baseObj.initWithSize(1, 1)
+	sprite.runtimeState.Scale = 1
+	sprite.spriteState.IsVisible = true
+	sprite.runtimeState.SyncSprite = &internalengine.Sprite{}
+	sprite.runtimeState.SyncSprite.SetId(id)
+	return sprite
+}
+
+func TestTouchingSpriteSyncsDirtyTransformImmediately(t *testing.T) {
+	mgr := &touchingSyncSpriteMgr{
+		positions:         map[pkgengine.Object]mathf.Vec2{},
+		setTransformCalls: map[pkgengine.Object]int{},
+		setPositionCalls:  map[pkgengine.Object]int{},
+		setRotationCalls:  map[pkgengine.Object]int{},
+		setScaleCalls:     map[pkgengine.Object]int{},
+		setPivotCalls:     map[pkgengine.Object]int{},
+		setVisibleCalls:   map[pkgengine.Object]int{},
+	}
+	installTouchingSyncSpriteMgr(t, mgr)
+
+	mover := newTouchingTestSprite("mover", 0, 0, 1)
+	target := newTouchingTestSprite("target", 10, 0, 2)
+
+	mgr.positions[1] = mathf.NewVec2(0, 0)
+	mgr.positions[2] = mathf.NewVec2(10, 0)
+
+	mover.transform().direction = 90
+	mover.Step__0(10)
+
+	if !mover.touchingSprite(target) {
+		t.Fatal("touchingSprite() = false, want true after immediate step sync")
+	}
+	if got := mgr.setTransformCalls[1]; got != 1 {
+		t.Fatalf("SetTransform calls after first touching = %d, want 1", got)
+	}
+	if got := mgr.setPositionCalls[1]; got != 0 {
+		t.Fatalf("SetPosition calls after first touching = %d, want 0", got)
+	}
+	if got := mgr.setRotationCalls[1]; got != 0 {
+		t.Fatalf("SetRotation calls after first touching = %d, want 0", got)
+	}
+	if got := mgr.setScaleCalls[1]; got != 0 {
+		t.Fatalf("SetScale calls after first touching = %d, want 0", got)
+	}
+	if got := mgr.setPivotCalls[1]; got != 0 {
+		t.Fatalf("SetPivot calls after first touching = %d, want 0", got)
+	}
+	if got := mgr.setVisibleCalls[1]; got != 0 {
+		t.Fatalf("SetVisible calls after first touching = %d, want 0", got)
+	}
+
+	if !mover.touchingSprite(target) {
+		t.Fatal("second touchingSprite() = false, want cached proxy sync to remain valid")
+	}
+	if got := mgr.setTransformCalls[1]; got != 1 {
+		t.Fatalf("SetTransform calls after second touching = %d, want 1", got)
+	}
+
+	buffer := internalengine.NewSpriteSyncBuffer(1)
+	mover.collectProxyUpdate(buffer)
+	if got := buffer.UpdateCount(); got != 0 {
+		t.Fatalf("collectProxyUpdate() batched %d updates, want 0 after immediate query sync", got)
+	}
+	if mover.spriteState.IsDirty {
+		t.Fatal("spriteState.IsDirty = true, want false after frame-end collection")
+	}
+}

--- a/sprite_query_test.go
+++ b/sprite_query_test.go
@@ -27,13 +27,41 @@ import (
 
 type touchingSyncSpriteMgr struct {
 	enginewrap.SpriteMgrImpl
-	positions         map[pkgengine.Object]mathf.Vec2
-	setTransformCalls map[pkgengine.Object]int
-	setPositionCalls  map[pkgengine.Object]int
-	setRotationCalls  map[pkgengine.Object]int
-	setScaleCalls     map[pkgengine.Object]int
-	setPivotCalls     map[pkgengine.Object]int
-	setVisibleCalls   map[pkgengine.Object]int
+	positions               map[pkgengine.Object]mathf.Vec2
+	texturePaths            map[pkgengine.Object]string
+	expectedTexturePaths    map[pkgengine.Object]string
+	checkedTexturePaths     map[pkgengine.Object]string
+	setTransformCalls       map[pkgengine.Object]int
+	setPositionCalls        map[pkgengine.Object]int
+	setRotationCalls        map[pkgengine.Object]int
+	setScaleCalls           map[pkgengine.Object]int
+	setPivotCalls           map[pkgengine.Object]int
+	setVisibleCalls         map[pkgengine.Object]int
+	setTextureCalls         map[pkgengine.Object]int
+	setTextureAtlasCalls    map[pkgengine.Object]int
+	setRenderScaleCalls     map[pkgengine.Object]int
+	setTextureDirectCalls   map[pkgengine.Object]int
+	setTextureAtlasPathByID map[pkgengine.Object]string
+}
+
+func newTouchingSyncSpriteMgr() *touchingSyncSpriteMgr {
+	return &touchingSyncSpriteMgr{
+		positions:               map[pkgengine.Object]mathf.Vec2{},
+		texturePaths:            map[pkgengine.Object]string{},
+		expectedTexturePaths:    map[pkgengine.Object]string{},
+		checkedTexturePaths:     map[pkgengine.Object]string{},
+		setTransformCalls:       map[pkgengine.Object]int{},
+		setPositionCalls:        map[pkgengine.Object]int{},
+		setRotationCalls:        map[pkgengine.Object]int{},
+		setScaleCalls:           map[pkgengine.Object]int{},
+		setPivotCalls:           map[pkgengine.Object]int{},
+		setVisibleCalls:         map[pkgengine.Object]int{},
+		setTextureCalls:         map[pkgengine.Object]int{},
+		setTextureAtlasCalls:    map[pkgengine.Object]int{},
+		setRenderScaleCalls:     map[pkgengine.Object]int{},
+		setTextureDirectCalls:   map[pkgengine.Object]int{},
+		setTextureAtlasPathByID: map[pkgengine.Object]string{},
+	}
 }
 
 func (s *touchingSyncSpriteMgr) SetTransform(
@@ -69,8 +97,39 @@ func (s *touchingSyncSpriteMgr) SetVisible(obj pkgengine.Object, visible bool) {
 	s.setVisibleCalls[obj]++
 }
 
+func (s *touchingSyncSpriteMgr) SetTexture(obj pkgengine.Object, path string) {
+	s.texturePaths[obj] = path
+	s.setTextureCalls[obj]++
+}
+
+func (s *touchingSyncSpriteMgr) SetTextureAtlas(obj pkgengine.Object, path string, rect2 mathf.Rect2) {
+	s.texturePaths[obj] = path
+	s.setTextureAtlasPathByID[obj] = path
+	s.setTextureAtlasCalls[obj]++
+}
+
+func (s *touchingSyncSpriteMgr) SetTextureDirect(obj pkgengine.Object, path string) {
+	s.texturePaths[obj] = path
+	s.setTextureDirectCalls[obj]++
+}
+
+func (s *touchingSyncSpriteMgr) SetRenderScale(obj pkgengine.Object, scale mathf.Vec2) {
+	s.setRenderScaleCalls[obj]++
+}
+
+func (s *touchingSyncSpriteMgr) SetMaterialShader(obj pkgengine.Object, path string) {}
+
+func (s *touchingSyncSpriteMgr) SetMaterialParamsVec4(obj pkgengine.Object, effect string, vec4 mathf.Vec4) {
+}
+
 func (s *touchingSyncSpriteMgr) CheckCollisionWithSprite(obj, objB pkgengine.Object, alphaThreshold float64, usePixelPerfect bool) bool {
 	return s.positions[obj] == s.positions[objB]
+}
+
+func (s *touchingSyncSpriteMgr) CheckCollisionByColor(obj pkgengine.Object, color mathf.Color, colorThreshold, alphaThreshold float64) bool {
+	s.checkedTexturePaths[obj] = s.texturePaths[obj]
+	expected, ok := s.expectedTexturePaths[obj]
+	return !ok || s.texturePaths[obj] == expected
 }
 
 func installTouchingSyncSpriteMgr(t *testing.T, mgr *touchingSyncSpriteMgr) {
@@ -101,15 +160,7 @@ func newTouchingTestSprite(name string, x, y float64, id pkgengine.Object) *Spri
 }
 
 func TestTouchingSpriteSyncsDirtyTransformImmediately(t *testing.T) {
-	mgr := &touchingSyncSpriteMgr{
-		positions:         map[pkgengine.Object]mathf.Vec2{},
-		setTransformCalls: map[pkgengine.Object]int{},
-		setPositionCalls:  map[pkgengine.Object]int{},
-		setRotationCalls:  map[pkgengine.Object]int{},
-		setScaleCalls:     map[pkgengine.Object]int{},
-		setPivotCalls:     map[pkgengine.Object]int{},
-		setVisibleCalls:   map[pkgengine.Object]int{},
-	}
+	mgr := newTouchingSyncSpriteMgr()
 	installTouchingSyncSpriteMgr(t, mgr)
 
 	mover := newTouchingTestSprite("mover", 0, 0, 1)
@@ -157,5 +208,44 @@ func TestTouchingSpriteSyncsDirtyTransformImmediately(t *testing.T) {
 	}
 	if mover.spriteState.IsDirty {
 		t.Fatal("spriteState.IsDirty = true, want false after frame-end collection")
+	}
+}
+
+func TestTouchingColorSyncsDirtyCostumeImmediately(t *testing.T) {
+	mgr := newTouchingSyncSpriteMgr()
+	installTouchingSyncSpriteMgr(t, mgr)
+
+	sprite := newTouchingTestSprite("mover", 0, 0, 1)
+	sprite.costumes = []*costume{
+		{name: "idle", path: "idle.png", bitmapResolution: 1, width: 1, height: 1, setIndex: -1},
+		{name: "hit", path: "hit.png", bitmapResolution: 1, width: 1, height: 1, setIndex: -1},
+	}
+	sprite.costumeIndex = 0
+	sprite.runtimeState.IsCostumeDirty = false
+	sprite.runtimeState.IsAnimating = false
+
+	mgr.texturePaths[1] = internalengine.ToAssetPath("idle.png")
+	mgr.expectedTexturePaths[1] = internalengine.ToAssetPath("hit.png")
+
+	sprite.SetCostume__0("hit")
+
+	if !sprite.touchingColor(mathf.Color{}) {
+		t.Fatal("touchingColor() = false, want true after immediate costume sync")
+	}
+	if got := mgr.setTextureCalls[1]; got != 1 {
+		t.Fatalf("SetTexture calls after first touchingColor = %d, want 1", got)
+	}
+	if got := mgr.checkedTexturePaths[1]; got != internalengine.ToAssetPath("hit.png") {
+		t.Fatalf("collision used texture %q, want %q", got, internalengine.ToAssetPath("hit.png"))
+	}
+	if sprite.runtimeState.IsCostumeDirty {
+		t.Fatal("runtimeState.IsCostumeDirty = true, want false after immediate query sync")
+	}
+
+	if !sprite.touchingColor(mathf.Color{}) {
+		t.Fatal("second touchingColor() = false, want synced costume to remain valid")
+	}
+	if got := mgr.setTextureCalls[1]; got != 1 {
+		t.Fatalf("SetTexture calls after second touchingColor = %d, want 1", got)
 	}
 }

--- a/sprite_render.go
+++ b/sprite_render.go
@@ -33,7 +33,7 @@ func (p *SpriteImpl) setVisible(visible bool) {
 	}
 
 	p.spriteState.IsVisible = visible
-	p.spriteState.IsDirty = true
+	p.markProxyDirty()
 }
 
 func (p *SpriteImpl) Hide() {
@@ -70,7 +70,7 @@ func (p *SpriteImpl) setCostume(costume any) {
 		return
 	}
 	p.spriteState.DefaultCostumeIndex = p.costumeIndex
-	p.spriteState.IsDirty = true
+	p.markProxyDirty()
 }
 
 func (p *SpriteImpl) SetCostume__0(costume SpriteCostumeName) {


### PR DESCRIPTION
## Summary

- fix `step` followed immediately by `touching` reading stale proxy coordinates
- sync dirty sprite proxy transforms on demand before collision and boundary queries
- switch runtime proxy updates to the new single-call `SetTransform` bridge
- regenerate engine bindings and add a regression test

## Details

This change introduces per-sprite proxy sync version tracking so query-time sync and frame-end batch sync can coexist without duplicate updates in the same frame.

Query paths such as sprite touching, color touching, and edge checks now ensure the proxy transform is current before asking the engine for collision results.

## Testing

- `go test ./...`

## Dependency

- depends on the godot PR that adds `set_transform`