### PR TITLE
fix(pen): draw repeated pen down at current position

### DIFF
--- a/component_pen.go
+++ b/component_pen.go
@@ -100,12 +100,10 @@ func (p *penComponent) PenUp() {
 }
 
 func (p *penComponent) PenDown() {
-	if p.penDown && p.penObj != nil {
-		return
-	}
 	p.checkOrCreatePen()
+	x, y := p.sprite.getXY()
+	p.syncPenPosition(x, y)
 	p.penDown = true
-	p.movePen(p.sprite.getXY())
 	p.engine().PenMgr.PenDown(*p.penObj, false)
 }
 
@@ -264,7 +262,7 @@ func (p *penComponent) destroyPen() {
 }
 
 func (p *penComponent) movePen(x, y float64) {
-	if p.penObj == nil || !p.penDown {
+	if !p.penDown {
 		return
 	}
 	p.syncPenPosition(x, y)

--- a/component_pen_test.go
+++ b/component_pen_test.go
@@ -120,7 +120,7 @@ func setupSpyPenMgr(t *testing.T) *spyPenMgr {
 	return spy
 }
 
-func TestPenComponentPenDownIsIdempotent(t *testing.T) {
+func TestPenComponentRepeatedPenDownDrawsAtCurrentPosition(t *testing.T) {
 	spy := setupSpyPenMgr(t)
 	sprite := newPenTestSprite()
 
@@ -130,11 +130,11 @@ func TestPenComponentPenDownIsIdempotent(t *testing.T) {
 	if spy.createCalls != 1 {
 		t.Fatalf("CreatePen calls = %d, want 1", spy.createCalls)
 	}
-	if spy.penDownCalls != 1 {
-		t.Fatalf("PenDown calls = %d, want 1", spy.penDownCalls)
+	if spy.penDownCalls != 2 {
+		t.Fatalf("PenDown calls = %d, want 2", spy.penDownCalls)
 	}
-	if spy.moveCalls != 1 {
-		t.Fatalf("MovePenTo calls = %d, want 1", spy.moveCalls)
+	if spy.moveCalls != 2 {
+		t.Fatalf("MovePenTo calls = %d, want 2", spy.moveCalls)
 	}
 }
 


### PR DESCRIPTION
## Summary

This PR changes repeated `PenDown` behavior so it syncs the pen to the sprite's current position and draws there even when the pen is already down.

- Remove the early return for repeated `PenDown`.
- Sync the pen position before each `PenDown`.
- Keep pen object creation idempotent.
- Update the test to verify repeated `PenDown` draws at the current position.

## Motivation

The Godot layer already optimizes repeated pen-down handling, so the Go layer should not suppress repeated `PenDown` calls entirely.

Suppressing the call means a script that repeatedly performs `PenDown` at different positions cannot produce the expected point/drawing behavior. By always syncing the current sprite position and forwarding `PenDown`, we preserve Scratch-compatible drawing semantics while relying on the Godot-side optimization to avoid unnecessary low-level work.

## Test Plan

- `go test .`