### PR TITLE
fix: use macOS SDK-aware toolchain for Go builds

### DIFF
--- a/cmd/internal/macos_go_toolchain.sh
+++ b/cmd/internal/macos_go_toolchain.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+configure_macos_go_toolchain() {
+    if [ "$(go env GOOS)" != "darwin" ]; then
+        return 0
+    fi
+
+    # Use Apple's SDK-aware compiler by default. This avoids stale Homebrew LLVM
+    # sysroot configs after macOS or Command Line Tools upgrades.
+    if [ -z "${CC:-}" ]; then
+        export CC="$(xcrun --find clang)"
+    fi
+    if [ -z "${CXX:-}" ]; then
+        export CXX="$(xcrun --find clang++)"
+    fi
+    if [ -z "${SDKROOT:-}" ] || [ ! -d "${SDKROOT}" ]; then
+        export SDKROOT="$(xcrun --show-sdk-path)"
+    fi
+}

--- a/cmd/ispxnative/build.sh
+++ b/cmd/ispxnative/build.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -e
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$SCRIPT_DIR/../internal/macos_go_toolchain.sh"
+configure_macos_go_toolchain
+
 GOOS="$(go env GOOS)"
 GOARCH="$(go env GOARCH)"
 

--- a/cmd/spx/install.sh
+++ b/cmd/spx/install.sh
@@ -8,6 +8,9 @@ cd "$SCRIPT_DIR"
 # Pin Go toolchain version
 export GOTOOLCHAIN=go1.25.8
 
+. "$SCRIPT_DIR/../internal/macos_go_toolchain.sh"
+configure_macos_go_toolchain
+
 target_font_dir=./template/project/engine/fonts/
 mkdir -p "$target_font_dir"
 font_path=$target_font_dir/CnFont.ttf


### PR DESCRIPTION
## Summary

Fix macOS Go/CGO builds after macOS or Command Line Tools upgrades when Homebrew LLVM is earlier in `PATH`.

This adds a shared macOS Go toolchain helper that defaults `CC`, `CXX`, and invalid/missing `SDKROOT` to Apple `xcrun`-resolved values. `cmd/spx/install.sh` and `cmd/ispxnative/build.sh` now source that helper before running Go builds, avoiding stale Homebrew LLVM sysroot configs such as missing `MacOSX26.sdk`.

## Changes

- Add `cmd/internal/macos_go_toolchain.sh` for shared macOS Go toolchain setup.
- Use Apple SDK-aware `clang`/`clang++` by default when `CC`/`CXX` are not explicitly set.
- Repair empty or stale `SDKROOT` with `xcrun --show-sdk-path`.
- Apply the setup to `cmd/spx/install.sh` and `cmd/ispxnative/build.sh`.

## Testing

- `bash -n cmd/internal/macos_go_toolchain.sh cmd/ispxnative/build.sh cmd/spx/install.sh`
- `cd cmd/ispxnative && GOTOOLCHAIN=go1.25.8 ./build.sh`
- `./.bin/buildctl tool install --no-embed-runtime`