### PR TITLE
fix: skip fully ghosted sprites in click selection

### DIFF
--- a/runtime_events.go
+++ b/runtime_events.go
@@ -199,20 +199,30 @@ type clicker interface {
 	Visible() bool
 }
 
+func (p *Game) pointHitsClickTarget(target clicker, point mathf.Vec2) bool {
+	syncSprite := target.getProxy()
+	if syncSprite == nil || !target.Visible() {
+		return false
+	}
+
+	sprite, ok := target.(*SpriteImpl)
+	if ok {
+		sprite.ensureProxyQueryStateSynced()
+		if sprite.isFullyGhosted() {
+			return false
+		}
+	}
+
+	return p.engine().SpriteMgr.CheckCollisionWithPoint(syncSprite.GetId(), point, true)
+}
+
 func (p *Game) findClickTarget(point mathf.Vec2) (coreruntime.ClickSelection[clicker, *SpriteImpl], bool) {
 	return coreruntime.FindClickTarget(p.getTempShapes(), func(item Shape) (coreruntime.ClickSelection[clicker, *SpriteImpl], bool) {
 		o, ok := item.(clicker)
 		if !ok {
 			return coreruntime.ClickSelection[clicker, *SpriteImpl]{}, false
 		}
-		syncSprite := o.getProxy()
-		if syncSprite == nil || !o.Visible() {
-			return coreruntime.ClickSelection[clicker, *SpriteImpl]{}, false
-		}
-		if sprite, ok := o.(*SpriteImpl); ok && sprite.isFullyGhosted() {
-			return coreruntime.ClickSelection[clicker, *SpriteImpl]{}, false
-		}
-		if !p.engine().SpriteMgr.CheckCollisionWithPoint(syncSprite.GetId(), point, true) {
+		if !p.pointHitsClickTarget(o, point) {
 			return coreruntime.ClickSelection[clicker, *SpriteImpl]{}, false
 		}
 		if sprite, ok := o.(*SpriteImpl); ok {

--- a/runtime_events_test.go
+++ b/runtime_events_test.go
@@ -55,7 +55,7 @@ func (s *clickThroughSpriteMgr) CheckCollisionWithPoint(obj pkgengine.Object, po
 	return s.hits[obj]
 }
 
-func setupClickThroughSpriteMgr(t *testing.T, hits map[pkgengine.Object]bool) {
+func setupClickThroughSpriteMgr(t *testing.T, hits map[pkgengine.Object]bool) *clickThroughSpriteMgr {
 	t.Helper()
 
 	enginewrap.Init(func(call func()) {
@@ -63,10 +63,14 @@ func setupClickThroughSpriteMgr(t *testing.T, hits map[pkgengine.Object]bool) {
 	})
 
 	original := pkgengine.SpriteMgr
-	pkgengine.SpriteMgr = &clickThroughSpriteMgr{hits: hits}
+	mgr := &clickThroughSpriteMgr{
+		hits: hits,
+	}
+	pkgengine.SpriteMgr = mgr
 	t.Cleanup(func() {
 		pkgengine.SpriteMgr = original
 	})
+	return mgr
 }
 
 func newClickTestSprite(g *Game, name string, id pkgengine.Object, registerClick bool) *SpriteImpl {


### PR DESCRIPTION
## Summary
- centralize click target point-hit checks in `pointHitsClickTarget`
- skip fully ghosted sprites before selecting click targets
- add test helper cleanup and keep click-target selection tests covering topmost and fully ghosted cases

## Background
Even with the renderer-side point-hit fix, SPX still needed to avoid selecting sprites that are fully ghosted. This keeps click target resolution aligned with Scratch behavior when overlapping sprites are involved.