### PR TITLE
fix: avoid hanging Godot import during CI web builds

### DIFF
--- a/cmd/spx/internal/command/env.go
+++ b/cmd/spx/internal/command/env.go
@@ -17,6 +17,7 @@
 package command
 
 import (
+	"context"
 	"embed"
 	"errors"
 	"fmt"
@@ -28,11 +29,14 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/goplus/spx/v2/cmd/spx/internal/util"
 )
 
 const envName = "gdspx"
+const projectImportTimeoutEnvVar = "SPX_GODOT_IMPORT_TIMEOUT"
+const defaultProjectImportTimeout = 10 * time.Minute
 
 var projectNameReplacer = strings.NewReplacer("_", "", " ", "", "\"", "", "\n", "", "\r", "")
 var spxModuleReplaceLinePattern = regexp.MustCompile(`^(\s*)(replace\s+)?github\.com/goplus/spx/v2\s*=>\s*(\S+)(\s*//.*)?$`)
@@ -89,7 +93,9 @@ func (cmd *CmdTool) SetupEnv(version string, fs embed.FS, fsRelDir string, proje
 	}
 
 	if cmd.ShouldReimport() {
-		cmd.Reimport()
+		if err := cmd.Reimport(); err != nil {
+			return err
+		}
 	}
 	return
 }
