### PR TITLE
fix: split mouse sensing from click hit testing

### DIFF
--- a/internal/enginewrap/sync.gen.go
+++ b/internal/enginewrap/sync.gen.go
@@ -1025,10 +1025,10 @@ func (*spriteMgrImpl) CheckCollision(obj gdx.Object, target gdx.Object, is_src_t
 	})
 	return _ret1
 }
-func (*spriteMgrImpl) CheckCollisionWithPoint(obj gdx.Object, point Vec2, is_trigger bool) bool {
+func (*spriteMgrImpl) CheckCollisionWithPoint(obj gdx.Object, point Vec2, is_click_query bool) bool {
 	var _ret1 bool
 	callInMainThread(func() {
-		_ret1 = gdx.SpriteMgr.CheckCollisionWithPoint(obj, point, is_trigger)
+		_ret1 = gdx.SpriteMgr.CheckCollisionWithPoint(obj, point, is_click_query)
 	})
 	return _ret1
 }

--- a/internal/enginewrap/sync_pure.gen.go
+++ b/internal/enginewrap/sync_pure.gen.go
@@ -452,7 +452,7 @@ func (*spriteMgrImpl) GetChildScale(obj gdx.Object, path string) Vec2 {
 func (*spriteMgrImpl) CheckCollision(obj gdx.Object, target gdx.Object, is_src_trigger bool, is_dst_trigger bool) bool {
 	return false
 }
-func (*spriteMgrImpl) CheckCollisionWithPoint(obj gdx.Object, point Vec2, is_trigger bool) bool {
+func (*spriteMgrImpl) CheckCollisionWithPoint(obj gdx.Object, point Vec2, is_click_query bool) bool {
 	return false
 }
 func (*spriteMgrImpl) SetDebugCollisionVisible(obj gdx.Object, visible bool) {}

--- a/internal/gdengine/binding/native/ffi_wrapper.gen.go
+++ b/internal/gdengine/binding/native/ffi_wrapper.gen.go
@@ -1864,12 +1864,12 @@ func CallSpriteCheckCollision(
 func CallSpriteCheckCollisionWithPoint(
 	obj GdObj,
 	point GdVec2,
-	is_trigger GdBool,
+	is_click_query GdBool,
 ) GdBool {
 	arg0 := (C.GDExtensionSpxSpriteCheckCollisionWithPoint)(api.SpxSpriteCheckCollisionWithPoint)
 	arg1 := (C.GdObj)(obj)
 	arg2 := (C.GdVec2)(point)
-	arg3 := (C.GdBool)(is_trigger)
+	arg3 := (C.GdBool)(is_click_query)
 	var ret_val C.GdBool
 	C.cgo_callfn_GDExtensionSpxSpriteCheckCollisionWithPoint(arg0, arg1, arg2, arg3, &ret_val)
 

--- a/internal/gdengine/binding/native/ffi_wrapper.gen.h
+++ b/internal/gdengine/binding/native/ffi_wrapper.gen.h
@@ -876,11 +876,11 @@ void cgo_callfn_GDExtensionSpxSpriteCheckCollision(const GDExtensionSpxSpriteChe
 	}
 	fn(obj, target, is_src_trigger, is_dst_trigger, ret_val);
 }
-void cgo_callfn_GDExtensionSpxSpriteCheckCollisionWithPoint(const GDExtensionSpxSpriteCheckCollisionWithPoint fn, GdObj obj, GdVec2 point, GdBool is_trigger, GdBool* ret_val) {
+void cgo_callfn_GDExtensionSpxSpriteCheckCollisionWithPoint(const GDExtensionSpxSpriteCheckCollisionWithPoint fn, GdObj obj, GdVec2 point, GdBool is_click_query, GdBool* ret_val) {
 	if (!fn) {
 		return;
 	}
-	fn(obj, point, is_trigger, ret_val);
+	fn(obj, point, is_click_query, ret_val);
 }
 void cgo_callfn_GDExtensionSpxSpriteSetDebugCollisionVisible(const GDExtensionSpxSpriteSetDebugCollisionVisible fn, GdObj obj, GdBool visible) {
 	if (!fn) {

--- a/internal/gdengine/binding/native/gdextension_spx_ext.h
+++ b/internal/gdengine/binding/native/gdextension_spx_ext.h
@@ -372,7 +372,7 @@ typedef void (*GDExtensionSpxSpriteGetChildRotation)(GdObj obj, GdString path, G
 typedef void (*GDExtensionSpxSpriteSetChildScale)(GdObj obj, GdString path, GdVec2 scale);
 typedef void (*GDExtensionSpxSpriteGetChildScale)(GdObj obj, GdString path, GdVec2 *ret_value);
 typedef void (*GDExtensionSpxSpriteCheckCollision)(GdObj obj, GdObj target, GdBool is_src_trigger, GdBool is_dst_trigger, GdBool *ret_value);
-typedef void (*GDExtensionSpxSpriteCheckCollisionWithPoint)(GdObj obj, GdVec2 point, GdBool is_trigger, GdBool *ret_value);
+typedef void (*GDExtensionSpxSpriteCheckCollisionWithPoint)(GdObj obj, GdVec2 point, GdBool is_click_query, GdBool *ret_value);
 typedef void (*GDExtensionSpxSpriteSetDebugCollisionVisible)(GdObj obj, GdBool visible);
 typedef void (*GDExtensionSpxSpriteIsDebugCollisionVisible)(GdObj obj, GdBool *ret_value);
 typedef void (*GDExtensionSpxSpriteCreateBackdrop)(GdString path, GdObj *ret_value);

--- a/internal/gdengine/impl/manager_native.gen.go
+++ b/internal/gdengine/impl/manager_native.gen.go
@@ -964,10 +964,10 @@ func (pself *spriteMgr) CheckCollision(obj Object, target Object, is_src_trigger
 	retValue := CallSpriteCheckCollision(arg0, arg1, arg2, arg3)
 	return ToBool(retValue)
 }
-func (pself *spriteMgr) CheckCollisionWithPoint(obj Object, point Vec2, is_trigger bool) bool {
+func (pself *spriteMgr) CheckCollisionWithPoint(obj Object, point Vec2, is_click_query bool) bool {
 	arg0 := ToGdObj(obj)
 	arg1 := ToGdVec2(point)
-	arg2 := ToGdBool(is_trigger)
+	arg2 := ToGdBool(is_click_query)
 	retValue := CallSpriteCheckCollisionWithPoint(arg0, arg1, arg2)
 	return ToBool(retValue)
 }

--- a/internal/gdengine/impl/manager_web.gen.go
+++ b/internal/gdengine/impl/manager_web.gen.go
@@ -886,10 +886,10 @@ func (pself *spriteMgr) CheckCollision(obj Object, target Object, is_src_trigger
 	_retValue := API.SpxSpriteCheckCollision.Invoke(arg0Low, arg0High, arg1Low, arg1High, arg2, arg3)
 	return JsToGdBool(_retValue)
 }
-func (pself *spriteMgr) CheckCollisionWithPoint(obj Object, point Vec2, is_trigger bool) bool {
+func (pself *spriteMgr) CheckCollisionWithPoint(obj Object, point Vec2, is_click_query bool) bool {
 	arg0Low, arg0High := JsSplitGdObj(obj)
 	arg1 := JsFromGdVec2(point)
-	arg2 := JsFromGdBool(is_trigger)
+	arg2 := JsFromGdBool(is_click_query)
 	_retValue := API.SpxSpriteCheckCollisionWithPoint.Invoke(arg0Low, arg0High, arg1, arg2)
 	return JsToGdBool(_retValue)
 }

--- a/pkg/spx/pkg/engine/interface.gen.go
+++ b/pkg/spx/pkg/engine/interface.gen.go
@@ -226,7 +226,7 @@ type ISpriteMgr interface {
 	SetChildScale(obj Object, path string, scale Vec2)
 	GetChildScale(obj Object, path string) Vec2
 	CheckCollision(obj Object, target Object, is_src_trigger bool, is_dst_trigger bool) bool
-	CheckCollisionWithPoint(obj Object, point Vec2, is_trigger bool) bool
+	CheckCollisionWithPoint(obj Object, point Vec2, is_click_query bool) bool
 	SetDebugCollisionVisible(obj Object, visible bool)
 	IsDebugCollisionVisible(obj Object) bool
 	CreateBackdrop(path string) Object

--- a/pkg/spx/pkg/engine/sprite.gen.go
+++ b/pkg/spx/pkg/engine/sprite.gen.go
@@ -74,8 +74,8 @@ func (pself *Sprite) CheckCollisionByColors(sprite_color Color, target_color Col
 	return SpriteMgr.CheckCollisionByColors(pself.Id, sprite_color, target_color, color_threshold, alpha_threshold)
 }
 
-func (pself *Sprite) CheckCollisionWithPoint(point Vec2, is_trigger bool) bool {
-	return SpriteMgr.CheckCollisionWithPoint(pself.Id, point, is_trigger)
+func (pself *Sprite) CheckCollisionWithPoint(point Vec2, is_click_query bool) bool {
+	return SpriteMgr.CheckCollisionWithPoint(pself.Id, point, is_click_query)
 }
 
 func (pself *Sprite) CheckCollisionWithSprite(obj_b Object, alpha_threshold float64, use_pixel_perfect bool) bool {

--- a/pkg/spx/pkg/engine/sprite_pure.gen.go
+++ b/pkg/spx/pkg/engine/sprite_pure.gen.go
@@ -69,7 +69,7 @@ func (pself *Sprite) CheckCollisionByColors(sprite_color Color, target_color Col
 	return false
 }
 
-func (pself *Sprite) CheckCollisionWithPoint(point Vec2, is_trigger bool) bool {
+func (pself *Sprite) CheckCollisionWithPoint(point Vec2, is_click_query bool) bool {
 	return false
 }
 

--- a/runtime_events_test.go
+++ b/runtime_events_test.go
@@ -48,10 +48,14 @@ func TestGameRunBootstrapTasksExecutesQueuedHooksOnce(t *testing.T) {
 
 type clickThroughSpriteMgr struct {
 	enginewrap.SpriteMgrImpl
-	hits map[pkgengine.Object]bool
+	hits          map[pkgengine.Object]bool
+	lastIsTrigger map[pkgengine.Object]bool
 }
 
 func (s *clickThroughSpriteMgr) CheckCollisionWithPoint(obj pkgengine.Object, point mathf.Vec2, isTrigger bool) bool {
+	if s.lastIsTrigger != nil {
+		s.lastIsTrigger[obj] = isTrigger
+	}
 	return s.hits[obj]
 }
 
@@ -64,7 +68,8 @@ func setupClickThroughSpriteMgr(t *testing.T, hits map[pkgengine.Object]bool) *c
 
 	original := pkgengine.SpriteMgr
 	mgr := &clickThroughSpriteMgr{
-		hits: hits,
+		hits:          hits,
+		lastIsTrigger: make(map[pkgengine.Object]bool),
 	}
 	pkgengine.SpriteMgr = mgr
 	t.Cleanup(func() {
@@ -163,5 +168,38 @@ func TestFindClickTargetSkipsFullyGhostedSpriteEvenWithClickHandler(t *testing.T
 	}
 	if selection.SwipeTarget != bottom {
 		t.Fatalf("swipe target = %p, want bottom %p", selection.SwipeTarget, bottom)
+	}
+}
+
+func TestTouchPointUsesScratchSensingQuery(t *testing.T) {
+	mgr := setupClickThroughSpriteMgr(t, map[pkgengine.Object]bool{
+		1: true,
+	})
+
+	var g Game
+	sprite := newClickTestSprite(&g, "probe", 1, false)
+	sprite.spriteState.IsVisible = false
+
+	if !sprite.touchPoint(12, 34) {
+		t.Fatal("expected touchPoint hit")
+	}
+	if got := mgr.lastIsTrigger[1]; got {
+		t.Fatalf("touchPoint used click query, want sensing query")
+	}
+}
+
+func TestPointHitsClickTargetUsesClickQuery(t *testing.T) {
+	mgr := setupClickThroughSpriteMgr(t, map[pkgengine.Object]bool{
+		1: true,
+	})
+
+	var g Game
+	sprite := newClickTestSprite(&g, "button", 1, true)
+
+	if !g.pointHitsClickTarget(sprite, mathf.NewVec2(0, 0)) {
+		t.Fatal("expected click hit")
+	}
+	if got := mgr.lastIsTrigger[1]; !got {
+		t.Fatalf("pointHitsClickTarget used sensing query, want click query")
 	}
 }

--- a/runtime_sync.go
+++ b/runtime_sync.go
@@ -225,9 +225,8 @@ func (p *SpriteImpl) ensureProxyQueryStateSynced() {
 	if p.isDestroyed() || p.runtimeState.SyncSprite == nil {
 		return
 	}
-	if p.spriteState.IsVisible {
-		p.baseObj.applyCostumeUpdate()
-	}
+	// Query paths need the latest silhouette even when the sprite is hidden.
+	p.baseObj.applyCostumeUpdate()
 	if !p.spriteState.IsDirty {
 		return
 	}

--- a/sprite_query.go
+++ b/sprite_query.go
@@ -114,7 +114,9 @@ func (p *SpriteImpl) touchPoint(x, y float64) bool {
 	if !p.prepareSelfCollisionQuery() {
 		return false
 	}
-	return p.engine().SpriteMgr.CheckCollisionWithPoint(p.runtimeState.SyncSprite.GetId(), mathf.NewVec2(x, y), true)
+	// Scratch's sensing path ignores visible/ghost when checking whether a sprite
+	// is touching the mouse, so use the sensing branch in the engine query.
+	return p.engine().SpriteMgr.CheckCollisionWithPoint(p.runtimeState.SyncSprite.GetId(), mathf.NewVec2(x, y), false)
 }
 
 func (p *SpriteImpl) touchingColor(color mathf.Color) bool {


### PR DESCRIPTION
## Summary

Route `touching(mouse)` through a Scratch-style sensing query instead of the click hit-testing path.

This keeps click-through behavior for `GhostEffect = 100` while allowing hidden sprites to continue sensing the mouse.

## Why

We had two expected Scratch-compatible behaviors:

- hidden sprites can still return true for `touching(mouse)`
- fully ghosted front sprites should not intercept clicks

The engine now distinguishes these two query types. This PR updates SPX to use that split correctly.

## Changes

- change `touchPoint` to call point collision in sensing mode
- always sync costume/query silhouette before point queries, even when the sprite is hidden
- add tests to lock in:
- `touching(mouse)` uses the sensing query path
- click hit testing continues to use the click query path

## Validation

- `go test ./...`

## Dependency

Depends on the paired Godot change which implements the sensing-vs-click point-query split in the engine.