### PR TITLE
fix: improve Godot import diagnostics and add missing font import metadata

### DIFF
--- a/cmd/spx/internal/command/env.go
+++ b/cmd/spx/internal/command/env.go
@@ -194,7 +194,17 @@ func (cmd *CmdTool) runProjectImport() error {
 		if timeout > 0 && errors.Is(ctx.Err(), context.DeadlineExceeded) {
 			return fmt.Errorf("godot import timed out after %s; override with %s: %w", timeout, projectImportTimeoutEnvVar, err)
 		}
-		return fmt.Errorf("godot import failed: %w", err)
+		args := execCmd.Args
+		if len(args) > 0 {
+			args = args[1:]
+		}
+		return fmt.Errorf(
+			"godot import failed (cmd=%q dir=%q args=%q): %w",
+			cmd.CmdPath,
+			cmd.ProjectDir,
+			args,
+			err,
+		)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
Improve Godot import failure debugging and add missing font import metadata for fresh template projects.

## What changed
- include richer context in Godot import failures from `cmd/spx`, including the command path, project directory, and import arguments
- trim the duplicated executable path from the logged `args` field to keep the error output concise
- add the missing `.import` metadata files for the scratch template fonts so fresh projects do not need a prior editor-open step to generate them
- keep the new import diagnostics and font metadata together in the same branch because they address the same fresh-import failure surface

## Why
Fresh runtime/template projects can fail in CI or first-run environments more easily than in local editor-opened projects, especially when new font assets have been added but their `.import` metadata has never been generated and committed.

This PR improves the situation in two ways:
- it makes Godot import failures much easier to reproduce and diagnose
- it removes one likely source of fresh-import instability by committing the missing scratch font import metadata

## Included commits
- `0a08dd9c` `fix: add context to Godot import failures`
- `95ff9660` `fix: trim duplicated import args in error context`
- `97c8f4d4` `chore: add missing scratch font import metadata`

## Testing
- `go test ./cmd/spx/internal/command`
- manually verified `gdspx2.2.3 --headless --path <project> --import` on multiple temporary projects