### PR TITLE
perf: optimize web batch sync with shared transfer buffer

### DIFF
--- a/docs/zh/dev/engine/web_sync_batch.md
+++ b/docs/zh/dev/engine/web_sync_batch.md
@@ -1,0 +1,212 @@
+# Web 端批量同步数据面
+
+本文梳理 SPX Go 运行时和 Godot Web 运行时之间适合批量同步的数据面，并说明当前采用的共享传输缓冲实现边界。
+
+## 同步方向
+
+Web 端同步主要分为两条方向：
+
+1. SPX -> Godot：Go 逻辑把游戏状态、命令和资源引用同步给 Godot。
+2. Godot -> SPX：Godot 把输入、物理结果、生命周期事件和 UI 事件回传给 Go。
+
+批量同步适合处理高频、结构固定、以 primitive 数据为主的内容。不适合直接传 Godot 对象指针、Go 指针、Variant 或复杂字符串对象。
+
+## 已经批量同步的数据
+
+### Sprite transform
+
+当前每帧会收集 dirty sprite，并将以下字段序列化为 `[]float32` 后一次性发送：
+
+- sprite id
+- x, y
+- rotation
+- scale x, scale y
+- render offset x, render offset y
+- visible
+- delete ids
+
+对应入口：
+
+- Go: `Game.updateSpriteProxies`
+- Go: `SpriteSyncBuffer.Serialize`
+- Go: `engine.SyncBatchUpdateSprites`
+- Godot: `SpxSpriteMgr::batch_update_transforms`
+
+这是最适合批量同步的主路径，因为它具备高频、多对象、固定字段、无需字符串的特点。
+
+### Sprite visual
+
+当前已有视觉批量缓冲，用于同步：
+
+- sprite id
+- render scale
+- z index
+- uv remap
+- flags
+
+对应入口：
+
+- Go: `VisualSyncBuffer.Serialize`
+- Go: `engine.SyncBatchUpdateVisuals`
+- Godot: `SpxSpriteMgr::batch_update_visuals`
+
+它适合继续扩展成更多 sprite 视觉属性，但 texture path、animation name 这类字符串字段不应混入这个 float buffer。
+
+### Physics position pull
+
+当前 Godot -> SPX 已有批量位置拉取：
+
+- 输入：sprite id 列表
+- 输出：x, y 列表
+
+对应入口：
+
+- Go: `Game.pullPhysicsPositions`
+- Go: `engine.SyncBatchGetPositions`
+- Godot raw method: `SpxSpriteMgr::batch_retrieve_positions`
+- Godot Web raw export: `gdspx_sprite_batch_retrieve_positions`
+
+Web 端直接走 raw return 快路径：Go 传入 sprite id fast-array，JS 借用 Godot wasm heap 上独立的 return ring slot，Godot 直接把 `float32` 位置写入该 slot，Go 再按 fast-array wrapper 解码。高层 `BatchRetrievePositions` 接口由 codegen 根据 raw 方法自动合成，不再手写 `GdArray -> GdArray` 的 Godot 导出。
+
+### Input snapshot
+
+Web 端输入查询已改为每帧快照优先：
+
+- mouse world position
+- mouse button bitset
+- key pressed state cache
+- action pressed / just pressed / just released per-frame cache
+- axis value per-frame cache
+
+对应入口：
+
+- Go: `webffi.SyncWebInputSnapshot`
+- Go: `webffi.WebInputMousePos` / `WebInputMouseState` / `WebInputKeyState`
+- Go: `webffi.CachedActionBool` / `CachedActionAxis`
+- Godot: `SpxInputMgr::write_snapshot`
+- Godot Web raw export: `gdspx_input_write_snapshot`
+
+当前 mouse position 和 mouse button 直接来自 Godot snapshot。键盘状态由 Web 端 key callback 维护本地 cache；Go API 层仍使用 action name，但 Web bridge 内部会将 action name 注册成数字 id，并对 action/axis 做同帧缓存。
+
+action name 已增加注册表：
+
+- Go 首次看到 action name 时调用 `GdspxInputActionID`。
+- JS 将 action name 转成 Godot string 并调用 `gdspx_input_register_action`。
+- Godot 保存 `action id -> StringName`。
+- 后续 `IsActionPressed` / `IsActionJustPressed` / `IsActionJustReleased` / `GetAxis` 只传数字 id。
+
+这把 action 字符串跨桥成本限制在首次注册，普通帧只走数字参数。
+
+### Collision and trigger event queue
+
+Web 端 collision / trigger callback 已改成 JS 侧 event queue：
+
+- event type：collision enter / stay / exit，trigger enter / stay / exit
+- self id low/high
+- other id low/high
+
+对应入口：
+
+- JS: `GodotGdspx.queueContact`
+- JS: `GodotGdspx.flushContactEvents`
+- Go: `webffi.registerContactEventQueue`
+- Go: `webffi.dispatchContactEvent`
+
+Godot 触发事件时先写入 JS 数组队列，在 engine update / fixed update 前批量 flush 给 Go。若 Go direct handler 尚未注册，则回退到原有 `gdspx_dispatch` 逐条派发。
+
+### Sprite physics config
+
+Web 端新增 sprite physics command buffer，用于批量同步：
+
+- velocity
+- gravity / gravity scale
+- mass
+- physics mode
+- drag / friction
+- collision layer / mask
+- trigger layer / mask
+- collision enabled / trigger enabled
+
+对应入口：
+
+- Go: `PhysicsSyncBuffer.Serialize`
+- Go: `engine.SyncBatchUpdatePhysics`
+- Go Web wrapper: `WebSpriteBatchUpdatePhysics`
+- Godot: `SpxSpriteMgr::batch_update_physics`
+- Godot Web raw export: `gdspx_sprite_batch_update_physics`
+
+buffer 格式为 `[count, cmd, spriteIdLowBits, spriteIdHighBits, a, b, reserved0, ...]`。sprite id 和 layer / mask / mode 这类整数使用 `float32` lane 的 raw bits 编码，避免按数值转成 `float32` 时丢失高位。polygon points、collider shape 参数这类可变长 payload 暂不进入该 fixed record buffer。
+
+## 适合新增批量同步的数据
+
+### Pen and debug draw
+
+每帧绘制命令适合 command buffer：
+
+- draw circle
+- draw rect
+- draw line
+- pen move
+- pen down / up
+- stamp
+- clear
+
+这些命令天然是 append-only records，适合一帧 flush 一次。
+
+### UI numeric layout
+
+UI 的数值型属性可以批量：
+
+- rect
+- position
+- size
+- scale
+- rotation
+- visible
+- interactable
+- color
+- font size
+
+text、texture path、node path 仍然建议走字符串表或普通 bridge。
+
+### Tilemap bulk operations
+
+Tilemap 本身已有数组型批量接口空间，适合继续二进制化：
+
+- place tiles
+- erase tiles
+- set layer offset
+- collision points
+
+但 tile texture path 应用字符串表或资源 id。
+
+## 不适合批量共享内存的数据
+
+以下内容不建议直接进入 ring buffer：
+
+- Godot `Object*` 指针
+- Go pointer / slice header / string header
+- Godot `Variant`
+- 需要 Godot 生命周期管理的 Node / Resource
+- 资源加载、场景切换、动画创建
+- 任意长度字符串
+- 返回值依赖同步执行语义的查询调用
+
+这些内容可以通过稳定 id、字符串表、资源表或现有 JS bridge 处理。
+
+## 当前共享传输缓冲实现
+
+浏览器里不能让 Go wasm 和 Godot wasm 直接共用同一个内部 heap。当前实现采用更可控的方式：
+
+1. Go 将批量数据序列化为 `[]float32` 或其他 primitive slice。
+2. Web FFI 优先向 JS 借用 Godot wasm heap 上的 ring slot。
+3. Go 通过 `js.CopyBytesToJS` 直接写入这个 Godot wasm heap view。
+4. JS 调用 Godot C++ 导出的 batch 函数，只传入 pointer + length。
+5. 如果 ring slot 不可用，自动回退到旧的 `Uint8Array` scratch 再拷贝到 Godot wasm heap。
+6. 对 Godot -> SPX 的固定 primitive 返回值，JS 使用独立的 return ring slot，避免覆盖同一次调用中的入参 slot。
+
+该方案减少了一次中间 `Uint8Array -> Module.HEAPU8` 拷贝。在线程版 Godot Web 构建中，Godot wasm heap 的底层 buffer 是 `SharedArrayBuffer`；非线程构建中是普通 `ArrayBuffer`，但协议和调用路径保持一致。
+
+## 后续优先级
+
+暂无。

--- a/internal/cmd/codegen/generate/common/funcs.go
+++ b/internal/cmd/codegen/generate/common/funcs.go
@@ -63,6 +63,21 @@ type NativeArrayBridgeSpec struct {
 	FastArrayType int32
 }
 
