### PR TITLE
fix: align tween execution with Scratch semantics

### DIFF
--- a/component_animation.go
+++ b/component_animation.go
@@ -46,6 +46,7 @@ type animationComponent struct {
 	// Animation state (per-instance)
 	curAnimState      *animState
 	curTweenState     *animState
+	activeTweenStates []*animState
 	defaultAnimActive bool
 
 	// Animation tracking (per-instance)
@@ -103,9 +104,10 @@ func (a *animationComponent) initFromConfig(spriteCfg *coreproject.SpriteConfig)
 func (a *animationComponent) cloneFrom(src component, newSprite *SpriteImpl) component {
 	srcAnim := src.(*animationComponent)
 	newAnim := &animationComponent{
-		componentBase:   componentBase{sprite: newSprite},
-		shared:          srcAnim.shared,
-		donedAnimations: make([]string, 0),
+		componentBase:     componentBase{sprite: newSprite},
+		shared:            srcAnim.shared,
+		activeTweenStates: make([]*animState, 0),
+		donedAnimations:   make([]string, 0),
 	}
 	return newAnim
 }
@@ -113,7 +115,11 @@ func (a *animationComponent) cloneFrom(src component, newSprite *SpriteImpl) com
 // onDestroy cleanup when component is destroyed.
 func (a *animationComponent) onDestroy() {
 	a.stopAnimState(a.curAnimState)
-	a.stopAnimState(a.curTweenState)
+	for _, state := range a.activeTweenStates {
+		a.stopAnimState(state)
+	}
+	a.curTweenState = nil
+	a.activeTweenStates = nil
 	a.unRegisterOnAnimationLooped()
 	a.unRegisterOnAnimationFinished()
 }
@@ -386,13 +392,39 @@ func (a *animationComponent) getCurTweenState() *animState {
 	return a.curTweenState
 }
 
+func (a *animationComponent) registerTweenState(state *animState) {
+	a.activeTweenStates = append(a.activeTweenStates, state)
+	a.curTweenState = state
+}
+
+func (a *animationComponent) unregisterTweenState(state *animState) bool {
+	idx := -1
+	for i := len(a.activeTweenStates) - 1; i >= 0; i-- {
+		if a.activeTweenStates[i] == state {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		return false
+	}
+
+	a.activeTweenStates = append(a.activeTweenStates[:idx], a.activeTweenStates[idx+1:]...)
+	if len(a.activeTweenStates) == 0 {
+		a.curTweenState = nil
+	} else {
+		a.curTweenState = a.activeTweenStates[len(a.activeTweenStates)-1]
+	}
+	return true
+}
+
 // tweenParams holds pre-calculated parameters for tween animations.
 type tweenParams struct {
-	moveFrom  mathf.Vec2
-	moveDiff  mathf.Vec2
-	moveSpeed float64
-	moveDir   mathf.Vec2
-	turnDiff  float64
+	moveFrom     mathf.Vec2
+	moveTo       mathf.Vec2
+	moveVelocity mathf.Vec2
+	turnFrom     float64
+	turnTo       float64
 }
 
 func (a *animationComponent) doTween(name SpriteAnimationName, ani *coreproject.AniConfig) {
@@ -421,7 +453,7 @@ func (a *animationComponent) initTweenState(name SpriteAnimationName, ani *corep
 		Name:    name,
 		Speed:   ani.Speed,
 	}
-	a.curTweenState = info
+	a.registerTweenState(info)
 
 	var ownedPlayback *animState
 	if a.hasAnim(name) {
@@ -446,10 +478,9 @@ func (a *animationComponent) prepareTweenParams(ani *coreproject.AniConfig) (*tw
 		}
 
 		params.moveFrom = src
-		params.moveDiff = dst.Sub(src)
+		params.moveTo = dst
 		if ani.AniType == coreproject.AniTypeMove {
-			params.moveSpeed = params.moveDiff.Length() / duration
-			params.moveDir = params.moveDiff.Normalize()
+			params.moveVelocity = dst.Sub(src).Mulf(1 / duration)
 		}
 	case coreproject.AniTypeTurn:
 		src, srcOk := tools.GetFloat(ani.From)
@@ -459,7 +490,8 @@ func (a *animationComponent) prepareTweenParams(ani *coreproject.AniConfig) (*tw
 			return nil, false
 		}
 
-		params.turnDiff = dst - src
+		params.turnFrom = src
+		params.turnTo = dst
 	}
 
 	return params, true
@@ -467,7 +499,6 @@ func (a *animationComponent) prepareTweenParams(ani *coreproject.AniConfig) (*tw
 
 func (a *animationComponent) executeTweenLoop(info *animState, ani *coreproject.AniConfig, params *tweenParams) {
 	timer := 0.0
-	prePercent := 0.0
 	duration := ani.Duration
 
 	for timer < duration {
@@ -477,32 +508,35 @@ func (a *animationComponent) executeTweenLoop(info *animState, ani *coreproject.
 
 		timer += time.DeltaTime()
 		percent := mathf.Clamp01f(timer / duration)
-		deltaPercent := percent - prePercent
-		prePercent = percent
 
-		a.applyTweenStep(ani.AniType, percent, deltaPercent, params)
+		a.applyTweenStep(ani.AniType, percent, params)
 		engine.WaitNextFrame()
 	}
 }
 
-func (a *animationComponent) applyTweenStep(aniType coreproject.AniType, percent, deltaPercent float64, params *tweenParams) {
+func (a *animationComponent) applyTweenStep(aniType coreproject.AniType, percent float64, params *tweenParams) {
 	switch aniType {
 	case coreproject.AniTypeMove:
 		physicsMode := a.sprite.PhysicsMode()
 		if isPhysicsEnabled() && physicsMode != NoPhysics && physicsMode != StaticPhysics {
-			vel := params.moveDir.Mulf(params.moveSpeed)
-			a.sprite.SetVelocity(vel.X, vel.Y)
+			a.sprite.SetVelocity(params.moveVelocity.X, params.moveVelocity.Y)
 		} else {
-			val := params.moveDiff.Mulf(deltaPercent)
-			a.sprite.ChangeXYpos(val.X, val.Y)
+			a.applyTweenPosition(percent, params)
 		}
 	case coreproject.AniTypeGlide:
-		pos := params.moveFrom.Add(params.moveDiff.Mulf(percent))
-		a.sprite.SetXYpos(pos.X, pos.Y)
+		a.applyTweenPosition(percent, params)
 	case coreproject.AniTypeTurn:
-		val := params.turnDiff * deltaPercent
-		a.sprite.ChangeHeading(val)
+		a.sprite.SetHeading(a.interpolateTweenHeading(percent, params))
 	}
+}
+
+func (a *animationComponent) applyTweenPosition(percent float64, params *tweenParams) {
+	pos := params.moveFrom.Lerp(params.moveTo, percent)
+	a.sprite.SetXYpos(pos.X, pos.Y)
+}
+
+func (a *animationComponent) interpolateTweenHeading(percent float64, params *tweenParams) float64 {
+	return mathf.Lerpf(params.turnFrom, params.turnTo, percent)
 }
 
 func (a *animationComponent) cleanupTween(info, ownedPlayback *animState, name SpriteAnimationName, ani *coreproject.AniConfig) {
@@ -514,7 +548,8 @@ func (a *animationComponent) cleanupTween(info, ownedPlayback *animState, name S
 	}
 
 	a.stopAnimState(info)
-	if a.curTweenState != info {
+	wasActive := a.unregisterTweenState(info)
+	if !wasActive {
 		if ownedPlayback != nil && a.curAnimState == ownedPlayback {
 			a.stopCurrentAnimState(ownedPlayback)
 			a.playDefaultAnimIfIdle()
@@ -522,7 +557,6 @@ func (a *animationComponent) cleanupTween(info, ownedPlayback *animState, name S
 		return
 	}
 
-	a.curTweenState = nil
 	if name == a.shared.defaultAnimation || ani.IsKeepOnStop {
 		return
 	}

--- a/component_animation.go
+++ b/component_animation.go
@@ -388,6 +388,7 @@ func (a *animationComponent) getCurTweenState() *animState {
 
 // tweenParams holds pre-calculated parameters for tween animations.
 type tweenParams struct {
+	moveFrom  mathf.Vec2
 	moveDiff  mathf.Vec2
 	moveSpeed float64
 	moveDir   mathf.Vec2
@@ -420,7 +421,6 @@ func (a *animationComponent) initTweenState(name SpriteAnimationName, ani *corep
 		Name:    name,
 		Speed:   ani.Speed,
 	}
-	a.stopAnimState(a.curTweenState)
 	a.curTweenState = info
 
 	var ownedPlayback *animState
@@ -445,6 +445,7 @@ func (a *animationComponent) prepareTweenParams(ani *coreproject.AniConfig) (*tw
 			return nil, false
 		}
 
+		params.moveFrom = src
 		params.moveDiff = dst.Sub(src)
 		if ani.AniType == coreproject.AniTypeMove {
 			params.moveSpeed = params.moveDiff.Length() / duration
@@ -479,12 +480,12 @@ func (a *animationComponent) executeTweenLoop(info *animState, ani *coreproject.
 		deltaPercent := percent - prePercent
 		prePercent = percent
 
-		a.applyTweenStep(ani.AniType, deltaPercent, params)
+		a.applyTweenStep(ani.AniType, percent, deltaPercent, params)
 		engine.WaitNextFrame()
 	}
 }
 
-func (a *animationComponent) applyTweenStep(aniType coreproject.AniType, deltaPercent float64, params *tweenParams) {
+func (a *animationComponent) applyTweenStep(aniType coreproject.AniType, percent, deltaPercent float64, params *tweenParams) {
 	switch aniType {
 	case coreproject.AniTypeMove:
 		physicsMode := a.sprite.PhysicsMode()
@@ -496,8 +497,8 @@ func (a *animationComponent) applyTweenStep(aniType coreproject.AniType, deltaPe
 			a.sprite.ChangeXYpos(val.X, val.Y)
 		}
 	case coreproject.AniTypeGlide:
-		val := params.moveDiff.Mulf(deltaPercent)
-		a.sprite.ChangeXYpos(val.X, val.Y)
+		pos := params.moveFrom.Add(params.moveDiff.Mulf(percent))
+		a.sprite.SetXYpos(pos.X, pos.Y)
 	case coreproject.AniTypeTurn:
 		val := params.turnDiff * deltaPercent
 		a.sprite.ChangeHeading(val)
@@ -514,6 +515,10 @@ func (a *animationComponent) cleanupTween(info, ownedPlayback *animState, name S
 
 	a.stopAnimState(info)
 	if a.curTweenState != info {
+		if ownedPlayback != nil && a.curAnimState == ownedPlayback {
+			a.stopCurrentAnimState(ownedPlayback)
+			a.playDefaultAnimIfIdle()
+		}
 		return
 	}
 

--- a/component_animation_test.go
+++ b/component_animation_test.go
@@ -50,12 +50,17 @@ func newTestAnimationComponent() *animationComponent {
 			animBindings:      map[string]string{},
 			animationWrappers: map[SpriteAnimationName]*animationWrapper{},
 		},
-		donedAnimations: make([]string, 0),
+		activeTweenStates: make([]*animState, 0),
+		donedAnimations:   make([]string, 0),
 	}
 	sprite.components.animation = anim
 	sprite.components.sound = &soundComponent{
 		componentBase: componentBase{sprite: sprite},
 		pendingAudios: make([]string, 0),
+	}
+	sprite.components.physics = &physicsComponent{
+		componentBase: componentBase{sprite: sprite},
+		physicsMode:   NoPhysics,
 	}
 	return anim
 }
@@ -218,6 +223,7 @@ func TestCleanupTweenWithoutPlaybackKeepsActiveAnimation(t *testing.T) {
 	tween := &animState{Name: StateGlide, AniType: coreproject.AniTypeGlide}
 	anim.curAnimState = activeAnim
 	anim.curTweenState = tween
+	anim.activeTweenStates = []*animState{tween}
 
 	anim.cleanupTween(tween, nil, StateGlide, &coreproject.AniConfig{AniType: coreproject.AniTypeGlide})
 
@@ -240,6 +246,7 @@ func TestCleanupTweenWithoutPlaybackRestoresDefaultWhenIdle(t *testing.T) {
 
 	tween := &animState{Name: StateGlide, AniType: coreproject.AniTypeGlide}
 	anim.curTweenState = tween
+	anim.activeTweenStates = []*animState{tween}
 
 	anim.cleanupTween(tween, nil, StateGlide, &coreproject.AniConfig{AniType: coreproject.AniTypeGlide})
 
@@ -264,6 +271,7 @@ func TestCleanupTweenRestoresDefaultForOwnedPlayback(t *testing.T) {
 	}
 	anim.curAnimState = playback
 	anim.curTweenState = tween
+	anim.activeTweenStates = []*animState{tween}
 
 	anim.cleanupTween(tween, playback, StateGlide, &coreproject.AniConfig{AniType: coreproject.AniTypeGlide})
 
@@ -282,6 +290,7 @@ func TestInitTweenStateDoesNotCancelPreviousTween(t *testing.T) {
 	anim := newTestAnimationComponent()
 	previous := &animState{Name: StateGlide, AniType: coreproject.AniTypeGlide}
 	anim.curTweenState = previous
+	anim.activeTweenStates = []*animState{previous}
 
 	next, _ := anim.initTweenState(StateGlide, &coreproject.AniConfig{
 		AniType:  coreproject.AniTypeGlide,
@@ -303,14 +312,50 @@ func TestApplyTweenStepGlideUsesAbsolutePosition(t *testing.T) {
 
 	params := &tweenParams{
 		moveFrom: mathf.NewVec2(10, 20),
-		moveDiff: mathf.NewVec2(90, 0),
+		moveTo:   mathf.NewVec2(100, 20),
 	}
 
-	anim.applyTweenStep(coreproject.AniTypeGlide, 0.5, 0.25, params)
+	anim.applyTweenStep(coreproject.AniTypeGlide, 0.5, params)
 
 	x, y := anim.sprite.getXY()
 	if x != 55 || y != 20 {
 		t.Fatalf("glide position = (%v, %v), want (55, 20)", x, y)
+	}
+}
+
+func TestApplyTweenStepMoveUsesAbsolutePosition(t *testing.T) {
+	anim := newTestAnimationComponent()
+	anim.sprite.spriteState.IsVisible = false
+	initTestMotionComponents(anim.sprite, 100, 20)
+
+	params := &tweenParams{
+		moveFrom: mathf.NewVec2(10, 20),
+		moveTo:   mathf.NewVec2(100, 20),
+	}
+
+	anim.applyTweenStep(coreproject.AniTypeMove, 0.5, params)
+
+	x, y := anim.sprite.getXY()
+	if x != 55 || y != 20 {
+		t.Fatalf("move position = (%v, %v), want (55, 20)", x, y)
+	}
+}
+
+func TestApplyTweenStepTurnUsesAbsoluteHeading(t *testing.T) {
+	anim := newTestAnimationComponent()
+	anim.sprite.spriteState.IsVisible = false
+	initTestMotionComponents(anim.sprite, 0, 0)
+	anim.sprite.components.transform.direction = 100
+
+	params := &tweenParams{
+		turnFrom: 10,
+		turnTo:   100,
+	}
+
+	anim.applyTweenStep(coreproject.AniTypeTurn, 0.5, params)
+
+	if heading := anim.sprite.Heading(); heading != 55 {
+		t.Fatalf("heading = %v, want 55", heading)
 	}
 }
 
@@ -325,6 +370,7 @@ func TestCleanupTweenStopsStaleOwnedPlayback(t *testing.T) {
 	currentTween := &animState{Name: StateGlide, AniType: coreproject.AniTypeGlide}
 	anim.curAnimState = playback
 	anim.curTweenState = currentTween
+	anim.activeTweenStates = []*animState{currentTween}
 
 	anim.cleanupTween(staleTween, playback, StateGlide, &coreproject.AniConfig{AniType: coreproject.AniTypeGlide})
 
@@ -333,6 +379,24 @@ func TestCleanupTweenStopsStaleOwnedPlayback(t *testing.T) {
 	}
 	if anim.sprite.costumeIndex != 0 {
 		t.Fatalf("costumeIndex = %d, want default costume 0", anim.sprite.costumeIndex)
+	}
+}
+
+func TestCleanupTweenRestoresPreviousActiveTweenState(t *testing.T) {
+	anim := newTestAnimationComponent()
+	first, _ := anim.initTweenState(StateGlide, &coreproject.AniConfig{
+		AniType:  coreproject.AniTypeGlide,
+		Duration: 1,
+	})
+	second, _ := anim.initTweenState(StateGlide, &coreproject.AniConfig{
+		AniType:  coreproject.AniTypeGlide,
+		Duration: 1,
+	})
+
+	anim.cleanupTween(second, nil, StateGlide, &coreproject.AniConfig{AniType: coreproject.AniTypeGlide})
+
+	if anim.curTweenState != first {
+		t.Fatal("cleanupTween did not restore the previous active tween state")
 	}
 }
 

--- a/component_animation_test.go
+++ b/component_animation_test.go
@@ -19,6 +19,7 @@ package spx
 import (
 	"testing"
 
+	"github.com/goplus/spbase/mathf"
 	internalaudio "github.com/goplus/spx/v2/internal/audio"
 	coreproject "github.com/goplus/spx/v2/internal/core/project"
 	"github.com/goplus/spx/v2/internal/engine"
@@ -57,6 +58,17 @@ func newTestAnimationComponent() *animationComponent {
 		pendingAudios: make([]string, 0),
 	}
 	return anim
+}
+
+func initTestMotionComponents(sprite *SpriteImpl, x, y float64) {
+	sprite.components.transform = &transformComponent{
+		componentBase: componentBase{sprite: sprite},
+		x:             x,
+		y:             y,
+	}
+	sprite.components.pen = &penComponent{
+		componentBase: componentBase{sprite: sprite},
+	}
 }
 
 type animationAudioBackend struct {
@@ -260,6 +272,64 @@ func TestCleanupTweenRestoresDefaultForOwnedPlayback(t *testing.T) {
 	}
 	if anim.curAnimState != nil {
 		t.Fatal("cleanupTween did not clear its own animation playback state")
+	}
+	if anim.sprite.costumeIndex != 0 {
+		t.Fatalf("costumeIndex = %d, want default costume 0", anim.sprite.costumeIndex)
+	}
+}
+
+func TestInitTweenStateDoesNotCancelPreviousTween(t *testing.T) {
+	anim := newTestAnimationComponent()
+	previous := &animState{Name: StateGlide, AniType: coreproject.AniTypeGlide}
+	anim.curTweenState = previous
+
+	next, _ := anim.initTweenState(StateGlide, &coreproject.AniConfig{
+		AniType:  coreproject.AniTypeGlide,
+		Duration: 1,
+	})
+
+	if previous.IsCanceled {
+		t.Fatal("initTweenState canceled the previous tween")
+	}
+	if anim.curTweenState != next {
+		t.Fatal("initTweenState did not track the new tween state")
+	}
+}
+
+func TestApplyTweenStepGlideUsesAbsolutePosition(t *testing.T) {
+	anim := newTestAnimationComponent()
+	anim.sprite.spriteState.IsVisible = false
+	initTestMotionComponents(anim.sprite, 100, 20)
+
+	params := &tweenParams{
+		moveFrom: mathf.NewVec2(10, 20),
+		moveDiff: mathf.NewVec2(90, 0),
+	}
+
+	anim.applyTweenStep(coreproject.AniTypeGlide, 0.5, 0.25, params)
+
+	x, y := anim.sprite.getXY()
+	if x != 55 || y != 20 {
+		t.Fatalf("glide position = (%v, %v), want (55, 20)", x, y)
+	}
+}
+
+func TestCleanupTweenStopsStaleOwnedPlayback(t *testing.T) {
+	anim := newTestAnimationComponent()
+	anim.sprite.costumes = []*costume{newCostumeWithSize(1, 1), newCostumeWithSize(1, 1)}
+	anim.sprite.spriteState.DefaultCostumeIndex = 0
+	anim.sprite.costumeIndex = 1
+
+	playback := &animState{Name: StateGlide}
+	staleTween := &animState{Name: StateGlide, AniType: coreproject.AniTypeGlide}
+	currentTween := &animState{Name: StateGlide, AniType: coreproject.AniTypeGlide}
+	anim.curAnimState = playback
+	anim.curTweenState = currentTween
+
+	anim.cleanupTween(staleTween, playback, StateGlide, &coreproject.AniConfig{AniType: coreproject.AniTypeGlide})
+
+	if anim.curAnimState != nil {
+		t.Fatal("cleanupTween did not clear the stale playback state")
 	}
 	if anim.sprite.costumeIndex != 0 {
 		t.Fatalf("costumeIndex = %d, want default costume 0", anim.sprite.costumeIndex)


### PR DESCRIPTION
## Summary

Align tween execution with real Scratch semantics so converted projects reach the intended target position and behave correctly when multiple script threads trigger motion at the same time.

## Background

Issue: https://github.com/goplus/sb2xbp/issues/338

In the reported demo, multiple `forever` threads could overlap and start new motion tweens while an earlier tween was still active. Our previous implementation mixed single-slot tween ownership with per-frame incremental updates, which diverged from Scratch and could lead to inconsistent motion completion and state cleanup.

## Changes

- switch tween interpolation to absolute target sampling instead of cumulative per-frame deltas
- keep concurrent tween threads alive instead of canceling the previous tween immediately
- track active tween states explicitly and restore the previous active tween on cleanup
- clean up stale tween-owned animation playback without clobbering replacement state
- apply the same absolute interpolation model to `glide`, non-physics `move`, and `turn`
- reuse existing `mathf` lerp helpers and add regression coverage for absolute interpolation and concurrent tween cleanup

## Verification

- `go test ./... -run 'Test(InitTweenStateDoesNotCancelPreviousTween|ApplyTweenStepGlideUsesAbsolutePosition|ApplyTweenStepMoveUsesAbsolutePosition|ApplyTweenStepTurnUsesAbsoluteHeading|CleanupTweenStopsStaleOwnedPlayback|CleanupTweenRestoresPreviousActiveTweenState|CleanupTweenRestoresDefaultForOwnedPlayback|CleanupTweenWithoutPlaybackKeepsActiveAnimation|CleanupTweenWithoutPlaybackRestoresDefaultWhenIdle|HandleAnimationLoopedRestartsOnPlaySoundForAnimationAndTweenStates)'`
