### PR TITLE
revert: undo bc44af44 spx-side collision filtering

### DIFF
--- a/collision_optimizer.go
+++ b/collision_optimizer.go
@@ -58,7 +58,7 @@ func (p *Game) buildSpatialHashForNames(dst *SpriteImpl, nameFilter func(string)
 
 	for _, item := range p.shapeMgr.items {
 		if sp, ok := item.(*SpriteImpl); ok && sp != dst {
-			if nameFilter(sp.name) && sp.canParticipateInCollisionQuery() && sp.runtimeState.SyncSprite != nil {
+			if nameFilter(sp.name) && sp.spriteState.IsVisible && !sp.spriteState.IsDying && sp.runtimeState.SyncSprite != nil {
 				aabb := newSpriteAABB(sp)
 				if aabb != nil {
 					p.spatialHash.Insert(aabb)
@@ -101,7 +101,7 @@ func findCollisionsInSpatialHash(
 
 // findTouchingSpriteOptimized uses spatial partitioning for efficient collision detection.
 func (p *Game) findTouchingSpriteOptimized(dst *SpriteImpl, name string) *SpriteImpl {
-	if !dst.canParticipateInCollisionQuery() || dst.runtimeState.SyncSprite == nil {
+	if dst == nil || dst.runtimeState.SyncSprite == nil {
 		return nil
 	}
 

--- a/runtime_events.go
+++ b/runtime_events.go
@@ -205,14 +205,11 @@ func (p *Game) findClickTarget(point mathf.Vec2) (coreruntime.ClickSelection[cli
 		if !ok {
 			return coreruntime.ClickSelection[clicker, *SpriteImpl]{}, false
 		}
-		if !o.Visible() {
-			return coreruntime.ClickSelection[clicker, *SpriteImpl]{}, false
-		}
-		if sprite, ok := o.(*SpriteImpl); ok && !sprite.canParticipateInCollisionQuery() {
-			return coreruntime.ClickSelection[clicker, *SpriteImpl]{}, false
-		}
 		syncSprite := o.getProxy()
-		if syncSprite == nil {
+		if syncSprite == nil || !o.Visible() {
+			return coreruntime.ClickSelection[clicker, *SpriteImpl]{}, false
+		}
+		if sprite, ok := o.(*SpriteImpl); ok && sprite.isFullyGhosted() {
 			return coreruntime.ClickSelection[clicker, *SpriteImpl]{}, false
 		}
 		if !p.engine().SpriteMgr.CheckCollisionWithPoint(syncSprite.GetId(), point, true) {

--- a/sprite_query.go
+++ b/sprite_query.go
@@ -94,7 +94,7 @@ func (p *SpriteImpl) touching(obj Target) bool {
 		}
 	case Sprite:
 		src := spriteOf(v)
-		if src == nil {
+		if src == nil || src.spriteState.IsDying {
 			return false
 		}
 		return src.touchingSprite(p)
@@ -102,20 +102,12 @@ func (p *SpriteImpl) touching(obj Target) bool {
 	panic("Touching: unexpected input")
 }
 
-func (p *SpriteImpl) canParticipateInCollisionQuery() bool {
-	return p != nil && p.spriteState.IsVisible && !p.spriteState.IsDying && !p.isFullyGhosted()
-}
-
-func (p *SpriteImpl) ensureCollisionQuerySynced() bool {
-	if p == nil || p.runtimeState.SyncSprite == nil {
+func (p *SpriteImpl) prepareSelfCollisionQuery() bool {
+	if p.runtimeState.SyncSprite == nil {
 		return false
 	}
 	p.ensureProxyQueryStateSynced()
 	return true
-}
-
-func (p *SpriteImpl) prepareSelfCollisionQuery() bool {
-	return p.canParticipateInCollisionQuery() && p.ensureCollisionQuerySynced()
 }
 
 func (p *SpriteImpl) touchPoint(x, y float64) bool {
@@ -146,10 +138,7 @@ func (p *SpriteImpl) touchingColors(spriteColor, targetColor mathf.Color) bool {
 }
 
 func (p *SpriteImpl) touchingSprite(dst *SpriteImpl) bool {
-	if !p.prepareSelfCollisionQuery() {
-		return false
-	}
-	if !dst.prepareSelfCollisionQuery() {
+	if !p.prepareSelfCollisionQuery() || !dst.prepareSelfCollisionQuery() {
 		return false
 	}
 	return p.engine().SpriteMgr.CheckCollisionWithSprite(p.runtimeState.SyncSprite.GetId(), dst.runtimeState.SyncSprite.GetId(), alphaThreshold, !isPhysicsEnabled())

--- a/sprite_query_test.go
+++ b/sprite_query_test.go
@@ -31,8 +31,6 @@ type touchingSyncSpriteMgr struct {
 	texturePaths            map[pkgengine.Object]string
 	expectedTexturePaths    map[pkgengine.Object]string
 	checkedTexturePaths     map[pkgengine.Object]string
-	checkColorCalls         map[pkgengine.Object]int
-	checkSpriteCalls        map[[2]pkgengine.Object]int
 	setTransformCalls       map[pkgengine.Object]int
 	setPositionCalls        map[pkgengine.Object]int
 	setRotationCalls        map[pkgengine.Object]int
@@ -52,8 +50,6 @@ func newTouchingSyncSpriteMgr() *touchingSyncSpriteMgr {
 		texturePaths:            map[pkgengine.Object]string{},
 		expectedTexturePaths:    map[pkgengine.Object]string{},
 		checkedTexturePaths:     map[pkgengine.Object]string{},
-		checkColorCalls:         map[pkgengine.Object]int{},
-		checkSpriteCalls:        map[[2]pkgengine.Object]int{},
 		setTransformCalls:       map[pkgengine.Object]int{},
 		setPositionCalls:        map[pkgengine.Object]int{},
 		setRotationCalls:        map[pkgengine.Object]int{},
@@ -127,12 +123,10 @@ func (s *touchingSyncSpriteMgr) SetMaterialParamsVec4(obj pkgengine.Object, effe
 }
 
 func (s *touchingSyncSpriteMgr) CheckCollisionWithSprite(obj, objB pkgengine.Object, alphaThreshold float64, usePixelPerfect bool) bool {
-	s.checkSpriteCalls[[2]pkgengine.Object{obj, objB}]++
 	return s.positions[obj] == s.positions[objB]
 }
 
 func (s *touchingSyncSpriteMgr) CheckCollisionByColor(obj pkgengine.Object, color mathf.Color, colorThreshold, alphaThreshold float64) bool {
-	s.checkColorCalls[obj]++
 	s.checkedTexturePaths[obj] = s.texturePaths[obj]
 	expected, ok := s.expectedTexturePaths[obj]
 	return !ok || s.texturePaths[obj] == expected
@@ -253,58 +247,5 @@ func TestTouchingColorSyncsDirtyCostumeImmediately(t *testing.T) {
 	}
 	if got := mgr.setTextureCalls[1]; got != 1 {
 		t.Fatalf("SetTexture calls after second touchingColor = %d, want 1", got)
-	}
-}
-
-func TestTouchingSpriteIgnoresHiddenTarget(t *testing.T) {
-	mgr := newTouchingSyncSpriteMgr()
-	installTouchingSyncSpriteMgr(t, mgr)
-
-	mover := newTouchingTestSprite("mover", 0, 0, 1)
-	target := newTouchingTestSprite("target", 0, 0, 2)
-	target.spriteState.IsVisible = false
-
-	mgr.positions[1] = mathf.NewVec2(0, 0)
-	mgr.positions[2] = mathf.NewVec2(0, 0)
-
-	if mover.touchingSprite(target) {
-		t.Fatal("touchingSprite() = true, want false when target sprite is hidden")
-	}
-	if got := mgr.setTransformCalls[2]; got != 0 {
-		t.Fatalf("SetTransform calls for hidden target = %d, want 0", got)
-	}
-}
-
-func TestTouchingSpriteIgnoresFullyGhostedTarget(t *testing.T) {
-	mgr := newTouchingSyncSpriteMgr()
-	installTouchingSyncSpriteMgr(t, mgr)
-
-	mover := newTouchingTestSprite("mover", 0, 0, 1)
-	target := newTouchingTestSprite("target", 0, 0, 2)
-	target.greffUniforms = map[EffectKind]float64{GhostEffect: 100}
-
-	mgr.positions[1] = mathf.NewVec2(0, 0)
-	mgr.positions[2] = mathf.NewVec2(0, 0)
-
-	if mover.touchingSprite(target) {
-		t.Fatal("touchingSprite() = true, want false when target sprite is fully ghosted")
-	}
-	if got := mgr.checkSpriteCalls[[2]pkgengine.Object{1, 2}]; got != 0 {
-		t.Fatalf("CheckCollisionWithSprite calls for fully ghosted target = %d, want 0", got)
-	}
-}
-
-func TestTouchingColorSkipsFullyGhostedSprite(t *testing.T) {
-	mgr := newTouchingSyncSpriteMgr()
-	installTouchingSyncSpriteMgr(t, mgr)
-
-	sprite := newTouchingTestSprite("mover", 0, 0, 1)
-	sprite.greffUniforms = map[EffectKind]float64{GhostEffect: 100}
-
-	if sprite.touchingColor(mathf.Color{}) {
-		t.Fatal("touchingColor() = true, want false when sprite is fully ghosted")
-	}
-	if got := mgr.checkColorCalls[1]; got != 0 {
-		t.Fatalf("CheckCollisionByColor calls for fully ghosted sprite = %d, want 0", got)
 	}
 }


### PR DESCRIPTION
## Summary

This reverts the SPX-side collision-query filtering introduced in `bc44af44`.

- remove Go-side `hidden` / `fully ghosted` filtering from `touchingSprite` and `touchingColor*`
- restore `touching(SpriteName)` broad-phase candidate filtering to the pre-`bc44af44` behavior
- keep click-target filtering explicit in `runtime_events.go` instead of reusing collision-query eligibility rules

## Why

After aligning the native runtime with Scratch behavior, the filtering introduced in `bc44af44` turned out to be in the wrong layer.

In Scratch:
- `touching(sprite)` does not become false just because a sprite is ghosted
- `touchingColor*` uses the caller's silhouette as the query mask, rather than being short-circuited by SPX-side ghost filtering

Those semantics now live in the native `godot/modules/spx/spx_sprite_mgr.cpp` implementation, so SPX should not pre-filter these queries in Go.

## Testing

- `go test .`