### PR TITLE
chore: unify component comment style

### DIFF
--- a/component.go
+++ b/component.go
@@ -19,25 +19,25 @@ package spx
 import coreproject "github.com/goplus/spx/v2/internal/core/project"
 
 // ============================================================================
-// Component System - Base Interfaces and Structures
+// Component System
 // ============================================================================
 // This file defines the component-based architecture for sprites.
 // Each component encapsulates a specific aspect of sprite functionality.
 
-// component is the base interface for all sprite components
+// component is the base interface for all sprite components.
 type component interface {
-	// initialize is called when the component is first created
-	// spriteCfg can be nil when cloning
+	// initialize is called when the component is first created.
+	// spriteCfg can be nil when cloning.
 	initialize(sprite *SpriteImpl, spriteCfg *coreproject.SpriteConfig)
 
-	// cloneFrom creates a new component instance by cloning from source
+	// cloneFrom creates a new component instance by cloning from source.
 	cloneFrom(src component, newSprite *SpriteImpl) component
 
-	// onDestroy is called when the sprite is being destroyed
+	// onDestroy is called when the sprite is being destroyed.
 	onDestroy()
 }
 
-// componentBase provides default implementations for component interface
+// componentBase provides default implementations for the component interface.
 type componentBase struct {
 	sprite *SpriteImpl
 }
