### PR TITLE
refactor: remove ChangeLayer public API

### DIFF
--- a/sprite.go
+++ b/sprite.go
@@ -141,13 +141,13 @@ const (
 	XGoo_Sprite_GlideWith    = ".GlideToTarget,.GlideToXYpos"
 	XGoo_Sprite_StepToWith   = ".StepToTarget,.StepToXYpos"
 	XGoo_Sprite_TurnToWith   = ".TurnToDir,.TurnToTarget,.TurnToXYpos"
-	XGoo_Sprite_SetLayerWith = ".SetLayerTo,.ChangeLayer"
+	XGoo_Sprite_SetLayerWith = ".SetLayerTo,.SetLayer__1"
 	XGoo_Sprite_QuoteWith    = ".QuoteMsg,.QuoteMsgEx"
 
 	XGoo_SpriteImpl_GlideWith    = ".GlideToTarget,.GlideToXYpos"
 	XGoo_SpriteImpl_StepToWith   = ".StepToTarget,.StepToXYpos"
 	XGoo_SpriteImpl_TurnToWith   = ".TurnToDir,.TurnToTarget,.TurnToXYpos"
-	XGoo_SpriteImpl_SetLayerWith = ".SetLayerTo,.ChangeLayer"
+	XGoo_SpriteImpl_SetLayerWith = ".SetLayerTo,.SetLayer__1"
 	XGoo_SpriteImpl_QuoteWith    = ".QuoteMsg,.QuoteMsgEx"
 )
 
@@ -265,7 +265,6 @@ type Sprite interface {
 	SetLayer__1(dir dirAction, delta int)
 
 	SetLayerTo(layer layerAction)
-	ChangeLayer(dir dirAction, delta int)
 
 	// Costume Methods
 	CostumeName() SpriteCostumeName

--- a/sprite_api_test.go
+++ b/sprite_api_test.go
@@ -10,6 +10,9 @@ func TestSetLayerPublicAPI(t *testing.T) {
 	if _, ok := spriteType.MethodByName("ChangeLayer"); ok {
 		t.Fatal("Sprite should not expose ChangeLayer")
 	}
+	if _, ok := spriteType.MethodByName("SetLayer__1"); !ok {
+		t.Fatal("Sprite should keep SetLayer__1 for overload dispatch")
+	}
 
 	spriteImplType := reflect.TypeOf((*SpriteImpl)(nil))
 	if _, ok := spriteImplType.MethodByName("ChangeLayer"); ok {

--- a/sprite_api_test.go
+++ b/sprite_api_test.go
@@ -1,0 +1,28 @@
+package spx
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSetLayerPublicAPI(t *testing.T) {
+	spriteType := reflect.TypeOf((*Sprite)(nil)).Elem()
+	if _, ok := spriteType.MethodByName("ChangeLayer"); ok {
+		t.Fatal("Sprite should not expose ChangeLayer")
+	}
+
+	spriteImplType := reflect.TypeOf((*SpriteImpl)(nil))
+	if _, ok := spriteImplType.MethodByName("ChangeLayer"); ok {
+		t.Fatal("SpriteImpl should not expose ChangeLayer")
+	}
+	if _, ok := spriteImplType.MethodByName("SetLayer__1"); !ok {
+		t.Fatal("SpriteImpl should keep SetLayer__1 for overload dispatch")
+	}
+
+	if XGoo_Sprite_SetLayerWith != ".SetLayerTo,.SetLayer__1" {
+		t.Fatalf("XGoo_Sprite_SetLayerWith = %q, want %q", XGoo_Sprite_SetLayerWith, ".SetLayerTo,.SetLayer__1")
+	}
+	if XGoo_SpriteImpl_SetLayerWith != ".SetLayerTo,.SetLayer__1" {
+		t.Fatalf("XGoo_SpriteImpl_SetLayerWith = %q, want %q", XGoo_SpriteImpl_SetLayerWith, ".SetLayerTo,.SetLayer__1")
+	}
+}

--- a/sprite_render.go
+++ b/sprite_render.go
@@ -120,7 +120,12 @@ func (p *SpriteImpl) SetLayer__0(layer layerAction) {
 }
 
 func (p *SpriteImpl) SetLayer__1(dir dirAction, delta int) {
-	p.ChangeLayer(dir, delta)
+	switch dir {
+	case Forward:
+		p.g.goBackLayers(p, -delta)
+	case Backward:
+		p.g.goBackLayers(p, delta)
+	}
 }
 
 func (p *SpriteImpl) SetLayerTo(layer layerAction) {
@@ -129,14 +134,5 @@ func (p *SpriteImpl) SetLayerTo(layer layerAction) {
 		p.g.gotoFront(p)
 	case Back:
 		p.g.gotoBack(p)
-	}
-}
-
-func (p *SpriteImpl) ChangeLayer(dir dirAction, delta int) {
-	switch dir {
-	case Forward:
-		p.g.goBackLayers(p, -delta)
-	case Backward:
-		p.g.goBackLayers(p, delta)
 	}
 }


### PR DESCRIPTION
## Summary

This PR removes `ChangeLayer` from the public Sprite API and keeps layer movement routed through `SetLayer` overload dispatch.

## Changes

- remove `ChangeLayer` from the `Sprite` public interface
- update XGo `SetLayer` overload mapping to use `SetLayer__1`
- inline the layer delta handling into `SetLayer__1`
- add an API regression test to ensure `ChangeLayer` is no longer publicly exposed

## Why

We only want a single public entrypoint for layer changes. This keeps the API surface smaller while preserving the existing `SetLayer(Forward|Backward, delta)` behavior.

## Validation

- `go test ./...`