+type RawExportParam struct {
+	CType string
+	Name  string
+}
+
+type ArrayTransformBridgeSpec struct {
+	FunctionName     string
+	ArrayArgName     string
+	MethodName       string
+	Params           []RawExportParam
+	InputArrayType   int32
+	OutputArrayType  int32
+	OutputCountScale int
+}
+
 func init() {
 	// Set callback function so the clang package can get the list of known manager names
 	clang.KnownManagerNamesProvider = func() []string {
@@ -455,10 +470,11 @@ func TrimPrefix(typeName, prefix string) string {
 }
 
 var (
-	managerSet         = map[string]bool{}
-	cppType2Go         = map[string]string{}
-	KnownManagerNames  = []string{} // List of correct manager names obtained from header parsing
-	nativeArrayBridges = map[string]NativeArrayBridgeSpec{}
+	managerSet            = map[string]bool{}
+	cppType2Go            = map[string]string{}
+	KnownManagerNames     = []string{} // List of correct manager names obtained from header parsing
+	nativeArrayBridges    = map[string]NativeArrayBridgeSpec{}
+	arrayTransformBridges = map[string]ArrayTransformBridgeSpec{}
 )
 
 type ManagerData struct {
@@ -487,13 +503,45 @@ func ClearNativeArrayBridgeSpecs() {
 	nativeArrayBridges = map[string]NativeArrayBridgeSpec{}
 }
 
+func ClearArrayTransformBridgeSpecs() {
+	arrayTransformBridges = map[string]ArrayTransformBridgeSpec{}
+}
+
 func RegisterNativeArrayBridgeSpec(spec NativeArrayBridgeSpec) {
 	nativeArrayBridges[spec.BaseFunctionName] = spec
+}
+
+func RegisterArrayTransformBridgeSpec(spec ArrayTransformBridgeSpec) {
+	arrayTransformBridges[spec.FunctionName] = spec
+}
+
+func HasArrayTransformBridgeSpec(function *clang.TypedefFunction) bool {
+	if function == nil {
+		return false
+	}
+	_, ok := arrayTransformBridges[function.Name]
+	return ok
 }
 
 func GetNativeArrayBridgeSpec(functionName string) (NativeArrayBridgeSpec, bool) {
 	spec, ok := nativeArrayBridges[functionName]
 	return spec, ok
+}
+
+func GetArrayTransformBridgeSpec(functionName string) (ArrayTransformBridgeSpec, bool) {
+	spec, ok := arrayTransformBridges[functionName]
+	return spec, ok
+}
+
+func ListArrayTransformBridgeSpecs() []ArrayTransformBridgeSpec {
+	specs := make([]ArrayTransformBridgeSpec, 0, len(arrayTransformBridges))
+	for _, spec := range arrayTransformBridges {
+		specs = append(specs, spec)
+	}
+	sort.Slice(specs, func(i, j int) bool {
+		return specs[i].FunctionName < specs[j].FunctionName
+	})
+	return specs
 }
 
 func HasNativeArrayBridgeSpec(function *clang.TypedefFunction) bool {

--- a/internal/cmd/codegen/generate/gdext/gdextension_spx_ext.cpp.tmpl
+++ b/internal/cmd/codegen/generate/gdext/gdextension_spx_ext.cpp.tmpl
@@ -51,6 +51,51 @@ static void gdextension_spx_global_register_callbacks(GDExtensionSpxCallbackInfo
 
 {{- range $i, $f := $view.Ast.CollectGDExtensionInterfaceFunctions -}}
 {{- if isManagerMethod $f }}
+{{- if hasArrayTransformBridgeSpec $f }}
+	{{- $spec := getArrayTransformBridgeSpec $f }}
+static void gdextension_{{ loadProcAddressName $f.Name }}(
+	{{- range $j, $arg := $f.Arguments -}}
+		{{ $arg.CStyleString $j }}
+		{{- if ne $j (sub (len $f.Arguments) 1) -}}, {{ end -}}
+	{{- end -}}
+	{{ if ne "void" $f.ReturnType.CStyleString -}} 
+	{{- if ne 0 (len $f.Arguments) -}}, {{ end -}}{{$f.ReturnType.CStyleString }} *ret_val
+	{{- end -}}
+) {
+	if (!{{ $spec.ArrayArgName }}) {
+		*ret_val = nullptr;
+		return;
+	}
+
+	int count = {{ $spec.ArrayArgName }}->size;
+	if (count == 0) {
+		*ret_val = nullptr;
+		return;
+	}
+	if (count > 0x7fffffff / {{ $spec.OutputCountScale }}) {
+		*ret_val = nullptr;
+		return;
+	}
+
+	int out_len = count * {{ $spec.OutputCountScale }};
+	GdArray result = SpxBaseMgr::create_array({{ fastArrayTypeConst $spec.OutputArrayType }}, out_len);
+	if (!result) {
+		*ret_val = nullptr;
+		return;
+	}
+
+	const {{ fastArrayElemCppType $spec.InputArrayType }} *input = SpxBaseMgr::get_array<{{ fastArrayElemCppType $spec.InputArrayType }}>({{ $spec.ArrayArgName }}, 0);
+	{{ fastArrayElemCppType $spec.OutputArrayType }} *out = SpxBaseMgr::get_array<{{ fastArrayElemCppType $spec.OutputArrayType }}>(result, 0);
+	if (!input || !out) {
+		SpxBaseMgr::free_array(result);
+		*ret_val = nullptr;
+		return;
+	}
+
+	{{ getManagerName $spec.FunctionName }}Mgr->{{ $spec.MethodName }}(input, count, out, out_len);
+	*ret_val = result;
+}
+{{- else }}
 static void gdextension_{{ loadProcAddressName $f.Name }}(
 	{{- range $j, $arg := $f.Arguments -}}
 		{{ $arg.CStyleString $j }}
@@ -69,6 +114,7 @@ static void gdextension_{{ loadProcAddressName $f.Name }}(
 	);
 }
 {{- end -}}
+{{ end }}
 {{ end }}
 
 void gdextension_spx_setup_interface() {

--- a/internal/cmd/codegen/generate/gdext/gdextension_spx_ext.cpp.tmpl
+++ b/internal/cmd/codegen/generate/gdext/gdextension_spx_ext.cpp.tmpl
@@ -68,7 +68,7 @@ static void gdextension_{{ loadProcAddressName $f.Name }}(
 	}
 
 	int count = {{ $spec.ArrayArgName }}->size;
-	if (count == 0) {
+	if (count <= 0) {
 		*ret_val = nullptr;
 		return;
 	}

--- a/internal/cmd/codegen/generate/gdext/generate.go
+++ b/internal/cmd/codegen/generate/gdext/generate.go
@@ -107,25 +107,59 @@ func Generate(projectPath, godotPath string, ast clang.CHeaderFileAST) {
 
 func generateGdCppFile(projectPath string, templateStr string, ast clang.CHeaderFileAST, outputFileName string) error {
 	funcs := template.FuncMap{
-		"gdiVariableName":          GdiVariableName,
-		"snakeCase":                strcase.ToSnake,
-		"camelCase":                strcase.ToCamel,
-		"goReturnType":             GoReturnType,
-		"goArgumentType":           GoArgumentType,
-		"goEnumValue":              GoEnumValue,
-		"add":                      Add,
-		"sub":                      Sub,
-		"cgoCastArgument":          CgoCastArgument,
-		"cgoCastReturnType":        CgoCastReturnType,
-		"cgoCleanUpArgument":       CgoCleanUpArgument,
-		"trimPrefix":               TrimPrefix,
-		"loadProcAddressName":      LoadProcAddressName,
-		"isManagerMethod":          IsManagerMethod,
-		"getManagerName":           GetManagerName,
-		"hasNativeArrayBridgeSpec": HasNativeArrayBridgeSpec,
+		"gdiVariableName":             GdiVariableName,
+		"snakeCase":                   strcase.ToSnake,
+		"camelCase":                   strcase.ToCamel,
+		"goReturnType":                GoReturnType,
+		"goArgumentType":              GoArgumentType,
+		"goEnumValue":                 GoEnumValue,
+		"add":                         Add,
+		"sub":                         Sub,
+		"cgoCastArgument":             CgoCastArgument,
+		"cgoCastReturnType":           CgoCastReturnType,
+		"cgoCleanUpArgument":          CgoCleanUpArgument,
+		"trimPrefix":                  TrimPrefix,
+		"loadProcAddressName":         LoadProcAddressName,
+		"isManagerMethod":             IsManagerMethod,
+		"getManagerName":              GetManagerName,
+		"hasArrayTransformBridgeSpec": HasArrayTransformBridgeSpec,
+		"hasNativeArrayBridgeSpec":    HasNativeArrayBridgeSpec,
+		"getArrayTransformBridgeSpec": func(function *clang.TypedefFunction) ArrayTransformBridgeSpec {
+			spec, _ := GetArrayTransformBridgeSpec(function.Name)
+			return spec
+		},
 		"getNativeArrayBridgeSpec": func(function *clang.TypedefFunction) NativeArrayBridgeSpec {
 			spec, _ := GetNativeArrayBridgeSpec(function.Name)
 			return spec
+		},
+		"listArrayTransformBridgeSpecs": ListArrayTransformBridgeSpecs,
+		"fastArrayElemCppType": func(arrayType int32) string {
+			switch arrayType {
+			case 1:
+				return "int64_t"
+			case 2:
+				return "float"
+			case 5:
+				return "uint8_t"
+			case 6:
+				return "GdObj"
+			default:
+				panic("unsupported fast array element type")
+			}
+		},
+		"fastArrayTypeConst": func(arrayType int32) string {
+			switch arrayType {
+			case 1:
+				return "GD_ARRAY_TYPE_INT64"
+			case 2:
+				return "GD_ARRAY_TYPE_FLOAT"
+			case 5:
+				return "GD_ARRAY_TYPE_BYTE"
+			case 6:
+				return "GD_ARRAY_TYPE_GDOBJ"
+			default:
+				panic("unsupported fast array type constant")
+			}
 		},
 		"cDecl": func(typeName, name string) string {
 			typeName = strings.TrimSpace(typeName)

--- a/internal/cmd/codegen/generate/gdext/godot_js_spx.cpp.tmpl
+++ b/internal/cmd/codegen/generate/gdext/godot_js_spx.cpp.tmpl
@@ -57,9 +57,9 @@ EMSCRIPTEN_KEEPALIVE
 void cfree(void* ptr) {
 	free(ptr);
 }
-
 {{- range $i, $f := $view.Ast.CollectGDExtensionInterfaceFunctions -}}
 {{- if isManagerMethod $f }}
+{{- if not (hasArrayTransformBridgeSpec $f) }}
 {{- if hasNativeArrayBridgeSpec $f }}
 	{{- $spec := getNativeArrayBridgeSpec $f }}
 EMSCRIPTEN_KEEPALIVE
@@ -87,6 +87,22 @@ void gd{{ loadProcAddressName $f.Name }}(
 }
 {{- end }}
 {{- end -}}
+{{- end -}}
 	{{ end }}
+{{- range $spec := listArrayTransformBridgeSpecs }}
+EMSCRIPTEN_KEEPALIVE
+void gd{{ loadProcAddressName $spec.FunctionName }}(
+	{{- range $i, $param := $spec.Params -}}
+		{{ cDecl $param.CType $param.Name }}
+		{{- if ne $i (sub (len $spec.Params) 1) -}}, {{ end -}}
+	{{- end -}}
+) {
+	{{ getManagerName $spec.FunctionName }}Mgr->{{ $spec.MethodName }}(
+		{{- range $i, $param := $spec.Params -}}
+			{{- if gt $i 0 }}, {{ end -}}{{ $param.Name }}
+		{{- end -}}
+	);
+}
+{{- end }}
 
 }

--- a/internal/cmd/codegen/generate/gdext/header_generator.go
+++ b/internal/cmd/codegen/generate/gdext/header_generator.go
@@ -46,12 +46,13 @@ var (
 	reMethodReturn         = regexp.MustCompile(`\s*(?:SPX_API|SPX_BIND)\s+(\w+)\s+(\w+)\((.*)\);`)
 	reSingleGdArrayParam   = regexp.MustCompile(`^\s*GdArray\s+([A-Za-z_][A-Za-z0-9_]*)\s*$`)
 	reRawNativeArrayParams = regexp.MustCompile(`^\s*((?:const\s+)?[A-Za-z_][A-Za-z0-9_]*\s*\*)\s*([A-Za-z_][A-Za-z0-9_]*)\s*,\s*(int32_t|int)\s+([A-Za-z_][A-Za-z0-9_]*)\s*$`)
+	reParamDecl            = regexp.MustCompile(`^\s*(.+?[*\s])([A-Za-z_][A-Za-z0-9_]*)\s*$`)
 )
 
 func shouldSkipGeneratedMethod(methodName string) bool {
 	// Raw helpers are web-only entry points and should not leak into the shared
 	// gdextension interface consumed by native ffi/codegen.
-	return strings.HasSuffix(methodName, "_raw")
+	return strings.HasSuffix(methodName, "_raw") || isArrayTransformBridgeMethod(methodName)
 }
 
 type classMethodDecl struct {
@@ -173,6 +174,7 @@ func generateManagerHeader(input string, rawFormat bool) string {
 	// Clear the previous list of manager names
 	common.ClearKnownManagerNames()
 	common.ClearNativeArrayBridgeSpecs()
+	common.ClearArrayTransformBridgeSpecs()
 
 	baseMethods := map[string]classMethodDecl{}
 	rawMethods := map[string]classMethodDecl{}
@@ -239,6 +241,8 @@ func generateManagerHeader(input string, rawFormat bool) string {
 	}
 
 	registerNativeArrayBridgeSpecs(baseMethods, rawMethods)
+	registerArrayTransformBridgeSpecs(baseMethods, rawMethods)
+	appendSyntheticArrayTransformTypedefs(&builder, rawFormat, baseMethods)
 
 	return builder.String()
 }
@@ -309,6 +313,125 @@ func registerNativeArrayBridgeSpecs(baseMethods map[string]classMethodDecl, rawM
 	}
 }
 
+type arrayTransformOverride struct {
+	ArrayArgName     string
+	OutputCountScale int
+}
+
+var arrayTransformOverrides = map[string]arrayTransformOverride{
+	// The raw signature does not encode the return length formula, so keep the
+	// minimal transform metadata here and let codegen synthesize the high-level
+	// GdArray return bridge generically.
+	"batch_retrieve_positions": {
+		ArrayArgName:     "objs",
+		OutputCountScale: 2,
+	},
+}
+
+func isArrayTransformBridgeMethod(methodName string) bool {
+	_, ok := arrayTransformOverrides[methodName]
+	return ok
+}
+
+func registerArrayTransformBridgeSpecs(baseMethods map[string]classMethodDecl, rawMethods map[string]classMethodDecl) {
+	for key, rawMethod := range rawMethods {
+		baseMethod, hasBaseMethod := baseMethods[key]
+		baseMethodName := strings.TrimSuffix(rawMethod.MethodName, "_raw")
+		if rawMethod.ReturnType != "void" {
+			continue
+		}
+		if hasBaseMethod && baseMethod.ReturnType != "GdArray" {
+			continue
+		}
+		if _, _, _, _, _, _, _, _, ok := parseRawNativeArrayParams(rawMethod.Params); ok {
+			continue
+		}
+
+		params, ok := parseRawExportParams(rawMethod.Params)
+		if !ok || len(params) != 4 {
+			continue
+		}
+
+		override, ok := arrayTransformOverrides[rawMethod.MethodName]
+		if !ok {
+			continue
+		}
+
+		baseArgName := override.ArrayArgName
+		if hasBaseMethod {
+			baseArgName, ok = parseSingleGdArrayParam(baseMethod.Params)
+			if !ok {
+				continue
+			}
+		} else if baseArgName == "" {
+			baseArgName = highLevelArrayArgName(params[0].Name)
+		}
+
+		inputType, ok := rawArrayFastType(params[0].CType)
+		if !ok || !isRawArrayLenType(params[1].CType) {
+			continue
+		}
+		outputType, ok := rawArrayFastType(params[2].CType)
+		if !ok || !isRawArrayLenType(params[3].CType) {
+			continue
+		}
+
+		baseFunctionName := "GDExtension" + rawMethod.ClassName + strcase.ToCamel(baseMethodName)
+		common.RegisterArrayTransformBridgeSpec(common.ArrayTransformBridgeSpec{
+			FunctionName:     baseFunctionName,
+			ArrayArgName:     baseArgName,
+			MethodName:       rawMethod.MethodName,
+			Params:           params,
+			InputArrayType:   inputType,
+			OutputArrayType:  outputType,
+			OutputCountScale: override.OutputCountScale,
+		})
+	}
+}
+
+func appendSyntheticArrayTransformTypedefs(builder *strings.Builder, rawFormat bool, baseMethods map[string]classMethodDecl) {
+	existingFunctions := make(map[string]struct{}, len(baseMethods))
+	for _, baseMethod := range baseMethods {
+		functionName := "GDExtension" + baseMethod.ClassName + strcase.ToCamel(baseMethod.MethodName)
+		existingFunctions[functionName] = struct{}{}
+	}
+
+	for _, spec := range common.ListArrayTransformBridgeSpecs() {
+		if _, ok := existingFunctions[spec.FunctionName]; ok {
+			continue
+		}
+		if rawFormat {
+			builder.WriteString(fmt.Sprintf("typedef GdArray (*%s)(GdArray %s);\n", spec.FunctionName, spec.ArrayArgName))
+			continue
+		}
+		builder.WriteString(fmt.Sprintf("typedef void (*%s)(GdArray %s, GdArray *ret_value);\n", spec.FunctionName, spec.ArrayArgName))
+	}
+}
+
+func rawArrayFastType(rawType string) (int32, bool) {
+	switch strings.TrimPrefix(normalizeRawDataType(rawType), "const ") {
+	case "int64_t *":
+		return 1, true
+	case "float *", "real_t *":
+		return 2, true
+	case "uint8_t *":
+		return 5, true
+	case "GdObj *":
+		return 6, true
+	default:
+		return 0, false
+	}
+}
+
+func isRawArrayLenType(typeName string) bool {
+	switch normalizeRawDataType(typeName) {
+	case "int", "int32_t":
+		return true
+	default:
+		return false
+	}
+}
+
 func parseSingleGdArrayParam(params string) (string, bool) {
 	matches := reSingleGdArrayParam.FindStringSubmatch(params)
 	if len(matches) != 2 {
@@ -346,6 +469,28 @@ func normalizeRawDataType(rawDataType string) string {
 	rawDataType = strings.Join(strings.Fields(rawDataType), " ")
 	rawDataType = strings.ReplaceAll(rawDataType, " *", " *")
 	return rawDataType
+}
+
+func parseRawExportParams(params string) ([]common.RawExportParam, bool) {
+	params = strings.TrimSpace(params)
+	if params == "" {
+		return nil, true
+	}
+
+	parts := strings.Split(params, ",")
+	result := make([]common.RawExportParam, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		matches := reParamDecl.FindStringSubmatch(part)
+		if len(matches) != 3 {
+			return nil, false
+		}
+		result = append(result, common.RawExportParam{
+			CType: normalizeRawDataType(matches[1]),
+			Name:  matches[2],
+		})
+	}
+	return result, true
 }
 
 func highLevelArrayArgName(rawDataArgName string) string {

--- a/internal/cmd/codegen/generate/gdext/header_generator_test.go
+++ b/internal/cmd/codegen/generate/gdext/header_generator_test.go
@@ -72,3 +72,45 @@ public:
 	require.Equal(t, "*float32", spec.DataArgPtrType)
 	require.Equal(t, "int32", spec.LenArgGoType)
 }
+
+func TestGenerateManagerHeaderRegistersArrayTransformBridge(t *testing.T) {
+	input := strings.TrimSpace(`
+class SpxSpriteMgr {
+public:
+	SPX_API void batch_retrieve_positions(const GdObj *ids, int count, float *out, int out_len);
+};
+`)
+
+	output := generateManagerHeader(input, false)
+
+	require.Contains(t, output, "GDExtensionSpxSpriteBatchRetrievePositions")
+	require.NotContains(t, output, "GDExtensionSpxSpriteBatchRetrievePositionsRaw")
+
+	specs := common.ListArrayTransformBridgeSpecs()
+	require.Len(t, specs, 1)
+	require.Equal(t, "GDExtensionSpxSpriteBatchRetrievePositions", specs[0].FunctionName)
+	require.Equal(t, "objs", specs[0].ArrayArgName)
+	require.Equal(t, "batch_retrieve_positions", specs[0].MethodName)
+	require.EqualValues(t, 6, specs[0].InputArrayType)
+	require.EqualValues(t, 2, specs[0].OutputArrayType)
+	require.Equal(t, 2, specs[0].OutputCountScale)
+	require.Len(t, specs[0].Params, 4)
+	require.Equal(t, "const GdObj *", specs[0].Params[0].CType)
+	require.Equal(t, "ids", specs[0].Params[0].Name)
+	require.Equal(t, "float *", specs[0].Params[2].CType)
+	require.Equal(t, "out", specs[0].Params[2].Name)
+}
+
+func TestGenerateManagerHeaderSynthesizesFastReturnTypedefForRawFormat(t *testing.T) {
+	input := strings.TrimSpace(`
+class SpxSpriteMgr {
+public:
+	SPX_API void batch_retrieve_positions(const GdObj *ids, int count, float *out, int out_len);
+};
+`)
+
+	output := generateManagerHeader(input, true)
+
+	require.Contains(t, output, "typedef GdArray (*GDExtensionSpxSpriteBatchRetrievePositions)(GdArray objs);")
+	require.NotContains(t, output, "GDExtensionSpxSpriteBatchRetrievePositionsRaw")
+}

--- a/internal/cmd/codegen/generate/webffi/callbacks.go.tmpl
+++ b/internal/cmd/codegen/generate/webffi/callbacks.go.tmpl
@@ -42,6 +42,12 @@ func gdspxDispatch(this js.Value, args []js.Value) any {
 		{{ range $j, $arg := $f.Arguments -}}
 		arg{{ $j }} := JsTo{{mustPrimitiveTypeName $arg $f.Name}}(args[{{add $j 1}}])
 		{{ end -}}
+		{{ $cbName := trimPrefix $f.Name "GDExtensionSpxCallback" -}}
+		{{ if eq $cbName "OnKeyPressed" -}}
+		RecordWebKeyState(arg0, true)
+		{{ else if eq $cbName "OnKeyReleased" -}}
+		RecordWebKeyState(arg0, false)
+		{{ end -}}
 		callbacks.{{ trimPrefix $f.Name "GDExtensionSpxCallback" }}(
 			{{- range $j, $arg := $f.Arguments -}}
 				arg{{ $j }},

--- a/internal/cmd/codegen/generate/webffi/generate.go
+++ b/internal/cmd/codegen/generate/webffi/generate.go
@@ -245,6 +245,10 @@ func getManagerFuncName(function *clang.TypedefFunction) string {
 }
 
 func getManagerFuncBody(function *clang.TypedefFunction) string {
+	if body, ok := getInputCacheManagerFuncBody(function.Name); ok {
+		return body
+	}
+
 	sb := strings.Builder{}
 	prefixTab := "\t"
 	params := []string{}
@@ -316,6 +320,108 @@ func getManagerFuncBody(function *clang.TypedefFunction) string {
 	}
 	return sb.String()
 }
+
+type managerFuncBodySpec struct {
+	call      string
+	fallback  []string
+	boolAsInt bool
+}
+
+var inputCacheManagerFuncBodies = map[string]managerFuncBodySpec{
+	"GDExtensionSpxInputGetGlobalMousePos": {
+		call: "WebInputMousePos(func() Vec2",
+		fallback: []string{
+			"_retValue := API.SpxInputGetGlobalMousePos.Invoke()",
+			"return JsToGdVec2(_retValue)",
+		},
+	},
+	"GDExtensionSpxInputGetKey": {
+		call: "WebInputKeyState(key, func() bool",
+		fallback: []string{
+			"arg0Low, arg0High := JsSplitGdInt(key)",
+			"_retValue := API.SpxInputGetKey.Invoke(arg0Low, arg0High)",
+			"return JsToGdBool(_retValue)",
+		},
+	},
+	"GDExtensionSpxInputGetMouseState": {
+		call: "WebInputMouseState(mouse_id, func() bool",
+		fallback: []string{
+			"arg0Low, arg0High := JsSplitGdInt(mouse_id)",
+			"_retValue := API.SpxInputGetMouseState.Invoke(arg0Low, arg0High)",
+			"return JsToGdBool(_retValue)",
+		},
+	},
+	"GDExtensionSpxInputGetKeyState": {
+		call: "WebInputKeyState(key, func() bool",
+		fallback: []string{
+			"arg0Low, arg0High := JsSplitGdInt(key)",
+			"_retValue := API.SpxInputGetKeyState.Invoke(arg0Low, arg0High)",
+			"return JsToGdInt(_retValue) != 0",
+		},
+		boolAsInt: true,
+	},
+	"GDExtensionSpxInputGetAxis": {
+		call: "CachedActionAxis(neg_action, pos_action, func() float64",
+		fallback: []string{
+			"arg0 := JsFromGdString(neg_action)",
+			"arg1 := JsFromGdString(pos_action)",
+			"_retValue := API.SpxInputGetAxis.Invoke(arg0, arg1)",
+			"return JsToGdFloat(_retValue)",
+		},
+	},
+	"GDExtensionSpxInputIsActionPressed":      actionBoolManagerFuncBody("pressed", "API.SpxInputIsActionPressed"),
+	"GDExtensionSpxInputIsActionJustPressed":  actionBoolManagerFuncBody("just_pressed", "API.SpxInputIsActionJustPressed"),
+	"GDExtensionSpxInputIsActionJustReleased": actionBoolManagerFuncBody("just_released", "API.SpxInputIsActionJustReleased"),
+}
+
+func getInputCacheManagerFuncBody(name string) (string, bool) {
+	spec, ok := inputCacheManagerFuncBodies[name]
+	if !ok {
+		return "", false
+	}
+	if spec.boolAsInt {
+		return cachedBoolAsIntBody(spec.call, spec.fallback...), true
+	}
+	return cachedReturnBody(spec.call, spec.fallback...), true
+}
+
+func actionBoolManagerFuncBody(kind, api string) managerFuncBodySpec {
+	return managerFuncBodySpec{
+		call: fmt.Sprintf("CachedActionBool(%q, action, func() bool", kind),
+		fallback: []string{
+			"arg0 := JsFromGdString(action)",
+			"_retValue := " + api + ".Invoke(arg0)",
+			"return JsToGdBool(_retValue)",
+		},
+	}
+}
+
+func cachedReturnBody(call string, fallbackLines ...string) string {
+	lines := []string{"return " + call + " {"}
+	lines = appendIndented(lines, "\t\t", fallbackLines...)
+	lines = append(lines, "\t})")
+	return strings.Join(lines, "\n")
+}
+
+func cachedBoolAsIntBody(call string, fallbackLines ...string) string {
+	lines := []string{"if " + call + " {"}
+	lines = appendIndented(lines, "\t\t", fallbackLines...)
+	lines = append(lines,
+		"\t}) {",
+		"\t\treturn 1",
+		"\t}",
+		"\treturn 0",
+	)
+	return strings.Join(lines, "\n")
+}
+
+func appendIndented(lines []string, indent string, values ...string) []string {
+	for _, value := range values {
+		lines = append(lines, indent+value)
+	}
+	return lines
+}
+
 func getManagerInterface(function *clang.TypedefFunction) string {
 	prefix := "GDExtensionSpx"
 	sb := strings.Builder{}
@@ -417,12 +523,21 @@ func flatJsScratchAccessor(typeName string) string {
 }
 
 func getJsFuncBody(function *clang.TypedefFunction) string {
+	if spec, ok := GetArrayTransformBridgeSpec(function.Name); ok {
+		return "var _fastRetValue = TryArrayTransformFastPath(_gdFuncPtr, " + spec.ArrayArgName + ", " +
+			strconv.Itoa(int(spec.InputArrayType)) + ", " + strconv.Itoa(int(spec.OutputArrayType)) + ", " +
+			strconv.Itoa(spec.OutputCountScale) + ");\n" +
+			"\tif (_fastRetValue == null) {\n" +
+			"\t\tthrow new Error(\"gd" + LoadProcAddressName(function.Name) + " fast path unavailable\");\n" +
+			"\t}\n" +
+			"\treturn _fastRetValue"
+	}
 	if spec, ok := GetNativeArrayBridgeSpec(function.Name); ok {
 		if HasEffectiveReturn(function) {
 			panic(fmt.Sprintf("native-array webffi path does not support return values: %s", function.Name))
 		}
 		argName := spec.BaseArgName
-		return "var _arg0 = CopyFastArrayToWasm(" + argName + ");\n" +
+		return "var _arg0 = GetFastArrayWasmPtr(" + argName + ");\n" +
 			"\tvar _arg1 = " + argName + ".count;\n" +
 			"\t_gdFuncPtr(_arg0, _arg1);"
 	}
@@ -440,7 +555,6 @@ func getJsFuncBody(function *clang.TypedefFunction) string {
 			"\tFreeGdVec2(_retValue);\n" +
 			"\treturn _scratch"
 	}
-
 	sb := strings.Builder{}
 	prefixTab := "\t"
 	params := []string{}

--- a/internal/cmd/codegen/generate/webffi/generate.go
+++ b/internal/cmd/codegen/generate/webffi/generate.go
@@ -532,6 +532,11 @@ func getJsFuncBody(function *clang.TypedefFunction) string {
 			"\t}\n" +
 			"\treturn _fastRetValue"
 	}
+	if function.Name == "GDExtensionSpxInputWriteSnapshot" {
+		return "var _arg0 = RequireWasmFastArray(out, \"gdspx_input_write_snapshot\");\n" +
+			"\tvar _arg1 = out.count;\n" +
+			"\t_gdFuncPtr(_arg0, _arg1);"
+	}
 	if spec, ok := GetNativeArrayBridgeSpec(function.Name); ok {
 		if HasEffectiveReturn(function) {
 			panic(fmt.Sprintf("native-array webffi path does not support return values: %s", function.Name))

--- a/internal/cmd/codegen/generate/webffi/generate_test.go
+++ b/internal/cmd/codegen/generate/webffi/generate_test.go
@@ -157,6 +157,17 @@ func TestGetJsFuncBodyUsesArrayTransformBridgeSpec(t *testing.T) {
 	require.Contains(t, body, `throw new Error("gdspx_sprite_batch_retrieve_positions fast path unavailable")`)
 }
 
+func TestGetJsFuncBodyRequiresWasmArrayForInputSnapshot(t *testing.T) {
+	function := &clang.TypedefFunction{
+		Name: "GDExtensionSpxInputWriteSnapshot",
+	}
+
+	body := getJsFuncBody(function)
+	require.Contains(t, body, `RequireWasmFastArray(out, "gdspx_input_write_snapshot")`)
+	require.Contains(t, body, "var _arg1 = out.count;")
+	require.NotContains(t, body, "GetFastArrayWasmPtr(out)")
+}
+
 func TestJsTemplateUsesHeapU32ForFlatReads(t *testing.T) {
 	require.Contains(t, jsEngineJsFileText, "var _u32 = Module.HEAPU32;")
 	require.Contains(t, jsEngineJsFileText, "scratch.low = _u32[_word];")

--- a/internal/cmd/codegen/generate/webffi/generate_test.go
+++ b/internal/cmd/codegen/generate/webffi/generate_test.go
@@ -137,6 +137,26 @@ func TestGetJsFuncBodyUsesFixedScratchAccessorForFlatReturn(t *testing.T) {
 	require.NotContains(t, body, `"_gdIntScratch"`)
 }
 
+func TestGetJsFuncBodyUsesArrayTransformBridgeSpec(t *testing.T) {
+	common.ClearArrayTransformBridgeSpecs()
+	t.Cleanup(common.ClearArrayTransformBridgeSpecs)
+	common.RegisterArrayTransformBridgeSpec(common.ArrayTransformBridgeSpec{
+		FunctionName:     "GDExtensionSpxSpriteBatchRetrievePositions",
+		ArrayArgName:     "objs",
+		InputArrayType:   6,
+		OutputArrayType:  2,
+		OutputCountScale: 2,
+	})
+
+	function := &clang.TypedefFunction{
+		Name: "GDExtensionSpxSpriteBatchRetrievePositions",
+	}
+
+	body := getJsFuncBody(function)
+	require.Contains(t, body, "TryArrayTransformFastPath(_gdFuncPtr, objs, 6, 2, 2)")
+	require.Contains(t, body, `throw new Error("gdspx_sprite_batch_retrieve_positions fast path unavailable")`)
+}
+
 func TestJsTemplateUsesHeapU32ForFlatReads(t *testing.T) {
 	require.Contains(t, jsEngineJsFileText, "var _u32 = Module.HEAPU32;")
 	require.Contains(t, jsEngineJsFileText, "scratch.low = _u32[_word];")
@@ -170,14 +190,23 @@ func TestGetJsFuncBodyUsesInstanceScratchForMousePos(t *testing.T) {
 	require.NotContains(t, body, "GdspxFuncs._inputMousePosScratch")
 }
 
-func TestJsTemplateDoesNotCarryScratchFontAliasCompat(t *testing.T) {
-	require.NotContains(t, jsEngineJsFileText, "SPX_SCRATCH_PACKAGED_FONT_DEFS")
-	require.NotContains(t, jsEngineJsFileText, "SPX_SCRATCH_CJK_FONT_STACKS")
-	require.NotContains(t, jsEngineJsFileText, "spxResolveFontRequest")
-	require.NotContains(t, jsEngineJsFileText, "_invokeResRegisterSvgFontFace")
-	require.NotContains(t, jsEngineJsFileText, "_invokeResSetDefaultFont")
-	require.NotContains(t, jsEngineJsFileText, "spx-register-only=1")
-	require.NotContains(t, jsEngineJsFileText, `spx-family=`)
-	require.NotContains(t, jsEngineJsFileText, "queryLocalFonts")
-	require.NotContains(t, jsEngineJsFileText, "useLocalFontAccess")
+func TestGetManagerFuncBodyUsesInputCacheOverride(t *testing.T) {
+	function := &clang.TypedefFunction{
+		Name: "GDExtensionSpxInputIsActionPressed",
+	}
+
+	body := getManagerFuncBody(function)
+	require.Contains(t, body, `return CachedActionBool("pressed", action, func() bool {`)
+	require.Contains(t, body, "_retValue := API.SpxInputIsActionPressed.Invoke(arg0)")
+	require.NotContains(t, body, "actionSuffix")
+}
+
+func TestGetManagerFuncBodyUsesActionAxisOverride(t *testing.T) {
+	function := &clang.TypedefFunction{
+		Name: "GDExtensionSpxInputGetAxis",
+	}
+
+	body := getManagerFuncBody(function)
+	require.Contains(t, body, "return CachedActionAxis(neg_action, pos_action, func() float64 {")
+	require.Contains(t, body, "_retValue := API.SpxInputGetAxis.Invoke(arg0, arg1)")
 }

--- a/internal/core/runtime/runtime_test.go
+++ b/internal/core/runtime/runtime_test.go
@@ -17,6 +17,7 @@
 package runtime
 
 import (
+	"math"
 	"testing"
 	"time"
 
@@ -472,6 +473,37 @@ func TestSyncBatchPositions(t *testing.T) {
 	}
 	if items[2].x != 31 || items[2].y != 32 {
 		t.Fatalf("item 2 = %+v, want synced coordinates", items[2])
+	}
+}
+
+func TestSyncBatchPositionsSkipsMissingSentinel(t *testing.T) {
+	type target struct {
+		id   int64
+		x, y float64
+	}
+
+	items := []*target{{id: 1}, {id: 2}}
+	SyncBatchPositions(
+		items,
+		func(item *target) bool { return true },
+		func(item *target) int64 { return item.id },
+		func(ids []int64) []float32 {
+			if len(ids) != 2 || ids[0] != 1 || ids[1] != 2 {
+				t.Fatalf("unexpected ids: %+v", ids)
+			}
+			missing := float32(math.NaN())
+			return []float32{11, 12, missing, missing}
+		},
+		func(item *target, x, y float64) {
+			item.x, item.y = x, y
+		},
+	)
+
+	if items[0].x != 11 || items[0].y != 12 {
+		t.Fatalf("item 0 = %+v, want synced coordinates", items[0])
+	}
+	if items[1].x != 0 || items[1].y != 0 {
+		t.Fatalf("item 1 should remain untouched when sprite is missing: %+v", items[1])
 	}
 }
 

--- a/internal/core/runtime/sync.go
+++ b/internal/core/runtime/sync.go
@@ -17,6 +17,7 @@
 package runtime
 
 import (
+	"math"
 	"sync"
 
 	"github.com/goplus/spbase/mathf"
@@ -53,7 +54,15 @@ func SyncBatchPositions[T any](
 
 	positions := fetchPositions(spriteIDs)
 	for i, target := range targets {
-		applyPosition(target, float64(positions[i*2]), float64(positions[i*2+1]))
+		if i*2+1 >= len(positions) {
+			return
+		}
+		x := float64(positions[i*2])
+		y := float64(positions[i*2+1])
+		if math.IsNaN(x) || math.IsNaN(y) {
+			continue
+		}
+		applyPosition(target, x, y)
 	}
 }
 

--- a/internal/engine/sync_batch.go
+++ b/internal/engine/sync_batch.go
@@ -16,6 +16,8 @@
 
 package engine
 
+import "math"
+
 const (
 	// Batch sync constants
 	SyncFieldsPerSprite     = 9  // id, x, y, rotation, scaleX, scaleY, offsetX, offsetY, visibility
@@ -286,6 +288,184 @@ func SyncBatchUpdateVisuals(buffer []float32) {
 		return
 	}
 	Managers().SpriteMgr.BatchUpdateVisuals(buffer)
+}
+
+// -------------------------------------------------------------------------------------
+// Physics Sync Buffer - Batches sprite physics configuration commands
+// -------------------------------------------------------------------------------------
+
+const (
+	// PhysicsCmdFields is the number of float32 fields per physics command.
+	// [cmd, spriteIdLowBits, spriteIdHighBits, a, b, reserved0]
+	PhysicsCmdFields = 6
+
+	PhysicsCmdVelocity = 1 + iota
+	PhysicsCmdGravity
+	PhysicsCmdMass
+	PhysicsCmdMode
+	PhysicsCmdUseGravity
+	PhysicsCmdGravityScale
+	PhysicsCmdDrag
+	PhysicsCmdFriction
+	PhysicsCmdCollisionLayer
+	PhysicsCmdCollisionMask
+	PhysicsCmdTriggerLayer
+	PhysicsCmdTriggerMask
+	PhysicsCmdCollisionEnabled
+	PhysicsCmdTriggerEnabled
+)
+
+type physicsCmd struct {
+	kind     int32
+	spriteID int64
+	a        float32
+	b        float32
+}
+
+// PhysicsSyncBuffer collects sprite physics config commands for batch processing.
+type PhysicsSyncBuffer struct {
+	cmds       []physicsCmd
+	serialized []float32
+}
+
+func NewPhysicsSyncBuffer(capacity int) *PhysicsSyncBuffer {
+	return &PhysicsSyncBuffer{
+		cmds:       make([]physicsCmd, 0, capacity),
+		serialized: make([]float32, 0, 1+capacity*PhysicsCmdFields),
+	}
+}
+
+func (b *PhysicsSyncBuffer) SetVelocity(id int64, x, y float64) {
+	b.add(PhysicsCmdVelocity, id, x, y)
+}
+
+func (b *PhysicsSyncBuffer) SetGravity(id int64, gravity float64) {
+	b.add1(PhysicsCmdGravity, id, gravity)
+}
+
+func (b *PhysicsSyncBuffer) SetMass(id int64, mass float64) {
+	b.add1(PhysicsCmdMass, id, mass)
+}
+
+func (b *PhysicsSyncBuffer) SetPhysicsMode(id int64, mode int64) {
+	b.addBits(PhysicsCmdMode, id, uint32(mode))
+}
+
+func (b *PhysicsSyncBuffer) SetUseGravity(id int64, enabled bool) {
+	b.addBool(PhysicsCmdUseGravity, id, enabled)
+}
+
+func (b *PhysicsSyncBuffer) SetGravityScale(id int64, scale float64) {
+	b.add1(PhysicsCmdGravityScale, id, scale)
+}
+
+func (b *PhysicsSyncBuffer) SetDrag(id int64, drag float64) {
+	b.add1(PhysicsCmdDrag, id, drag)
+}
+
+func (b *PhysicsSyncBuffer) SetFriction(id int64, friction float64) {
+	b.add1(PhysicsCmdFriction, id, friction)
+}
+
+func (b *PhysicsSyncBuffer) SetCollisionLayer(id int64, layer int64) {
+	b.addBits(PhysicsCmdCollisionLayer, id, uint32(layer))
+}
+
+func (b *PhysicsSyncBuffer) SetCollisionMask(id int64, mask int64) {
+	b.addBits(PhysicsCmdCollisionMask, id, uint32(mask))
+}
+
+func (b *PhysicsSyncBuffer) SetTriggerLayer(id int64, layer int64) {
+	b.addBits(PhysicsCmdTriggerLayer, id, uint32(layer))
+}
+
+func (b *PhysicsSyncBuffer) SetTriggerMask(id int64, mask int64) {
+	b.addBits(PhysicsCmdTriggerMask, id, uint32(mask))
+}
+
+func (b *PhysicsSyncBuffer) SetCollisionEnabled(id int64, enabled bool) {
+	b.addBool(PhysicsCmdCollisionEnabled, id, enabled)
+}
+
+func (b *PhysicsSyncBuffer) SetTriggerEnabled(id int64, enabled bool) {
+	b.addBool(PhysicsCmdTriggerEnabled, id, enabled)
+}
+
+func (b *PhysicsSyncBuffer) Clear() {
+	b.cmds = b.cmds[:0]
+}
+
+func (b *PhysicsSyncBuffer) Count() int {
+	return len(b.cmds)
+}
+
+// Serialize converts the command buffer to:
+// [count, cmd0, spriteIdLowBits0, spriteIdHighBits0, a0, b0, reserved0, ...]
+func (b *PhysicsSyncBuffer) Serialize() []float32 {
+	count := len(b.cmds)
+	if count == 0 {
+		return nil
+	}
+
+	totalSize := 1 + count*PhysicsCmdFields
+	b.serialized = ensureFloat32BufferSize(b.serialized, totalSize)
+	result := b.serialized
+	result[0] = float32(count)
+
+	idx := 1
+	for _, cmd := range b.cmds {
+		idLow, idHigh := splitInt64BitsToFloat32(cmd.spriteID)
+		result[idx] = float32(cmd.kind)
+		result[idx+1] = idLow
+		result[idx+2] = idHigh
+		result[idx+3] = cmd.a
+		result[idx+4] = cmd.b
+		result[idx+5] = 0
+		idx += PhysicsCmdFields
+	}
+
+	return result[:totalSize:totalSize]
+}
+
+func (b *PhysicsSyncBuffer) add(kind int, id int64, a, bval float64) {
+	b.cmds = append(b.cmds, physicsCmd{
+		kind:     int32(kind),
+		spriteID: id,
+		a:        float32(a),
+		b:        float32(bval),
+	})
+}
+
+func (b *PhysicsSyncBuffer) add1(kind int, id int64, value float64) {
+	b.add(kind, id, value, 0)
+}
+
+func (b *PhysicsSyncBuffer) addBits(kind int, id int64, bits uint32) {
+	b.cmds = append(b.cmds, physicsCmd{
+		kind:     int32(kind),
+		spriteID: id,
+		a:        uint32BitsToFloat32(bits),
+	})
+}
+
+func (b *PhysicsSyncBuffer) addBool(kind int, id int64, value bool) {
+	b.add1(kind, id, boolArg(value))
+}
+
+func boolArg(value bool) float64 {
+	if value {
+		return 1
+	}
+	return 0
+}
+
+func splitInt64BitsToFloat32(value int64) (low, high float32) {
+	u := uint64(value)
+	return uint32BitsToFloat32(uint32(u)), uint32BitsToFloat32(uint32(u >> 32))
+}
+
+func uint32BitsToFloat32(value uint32) float32 {
+	return math.Float32frombits(value)
 }
 
 func ensureFloat32BufferSize(buffer []float32, size int) []float32 {

--- a/internal/engine/sync_batch_test.go
+++ b/internal/engine/sync_batch_test.go
@@ -16,7 +16,10 @@
 
 package engine
 
-import "testing"
+import (
+	"math"
+	"testing"
+)
 
 func TestSpriteSyncBufferSerializeReusesScratch(t *testing.T) {
 	buffer := NewSpriteSyncBuffer(1)
@@ -87,6 +90,71 @@ func TestVisualSyncBufferSerializeReusesScratch(t *testing.T) {
 	}
 	if got, want := second[1], float32(8); got != want {
 		t.Fatalf("sprite id = %v, want %v", got, want)
+	}
+}
+
+func TestPhysicsSyncBufferSerializeReusesScratch(t *testing.T) {
+	buffer := NewPhysicsSyncBuffer(2)
+	buffer.SetVelocity(7, 1.5, -2.5)
+	buffer.SetGravity(7, 9.8)
+
+	first := buffer.Serialize()
+	if len(first) == 0 {
+		t.Fatal("Serialize returned an empty buffer")
+	}
+	firstPtr := &first[0]
+
+	buffer.Clear()
+	buffer.SetUseGravity(8, true)
+
+	second := buffer.Serialize()
+	if len(second) == 0 {
+		t.Fatal("Serialize returned an empty buffer after reuse")
+	}
+	if firstPtr != &second[0] {
+		t.Fatal("Serialize allocated a new backing array instead of reusing scratch storage")
+	}
+	if got, want := len(second), 1+PhysicsCmdFields; got != want {
+		t.Fatalf("Serialize len = %d, want %d", got, want)
+	}
+	if got, want := cap(second), len(second); got != want {
+		t.Fatalf("Serialize cap = %d, want %d", got, want)
+	}
+	if got, want := second[0], float32(1); got != want {
+		t.Fatalf("header count = %v, want %v", got, want)
+	}
+	if got, want := second[1], float32(PhysicsCmdUseGravity); got != want {
+		t.Fatalf("first cmd = %v, want %v", got, want)
+	}
+	if got, want := math.Float32bits(second[2]), uint32(8); got != want {
+		t.Fatalf("first sprite id low bits = %x, want %x", got, want)
+	}
+	if got, want := math.Float32bits(second[3]), uint32(0); got != want {
+		t.Fatalf("first sprite id high bits = %x, want %x", got, want)
+	}
+	if got, want := second[4], float32(1); got != want {
+		t.Fatalf("first arg = %v, want %v", got, want)
+	}
+}
+
+func TestPhysicsSyncBufferSerializePreservesIntegerBits(t *testing.T) {
+	buffer := NewPhysicsSyncBuffer(1)
+	const id = int64(0x1122334455667788)
+	const layer = int64(0xf0000001)
+	buffer.SetCollisionLayer(id, layer)
+
+	got := buffer.Serialize()
+	if len(got) != 1+PhysicsCmdFields {
+		t.Fatalf("Serialize len = %d, want %d", len(got), 1+PhysicsCmdFields)
+	}
+	if got, want := math.Float32bits(got[2]), uint32(0x55667788); got != want {
+		t.Fatalf("sprite id low bits = %x, want %x", got, want)
+	}
+	if got, want := math.Float32bits(got[3]), uint32(0x11223344); got != want {
+		t.Fatalf("sprite id high bits = %x, want %x", got, want)
+	}
+	if got, want := math.Float32bits(got[4]), uint32(layer); got != want {
+		t.Fatalf("layer bits = %x, want %x", got, want)
 	}
 }
 

--- a/internal/enginewrap/sync.gen.go
+++ b/internal/enginewrap/sync.gen.go
@@ -450,6 +450,46 @@ func (*inputMgrImpl) IsActionJustReleased(action string) bool {
 	})
 	return _ret1
 }
+func (*inputMgrImpl) RegisterAction(action string) int64 {
+	var _ret1 int64
+	callInMainThread(func() {
+		_ret1 = gdx.InputMgr.RegisterAction(action)
+	})
+	return _ret1
+}
+func (*inputMgrImpl) GetAxisId(neg_action_id int64, pos_action_id int64) float64 {
+	var _ret1 float64
+	callInMainThread(func() {
+		_ret1 = gdx.InputMgr.GetAxisId(neg_action_id, pos_action_id)
+	})
+	return _ret1
+}
+func (*inputMgrImpl) IsActionPressedId(action_id int64) bool {
+	var _ret1 bool
+	callInMainThread(func() {
+		_ret1 = gdx.InputMgr.IsActionPressedId(action_id)
+	})
+	return _ret1
+}
+func (*inputMgrImpl) IsActionJustPressedId(action_id int64) bool {
+	var _ret1 bool
+	callInMainThread(func() {
+		_ret1 = gdx.InputMgr.IsActionJustPressedId(action_id)
+	})
+	return _ret1
+}
+func (*inputMgrImpl) IsActionJustReleasedId(action_id int64) bool {
+	var _ret1 bool
+	callInMainThread(func() {
+		_ret1 = gdx.InputMgr.IsActionJustReleasedId(action_id)
+	})
+	return _ret1
+}
+func (*inputMgrImpl) WriteSnapshot(out []float32) {
+	callInMainThread(func() {
+		gdx.InputMgr.WriteSnapshot(out)
+	})
+}
 
 // INavigationMgr
 func (*navigationMgrImpl) SetupPathFinderWithSize(grid_size Vec2, cell_size Vec2, with_jump bool, with_debug bool) {
@@ -1688,6 +1728,11 @@ func (*spriteMgrImpl) BatchUpdateTransforms(buffer []float32) {
 func (*spriteMgrImpl) BatchUpdateVisuals(buffer []float32) {
 	callInMainThread(func() {
 		gdx.SpriteMgr.BatchUpdateVisuals(buffer)
+	})
+}
+func (*spriteMgrImpl) BatchUpdatePhysics(buffer []float32) {
+	callInMainThread(func() {
+		gdx.SpriteMgr.BatchUpdatePhysics(buffer)
 	})
 }
 func (*spriteMgrImpl) BatchRetrievePositions(objs gdx.Array) gdx.Array {

--- a/internal/enginewrap/sync_pure.gen.go
+++ b/internal/enginewrap/sync_pure.gen.go
@@ -254,6 +254,22 @@ func (*inputMgrImpl) IsActionJustPressed(action string) bool {
 func (*inputMgrImpl) IsActionJustReleased(action string) bool {
 	return false
 }
+func (*inputMgrImpl) RegisterAction(action string) int64 {
+	return 0
+}
+func (*inputMgrImpl) GetAxisId(neg_action_id int64, pos_action_id int64) float64 {
+	return 0
+}
+func (*inputMgrImpl) IsActionPressedId(action_id int64) bool {
+	return false
+}
+func (*inputMgrImpl) IsActionJustPressedId(action_id int64) bool {
+	return false
+}
+func (*inputMgrImpl) IsActionJustReleasedId(action_id int64) bool {
+	return false
+}
+func (*inputMgrImpl) WriteSnapshot(out []float32) {}
 
 // INavigationMgr
 func (*navigationMgrImpl) SetupPathFinderWithSize(grid_size Vec2, cell_size Vec2, with_jump bool, with_debug bool) {
@@ -676,6 +692,7 @@ func (*spriteMgrImpl) GetPixelCollisionSamplingStep() int64 {
 }
 func (*spriteMgrImpl) BatchUpdateTransforms(buffer []float32) {}
 func (*spriteMgrImpl) BatchUpdateVisuals(buffer []float32)    {}
+func (*spriteMgrImpl) BatchUpdatePhysics(buffer []float32)    {}
 func (*spriteMgrImpl) BatchRetrievePositions(objs gdx.Array) gdx.Array {
 	return nil
 }

--- a/internal/gdengine/binding/native/ffi.gen.go
+++ b/internal/gdengine/binding/native/ffi.gen.go
@@ -85,6 +85,12 @@ type GDExtensionInterface struct {
 	SpxInputIsActionPressed                     GDExtensionSpxInputIsActionPressed
 	SpxInputIsActionJustPressed                 GDExtensionSpxInputIsActionJustPressed
 	SpxInputIsActionJustReleased                GDExtensionSpxInputIsActionJustReleased
+	SpxInputRegisterAction                      GDExtensionSpxInputRegisterAction
+	SpxInputGetAxisId                           GDExtensionSpxInputGetAxisId
+	SpxInputIsActionPressedId                   GDExtensionSpxInputIsActionPressedId
+	SpxInputIsActionJustPressedId               GDExtensionSpxInputIsActionJustPressedId
+	SpxInputIsActionJustReleasedId              GDExtensionSpxInputIsActionJustReleasedId
+	SpxInputWriteSnapshot                       GDExtensionSpxInputWriteSnapshot
 	SpxNavigationSetupPathFinderWithSize        GDExtensionSpxNavigationSetupPathFinderWithSize
 	SpxNavigationSetupPathFinder                GDExtensionSpxNavigationSetupPathFinder
 	SpxNavigationSetObstacle                    GDExtensionSpxNavigationSetObstacle
@@ -291,7 +297,7 @@ type GDExtensionInterface struct {
 	SpxSpriteGetPixelCollisionSamplingStep      GDExtensionSpxSpriteGetPixelCollisionSamplingStep
 	SpxSpriteBatchUpdateTransforms              GDExtensionSpxSpriteBatchUpdateTransforms
 	SpxSpriteBatchUpdateVisuals                 GDExtensionSpxSpriteBatchUpdateVisuals
-	SpxSpriteBatchRetrievePositions             GDExtensionSpxSpriteBatchRetrievePositions
+	SpxSpriteBatchUpdatePhysics                 GDExtensionSpxSpriteBatchUpdatePhysics
 	SpxTilemapOpenDrawTilesWithSize             GDExtensionSpxTilemapOpenDrawTilesWithSize
 	SpxTilemapOpenDrawTiles                     GDExtensionSpxTilemapOpenDrawTiles
 	SpxTilemapSetLayerIndex                     GDExtensionSpxTilemapSetLayerIndex
@@ -356,6 +362,7 @@ type GDExtensionInterface struct {
 	SpxUiSetRotation                            GDExtensionSpxUiSetRotation
 	SpxUiGetFlip                                GDExtensionSpxUiGetFlip
 	SpxUiSetFlip                                GDExtensionSpxUiSetFlip
+	SpxSpriteBatchRetrievePositions             GDExtensionSpxSpriteBatchRetrievePositions
 }
 
 func (x *GDExtensionInterface) resolveAPIFunctions() {
@@ -408,6 +415,12 @@ func (x *GDExtensionInterface) resolveAPIFunctions() {
 	x.SpxInputIsActionPressed = (GDExtensionSpxInputIsActionPressed)(resolveCFunc("spx_input_is_action_pressed"))
 	x.SpxInputIsActionJustPressed = (GDExtensionSpxInputIsActionJustPressed)(resolveCFunc("spx_input_is_action_just_pressed"))
 	x.SpxInputIsActionJustReleased = (GDExtensionSpxInputIsActionJustReleased)(resolveCFunc("spx_input_is_action_just_released"))
+	x.SpxInputRegisterAction = (GDExtensionSpxInputRegisterAction)(resolveCFunc("spx_input_register_action"))
+	x.SpxInputGetAxisId = (GDExtensionSpxInputGetAxisId)(resolveCFunc("spx_input_get_axis_id"))
+	x.SpxInputIsActionPressedId = (GDExtensionSpxInputIsActionPressedId)(resolveCFunc("spx_input_is_action_pressed_id"))
+	x.SpxInputIsActionJustPressedId = (GDExtensionSpxInputIsActionJustPressedId)(resolveCFunc("spx_input_is_action_just_pressed_id"))
+	x.SpxInputIsActionJustReleasedId = (GDExtensionSpxInputIsActionJustReleasedId)(resolveCFunc("spx_input_is_action_just_released_id"))
+	x.SpxInputWriteSnapshot = (GDExtensionSpxInputWriteSnapshot)(resolveCFunc("spx_input_write_snapshot"))
 	x.SpxNavigationSetupPathFinderWithSize = (GDExtensionSpxNavigationSetupPathFinderWithSize)(resolveCFunc("spx_navigation_setup_path_finder_with_size"))
 	x.SpxNavigationSetupPathFinder = (GDExtensionSpxNavigationSetupPathFinder)(resolveCFunc("spx_navigation_setup_path_finder"))
 	x.SpxNavigationSetObstacle = (GDExtensionSpxNavigationSetObstacle)(resolveCFunc("spx_navigation_set_obstacle"))
@@ -614,7 +627,7 @@ func (x *GDExtensionInterface) resolveAPIFunctions() {
 	x.SpxSpriteGetPixelCollisionSamplingStep = (GDExtensionSpxSpriteGetPixelCollisionSamplingStep)(resolveCFunc("spx_sprite_get_pixel_collision_sampling_step"))
 	x.SpxSpriteBatchUpdateTransforms = (GDExtensionSpxSpriteBatchUpdateTransforms)(resolveCFunc("spx_sprite_batch_update_transforms"))
 	x.SpxSpriteBatchUpdateVisuals = (GDExtensionSpxSpriteBatchUpdateVisuals)(resolveCFunc("spx_sprite_batch_update_visuals"))
-	x.SpxSpriteBatchRetrievePositions = (GDExtensionSpxSpriteBatchRetrievePositions)(resolveCFunc("spx_sprite_batch_retrieve_positions"))
+	x.SpxSpriteBatchUpdatePhysics = (GDExtensionSpxSpriteBatchUpdatePhysics)(resolveCFunc("spx_sprite_batch_update_physics"))
 	x.SpxTilemapOpenDrawTilesWithSize = (GDExtensionSpxTilemapOpenDrawTilesWithSize)(resolveCFunc("spx_tilemap_open_draw_tiles_with_size"))
 	x.SpxTilemapOpenDrawTiles = (GDExtensionSpxTilemapOpenDrawTiles)(resolveCFunc("spx_tilemap_open_draw_tiles"))
 	x.SpxTilemapSetLayerIndex = (GDExtensionSpxTilemapSetLayerIndex)(resolveCFunc("spx_tilemap_set_layer_index"))
@@ -679,4 +692,5 @@ func (x *GDExtensionInterface) resolveAPIFunctions() {
 	x.SpxUiSetRotation = (GDExtensionSpxUiSetRotation)(resolveCFunc("spx_ui_set_rotation"))
 	x.SpxUiGetFlip = (GDExtensionSpxUiGetFlip)(resolveCFunc("spx_ui_get_flip"))
 	x.SpxUiSetFlip = (GDExtensionSpxUiSetFlip)(resolveCFunc("spx_ui_set_flip"))
+	x.SpxSpriteBatchRetrievePositions = (GDExtensionSpxSpriteBatchRetrievePositions)(resolveCFunc("spx_sprite_batch_retrieve_positions"))
 }

--- a/internal/gdengine/binding/native/ffi_wrapper.gen.go
+++ b/internal/gdengine/binding/native/ffi_wrapper.gen.go
@@ -150,6 +150,12 @@ type GDExtensionSpxInputGetAxis C.GDExtensionSpxInputGetAxis
 type GDExtensionSpxInputIsActionPressed C.GDExtensionSpxInputIsActionPressed
 type GDExtensionSpxInputIsActionJustPressed C.GDExtensionSpxInputIsActionJustPressed
 type GDExtensionSpxInputIsActionJustReleased C.GDExtensionSpxInputIsActionJustReleased
+type GDExtensionSpxInputRegisterAction C.GDExtensionSpxInputRegisterAction
+type GDExtensionSpxInputGetAxisId C.GDExtensionSpxInputGetAxisId
+type GDExtensionSpxInputIsActionPressedId C.GDExtensionSpxInputIsActionPressedId
+type GDExtensionSpxInputIsActionJustPressedId C.GDExtensionSpxInputIsActionJustPressedId
+type GDExtensionSpxInputIsActionJustReleasedId C.GDExtensionSpxInputIsActionJustReleasedId
+type GDExtensionSpxInputWriteSnapshot C.GDExtensionSpxInputWriteSnapshot
 type GDExtensionSpxNavigationSetupPathFinderWithSize C.GDExtensionSpxNavigationSetupPathFinderWithSize
 type GDExtensionSpxNavigationSetupPathFinder C.GDExtensionSpxNavigationSetupPathFinder
 type GDExtensionSpxNavigationSetObstacle C.GDExtensionSpxNavigationSetObstacle
@@ -356,7 +362,7 @@ type GDExtensionSpxSpriteSetPixelCollisionSamplingStep C.GDExtensionSpxSpriteSet
 type GDExtensionSpxSpriteGetPixelCollisionSamplingStep C.GDExtensionSpxSpriteGetPixelCollisionSamplingStep
 type GDExtensionSpxSpriteBatchUpdateTransforms C.GDExtensionSpxSpriteBatchUpdateTransforms
 type GDExtensionSpxSpriteBatchUpdateVisuals C.GDExtensionSpxSpriteBatchUpdateVisuals
-type GDExtensionSpxSpriteBatchRetrievePositions C.GDExtensionSpxSpriteBatchRetrievePositions
+type GDExtensionSpxSpriteBatchUpdatePhysics C.GDExtensionSpxSpriteBatchUpdatePhysics
 type GDExtensionSpxTilemapOpenDrawTilesWithSize C.GDExtensionSpxTilemapOpenDrawTilesWithSize
 type GDExtensionSpxTilemapOpenDrawTiles C.GDExtensionSpxTilemapOpenDrawTiles
 type GDExtensionSpxTilemapSetLayerIndex C.GDExtensionSpxTilemapSetLayerIndex
@@ -421,6 +427,7 @@ type GDExtensionSpxUiGetRotation C.GDExtensionSpxUiGetRotation
 type GDExtensionSpxUiSetRotation C.GDExtensionSpxUiSetRotation
 type GDExtensionSpxUiGetFlip C.GDExtensionSpxUiGetFlip
 type GDExtensionSpxUiSetFlip C.GDExtensionSpxUiSetFlip
+type GDExtensionSpxSpriteBatchRetrievePositions C.GDExtensionSpxSpriteBatchRetrievePositions
 
 // call gdextension interface functions
 func CallAudioStopAll() {
@@ -871,6 +878,69 @@ func CallInputIsActionJustReleased(
 	C.cgo_callfn_GDExtensionSpxInputIsActionJustReleased(arg0, arg1, &ret_val)
 
 	return (GdBool)(ret_val)
+}
+func CallInputRegisterAction(
+	action GdString,
+) GdInt {
+	arg0 := (C.GDExtensionSpxInputRegisterAction)(api.SpxInputRegisterAction)
+	arg1 := (C.GdString)(action)
+	var ret_val C.GdInt
+	C.cgo_callfn_GDExtensionSpxInputRegisterAction(arg0, arg1, &ret_val)
+
+	return (GdInt)(ret_val)
+}
+func CallInputGetAxisId(
+	neg_action_id GdInt,
+	pos_action_id GdInt,
+) GdFloat {
+	arg0 := (C.GDExtensionSpxInputGetAxisId)(api.SpxInputGetAxisId)
+	arg1 := (C.GdInt)(neg_action_id)
+	arg2 := (C.GdInt)(pos_action_id)
+	var ret_val C.GdFloat
+	C.cgo_callfn_GDExtensionSpxInputGetAxisId(arg0, arg1, arg2, &ret_val)
+
+	return (GdFloat)(ret_val)
+}
+func CallInputIsActionPressedId(
+	action_id GdInt,
+) GdBool {
+	arg0 := (C.GDExtensionSpxInputIsActionPressedId)(api.SpxInputIsActionPressedId)
+	arg1 := (C.GdInt)(action_id)
+	var ret_val C.GdBool
+	C.cgo_callfn_GDExtensionSpxInputIsActionPressedId(arg0, arg1, &ret_val)
+
+	return (GdBool)(ret_val)
+}
+func CallInputIsActionJustPressedId(
+	action_id GdInt,
+) GdBool {
+	arg0 := (C.GDExtensionSpxInputIsActionJustPressedId)(api.SpxInputIsActionJustPressedId)
+	arg1 := (C.GdInt)(action_id)
+	var ret_val C.GdBool
+	C.cgo_callfn_GDExtensionSpxInputIsActionJustPressedId(arg0, arg1, &ret_val)
+
+	return (GdBool)(ret_val)
+}
+func CallInputIsActionJustReleasedId(
+	action_id GdInt,
+) GdBool {
+	arg0 := (C.GDExtensionSpxInputIsActionJustReleasedId)(api.SpxInputIsActionJustReleasedId)
+	arg1 := (C.GdInt)(action_id)
+	var ret_val C.GdBool
+	C.cgo_callfn_GDExtensionSpxInputIsActionJustReleasedId(arg0, arg1, &ret_val)
+
+	return (GdBool)(ret_val)
+}
+func CallInputWriteSnapshot(
+	out *float32,
+	len int32,
+) {
+	arg0 := (C.GDExtensionSpxInputWriteSnapshot)(api.SpxInputWriteSnapshot)
+	arg1 := (*C.float)(out)
+	arg2 := (C.int)(len)
+
+	C.cgo_callfn_GDExtensionSpxInputWriteSnapshot(arg0, arg1, arg2)
+
 }
 func CallNavigationSetupPathFinderWithSize(
 	grid_size GdVec2,
@@ -3088,15 +3158,16 @@ func CallSpriteBatchUpdateVisuals(
 	C.cgo_callfn_GDExtensionSpxSpriteBatchUpdateVisuals(arg0, arg1, arg2)
 
 }
-func CallSpriteBatchRetrievePositions(
-	objs GdArray,
-) GdArray {
-	arg0 := (C.GDExtensionSpxSpriteBatchRetrievePositions)(api.SpxSpriteBatchRetrievePositions)
-	arg1 := (C.GdArray)(objs)
-	var ret_val C.GdArray
-	C.cgo_callfn_GDExtensionSpxSpriteBatchRetrievePositions(arg0, arg1, &ret_val)
+func CallSpriteBatchUpdatePhysics(
+	buffer_data *float32,
+	len int32,
+) {
+	arg0 := (C.GDExtensionSpxSpriteBatchUpdatePhysics)(api.SpxSpriteBatchUpdatePhysics)
+	arg1 := (*C.float)(buffer_data)
+	arg2 := (C.int)(len)
 
-	return GdArray(ret_val)
+	C.cgo_callfn_GDExtensionSpxSpriteBatchUpdatePhysics(arg0, arg1, arg2)
+
 }
 func CallTilemapOpenDrawTilesWithSize(
 	tile_size GdInt,
@@ -3758,4 +3829,14 @@ func CallUiSetFlip(
 
 	C.cgo_callfn_GDExtensionSpxUiSetFlip(arg0, arg1, arg2, arg3)
 
+}
+func CallSpriteBatchRetrievePositions(
+	objs GdArray,
+) GdArray {
+	arg0 := (C.GDExtensionSpxSpriteBatchRetrievePositions)(api.SpxSpriteBatchRetrievePositions)
+	arg1 := (C.GdArray)(objs)
+	var ret_val C.GdArray
+	C.cgo_callfn_GDExtensionSpxSpriteBatchRetrievePositions(arg0, arg1, &ret_val)
+
+	return GdArray(ret_val)
 }

--- a/internal/gdengine/binding/native/ffi_wrapper.gen.h
+++ b/internal/gdengine/binding/native/ffi_wrapper.gen.h
@@ -306,6 +306,42 @@ void cgo_callfn_GDExtensionSpxInputIsActionJustReleased(const GDExtensionSpxInpu
 	}
 	fn(action, ret_val);
 }
+void cgo_callfn_GDExtensionSpxInputRegisterAction(const GDExtensionSpxInputRegisterAction fn, GdString action, GdInt* ret_val) {
+	if (!fn) {
+		return;
+	}
+	fn(action, ret_val);
+}
+void cgo_callfn_GDExtensionSpxInputGetAxisId(const GDExtensionSpxInputGetAxisId fn, GdInt neg_action_id, GdInt pos_action_id, GdFloat* ret_val) {
+	if (!fn) {
+		return;
+	}
+	fn(neg_action_id, pos_action_id, ret_val);
+}
+void cgo_callfn_GDExtensionSpxInputIsActionPressedId(const GDExtensionSpxInputIsActionPressedId fn, GdInt action_id, GdBool* ret_val) {
+	if (!fn) {
+		return;
+	}
+	fn(action_id, ret_val);
+}
+void cgo_callfn_GDExtensionSpxInputIsActionJustPressedId(const GDExtensionSpxInputIsActionJustPressedId fn, GdInt action_id, GdBool* ret_val) {
+	if (!fn) {
+		return;
+	}
+	fn(action_id, ret_val);
+}
+void cgo_callfn_GDExtensionSpxInputIsActionJustReleasedId(const GDExtensionSpxInputIsActionJustReleasedId fn, GdInt action_id, GdBool* ret_val) {
+	if (!fn) {
+		return;
+	}
+	fn(action_id, ret_val);
+}
+void cgo_callfn_GDExtensionSpxInputWriteSnapshot(const GDExtensionSpxInputWriteSnapshot fn, float *out, int len) {
+	if (!fn) {
+		return;
+	}
+	fn(out, len);
+}
 void cgo_callfn_GDExtensionSpxNavigationSetupPathFinderWithSize(const GDExtensionSpxNavigationSetupPathFinderWithSize fn, GdVec2 grid_size, GdVec2 cell_size, GdBool with_jump, GdBool with_debug) {
 	if (!fn) {
 		return;
@@ -1542,11 +1578,11 @@ void cgo_callfn_GDExtensionSpxSpriteBatchUpdateVisuals(const GDExtensionSpxSprit
 	}
 	fn(buffer_data, len);
 }
-void cgo_callfn_GDExtensionSpxSpriteBatchRetrievePositions(const GDExtensionSpxSpriteBatchRetrievePositions fn, GdArray objs, GdArray* ret_val) {
+void cgo_callfn_GDExtensionSpxSpriteBatchUpdatePhysics(const GDExtensionSpxSpriteBatchUpdatePhysics fn, const float *buffer_data, int len) {
 	if (!fn) {
 		return;
 	}
-	fn(objs, ret_val);
+	fn(buffer_data, len);
 }
 void cgo_callfn_GDExtensionSpxTilemapOpenDrawTilesWithSize(const GDExtensionSpxTilemapOpenDrawTilesWithSize fn, GdInt tile_size) {
 	if (!fn) {
@@ -1931,5 +1967,11 @@ void cgo_callfn_GDExtensionSpxUiSetFlip(const GDExtensionSpxUiSetFlip fn, GdObj 
 		return;
 	}
 	fn(obj, horizontal, is_flip);
+}
+void cgo_callfn_GDExtensionSpxSpriteBatchRetrievePositions(const GDExtensionSpxSpriteBatchRetrievePositions fn, GdArray objs, GdArray* ret_val) {
+	if (!fn) {
+		return;
+	}
+	fn(objs, ret_val);
 }
 #endif

--- a/internal/gdengine/binding/native/gdextension_spx_ext.h
+++ b/internal/gdengine/binding/native/gdextension_spx_ext.h
@@ -270,6 +270,12 @@ typedef void (*GDExtensionSpxInputGetAxis)(GdString neg_action, GdString pos_act
 typedef void (*GDExtensionSpxInputIsActionPressed)(GdString action, GdBool *ret_value);
 typedef void (*GDExtensionSpxInputIsActionJustPressed)(GdString action, GdBool *ret_value);
 typedef void (*GDExtensionSpxInputIsActionJustReleased)(GdString action, GdBool *ret_value);
+typedef void (*GDExtensionSpxInputRegisterAction)(GdString action, GdInt *ret_value);
+typedef void (*GDExtensionSpxInputGetAxisId)(GdInt neg_action_id, GdInt pos_action_id, GdFloat *ret_value);
+typedef void (*GDExtensionSpxInputIsActionPressedId)(GdInt action_id, GdBool *ret_value);
+typedef void (*GDExtensionSpxInputIsActionJustPressedId)(GdInt action_id, GdBool *ret_value);
+typedef void (*GDExtensionSpxInputIsActionJustReleasedId)(GdInt action_id, GdBool *ret_value);
+typedef void (*GDExtensionSpxInputWriteSnapshot)(float *out, int len);
 // SpxNavigation
 typedef void (*GDExtensionSpxNavigationSetupPathFinderWithSize)(GdVec2 grid_size, GdVec2 cell_size, GdBool with_jump, GdBool with_debug);
 typedef void (*GDExtensionSpxNavigationSetupPathFinder)(GdBool with_jump);
@@ -483,7 +489,7 @@ typedef void (*GDExtensionSpxSpriteSetPixelCollisionSamplingStep)(GdInt step);
 typedef void (*GDExtensionSpxSpriteGetPixelCollisionSamplingStep)(GdInt *ret_value);
 typedef void (*GDExtensionSpxSpriteBatchUpdateTransforms)(const float *buffer_data, int len);
 typedef void (*GDExtensionSpxSpriteBatchUpdateVisuals)(const float *buffer_data, int len);
-typedef void (*GDExtensionSpxSpriteBatchRetrievePositions)(GdArray objs, GdArray *ret_value);
+typedef void (*GDExtensionSpxSpriteBatchUpdatePhysics)(const float *buffer_data, int len);
 // SpxTilemap
 typedef void (*GDExtensionSpxTilemapOpenDrawTilesWithSize)(GdInt tile_size);
 typedef void (*GDExtensionSpxTilemapOpenDrawTiles)();
@@ -551,6 +557,7 @@ typedef void (*GDExtensionSpxUiGetRotation)(GdObj obj, GdFloat *ret_value);
 typedef void (*GDExtensionSpxUiSetRotation)(GdObj obj, GdFloat value);
 typedef void (*GDExtensionSpxUiGetFlip)(GdObj obj, GdBool horizontal, GdBool *ret_value);
 typedef void (*GDExtensionSpxUiSetFlip)(GdObj obj, GdBool horizontal, GdBool is_flip);
+typedef void (*GDExtensionSpxSpriteBatchRetrievePositions)(GdArray objs, GdArray *ret_value);
 
 
 #ifdef __cplusplus

--- a/internal/gdengine/binding/web/callbacks.gen.go
+++ b/internal/gdengine/binding/web/callbacks.gen.go
@@ -217,12 +217,14 @@ func gdspxDispatch(this js.Value, args []js.Value) any {
 			return nil
 		}
 		arg0 := JsToGdInt(args[1])
+		RecordWebKeyState(arg0, true)
 		callbacks.OnKeyPressed(arg0)
 	} else if eventVal.Equal(jsEventOnKeyReleased) {
 		if callbacks.OnKeyReleased == nil {
 			return nil
 		}
 		arg0 := JsToGdInt(args[1])
+		RecordWebKeyState(arg0, false)
 		callbacks.OnKeyReleased(arg0)
 	} else if eventVal.Equal(jsEventOnActionPressed) {
 		if callbacks.OnActionPressed == nil {

--- a/internal/gdengine/binding/web/contact_events.go
+++ b/internal/gdengine/binding/web/contact_events.go
@@ -18,7 +18,10 @@
 
 package webffi
 
-import "syscall/js"
+import (
+	"encoding/binary"
+	"syscall/js"
+)
 
 const (
 	contactCollisionEnter = 1
@@ -28,9 +31,11 @@ const (
 	contactTriggerStay    = 5
 	contactTriggerExit    = 6
 	contactEventFields    = 5
+	contactEventBytes     = contactEventFields * 4
 )
 
 var contactEventsHandle js.Func
+var contactEventScratch []byte
 
 func registerContactEventQueue() {
 	if contactEventsHandle.Type() != js.TypeUndefined {
@@ -46,6 +51,34 @@ func gdspxContactEvents(this js.Value, args []js.Value) any {
 	}
 
 	events := args[0]
+	uint8ArrayCtor := js.Global().Get("Uint8Array")
+	if uint8ArrayCtor.Type() != js.TypeUndefined && events.InstanceOf(uint8ArrayCtor) {
+		length := events.Length()
+		if length < contactEventBytes {
+			return nil
+		}
+
+		if cap(contactEventScratch) < length {
+			contactEventScratch = make([]byte, length)
+		}
+		buf := contactEventScratch[:length]
+		js.CopyBytesToGo(buf, events)
+
+		for i := 0; i+contactEventBytes <= len(buf); i += contactEventBytes {
+			kind := int(binary.LittleEndian.Uint32(buf[i : i+4]))
+			self := gdIntFromParts(
+				binary.LittleEndian.Uint32(buf[i+4:i+8]),
+				binary.LittleEndian.Uint32(buf[i+8:i+12]),
+			)
+			other := gdIntFromParts(
+				binary.LittleEndian.Uint32(buf[i+12:i+16]),
+				binary.LittleEndian.Uint32(buf[i+16:i+20]),
+			)
+			dispatchContactEvent(kind, self, other)
+		}
+		return nil
+	}
+
 	n := events.Length()
 	for i := 0; i+contactEventFields <= n; i += contactEventFields {
 		kind := events.Index(i).Int()

--- a/internal/gdengine/binding/web/contact_events.go
+++ b/internal/gdengine/binding/web/contact_events.go
@@ -1,0 +1,78 @@
+//go:build js && wasm
+
+/*
+ * Copyright (c) 2021 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package webffi
+
+import "syscall/js"
+
+const (
+	contactCollisionEnter = 1
+	contactCollisionStay  = 2
+	contactCollisionExit  = 3
+	contactTriggerEnter   = 4
+	contactTriggerStay    = 5
+	contactTriggerExit    = 6
+	contactEventFields    = 5
+)
+
+var contactEventsHandle js.Func
+
+func registerContactEventQueue() {
+	if contactEventsHandle.Type() != js.TypeUndefined {
+		return
+	}
+	contactEventsHandle = js.FuncOf(gdspxContactEvents)
+	js.Global().Set("gdspx_on_contact_events", contactEventsHandle)
+}
+
+func gdspxContactEvents(this js.Value, args []js.Value) any {
+	if len(args) == 0 || args[0].IsUndefined() || args[0].IsNull() {
+		return nil
+	}
+
+	events := args[0]
+	n := events.Length()
+	for i := 0; i+contactEventFields <= n; i += contactEventFields {
+		kind := events.Index(i).Int()
+		self := gdIntFromParts(uint32(events.Index(i+1).Int()), uint32(events.Index(i+2).Int()))
+		other := gdIntFromParts(uint32(events.Index(i+3).Int()), uint32(events.Index(i+4).Int()))
+		dispatchContactEvent(kind, self, other)
+	}
+	return nil
+}
+
+func dispatchContactEvent(kind int, self, other int64) {
+	var cb func(int64, int64)
+	switch kind {
+	case contactCollisionEnter:
+		cb = callbacks.OnCollisionEnter
+	case contactCollisionStay:
+		cb = callbacks.OnCollisionStay
+	case contactCollisionExit:
+		cb = callbacks.OnCollisionExit
+	case contactTriggerEnter:
+		cb = callbacks.OnTriggerEnter
+	case contactTriggerStay:
+		cb = callbacks.OnTriggerStay
+	case contactTriggerExit:
+		cb = callbacks.OnTriggerExit
+	}
+	if cb != nil {
+		cb(self, other)
+	}
+}

--- a/internal/gdengine/binding/web/exports.go
+++ b/internal/gdengine/binding/web/exports.go
@@ -27,6 +27,7 @@ func directBool(value uint32) bool {
 
 //go:wasmexport gdspx_on_engine_update
 func GdspxOnEngineUpdate(delta float64) {
+	SyncWebInputSnapshot()
 	if callbacks.OnEngineUpdate != nil {
 		callbacks.OnEngineUpdate(delta)
 	}
@@ -34,6 +35,7 @@ func GdspxOnEngineUpdate(delta float64) {
 
 //go:wasmexport gdspx_on_engine_fixed_update
 func GdspxOnEngineFixedUpdate(delta float64) {
+	SyncWebInputSnapshot()
 	if callbacks.OnEngineFixedUpdate != nil {
 		callbacks.OnEngineFixedUpdate(delta)
 	}
@@ -160,6 +162,7 @@ func GdspxOnMouseReleased(keyID int64) {
 
 //go:wasmexport gdspx_on_key_pressed
 func GdspxOnKeyPressed(keyID int64) {
+	RecordWebKeyState(keyID, true)
 	if callbacks.OnKeyPressed != nil {
 		callbacks.OnKeyPressed(keyID)
 	}
@@ -167,6 +170,7 @@ func GdspxOnKeyPressed(keyID int64) {
 
 //go:wasmexport gdspx_on_key_released
 func GdspxOnKeyReleased(keyID int64) {
+	RecordWebKeyState(keyID, false)
 	if callbacks.OnKeyReleased != nil {
 		callbacks.OnKeyReleased(keyID)
 	}

--- a/internal/gdengine/binding/web/ffi.gen.go
+++ b/internal/gdengine/binding/web/ffi.gen.go
@@ -89,6 +89,12 @@ type GDExtensionInterface struct {
 	SpxInputIsActionPressed                     js.Value
 	SpxInputIsActionJustPressed                 js.Value
 	SpxInputIsActionJustReleased                js.Value
+	SpxInputRegisterAction                      js.Value
+	SpxInputGetAxisId                           js.Value
+	SpxInputIsActionPressedId                   js.Value
+	SpxInputIsActionJustPressedId               js.Value
+	SpxInputIsActionJustReleasedId              js.Value
+	SpxInputWriteSnapshot                       js.Value
 	SpxNavigationSetupPathFinderWithSize        js.Value
 	SpxNavigationSetupPathFinder                js.Value
 	SpxNavigationSetObstacle                    js.Value
@@ -295,7 +301,7 @@ type GDExtensionInterface struct {
 	SpxSpriteGetPixelCollisionSamplingStep      js.Value
 	SpxSpriteBatchUpdateTransforms              js.Value
 	SpxSpriteBatchUpdateVisuals                 js.Value
-	SpxSpriteBatchRetrievePositions             js.Value
+	SpxSpriteBatchUpdatePhysics                 js.Value
 	SpxTilemapOpenDrawTilesWithSize             js.Value
 	SpxTilemapOpenDrawTiles                     js.Value
 	SpxTilemapSetLayerIndex                     js.Value
@@ -360,6 +366,7 @@ type GDExtensionInterface struct {
 	SpxUiSetRotation                            js.Value
 	SpxUiGetFlip                                js.Value
 	SpxUiSetFlip                                js.Value
+	SpxSpriteBatchRetrievePositions             js.Value
 }
 
 func (x *GDExtensionInterface) resolveAPIFunctions() {
@@ -412,6 +419,12 @@ func (x *GDExtensionInterface) resolveAPIFunctions() {
 	x.SpxInputIsActionPressed = resolveJSFunc("gdspx_input_is_action_pressed")
 	x.SpxInputIsActionJustPressed = resolveJSFunc("gdspx_input_is_action_just_pressed")
 	x.SpxInputIsActionJustReleased = resolveJSFunc("gdspx_input_is_action_just_released")
+	x.SpxInputRegisterAction = resolveJSFunc("gdspx_input_register_action")
+	x.SpxInputGetAxisId = resolveJSFunc("gdspx_input_get_axis_id")
+	x.SpxInputIsActionPressedId = resolveJSFunc("gdspx_input_is_action_pressed_id")
+	x.SpxInputIsActionJustPressedId = resolveJSFunc("gdspx_input_is_action_just_pressed_id")
+	x.SpxInputIsActionJustReleasedId = resolveJSFunc("gdspx_input_is_action_just_released_id")
+	x.SpxInputWriteSnapshot = resolveJSFunc("gdspx_input_write_snapshot")
 	x.SpxNavigationSetupPathFinderWithSize = resolveJSFunc("gdspx_navigation_setup_path_finder_with_size")
 	x.SpxNavigationSetupPathFinder = resolveJSFunc("gdspx_navigation_setup_path_finder")
 	x.SpxNavigationSetObstacle = resolveJSFunc("gdspx_navigation_set_obstacle")
@@ -618,7 +631,7 @@ func (x *GDExtensionInterface) resolveAPIFunctions() {
 	x.SpxSpriteGetPixelCollisionSamplingStep = resolveJSFunc("gdspx_sprite_get_pixel_collision_sampling_step")
 	x.SpxSpriteBatchUpdateTransforms = resolveJSFunc("gdspx_sprite_batch_update_transforms")
 	x.SpxSpriteBatchUpdateVisuals = resolveJSFunc("gdspx_sprite_batch_update_visuals")
-	x.SpxSpriteBatchRetrievePositions = resolveJSFunc("gdspx_sprite_batch_retrieve_positions")
+	x.SpxSpriteBatchUpdatePhysics = resolveJSFunc("gdspx_sprite_batch_update_physics")
 	x.SpxTilemapOpenDrawTilesWithSize = resolveJSFunc("gdspx_tilemap_open_draw_tiles_with_size")
 	x.SpxTilemapOpenDrawTiles = resolveJSFunc("gdspx_tilemap_open_draw_tiles")
 	x.SpxTilemapSetLayerIndex = resolveJSFunc("gdspx_tilemap_set_layer_index")
@@ -683,4 +696,5 @@ func (x *GDExtensionInterface) resolveAPIFunctions() {
 	x.SpxUiSetRotation = resolveJSFunc("gdspx_ui_set_rotation")
 	x.SpxUiGetFlip = resolveJSFunc("gdspx_ui_get_flip")
 	x.SpxUiSetFlip = resolveJSFunc("gdspx_ui_set_flip")
+	x.SpxSpriteBatchRetrievePositions = resolveJSFunc("gdspx_sprite_batch_retrieve_positions")
 }

--- a/internal/gdengine/binding/web/ffi.go
+++ b/internal/gdengine/binding/web/ffi.go
@@ -73,6 +73,7 @@ func registerWebGlobals() {
 		js.Global().Set("go_wasm_init", goWasmInitCallbackHandle)
 	}
 	registerCallbackDispatcher()
+	registerContactEventQueue()
 }
 
 func registerCallbackDispatcher() {

--- a/internal/gdengine/binding/web/input_snapshot.go
+++ b/internal/gdengine/binding/web/input_snapshot.go
@@ -52,6 +52,7 @@ var (
 func SyncWebInputSnapshot() {
 	inputSnap.frame++
 	clearActionCache(inputSnap.frame)
+	syncActionIDCache()
 
 	fn := js.Global().Get("GdspxInputSnapshot")
 	if fn.Type() != js.TypeFunction {
@@ -78,8 +79,8 @@ func WebInputMousePos(fallback func() Vec2) Vec2 {
 }
 
 func WebInputMouseState(id int64, fallback func() bool) bool {
-	if inputSnap.ok && id >= 0 && id < 32 {
-		return inputSnap.mouseBits&(1<<uint(id)) != 0
+	if inputSnap.ok && id >= 1 && id <= 3 {
+		return inputSnap.mouseBits&(1<<uint(id-1)) != 0
 	}
 	return fallback()
 }
@@ -106,6 +107,7 @@ func CachedActionBool(kind, action string, fallback func() bool) bool {
 	key := kind + "\x00" + action
 
 	actionMu.Lock()
+	currentFrame := actionFrame
 	if value, ok := actionBool[key]; ok {
 		actionMu.Unlock()
 		return value
@@ -118,7 +120,9 @@ func CachedActionBool(kind, action string, fallback func() bool) bool {
 	}
 
 	actionMu.Lock()
-	actionBool[key] = value
+	if actionFrame == currentFrame {
+		actionBool[key] = value
+	}
 	actionMu.Unlock()
 	return value
 }
@@ -127,6 +131,7 @@ func CachedActionAxis(neg, pos string, fallback func() float64) float64 {
 	key := neg + "\x00" + pos
 
 	actionMu.Lock()
+	currentFrame := actionFrame
 	if value, ok := actionAxis[key]; ok {
 		actionMu.Unlock()
 		return value
@@ -139,7 +144,9 @@ func CachedActionAxis(neg, pos string, fallback func() float64) float64 {
 	}
 
 	actionMu.Lock()
-	actionAxis[key] = value
+	if actionFrame == currentFrame {
+		actionAxis[key] = value
+	}
 	actionMu.Unlock()
 	return value
 }
@@ -196,10 +203,17 @@ func webActionAxis(neg, pos string) (float64, bool) {
 }
 
 func webActionID(action string) (int, bool) {
+	actionIDMu.RLock()
+	id, ok := actionIDs[action]
+	actionIDMu.RUnlock()
+	if ok {
+		return id, true
+	}
+
 	syncActionIDCache()
 
 	actionIDMu.RLock()
-	id, ok := actionIDs[action]
+	id, ok = actionIDs[action]
 	actionIDMu.RUnlock()
 	if ok {
 		return id, true

--- a/internal/gdengine/binding/web/input_snapshot.go
+++ b/internal/gdengine/binding/web/input_snapshot.go
@@ -1,0 +1,250 @@
+//go:build js && wasm
+
+/*
+ * Copyright (c) 2021 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package webffi
+
+import (
+	"sync"
+	"syscall/js"
+
+	. "github.com/goplus/spbase/mathf"
+)
+
+type inputSnapshot struct {
+	mouse     Vec2
+	mouseBits uint32
+	ok        bool
+	frame     uint64
+}
+
+var (
+	inputSnap inputSnapshot
+
+	keyMu    sync.RWMutex
+	keyDown  = map[int64]bool{}
+	keyKnown = map[int64]bool{}
+
+	actionIDMu  sync.RWMutex
+	actionIDs   = map[string]int{}
+	actionEpoch int
+
+	actionMu    sync.Mutex
+	actionFrame uint64
+	actionBool  = map[string]bool{}
+	actionAxis  = map[string]float64{}
+)
+
+func SyncWebInputSnapshot() {
+	inputSnap.frame++
+	clearActionCache(inputSnap.frame)
+
+	fn := js.Global().Get("GdspxInputSnapshot")
+	if fn.Type() != js.TypeFunction {
+		inputSnap.ok = false
+		return
+	}
+
+	data, ok := JsToGdArray(fn.Invoke()).([]float32)
+	if !ok || len(data) < 3 {
+		inputSnap.ok = false
+		return
+	}
+
+	inputSnap.mouse = Vec2{X: float64(data[0]), Y: float64(data[1])}
+	inputSnap.mouseBits = uint32(data[2])
+	inputSnap.ok = true
+}
+
+func WebInputMousePos(fallback func() Vec2) Vec2 {
+	if inputSnap.ok {
+		return inputSnap.mouse
+	}
+	return fallback()
+}
+
+func WebInputMouseState(id int64, fallback func() bool) bool {
+	if inputSnap.ok && id >= 0 && id < 32 {
+		return inputSnap.mouseBits&(1<<uint(id)) != 0
+	}
+	return fallback()
+}
+
+func WebInputKeyState(key int64, fallback func() bool) bool {
+	keyMu.RLock()
+	known := keyKnown[key]
+	pressed := keyDown[key]
+	keyMu.RUnlock()
+	if known {
+		return pressed
+	}
+	return fallback()
+}
+
+func RecordWebKeyState(key int64, pressed bool) {
+	keyMu.Lock()
+	keyKnown[key] = true
+	keyDown[key] = pressed
+	keyMu.Unlock()
+}
+
+func CachedActionBool(kind, action string, fallback func() bool) bool {
+	key := kind + "\x00" + action
+
+	actionMu.Lock()
+	if value, ok := actionBool[key]; ok {
+		actionMu.Unlock()
+		return value
+	}
+	actionMu.Unlock()
+
+	value, ok := webActionBool(kind, action)
+	if !ok {
+		value = fallback()
+	}
+
+	actionMu.Lock()
+	actionBool[key] = value
+	actionMu.Unlock()
+	return value
+}
+
+func CachedActionAxis(neg, pos string, fallback func() float64) float64 {
+	key := neg + "\x00" + pos
+
+	actionMu.Lock()
+	if value, ok := actionAxis[key]; ok {
+		actionMu.Unlock()
+		return value
+	}
+	actionMu.Unlock()
+
+	value, ok := webActionAxis(neg, pos)
+	if !ok {
+		value = fallback()
+	}
+
+	actionMu.Lock()
+	actionAxis[key] = value
+	actionMu.Unlock()
+	return value
+}
+
+func clearActionCache(frame uint64) {
+	actionMu.Lock()
+	defer actionMu.Unlock()
+	if actionFrame == frame {
+		return
+	}
+	actionFrame = frame
+	clear(actionBool)
+	clear(actionAxis)
+}
+
+func webActionBool(kind, action string) (bool, bool) {
+	id, ok := webActionID(action)
+	if !ok {
+		return false, false
+	}
+
+	fn := js.Global().Get("GdspxInputActionBool")
+	if fn.Type() != js.TypeFunction {
+		return false, false
+	}
+
+	value := fn.Invoke(actionKindID(kind), id)
+	if value.IsUndefined() || value.IsNull() {
+		return false, false
+	}
+	return value.Bool(), true
+}
+
+func webActionAxis(neg, pos string) (float64, bool) {
+	negID, ok := webActionID(neg)
+	if !ok {
+		return 0, false
+	}
+	posID, ok := webActionID(pos)
+	if !ok {
+		return 0, false
+	}
+
+	fn := js.Global().Get("GdspxInputAxisByID")
+	if fn.Type() != js.TypeFunction {
+		return 0, false
+	}
+
+	value := fn.Invoke(negID, posID)
+	if value.IsUndefined() || value.IsNull() {
+		return 0, false
+	}
+	return value.Float(), true
+}
+
+func webActionID(action string) (int, bool) {
+	syncActionIDCache()
+
+	actionIDMu.RLock()
+	id, ok := actionIDs[action]
+	actionIDMu.RUnlock()
+	if ok {
+		return id, true
+	}
+
+	fn := js.Global().Get("GdspxInputActionID")
+	if fn.Type() != js.TypeFunction {
+		return 0, false
+	}
+
+	id = fn.Invoke(action).Int()
+	if id < 0 {
+		return 0, false
+	}
+
+	actionIDMu.Lock()
+	actionIDs[action] = id
+	actionIDMu.Unlock()
+	return id, true
+}
+
+func syncActionIDCache() {
+	fn := js.Global().Get("GdspxInputActionEpoch")
+	if fn.Type() != js.TypeFunction {
+		return
+	}
+
+	epoch := fn.Invoke().Int()
+	actionIDMu.Lock()
+	if epoch != actionEpoch {
+		actionEpoch = epoch
+		clear(actionIDs)
+	}
+	actionIDMu.Unlock()
+}
+
+func actionKindID(kind string) int {
+	switch kind {
+	case "pressed":
+		return 1
+	case "just_pressed":
+		return 2
+	case "just_released":
+		return 3
+	default:
+		return 0
+	}
+}

--- a/internal/gdengine/binding/web/marshal.go
+++ b/internal/gdengine/binding/web/marshal.go
@@ -550,6 +550,10 @@ func getFastGdArrayScratch(arrayType int32) *fastGdArrayScratch {
 }
 
 func newFastGdArrayValue(arrayType int32, count int, data []byte) js.Value {
+	if fastValue, ok := newBorrowedFastGdArrayValue(arrayType, count, data); ok {
+		return fastValue
+	}
+
 	scratch := getFastGdArrayScratch(arrayType)
 	if scratch.byteCap < len(data) || scratch.bytes.Type() == js.TypeUndefined {
 		scratch.bytes = jsUint8Array.New(len(data))
@@ -563,6 +567,32 @@ func newFastGdArrayValue(arrayType int32, count int, data []byte) js.Value {
 	scratch.wrapper.Set(fastGdArrayDataKey, scratch.bytes.Call("subarray", 0, len(data)))
 	scratch.wrapper.Set(fastGdArrayCountKey, count)
 	return scratch.wrapper
+}
+
+func newBorrowedFastGdArrayValue(arrayType int32, count int, data []byte) (js.Value, bool) {
+	borrow := js.Global().Get("GdspxBorrowFastArray")
+	if borrow.Type() != js.TypeFunction {
+		return js.Value{}, false
+	}
+
+	wrapper := borrow.Invoke(arrayType, count, len(data))
+	if wrapper.IsUndefined() || wrapper.IsNull() || wrapper.Type() != js.TypeObject {
+		return js.Value{}, false
+	}
+
+	bytes := wrapper.Get(fastGdArrayDataKey)
+	if bytes.IsUndefined() || bytes.IsNull() || bytes.Type() != js.TypeObject {
+		return js.Value{}, false
+	}
+	byteLength := bytes.Get("length")
+	if byteLength.Type() != js.TypeNumber || byteLength.Int() < len(data) {
+		return js.Value{}, false
+	}
+
+	if len(data) > 0 {
+		js.CopyBytesToJS(bytes, data)
+	}
+	return wrapper, true
 }
 
 func arrayToFastGdArrayValue(arrayPtr Array) (js.Value, bool) {
@@ -611,6 +641,10 @@ func JsToGdArray(val js.Value) Array {
 		return nil
 	}
 
+	if fastArray, ok := fastGdArrayToGo(val); ok {
+		return fastArray
+	}
+
 	length := val.Get("length").Int()
 	if length == 0 {
 		return nil
@@ -624,4 +658,66 @@ func JsToGdArray(val js.Value) Array {
 		return nil
 	}
 	return info.Data
+}
+
+func fastGdArrayToGo(val js.Value) (Array, bool) {
+	flag := val.Get(fastGdArrayFlagKey)
+	if flag.Type() != js.TypeBoolean || !flag.Bool() {
+		return nil, false
+	}
+
+	dataVal := val.Get(fastGdArrayDataKey)
+	if dataVal.IsUndefined() || dataVal.IsNull() || dataVal.Type() != js.TypeObject {
+		return nil, true
+	}
+
+	lengthVal := dataVal.Get("length")
+	if lengthVal.Type() != js.TypeNumber {
+		return nil, true
+	}
+	length := lengthVal.Int()
+	arrayTypeVal := val.Get(fastGdArrayTypeKey)
+	countVal := val.Get(fastGdArrayCountKey)
+	if arrayTypeVal.Type() != js.TypeNumber || countVal.Type() != js.TypeNumber {
+		return nil, true
+	}
+	arrayType := int32(arrayTypeVal.Int())
+	count := countVal.Int()
+	if length < 0 || count < 0 || count > maxInt32 {
+		return nil, true
+	}
+	if elemSize, ok := fixedGdArrayElemSize(arrayType); ok {
+		if count > maxInt/elemSize || length < count*elemSize {
+			return nil, true
+		}
+	}
+
+	bytes := make([]byte, length)
+	if length > 0 {
+		js.CopyBytesToGo(bytes, dataVal)
+	}
+
+	data, err := deserializeDataByType(arrayType, bytes, int32(count))
+	if err != nil {
+		return nil, true
+	}
+	return data, true
+}
+
+const (
+	maxInt   = int(^uint(0) >> 1)
+	maxInt32 = int(^uint32(0) >> 1)
+)
+
+func fixedGdArrayElemSize(arrayType int32) (int, bool) {
+	switch arrayType {
+	case GdArrayTypeInt64, GdArrayTypeGdObj:
+		return 8, true
+	case GdArrayTypeFloat:
+		return 4, true
+	case GdArrayTypeBool, GdArrayTypeByte:
+		return 1, true
+	default:
+		return 0, false
+	}
 }

--- a/internal/gdengine/impl/manager_native.gen.go
+++ b/internal/gdengine/impl/manager_native.gen.go
@@ -406,6 +406,42 @@ func (pself *inputMgr) IsActionJustReleased(action string) bool {
 	retValue := CallInputIsActionJustReleased(arg0)
 	return ToBool(retValue)
 }
+func (pself *inputMgr) RegisterAction(action string) int64 {
+	arg0Str := C.CString(action)
+	arg0 := (GdString)(arg0Str)
+	defer C.free(unsafe.Pointer(arg0Str))
+	retValue := CallInputRegisterAction(arg0)
+	return ToInt64(retValue)
+}
+func (pself *inputMgr) GetAxisId(neg_action_id int64, pos_action_id int64) float64 {
+	arg0 := ToGdInt(neg_action_id)
+	arg1 := ToGdInt(pos_action_id)
+	retValue := CallInputGetAxisId(arg0, arg1)
+	return ToFloat64(retValue)
+}
+func (pself *inputMgr) IsActionPressedId(action_id int64) bool {
+	arg0 := ToGdInt(action_id)
+	retValue := CallInputIsActionPressedId(arg0)
+	return ToBool(retValue)
+}
+func (pself *inputMgr) IsActionJustPressedId(action_id int64) bool {
+	arg0 := ToGdInt(action_id)
+	retValue := CallInputIsActionJustPressedId(arg0)
+	return ToBool(retValue)
+}
+func (pself *inputMgr) IsActionJustReleasedId(action_id int64) bool {
+	arg0 := ToGdInt(action_id)
+	retValue := CallInputIsActionJustReleasedId(arg0)
+	return ToBool(retValue)
+}
+func (pself *inputMgr) WriteSnapshot(out []float32) {
+	var arg0 *float32
+	if len(out) > 0 {
+		arg0 = &out[0]
+	}
+	arg1 := int32(len(out))
+	CallInputWriteSnapshot(arg0, arg1)
+}
 func (pself *navigationMgr) SetupPathFinderWithSize(grid_size Vec2, cell_size Vec2, with_jump bool, with_debug bool) {
 	arg0 := ToGdVec2(grid_size)
 	arg1 := ToGdVec2(cell_size)
@@ -1603,17 +1639,13 @@ func (pself *spriteMgr) BatchUpdateVisuals(buffer []float32) {
 	arg1 := int32(len(buffer))
 	CallSpriteBatchUpdateVisuals(arg0, arg1)
 }
-func (pself *spriteMgr) BatchRetrievePositions(objs Array) Array {
-	arg0Info := ToGdArrayInfo(objs)
-	if arg0Info != nil {
-		defer arg0Info.Free()
+func (pself *spriteMgr) BatchUpdatePhysics(buffer []float32) {
+	var arg0 *float32
+	if len(buffer) > 0 {
+		arg0 = &buffer[0]
 	}
-	arg0 := GdArray(nil)
-	if arg0Info != nil {
-		arg0 = arg0Info.Raw()
-	}
-	retValue := CallSpriteBatchRetrievePositions(arg0)
-	return ToArray(retValue)
+	arg1 := int32(len(buffer))
+	CallSpriteBatchUpdatePhysics(arg0, arg1)
 }
 func (pself *tilemapMgr) OpenDrawTilesWithSize(tile_size int64) {
 	arg0 := ToGdInt(tile_size)
@@ -1999,4 +2031,16 @@ func (pself *uiMgr) SetFlip(obj Object, horizontal bool, is_flip bool) {
 	arg1 := ToGdBool(horizontal)
 	arg2 := ToGdBool(is_flip)
 	CallUiSetFlip(arg0, arg1, arg2)
+}
+func (pself *spriteMgr) BatchRetrievePositions(objs Array) Array {
+	arg0Info := ToGdArrayInfo(objs)
+	if arg0Info != nil {
+		defer arg0Info.Free()
+	}
+	arg0 := GdArray(nil)
+	if arg0Info != nil {
+		arg0 = arg0Info.Raw()
+	}
+	retValue := CallSpriteBatchRetrievePositions(arg0)
+	return ToArray(retValue)
 }

--- a/internal/gdengine/impl/manager_web.gen.go
+++ b/internal/gdengine/impl/manager_web.gen.go
@@ -346,44 +346,93 @@ func (pself *extMgr) SetLayerSorterMode(mode int64) {
 	API.SpxExtSetLayerSorterMode.Invoke(arg0Low, arg0High)
 }
 func (pself *inputMgr) GetGlobalMousePos() Vec2 {
-	_retValue := API.SpxInputGetGlobalMousePos.Invoke()
-	return JsToGdVec2(_retValue)
+	return WebInputMousePos(func() Vec2 {
+		_retValue := API.SpxInputGetGlobalMousePos.Invoke()
+		return JsToGdVec2(_retValue)
+	})
 }
 func (pself *inputMgr) GetKey(key int64) bool {
-	arg0Low, arg0High := JsSplitGdInt(key)
-	_retValue := API.SpxInputGetKey.Invoke(arg0Low, arg0High)
-	return JsToGdBool(_retValue)
+	return WebInputKeyState(key, func() bool {
+		arg0Low, arg0High := JsSplitGdInt(key)
+		_retValue := API.SpxInputGetKey.Invoke(arg0Low, arg0High)
+		return JsToGdBool(_retValue)
+	})
 }
 func (pself *inputMgr) GetMouseState(mouse_id int64) bool {
-	arg0Low, arg0High := JsSplitGdInt(mouse_id)
-	_retValue := API.SpxInputGetMouseState.Invoke(arg0Low, arg0High)
-	return JsToGdBool(_retValue)
+	return WebInputMouseState(mouse_id, func() bool {
+		arg0Low, arg0High := JsSplitGdInt(mouse_id)
+		_retValue := API.SpxInputGetMouseState.Invoke(arg0Low, arg0High)
+		return JsToGdBool(_retValue)
+	})
 }
 func (pself *inputMgr) GetKeyState(key int64) int64 {
-	arg0Low, arg0High := JsSplitGdInt(key)
-	_retValue := API.SpxInputGetKeyState.Invoke(arg0Low, arg0High)
-	return JsToGdInt(_retValue)
+	if WebInputKeyState(key, func() bool {
+		arg0Low, arg0High := JsSplitGdInt(key)
+		_retValue := API.SpxInputGetKeyState.Invoke(arg0Low, arg0High)
+		return JsToGdInt(_retValue) != 0
+	}) {
+		return 1
+	}
+	return 0
 }
 func (pself *inputMgr) GetAxis(neg_action string, pos_action string) float64 {
-	arg0 := JsFromGdString(neg_action)
-	arg1 := JsFromGdString(pos_action)
-	_retValue := API.SpxInputGetAxis.Invoke(arg0, arg1)
-	return JsToGdFloat(_retValue)
+	return CachedActionAxis(neg_action, pos_action, func() float64 {
+		arg0 := JsFromGdString(neg_action)
+		arg1 := JsFromGdString(pos_action)
+		_retValue := API.SpxInputGetAxis.Invoke(arg0, arg1)
+		return JsToGdFloat(_retValue)
+	})
 }
 func (pself *inputMgr) IsActionPressed(action string) bool {
-	arg0 := JsFromGdString(action)
-	_retValue := API.SpxInputIsActionPressed.Invoke(arg0)
-	return JsToGdBool(_retValue)
+	return CachedActionBool("pressed", action, func() bool {
+		arg0 := JsFromGdString(action)
+		_retValue := API.SpxInputIsActionPressed.Invoke(arg0)
+		return JsToGdBool(_retValue)
+	})
 }
 func (pself *inputMgr) IsActionJustPressed(action string) bool {
-	arg0 := JsFromGdString(action)
-	_retValue := API.SpxInputIsActionJustPressed.Invoke(arg0)
-	return JsToGdBool(_retValue)
+	return CachedActionBool("just_pressed", action, func() bool {
+		arg0 := JsFromGdString(action)
+		_retValue := API.SpxInputIsActionJustPressed.Invoke(arg0)
+		return JsToGdBool(_retValue)
+	})
 }
 func (pself *inputMgr) IsActionJustReleased(action string) bool {
+	return CachedActionBool("just_released", action, func() bool {
+		arg0 := JsFromGdString(action)
+		_retValue := API.SpxInputIsActionJustReleased.Invoke(arg0)
+		return JsToGdBool(_retValue)
+	})
+}
+func (pself *inputMgr) RegisterAction(action string) int64 {
 	arg0 := JsFromGdString(action)
-	_retValue := API.SpxInputIsActionJustReleased.Invoke(arg0)
+	_retValue := API.SpxInputRegisterAction.Invoke(arg0)
+	return JsToGdInt(_retValue)
+}
+func (pself *inputMgr) GetAxisId(neg_action_id int64, pos_action_id int64) float64 {
+	arg0Low, arg0High := JsSplitGdInt(neg_action_id)
+	arg1Low, arg1High := JsSplitGdInt(pos_action_id)
+	_retValue := API.SpxInputGetAxisId.Invoke(arg0Low, arg0High, arg1Low, arg1High)
+	return JsToGdFloat(_retValue)
+}
+func (pself *inputMgr) IsActionPressedId(action_id int64) bool {
+	arg0Low, arg0High := JsSplitGdInt(action_id)
+	_retValue := API.SpxInputIsActionPressedId.Invoke(arg0Low, arg0High)
 	return JsToGdBool(_retValue)
+}
+func (pself *inputMgr) IsActionJustPressedId(action_id int64) bool {
+	arg0Low, arg0High := JsSplitGdInt(action_id)
+	_retValue := API.SpxInputIsActionJustPressedId.Invoke(arg0Low, arg0High)
+	return JsToGdBool(_retValue)
+}
+func (pself *inputMgr) IsActionJustReleasedId(action_id int64) bool {
+	arg0Low, arg0High := JsSplitGdInt(action_id)
+	_retValue := API.SpxInputIsActionJustReleasedId.Invoke(arg0Low, arg0High)
+	return JsToGdBool(_retValue)
+}
+func (pself *inputMgr) WriteSnapshot(out []float32) {
+	arg0 := JsFromGdArray(out)
+	API.SpxInputWriteSnapshot.Invoke(arg0)
 }
 func (pself *navigationMgr) SetupPathFinderWithSize(grid_size Vec2, cell_size Vec2, with_jump bool, with_debug bool) {
 	arg0 := JsFromGdVec2(grid_size)
@@ -1456,10 +1505,9 @@ func (pself *spriteMgr) BatchUpdateVisuals(buffer []float32) {
 	arg0 := JsFromGdArray(buffer)
 	API.SpxSpriteBatchUpdateVisuals.Invoke(arg0)
 }
-func (pself *spriteMgr) BatchRetrievePositions(objs Array) Array {
-	arg0 := JsFromGdArray(objs)
-	_retValue := API.SpxSpriteBatchRetrievePositions.Invoke(arg0)
-	return JsToGdArray(_retValue)
+func (pself *spriteMgr) BatchUpdatePhysics(buffer []float32) {
+	arg0 := JsFromGdArray(buffer)
+	API.SpxSpriteBatchUpdatePhysics.Invoke(arg0)
 }
 func (pself *tilemapMgr) OpenDrawTilesWithSize(tile_size int64) {
 	arg0Low, arg0High := JsSplitGdInt(tile_size)
@@ -1778,4 +1826,9 @@ func (pself *uiMgr) SetFlip(obj Object, horizontal bool, is_flip bool) {
 	arg1 := JsFromGdBool(horizontal)
 	arg2 := JsFromGdBool(is_flip)
 	API.SpxUiSetFlip.Invoke(arg0Low, arg0High, arg1, arg2)
+}
+func (pself *spriteMgr) BatchRetrievePositions(objs Array) Array {
+	arg0 := JsFromGdArray(objs)
+	_retValue := API.SpxSpriteBatchRetrievePositions.Invoke(arg0)
+	return JsToGdArray(_retValue)
 }

--- a/pkg/spx/pkg/engine/interface.gen.go
+++ b/pkg/spx/pkg/engine/interface.gen.go
@@ -110,6 +110,12 @@ type IInputMgr interface {
 	IsActionPressed(action string) bool
 	IsActionJustPressed(action string) bool
 	IsActionJustReleased(action string) bool
+	RegisterAction(action string) int64
+	GetAxisId(neg_action_id int64, pos_action_id int64) float64
+	IsActionPressedId(action_id int64) bool
+	IsActionJustPressedId(action_id int64) bool
+	IsActionJustReleasedId(action_id int64) bool
+	WriteSnapshot(out []float32)
 }
 
 type INavigationMgr interface {
@@ -337,6 +343,7 @@ type ISpriteMgr interface {
 	GetPixelCollisionSamplingStep() int64
 	BatchUpdateTransforms(buffer []float32)
 	BatchUpdateVisuals(buffer []float32)
+	BatchUpdatePhysics(buffer []float32)
 	BatchRetrievePositions(objs Array) Array
 }
 

--- a/pkg/spx/pkg/engine/sprite.gen.go
+++ b/pkg/spx/pkg/engine/sprite.gen.go
@@ -46,6 +46,10 @@ func (pself *Sprite) BatchRetrievePositions(objs Array) Array {
 	return SpriteMgr.BatchRetrievePositions(objs)
 }
 
+func (pself *Sprite) BatchUpdatePhysics(buffer []float32) {
+	SpriteMgr.BatchUpdatePhysics(buffer)
+}
+
 func (pself *Sprite) BatchUpdateTransforms(buffer []float32) {
 	SpriteMgr.BatchUpdateTransforms(buffer)
 }

--- a/pkg/spx/pkg/engine/sprite_pure.gen.go
+++ b/pkg/spx/pkg/engine/sprite_pure.gen.go
@@ -44,6 +44,9 @@ func (pself *Sprite) BatchRetrievePositions(objs Array) Array {
 	return nil
 }
 
+func (pself *Sprite) BatchUpdatePhysics(buffer []float32) {
+}
+
 func (pself *Sprite) BatchUpdateTransforms(buffer []float32) {
 }
 


### PR DESCRIPTION
## Summary
Improve the Web batch-sync pipeline by introducing fast-path bridges for shared transfer buffers and reducing JS/wasm marshaling overhead.

## What changed
- add Web-side fast paths for batch sync, input snapshot, and contact event delivery
- extend codegen to synthesize array-transform bridges from raw Godot methods
- update web/native manager wrappers and FFI bindings to use the new bridge model
- improve fast-array marshaling and shared buffer reuse on the Web path
- add documentation and tests for the new batch-sync behavior

## Why
The previous path relied more heavily on GdArray serialization and generic dispatch fallbacks.
This change moves hot batch-sync operations onto shared transfer buffers, reducing copies and making the Web runtime path more predictable.

## Testing
- `go test ./generate/common ./generate/gdext ./generate/webffi`
- `make generate-bindings`