@@ -50,7 +50,7 @@ func (c *componentBase) initialize(sprite *SpriteImpl, spriteCfg *coreproject.Sp
 // Component Registry
 // ============================================================================
 
-// spriteComponents holds all components attached to a sprite
+// spriteComponents holds all components attached to a sprite.
 type spriteComponents struct {
 	transform *transformComponent
 	animation *animationComponent
@@ -78,9 +78,9 @@ func (sc *spriteComponents) initComponents(sprite *SpriteImpl, spriteCfg *corepr
 	sc.sound.initialize(sprite, spriteCfg)
 }
 
-// cloneFrom creates new component instances by cloning from source components
-// This is used when cloning a sprite to ensure each sprite has independent components
-// Each component's cloneFrom method is responsible for its own cloning logic
+// cloneFrom creates new component instances by cloning from source components.
+// This is used when cloning a sprite to ensure each sprite has independent components.
+// Each component's cloneFrom method is responsible for its own cloning logic.
 func (sc *spriteComponents) cloneFrom(src *spriteComponents, newSprite *SpriteImpl) {
 	// Delegate cloning to each component
 	sc.transform = src.transform.cloneFrom(src.transform, newSprite).(*transformComponent)
@@ -92,7 +92,7 @@ func (sc *spriteComponents) cloneFrom(src *spriteComponents, newSprite *SpriteIm
 	sc.bubble = nil
 }
 
-// destroyComponents destroys all sprite components
+// destroyComponents destroys all sprite components.
 func (sc *spriteComponents) destroyComponents() {
 	if sc.transform != nil {
 		sc.transform.onDestroy()
@@ -114,32 +114,32 @@ func (sc *spriteComponents) destroyComponents() {
 	}
 }
 
-// Transform returns the transform component
+// Transform returns the transform component.
 func (sc *spriteComponents) Transform() *transformComponent {
 	return sc.transform
 }
 
-// Animation returns the animation component
+// Animation returns the animation component.
 func (sc *spriteComponents) Animation() *animationComponent {
 	return sc.animation
 }
 
-// Physics returns the physics component
+// Physics returns the physics component.
 func (sc *spriteComponents) Physics() *physicsComponent {
 	return sc.physics
 }
 
-// Pen returns the pen component
+// Pen returns the pen component.
 func (sc *spriteComponents) Pen() *penComponent {
 	return sc.pen
 }
 
-// Sound returns the sound component
+// Sound returns the sound component.
 func (sc *spriteComponents) Sound() *soundComponent {
 	return sc.sound
 }
 
-// Bubble returns the bubble component (lazy initialization)
+// Bubble returns the bubble component (lazy initialization).
 func (sc *spriteComponents) Bubble() *bubbleComponent {
 	if sc.bubble == nil {
 		sc.bubble = &bubbleComponent{}

--- a/component_animation.go
+++ b/component_animation.go
@@ -29,7 +29,12 @@ import (
 	"github.com/goplus/spx/v2/internal/tools"
 )
 
-// sharedAnimationData contains read-only animation data shared across cloned sprites (Flyweight Pattern).
+// ============================================================================
+// Animation Component
+// ============================================================================
+// This component manages sprite frame playback and tween-driven motion state.
+
+// sharedAnimationData stores read-only animation data shared across cloned sprites.
 type sharedAnimationData struct {
 	animations        map[SpriteAnimationName]*coreproject.AniConfig
 	animBindings      map[string]string
@@ -51,6 +56,10 @@ type animationComponent struct {
 	// Animation tracking (per-instance)
 	donedAnimations []string
 }
+
+// ============================================================================
+// Lifecycle
+// ============================================================================
 
 // initialize initializes the animation component from configuration.
 func (a *animationComponent) initialize(sprite *SpriteImpl, spriteCfg *coreproject.SpriteConfig) {
@@ -110,7 +119,7 @@ func (a *animationComponent) cloneFrom(src component, newSprite *SpriteImpl) com
 	return newAnim
 }
 
-// onDestroy cleanup when component is destroyed.
+// onDestroy cleans up when the component is destroyed.
 func (a *animationComponent) onDestroy() {
 	a.stopAnimState(a.curAnimState)
 	a.stopAnimState(a.curTweenState)
@@ -131,6 +140,10 @@ func (a *animationComponent) syncSpriteForPlayback() *engine.Sprite {
 	}
 	return a.sprite.runtimeState.SyncSprite
 }
+
+// ============================================================================
+// Playback
+// ============================================================================
 
 func (a *animationComponent) registerOnAnimationLooped(f func()) {
 	if syncSprite := a.syncSprite(); syncSprite != nil {
@@ -234,6 +247,10 @@ func (a *animationComponent) doAnimation(animName SpriteAnimationName, ani *core
 	}
 	return info
 }
+
+// ============================================================================
+// Animation State
+// ============================================================================
 
 func (a *animationComponent) playDefaultAnim() {
 	animName := ""
@@ -393,6 +410,10 @@ type tweenParams struct {
 	moveDir   mathf.Vec2
 	turnDiff  float64
 }
+
+// ============================================================================
+// Tween Execution
+// ============================================================================
 
 func (a *animationComponent) doTween(name SpriteAnimationName, ani *coreproject.AniConfig) {
 	info, ownedPlayback := a.initTweenState(name, ani)

--- a/component_animation_audio.go
+++ b/component_animation_audio.go
@@ -21,6 +21,15 @@ import (
 	"github.com/goplus/spx/v2/internal/engine"
 )
 
+// ============================================================================
+// Animation Audio
+// ============================================================================
+// This file manages animation-bound audio playback and replay state.
+
+// ============================================================================
+// Audio Playback
+// ============================================================================
+
 func (a *animationComponent) playAnimationAudio(ani *coreproject.AniConfig, state *animState) {
 	a.playOnStartAudio(ani.OnStart, state)
 	a.playOnPlayAudio(ani.OnPlay, state)
@@ -108,6 +117,10 @@ func (a *animationComponent) markOnPlayAudioRestartPending(state *animState) {
 	}
 	state.OnPlayAudioRestartPending = true
 }
+
+// ============================================================================
+// Pending Replay State
+// ============================================================================
 
 func (a *animationComponent) takePendingOnPlayAudioStates(buffer []*animState) []*animState {
 	buffer = a.takePendingOnPlayAudioState(buffer[:0], a.curAnimState)

--- a/component_bubble.go
+++ b/component_bubble.go
@@ -26,7 +26,7 @@ import (
 // ============================================================================
 // Bubble Component
 // ============================================================================
-// This component manages Say/Think and Quote bubbles for sprites
+// This component manages Say/Think and Quote bubbles for sprites.
 
 type bubbleComponent struct {
 	componentBase
@@ -39,6 +39,10 @@ type bubbleComponent struct {
 type bubbleShape interface {
 	destroyPanel()
 }
+
+// ============================================================================
+// Lifecycle
+// ============================================================================
 
 // initialize initializes the bubble component.
 func (b *bubbleComponent) initialize(sprite *SpriteImpl, spriteCfg *coreproject.SpriteConfig) {
@@ -59,10 +63,14 @@ func (b *bubbleComponent) cloneFrom(src component, newSprite *SpriteImpl) compon
 	return newBubble
 }
 
-// onDestroy cleanup when component is destroyed.
+// onDestroy cleans up when the component is destroyed.
 func (b *bubbleComponent) onDestroy() {
 	b.stopAll()
 }
+
+// ============================================================================
+// Bubble Control
+// ============================================================================
 
 func (b *bubbleComponent) upsertText(msg string, style int) {
 	b.mu.Lock()
@@ -144,6 +152,10 @@ func (b *bubbleComponent) stopAll() {
 	b.stopText()
 	b.stopQuote()
 }
+
+// ============================================================================
+// Internal Bubble Management
+// ============================================================================
 
 func (b *bubbleComponent) stopBubble(obj bubbleShape) {
 	obj.destroyPanel()

--- a/component_pen.go
+++ b/component_pen.go
@@ -27,7 +27,7 @@ import (
 // ============================================================================
 // Pen Component
 // ============================================================================
-// This component encapsulates all pen drawing functionality
+// This component encapsulates all pen drawing functionality.
 
 type penComponent struct {
 	componentBase
@@ -44,6 +44,10 @@ type penComponent struct {
 	penDown bool
 	penObj  *engine.Object
 }
+
+// ============================================================================
+// Lifecycle
+// ============================================================================
 
 // initialize initializes the pen component from config.
 func (p *penComponent) initialize(sprite *SpriteImpl, spriteCfg *coreproject.SpriteConfig) {
@@ -75,7 +79,7 @@ func (p *penComponent) cloneFrom(src component, newSprite *SpriteImpl) component
 	}
 }
 
-// OnDestroy cleanup when component is destroyed
+// onDestroy cleans up when the component is destroyed.
 func (p *penComponent) onDestroy() {
 	p.destroyPen()
 }

--- a/component_physics.go
+++ b/component_physics.go
@@ -27,6 +27,11 @@ import (
 	spxlog "github.com/goplus/spx/v2/internal/log"
 )
 
+// ============================================================================
+// Physics Component
+// ============================================================================
+// This component manages sprite physics state, collision, and trigger shapes.
+
 func parseLayerMaskValue(pval *int64) int64 {
 	return defaults.OrDefault(pval, 1)
 }
@@ -46,6 +51,10 @@ type physicsComponent struct {
 
 	collisionTargets map[string]bool
 }
+
+// ============================================================================
+// Lifecycle
+// ============================================================================
 
 // initialize initializes the physics component from config.
 func (p *physicsComponent) initialize(sprite *SpriteImpl, spriteCfg *coreproject.SpriteConfig) {
@@ -114,10 +123,14 @@ func (p *physicsComponent) cloneFrom(src component, newSprite *SpriteImpl) compo
 	return newPhys
 }
 
-// onDestroy cleanup when component is destroyed.
+// onDestroy cleans up when the component is destroyed.
 func (p *physicsComponent) onDestroy() {
 	// Nothing to cleanup.
 }
+
+// ============================================================================
+// Physics Control
+// ============================================================================
 
 // SetPhysicsMode sets the physics mode for the sprite.
 func (p *physicsComponent) SetPhysicsMode(mode PhysicsMode) {
@@ -223,6 +236,10 @@ func (p *physicsComponent) addCollisionTarget(target string) {
 	}
 }
 
+// ============================================================================
+// Collider Configuration
+// ============================================================================
+
 // SetColliderShape sets the collider shape type and parameters.
 func (p *physicsComponent) SetColliderShape(isTrigger bool, ctype ColliderShapeType, params []float64) error {
 	config := p.getPhysicConfig(isTrigger)
@@ -307,6 +324,10 @@ func (p *physicsComponent) applyPhysicShape(isTrigger bool) {
 		}
 	}
 }
+
+// ============================================================================
+// Proxy Sync
+// ============================================================================
 
 // initCollisionParams initializes collision parameters based on game settings.
 func (p *physicsComponent) initCollisionParams() {

--- a/component_sound.go
+++ b/component_sound.go
@@ -36,6 +36,10 @@ type soundComponent struct {
 	pendingAudios []string
 }
 
+// ============================================================================
+// Lifecycle
+// ============================================================================
+
 // initialize initializes the sound component from config.
 func (s *soundComponent) initialize(sprite *SpriteImpl, spriteCfg *coreproject.SpriteConfig) {
 	s.componentBase.initialize(sprite, spriteCfg)
@@ -54,7 +58,7 @@ func (s *soundComponent) cloneFrom(src component, newSprite *SpriteImpl) compone
 	}
 }
 
-// OnDestroy cleanup when component is destroyed.
+// onDestroy cleans up when the component is destroyed.
 func (s *soundComponent) onDestroy() {
 	if s.soundObj != 0 {
 		s.sprite.g.soundMgr.ReleaseSound(s.soundObj)

--- a/component_transform.go
+++ b/component_transform.go
@@ -25,6 +25,11 @@ import (
 	engine "github.com/goplus/spx/v2/pkg/spx/pkg/engine"
 )
 
+// ============================================================================
+// Transform Component
+// ============================================================================
+// This component manages sprite position, rotation, and scale state.
+
 const (
 	// minSpeed is the minimum allowed speed value to prevent division by zero.
 	minSpeed = 0.001
@@ -38,6 +43,10 @@ const (
 	// halfCircleDegrees represents half a rotation in degrees.
 	halfCircleDegrees = 180.0
 )
+
+// ============================================================================
+// Transform Helpers
+// ============================================================================
 
 func toRotationStyle(style string) RotationStyle {
 	switch style {
@@ -87,6 +96,10 @@ type transformComponent struct {
 	isDirty bool
 }
 
+// ============================================================================
+// Lifecycle
+// ============================================================================
+
 // initialize initializes the transform component from configuration.
 func (t *transformComponent) initialize(sprite *SpriteImpl, spriteCfg *coreproject.SpriteConfig) {
 	t.componentBase.initialize(sprite, spriteCfg)
@@ -128,6 +141,10 @@ func (t *transformComponent) markDirty() {
 func (t *transformComponent) getPivot() mathf.Vec2 {
 	return t.pivot
 }
+
+// ============================================================================
+// Position and Movement
+// ============================================================================
 
 // MoveForward moves the sprite forward by the specified step size
 // in the direction it's currently facing.
@@ -317,6 +334,10 @@ func (t *transformComponent) fixWorldRange(x, y float64) (float64, float64) {
 	return x, y
 }
 
+// ============================================================================
+// Rotation
+// ============================================================================
+
 // Heading returns the current direction the sprite is facing.
 func (t *transformComponent) Heading() Direction {
 	return t.direction
@@ -397,6 +418,10 @@ func (t *transformComponent) BounceOffEdge(area string) {
 	t.direction = normalizeDirection(newDirection)
 }
 
+// ============================================================================
+// Rotation Helpers
+// ============================================================================
+
 // applyDirection sets the sprite's direction to the normalized value.
 // Returns true if the direction was actually changed.
 func (t *transformComponent) applyDirection(dir float64) bool {
@@ -468,6 +493,10 @@ func (t *transformComponent) calculateBounceDirection(edge int, dx, dy float64) 
 	}
 	return dx, dy
 }
+
+// ============================================================================
+// Tween Helpers
+// ============================================================================
 
 // doTurnAnimation handles turn animation with fallback to direct heading change.
 // This helper eliminates code duplication between Turn and TurnTo methods.


### PR DESCRIPTION
## Summary

Unify comment structure and section headings across component files.

## Background

Several component files used slightly different comment styles, section layouts, and lifecycle wording. This change makes the component layer easier to scan and keeps comment structure consistent across files.

## Changes

- align component file headers and section dividers
- normalize lifecycle-related comments such as `onDestroy`
- add or adjust section headings for component-specific areas
- keep the change limited to comments and organization only

## Verification

- no logic changes
- no tests run
