### PR TITLE
fix: align reversed rand bounds with Scratch behavior

### DIFF
--- a/runtime_util.go
+++ b/runtime_util.go
@@ -27,7 +27,7 @@ import (
 // Rand__0 returns a random integer between from and to (inclusive).
 func Rand__0(from, to int) float64 {
 	if to < from {
-		to = from
+		from, to = to, from
 	}
 	return float64(from + rand.Intn(to-from+1))
 }
@@ -35,7 +35,7 @@ func Rand__0(from, to int) float64 {
 // Rand__1 returns a random float64 between from and to.
 func Rand__1(from, to float64) float64 {
 	if to < from {
-		to = from
+		from, to = to, from
 	}
 	return rand.Float64()*(to-from) + from
 }

--- a/runtime_util_test.go
+++ b/runtime_util_test.go
@@ -20,6 +20,28 @@ import (
 	"testing"
 )
 
+func TestRand0SwapsReversedBounds(t *testing.T) {
+	const (
+		from = 93
+		to   = -220
+	)
+
+	sawNonUpperBound := false
+	for i := 0; i < 100; i++ {
+		got := Rand__0(from, to)
+		if got < to || got > from {
+			t.Fatalf("Rand__0(%d, %d) = %v, want value in [%d, %d]", from, to, got, to, from)
+		}
+		if got != float64(from) {
+			sawNonUpperBound = true
+		}
+	}
+
+	if !sawNonUpperBound {
+		t.Fatalf("Rand__0(%d, %d) only returned the upper bound; reversed bounds should produce values across the range", from, to)
+	}
+}
+
 func TestCharAt(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## Summary
Align `spx.Rand__0` and `spx.Rand__1` with Scratch behavior when the input bounds are reversed.

Previously, calling `spx.Rand__0(93, -220)` would always return `93` because the code collapsed the range to the lower branch logic. With this change, reversed bounds are normalized by swapping `from` and `to`, so the result is generated from the full expected range `[-220, 93]`, matching Scratch semantics.

## Changes
- swap reversed bounds in `Rand__0`
- swap reversed bounds in `Rand__1` for consistency
- add a regression test covering `Rand__0(93, -220)`

## Testing
- `go test ./...`