@@ -126,28 +132,102 @@ func (cmd *CmdTool) shouldRunGoModTidy() bool {
 
 // ShouldReimport reports whether Godot reimport is needed.
 func (cmd *CmdTool) ShouldReimport() bool {
-	// TinyGo skips Godot import.
-	if cmd.Args.CmdName == "buildtinygo" {
+	if cmd.shouldSkipProjectImport() {
 		return false
 	}
-	return !util.IsFileExist(path.Join(cmd.ProjectDir, ".godot/uid_cache.bin")) && !cmd.RuntimeMode
+	return !util.IsFileExist(cmd.projectImportCachePath())
 }
 
 // Reimport refreshes Godot import data.
-func (cmd *CmdTool) Reimport() {
-	switch cmd.Args.CmdName {
-	case "buildtinygo":
-		return
-	case "buildweb", "runweb", "exportweb":
-		cmd.BuildWasm()
-	default:
-		cmd.BuildDll()
+func (cmd *CmdTool) Reimport() error {
+	if err := cmd.buildProjectImportArtifacts(); err != nil {
+		return err
 	}
+	return cmd.runProjectImport()
+}
+
+func (cmd *CmdTool) shouldSkipProjectImport() bool {
+	if cmd.RuntimeMode {
+		return true
+	}
+	switch cmd.Args.CmdName {
+	case "buildtinygo", "buildweb":
+		return true
+	default:
+		return false
+	}
+}
+
+func shouldBuildWasmForProjectImport(cmdName string) bool {
+	switch cmdName {
+	case "runweb", "exportweb":
+		return true
+	default:
+		return false
+	}
+}
+
+func (cmd *CmdTool) projectImportCachePath() string {
+	return path.Join(cmd.ProjectDir, ".godot", "uid_cache.bin")
+}
+
+func (cmd *CmdTool) buildProjectImportArtifacts() error {
+	switch {
+	case cmd.shouldSkipProjectImport():
+		return nil
+	case shouldBuildWasmForProjectImport(cmd.Args.CmdName):
+		return cmd.BuildWasm()
+	default:
+		return cmd.BuildDll()
+	}
+}
+
+func (cmd *CmdTool) runProjectImport() error {
 	logInfof("Importing project resources")
-	execCmd := exec.Command(cmd.CmdPath, "--import", "--headless")
+	execCmd, ctx, timeout, cancel := cmd.newProjectImportCommand()
+	defer cancel()
 	execCmd.Dir = cmd.ProjectDir
-	execCmd.Start()
-	execCmd.Wait()
+	execCmd.Stdout = os.Stdout
+	execCmd.Stderr = os.Stderr
+	if err := execCmd.Run(); err != nil {
+		if timeout > 0 && errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return fmt.Errorf("godot import timed out after %s; override with %s: %w", timeout, projectImportTimeoutEnvVar, err)
+		}
+		return fmt.Errorf("godot import failed: %w", err)
+	}
+	return nil
+}
+
+func (cmd *CmdTool) newProjectImportCommand() (*exec.Cmd, context.Context, time.Duration, context.CancelFunc) {
+	timeout := cmd.projectImportTimeout()
+	args := []string{"--headless", "--path", cmd.ProjectDir, "--import"}
+	if timeout <= 0 {
+		return exec.Command(cmd.CmdPath, args...), context.Background(), 0, func() {}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	return exec.CommandContext(ctx, cmd.CmdPath, args...), ctx, timeout, cancel
+}
+
+func (cmd *CmdTool) projectImportTimeout() time.Duration {
+	timeoutValue := strings.TrimSpace(os.Getenv(projectImportTimeoutEnvVar))
+	if timeoutValue == "" {
+		return defaultProjectImportTimeout
+	}
+	if timeoutValue == "0" {
+		return 0
+	}
+
+	timeout, err := time.ParseDuration(timeoutValue)
+	if err != nil {
+		logWarnf("Invalid %s=%q, using default %s", projectImportTimeoutEnvVar, timeoutValue, defaultProjectImportTimeout)
+		return defaultProjectImportTimeout
+	}
+	if timeout < 0 {
+		logWarnf("Ignoring negative %s=%q, using default %s", projectImportTimeoutEnvVar, timeoutValue, defaultProjectImportTimeout)
+		return defaultProjectImportTimeout
+	}
+	return timeout
 }
 
 // Clear removes generated project files.

--- a/cmd/spx/internal/command/env.go
+++ b/cmd/spx/internal/command/env.go
@@ -147,7 +147,7 @@ func (cmd *CmdTool) Reimport() error {
 }
 
 func (cmd *CmdTool) shouldSkipProjectImport() bool {
-	if cmd.RuntimeMode {
+	if cmd.RuntimeMode || cmd.usesPureEngine() {
 		return true
 	}
 	switch cmd.Args.CmdName {

--- a/cmd/spx/internal/command/env_test.go
+++ b/cmd/spx/internal/command/env_test.go
@@ -111,11 +111,13 @@ func TestShouldReimport(t *testing.T) {
 		cmdName     string
 		runtimeMode bool
 		cacheExists bool
+		tags        string
 		want        bool
 	}{
 		{name: "skips buildweb", cmdName: "buildweb", want: false},
 		{name: "reimports exportweb when cache missing", cmdName: "exportweb", want: true},
 		{name: "skips runtime mode", cmdName: "runweb", runtimeMode: true, want: false},
+		{name: "skips pure engine mode", cmdName: "build", tags: "pure_engine", want: false},
 		{name: "skips when cache exists", cmdName: "exportweb", cacheExists: true, want: false},
 	}
 
@@ -130,6 +132,10 @@ func TestShouldReimport(t *testing.T) {
 				ProjectDir:  projectDir,
 				RuntimeMode: tt.runtimeMode,
 				Args:        ExtraArgs{CmdName: tt.cmdName},
+			}
+			if tt.tags != "" {
+				tags := tt.tags
+				cmd.Args.Tags = &tags
 			}
 
 			if got := cmd.ShouldReimport(); got != tt.want {

--- a/cmd/spx/internal/command/env_test.go
+++ b/cmd/spx/internal/command/env_test.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestAdaptGoModAddsLocalReplaceForGeneratedGoMod(t *testing.T) {
@@ -104,6 +105,65 @@ func TestShouldRunGoModTidy(t *testing.T) {
 	}
 }
 
+func TestShouldReimport(t *testing.T) {
+	tests := []struct {
+		name        string
+		cmdName     string
+		runtimeMode bool
+		cacheExists bool
+		want        bool
+	}{
+		{name: "skips buildweb", cmdName: "buildweb", want: false},
+		{name: "reimports exportweb when cache missing", cmdName: "exportweb", want: true},
+		{name: "skips runtime mode", cmdName: "runweb", runtimeMode: true, want: false},
+		{name: "skips when cache exists", cmdName: "exportweb", cacheExists: true, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			projectDir := t.TempDir()
+			if tt.cacheExists {
+				writeProjectImportCache(t, projectDir)
+			}
+
+			cmd := CmdTool{
+				ProjectDir:  projectDir,
+				RuntimeMode: tt.runtimeMode,
+				Args:        ExtraArgs{CmdName: tt.cmdName},
+			}
+
+			if got := cmd.ShouldReimport(); got != tt.want {
+				t.Fatalf("ShouldReimport() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestProjectImportTimeout(t *testing.T) {
+	tests := []struct {
+		name     string
+		envValue string
+		want     time.Duration
+	}{
+		{name: "uses default", envValue: "", want: defaultProjectImportTimeout},
+		{name: "supports override", envValue: "90s", want: 90 * time.Second},
+		{name: "trims whitespace", envValue: " 90s ", want: 90 * time.Second},
+		{name: "supports disable", envValue: "0", want: 0},
+		{name: "falls back for invalid value", envValue: "abc", want: defaultProjectImportTimeout},
+		{name: "falls back for negative value", envValue: "-1s", want: defaultProjectImportTimeout},
+	}
+
+	cmd := CmdTool{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(projectImportTimeoutEnvVar, tt.envValue)
+			if got := cmd.projectImportTimeout(); got != tt.want {
+				t.Fatalf("projectImportTimeout() = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}
+
 func setupAdaptGoModFixture(t *testing.T) string {
 	t.Helper()
 
@@ -115,4 +175,16 @@ func setupAdaptGoModFixture(t *testing.T) string {
 	}
 	writeLocalSpxRepoMarker(t, repoRoot)
 	return targetDir
+}
+
+func writeProjectImportCache(t *testing.T, projectDir string) {
+	t.Helper()
+
+	cachePath := filepath.Join(projectDir, ".godot", "uid_cache.bin")
+	if err := os.MkdirAll(filepath.Dir(cachePath), 0o755); err != nil {
+		t.Fatalf("mkdir cache dir: %v", err)
+	}
+	if err := os.WriteFile(cachePath, []byte("cache"), 0o644); err != nil {
+		t.Fatalf("write cache: %v", err)
+	}
 }


### PR DESCRIPTION
## Summary
This PR makes the Godot reimport flow safer for CI web builds and improves the surrounding import logic.

## Changes
- skip Godot project import for `buildweb` and other commands that do not need import artifacts
- return import errors from `SetupEnv` instead of silently ignoring failures
- add a timeout for headless Godot import to avoid CI hangs
- support overriding or disabling the timeout with `SPX_GODOT_IMPORT_TIMEOUT`
- refactor the reimport flow into smaller helpers for skip checks, build preparation, and import execution
- add tests for reimport decisions and import timeout parsing

## Why
`buildweb` can hang during Godot import in CI even though the import artifacts are not needed for that path. This change avoids unnecessary imports for CI web builds, while also making non-skipped imports fail fast instead of hanging indefinitely.

## Testing
- `go test ./cmd/spx/internal/command`