### PR TITLE
fix: add context to Godot import failures

### DIFF
--- a/cmd/spx/internal/command/env.go
+++ b/cmd/spx/internal/command/env.go
@@ -194,7 +194,13 @@ func (cmd *CmdTool) runProjectImport() error {
 		if timeout > 0 && errors.Is(ctx.Err(), context.DeadlineExceeded) {
 			return fmt.Errorf("godot import timed out after %s; override with %s: %w", timeout, projectImportTimeoutEnvVar, err)
 		}
-		return fmt.Errorf("godot import failed: %w", err)
+		return fmt.Errorf(
+			"godot import failed (cmd=%q dir=%q args=%q): %w",
+			cmd.CmdPath,
+			cmd.ProjectDir,
+			execCmd.Args,
+			err,
+		)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

- include the Godot command path, project directory, and command arguments in import failure errors
- keep the existing timeout-specific error handling unchanged
- make Godot import failures easier to diagnose in local and CI environments

## Testing

- go test ./cmd/spx/internal/command/...