### PR TITLE
fix: parse compound-sign numeric strings

### DIFF
--- a/list.go
+++ b/list.go
@@ -57,16 +57,13 @@ func fromObj(v obj) any {
 	return v
 }
 
-func parseNumericString(s string) (float64, bool) {
+func normalizeNumericStringSigns(s string) (string, bool) {
 	s = strings.TrimSpace(s)
 	if s == "" {
-		return 0, false
-	}
-	if f, err := strconv.ParseFloat(s, 64); err == nil {
-		return f, true
+		return "", false
 	}
 
-	sign := 1.0
+	sign := 1
 	i := 0
 	for i < len(s) {
 		switch s[i] {
@@ -76,19 +73,55 @@ func parseNumericString(s string) (float64, bool) {
 			sign = -sign
 			i++
 		default:
-			goto parseRest
+			goto normalizeRest
 		}
 	}
 
-parseRest:
-	if i == 0 || i == len(s) {
+normalizeRest:
+	if i == len(s) {
+		return "", false
+	}
+	if i == 0 {
+		return s, true
+	}
+	if sign < 0 {
+		return "-" + s[i:], true
+	}
+	return s[i:], true
+}
+
+func parseFloatString(s string) (float64, bool) {
+	normalized, ok := normalizeNumericStringSigns(s)
+	if !ok {
 		return 0, false
 	}
-	f, err := strconv.ParseFloat(s[i:], 64)
+	f, err := strconv.ParseFloat(normalized, 64)
 	if err != nil {
 		return 0, false
 	}
-	return sign * f, true
+	return f, true
+}
+
+func parseIntString(s string) (int, bool) {
+	normalized, ok := normalizeNumericStringSigns(s)
+	if !ok {
+		return 0, false
+	}
+	if i, err := strconv.Atoi(normalized); err == nil {
+		return i, true
+	}
+
+	const maxInt = int(^uint(0) >> 1)
+	const minInt = -maxInt - 1
+
+	f, err := strconv.ParseFloat(normalized, 64)
+	if err != nil {
+		return 0, false
+	}
+	if f > float64(maxInt) || f < float64(minInt) {
+		return 0, false
+	}
+	return int(f), true
 }
 
 func toIntAny(v any) (int, bool) {
@@ -148,14 +181,8 @@ func toIntAny(v any) (int, bool) {
 		}
 		return 0, true
 	case string:
-		if i, err := strconv.Atoi(x); err == nil {
+		if i, ok := parseIntString(x); ok {
 			return i, true
-		}
-		if f, ok := parseNumericString(x); ok {
-			if f > float64(maxInt) || f < float64(minInt) {
-				return 0, false
-			}
-			return int(f), true
 		}
 	}
 	return 0, false
@@ -197,7 +224,7 @@ func toFloat64Any(v any) (float64, bool) {
 		}
 		return 0, true
 	case string:
-		if f, ok := parseNumericString(x); ok {
+		if f, ok := parseFloatString(x); ok {
 			return f, true
 		}
 	}

--- a/list.go
+++ b/list.go
@@ -148,6 +148,9 @@ func toIntAny(v any) (int, bool) {
 		}
 		return 0, true
 	case string:
+		if i, err := strconv.Atoi(x); err == nil {
+			return i, true
+		}
 		if f, ok := parseNumericString(x); ok {
 			if f > float64(maxInt) || f < float64(minInt) {
 				return 0, false

--- a/list.go
+++ b/list.go
@@ -57,6 +57,40 @@ func fromObj(v obj) any {
 	return v
 }
 
+func parseNumericString(s string) (float64, bool) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, false
+	}
+	if f, err := strconv.ParseFloat(s, 64); err == nil {
+		return f, true
+	}
+
+	sign := 1.0
+	i := 0
+	for i < len(s) {
+		switch s[i] {
+		case '+':
+			i++
+		case '-':
+			sign = -sign
+			i++
+		default:
+			goto parseRest
+		}
+	}
+
+parseRest:
+	if i == 0 || i == len(s) {
+		return 0, false
+	}
+	f, err := strconv.ParseFloat(s[i:], 64)
+	if err != nil {
+		return 0, false
+	}
+	return sign * f, true
+}
+
 func toIntAny(v any) (int, bool) {
 	if v == nil {
 		return 0, true
@@ -114,10 +148,7 @@ func toIntAny(v any) (int, bool) {
 		}
 		return 0, true
 	case string:
-		if i, err := strconv.Atoi(x); err == nil {
-			return i, true
-		}
-		if f, err := strconv.ParseFloat(x, 64); err == nil {
+		if f, ok := parseNumericString(x); ok {
 			if f > float64(maxInt) || f < float64(minInt) {
 				return 0, false
 			}
@@ -163,7 +194,7 @@ func toFloat64Any(v any) (float64, bool) {
 		}
 		return 0, true
 	case string:
-		if f, err := strconv.ParseFloat(x, 64); err == nil {
+		if f, ok := parseNumericString(x); ok {
 			return f, true
 		}
 	}

--- a/list_test.go
+++ b/list_test.go
@@ -188,6 +188,105 @@ func TestToFloat64AnyCompoundSignString(t *testing.T) {
 	}
 }
 
+func TestNormalizeNumericStringSigns(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+		shouldOk bool
+	}{
+		{
+			name:     "plain number unchanged",
+			input:    "12.5",
+			expected: "12.5",
+			shouldOk: true,
+		},
+		{
+			name:     "double minus becomes positive",
+			input:    "--7",
+			expected: "7",
+			shouldOk: true,
+		},
+		{
+			name:     "plus minus becomes negative",
+			input:    "+-12",
+			expected: "-12",
+			shouldOk: true,
+		},
+		{
+			name:     "trim surrounding spaces",
+			input:    "  --18.25  ",
+			expected: "18.25",
+			shouldOk: true,
+		},
+		{
+			name:     "signs only invalid",
+			input:    "--",
+			expected: "",
+			shouldOk: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, ok := normalizeNumericStringSigns(tt.input)
+			if ok != tt.shouldOk {
+				t.Fatalf("normalizeNumericStringSigns(%q) ok = %v, want %v", tt.input, ok, tt.shouldOk)
+			}
+			if result != tt.expected {
+				t.Fatalf("normalizeNumericStringSigns(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestParseIntString(t *testing.T) {
+	maxInt := int(^uint(0) >> 1)
+	tests := []struct {
+		name     string
+		input    string
+		expected int
+		shouldOk bool
+	}{
+		{
+			name:     "compound sign integer",
+			input:    "--7",
+			expected: 7,
+			shouldOk: true,
+		},
+		{
+			name:     "float string truncates like int conversion",
+			input:    "--7.9",
+			expected: 7,
+			shouldOk: true,
+		},
+		{
+			name:     "max int preserved",
+			input:    strconv.Itoa(maxInt),
+			expected: maxInt,
+			shouldOk: true,
+		},
+		{
+			name:     "signs only invalid",
+			input:    "--",
+			expected: 0,
+			shouldOk: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, ok := parseIntString(tt.input)
+			if ok != tt.shouldOk {
+				t.Fatalf("parseIntString(%q) ok = %v, want %v", tt.input, ok, tt.shouldOk)
+			}
+			if result != tt.expected {
+				t.Fatalf("parseIntString(%q) = %d, want %d", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
 func TestToIntAnyCompoundSignString(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/list_test.go
+++ b/list_test.go
@@ -17,6 +17,7 @@
 package spx
 
 import (
+	"fmt"
 	"testing"
 )
 
@@ -145,6 +146,73 @@ func TestToFloat64AnyBool(t *testing.T) {
 			}
 			if result != tt.expected {
 				t.Errorf("toFloat64Any(%v) = %f, want %f", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestToFloat64AnyCompoundSignString(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected float64
+	}{
+		{
+			name:     "double minus becomes positive",
+			input:    "--5.5",
+			expected: 5.5,
+		},
+		{
+			name:     "plus minus becomes negative",
+			input:    "+-12",
+			expected: -12,
+		},
+		{
+			name:     "generated negation pattern on negative value",
+			input:    "-" + fmt.Sprintf("%v", -18.25),
+			expected: 18.25,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, ok := toFloat64Any(tt.input)
+			if !ok {
+				t.Fatalf("toFloat64Any(%q) ok = false, want true", tt.input)
+			}
+			if result != tt.expected {
+				t.Fatalf("toFloat64Any(%q) = %f, want %f", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestToIntAnyCompoundSignString(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected int
+	}{
+		{
+			name:     "double minus becomes positive",
+			input:    "--7",
+			expected: 7,
+		},
+		{
+			name:     "generated negation pattern on negative integer",
+			input:    "-" + fmt.Sprintf("%v", -24),
+			expected: 24,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, ok := toIntAny(tt.input)
+			if !ok {
+				t.Fatalf("toIntAny(%q) ok = false, want true", tt.input)
+			}
+			if result != tt.expected {
+				t.Fatalf("toIntAny(%q) = %d, want %d", tt.input, result, tt.expected)
 			}
 		})
 	}

--- a/list_test.go
+++ b/list_test.go
@@ -18,6 +18,7 @@ package spx
 
 import (
 	"fmt"
+	"strconv"
 	"testing"
 )
 
@@ -203,6 +204,46 @@ func TestToIntAnyCompoundSignString(t *testing.T) {
 			input:    "-" + fmt.Sprintf("%v", -24),
 			expected: 24,
 		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, ok := toIntAny(tt.input)
+			if !ok {
+				t.Fatalf("toIntAny(%q) ok = false, want true", tt.input)
+			}
+			if result != tt.expected {
+				t.Fatalf("toIntAny(%q) = %d, want %d", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestToIntAnyPreservesLargeIntegerStringPrecision(t *testing.T) {
+	maxInt := int(^uint(0) >> 1)
+	tests := []struct {
+		name     string
+		input    string
+		expected int
+	}{
+		{
+			name:     "max int string",
+			input:    strconv.Itoa(maxInt),
+			expected: maxInt,
+		},
+	}
+
+	if int64(maxInt) > int64(1<<53) {
+		beyondFloatExact := int64(1<<53) + 1
+		tests = append(tests, struct {
+			name     string
+			input    string
+			expected int
+		}{
+			name:     "integer above float64 exact range",
+			input:    strconv.FormatInt(beyondFloatExact, 10),
+			expected: int(beyondFloatExact),
+		})
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- add a shared numeric-string parser for `toFloat64Any` and `toIntAny`
- handle generated strings with repeated leading signs such as `--5.5` and `+-12`
- add regression tests for the generated `"-"+sprintf("%v", value)` pattern

## Problem

Some generated SPX projects build numeric strings by prefixing `-` onto a formatted value before converting it back to a number.

When the formatted value is already negative, the runtime receives strings like `--18.25`, which previously failed numeric parsing and could trigger:

`spx.Value.Float() conversion failed for type:string`

## Fix

This change centralizes string-to-number parsing and normalizes repeated leading sign characters before parsing the numeric payload.

That keeps existing numeric-string support intact while making generated negation patterns behave correctly for both float and int conversions.

## Testing

- `go test .`