### PR TITLE
fix: log objectPos lookup failures instead of panicking

### DIFF
--- a/game_stage.go
+++ b/game_stage.go
@@ -311,7 +311,8 @@ func (p *Game) objectPos(obj Target) (float64, float64) {
 		if sp := p.shapeMgr.findSprite(v); sp != nil {
 			return sp.getXY()
 		}
-		engine.Panic("objectPos: sprite not found - " + v)
+		spxlog.Error("objectPos: sprite not found - %s", v)
+		return 0, 0
 	case specialObj:
 		if v == Mouse {
 			return p.getMousePos()
@@ -325,7 +326,7 @@ func (p *Game) objectPos(obj Target) (float64, float64) {
 	case Sprite:
 		return spriteOf(v).getXY()
 	}
-	engine.Panic("objectPos: unexpected input")
+	spxlog.Error("objectPos: unexpected input: %T", obj)
 	return 0, 0
 }
 


### PR DESCRIPTION
## Summary

This change updates `objectPos` to log errors instead of triggering a runtime panic when the target sprite cannot be resolved.

## Changes

- replace `engine.Panic` with `spxlog.Error` in `objectPos`
- return `(0, 0)` when a sprite name is missing
- log the concrete input type for unexpected `objectPos` inputs

## Why

Some invalid sprite references should surface as errors in logs without crashing the runtime immediately. This keeps the failure visible while avoiding a hard stop.

## Testing

- go test ./internal/engine ./...