### PR TITLE
feat: support fullwidth Latin characters in Scratch SVG text

### DIFF
--- a/internal/core/project/display.go
+++ b/internal/core/project/display.go
@@ -40,6 +40,7 @@ type SVGFontFaceRegistration struct {
 
 var scratchSVGFontRegistrations = []SVGFontFaceRegistration{
 	{Path: "res://engine/fonts/scratch/NotoSans-Medium.ttf", Family: "Sans Serif"},
+	{Path: defaultDisplayFontPath, Family: "Sans Serif"},
 	{Path: "res://engine/fonts/scratch/SourceSerifPro-Regular.otf", Family: "Serif"},
 	{Path: "res://engine/fonts/scratch/handlee-regular.ttf", Family: "Handwriting"},
 	{Path: "res://engine/fonts/scratch/Knewave.ttf", Family: "Marker"},

--- a/internal/core/project/project_test.go
+++ b/internal/core/project/project_test.go
@@ -242,6 +242,15 @@ func TestResolveDisplaySettings(t *testing.T) {
 	}) {
 		t.Fatalf("first font registration = %+v", got)
 	}
+	if len(settings.SVGFontFaceRegistrations) < 2 {
+		t.Fatalf("expected Sans Serif fallback registration: %+v", settings.SVGFontFaceRegistrations)
+	}
+	if got := settings.SVGFontFaceRegistrations[1]; got != (SVGFontFaceRegistration{
+		Path:   defaultDisplayFontPath,
+		Family: "Sans Serif",
+	}) {
+		t.Fatalf("second font registration = %+v", got)
+	}
 
 	settings = ResolveDisplaySettings(&ProjectConfig{})
 	if settings.WindowScale != 1 || !settings.StretchMode || settings.Debug {


### PR DESCRIPTION
## Summary

Add a fallback font for Scratch SVG `Sans Serif` text to support fullwidth Latin characters.

## Changes

- register `CnFont.ttf` as a secondary `Sans Serif` SVG font face after `NotoSans-Medium.ttf`
- add test coverage for the fallback registration order in `internal/core/project/project_test.go`

## Why

Some Scratch projects use fullwidth Latin characters in SVG `<text>` nodes, for example `ｗｅｌｃｏｍｅ`.

Our current Scratch `Sans Serif` mapping uses `NotoSans-Medium.ttf`, which does not cover these glyphs in the current runtime path. This can cause missing text or tofu boxes.

Adding a fallback font allows these characters to render instead of falling back to missing-glyph boxes.

## Testing

- `go test ./internal/core/project`