### PR TITLE
fix(input): preserve quick click snapshots

### DIFF
--- a/game_stage.go
+++ b/game_stage.go
@@ -132,19 +132,30 @@ func (p *Game) KeyPressed(key Key) bool {
 }
 
 func (p *Game) MouseX() float64 {
-	return p.inputMgr.currentMousePos().X
+	if x, _, ok := engine.GetPollingMousePos(); ok {
+		return x
+	}
+	return p.liveMousePos().X
 }
 
 func (p *Game) MouseY() float64 {
-	return p.inputMgr.currentMousePos().Y
+	if _, y, ok := engine.GetPollingMousePos(); ok {
+		return y
+	}
+	return p.liveMousePos().Y
 }
 
 func (p *Game) MousePressed() bool {
-	return engine.AnyMouseButtonPressed()
+	return engine.AnyMouseButtonPressedForPolling()
 }
 
 func (p *Game) getMousePos() (x, y float64) {
 	return p.MouseX(), p.MouseY()
+}
+
+func (p *Game) liveMousePos() mathf.Vec2 {
+	curMousePos := p.engine().InputMgr.GetGlobalMousePos()
+	return mathf.Vec2{X: float64(curMousePos.X), Y: float64(curMousePos.Y)}
 }
 
 func (p *Game) Username() string {

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -165,6 +165,7 @@ func onStart() {
 
 func onUpdate(delta float64) {
 	defer CheckPanic()
+	beginMouseInputFrame()
 	profiler.BeginSample()
 	updateTime(float64(delta))
 	cacheTriggerEvents()

--- a/internal/engine/input_state.go
+++ b/internal/engine/input_state.go
@@ -16,14 +16,45 @@
 
 package engine
 
-import "sync/atomic"
+import (
+	"math"
+	"sync/atomic"
+
+	gdx "github.com/goplus/spx/v2/pkg/spx/pkg/engine"
+)
 
 var mouseButtonStates [4]uint32
+var mouseButtonStickyUntil [4]uint64
+
+// Pending presses let slow script polling observe a click once even if the
+// physical button was already released before the next script iteration.
+var mouseButtonPending [4]uint32
+var mouseButtonPendingObservedEpoch [4]uint64
+var mouseButtonPendingXBits [4]uint64
+var mouseButtonPendingYBits [4]uint64
+var mouseInputEpoch uint64
+var mouseButtonSnapshotProvider = func() (float64, float64, bool) {
+	if gdx.InputMgr == nil {
+		return 0, 0, false
+	}
+	pos := gdx.InputMgr.GetGlobalMousePos()
+	return pos.X, pos.Y, true
+}
 
 func resetMouseButtonStates() {
 	for i := range mouseButtonStates {
 		atomic.StoreUint32(&mouseButtonStates[i], 0)
+		atomic.StoreUint64(&mouseButtonStickyUntil[i], 0)
+		atomic.StoreUint32(&mouseButtonPending[i], 0)
+		atomic.StoreUint64(&mouseButtonPendingObservedEpoch[i], 0)
+		atomic.StoreUint64(&mouseButtonPendingXBits[i], 0)
+		atomic.StoreUint64(&mouseButtonPendingYBits[i], 0)
 	}
+	atomic.StoreUint64(&mouseInputEpoch, 0)
+}
+
+func beginMouseInputFrame() {
+	atomic.AddUint64(&mouseInputEpoch, 1)
 }
 
 func setMouseButtonPressed(id int64, pressed bool) {
@@ -33,6 +64,13 @@ func setMouseButtonPressed(id int64, pressed bool) {
 	var state uint32
 	if pressed {
 		state = 1
+		// Keep short clicks visible through the current and next script frame,
+		// so polling code running behind a heavy warp loop can still observe them.
+		epoch := atomic.LoadUint64(&mouseInputEpoch)
+		atomic.StoreUint64(&mouseButtonStickyUntil[id], epoch+1)
+		atomic.StoreUint32(&mouseButtonPending[id], 1)
+		atomic.StoreUint64(&mouseButtonPendingObservedEpoch[id], 0)
+		storeMouseButtonPendingPos(id)
 	}
 	atomic.StoreUint32(&mouseButtonStates[id], state)
 }
@@ -41,9 +79,106 @@ func IsMouseButtonPressed(id int64) bool {
 	if id < 0 || id >= int64(len(mouseButtonStates)) {
 		return false
 	}
-	return atomic.LoadUint32(&mouseButtonStates[id]) != 0
+	if atomic.LoadUint32(&mouseButtonStates[id]) != 0 {
+		return true
+	}
+	stickyUntil := atomic.LoadUint64(&mouseButtonStickyUntil[id])
+	if stickyUntil == 0 {
+		return false
+	}
+	return atomic.LoadUint64(&mouseInputEpoch) <= stickyUntil
 }
 
 func AnyMouseButtonPressed() bool {
 	return IsMouseButtonPressed(1) || IsMouseButtonPressed(2)
+}
+
+func GetMouseButtonPressSnapshot(id int64) (float64, float64, bool) {
+	if id < 0 || id >= int64(len(mouseButtonStates)) {
+		return 0, 0, false
+	}
+	if atomic.LoadUint32(&mouseButtonStates[id]) != 0 {
+		return 0, 0, false
+	}
+	if atomic.LoadUint32(&mouseButtonPending[id]) == 0 {
+		return 0, 0, false
+	}
+
+	stickyUntil := atomic.LoadUint64(&mouseButtonStickyUntil[id])
+	if stickyUntil == 0 || atomic.LoadUint64(&mouseInputEpoch) > stickyUntil {
+		return 0, 0, false
+	}
+
+	x, y := loadMouseButtonPendingPos(id)
+	return x, y, true
+}
+
+func IsMouseButtonPressedForPolling(id int64) bool {
+	if id < 0 || id >= int64(len(mouseButtonStates)) {
+		return false
+	}
+
+	currentEpoch := atomic.LoadUint64(&mouseInputEpoch)
+	if atomic.LoadUint32(&mouseButtonStates[id]) != 0 {
+		atomic.StoreUint64(&mouseButtonPendingObservedEpoch[id], currentEpoch)
+		return true
+	}
+
+	if atomic.LoadUint32(&mouseButtonPending[id]) == 0 {
+		atomic.StoreUint64(&mouseButtonPendingObservedEpoch[id], 0)
+		return false
+	}
+
+	observedEpoch := atomic.LoadUint64(&mouseButtonPendingObservedEpoch[id])
+	if observedEpoch == 0 {
+		// Keep the pending press visible for the whole current input frame once a
+		// script has observed it, then clear it on the next frame.
+		atomic.StoreUint64(&mouseButtonPendingObservedEpoch[id], currentEpoch)
+		return true
+	}
+	if observedEpoch == currentEpoch {
+		return true
+	}
+
+	atomic.StoreUint32(&mouseButtonPending[id], 0)
+	atomic.StoreUint64(&mouseButtonPendingObservedEpoch[id], 0)
+	return false
+}
+
+func AnyMouseButtonPressedForPolling() bool {
+	return IsMouseButtonPressedForPolling(1) || IsMouseButtonPressedForPolling(2)
+}
+
+func GetPollingMousePos() (float64, float64, bool) {
+	const leftButtonID = 1
+	if atomic.LoadUint32(&mouseButtonStates[leftButtonID]) != 0 {
+		return 0, 0, false
+	}
+	if atomic.LoadUint32(&mouseButtonPending[leftButtonID]) == 0 {
+		return 0, 0, false
+	}
+
+	currentEpoch := atomic.LoadUint64(&mouseInputEpoch)
+	observedEpoch := atomic.LoadUint64(&mouseButtonPendingObservedEpoch[leftButtonID])
+	if observedEpoch != 0 && observedEpoch != currentEpoch {
+		return 0, 0, false
+	}
+
+	x, y := loadMouseButtonPendingPos(leftButtonID)
+	return x, y, true
+}
+
+func storeMouseButtonPendingPos(id int64) {
+	x, y, ok := mouseButtonSnapshotProvider()
+	if !ok {
+		return
+	}
+	atomic.StoreUint64(&mouseButtonPendingXBits[id], math.Float64bits(x))
+	atomic.StoreUint64(&mouseButtonPendingYBits[id], math.Float64bits(y))
+}
+
+func loadMouseButtonPendingPos(id int64) (float64, float64) {
+	x := math.Float64frombits(atomic.LoadUint64(&mouseButtonPendingXBits[id]))
+	y := math.Float64frombits(atomic.LoadUint64(&mouseButtonPendingYBits[id]))
+	return x, y
 }

--- a/internal/engine/input_state_test.go
+++ b/internal/engine/input_state_test.go
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2021 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package engine
+
+import "testing"
+
+func TestMouseButtonPressedStaysVisibleForNextFrame(t *testing.T) {
+	resetMouseButtonStates()
+
+	setMouseButtonPressed(1, true)
+	setMouseButtonPressed(1, false)
+	if !IsMouseButtonPressed(1) {
+		t.Fatal("expected quick click to remain visible before first frame")
+	}
+
+	beginMouseInputFrame()
+	if !IsMouseButtonPressed(1) {
+		t.Fatal("expected quick click to remain visible for the next frame")
+	}
+
+	beginMouseInputFrame()
+	if IsMouseButtonPressed(1) {
+		t.Fatal("expected quick click visibility to expire after the next frame")
+	}
+}
+
+func TestMouseButtonPressedWhileHeld(t *testing.T) {
+	resetMouseButtonStates()
+
+	beginMouseInputFrame()
+	setMouseButtonPressed(1, true)
+	if !IsMouseButtonPressed(1) {
+		t.Fatal("expected held mouse button to be pressed")
+	}
+
+	beginMouseInputFrame()
+	if !IsMouseButtonPressed(1) {
+		t.Fatal("expected held mouse button to remain pressed across frames")
+	}
+
+	setMouseButtonPressed(1, false)
+	beginMouseInputFrame()
+	if IsMouseButtonPressed(1) {
+		t.Fatal("expected held mouse button to clear immediately after release")
+	}
+}
+
+func TestMouseButtonPressedForPollingStaysPendingUntilObserved(t *testing.T) {
+	resetMouseButtonStates()
+
+	setMouseButtonPressed(1, true)
+	setMouseButtonPressed(1, false)
+
+	for range 4 {
+		beginMouseInputFrame()
+	}
+	if !IsMouseButtonPressedForPolling(1) {
+		t.Fatal("expected quick click to remain pending until script polling observes it")
+	}
+	if !IsMouseButtonPressedForPolling(1) {
+		t.Fatal("expected observed pending click to stay visible for the rest of the frame")
+	}
+
+	beginMouseInputFrame()
+	if IsMouseButtonPressedForPolling(1) {
+		t.Fatal("expected pending click to clear on the frame after it was observed")
+	}
+}
+
+func TestMouseButtonPressedForPollingDoesNotReplayAfterHeldRead(t *testing.T) {
+	resetMouseButtonStates()
+
+	beginMouseInputFrame()
+	setMouseButtonPressed(1, true)
+	if !IsMouseButtonPressedForPolling(1) {
+		t.Fatal("expected held mouse button to be reported to polling scripts")
+	}
+
+	setMouseButtonPressed(1, false)
+	beginMouseInputFrame()
+	if IsMouseButtonPressedForPolling(1) {
+		t.Fatal("expected polling helper not to replay a click already observed while held")
+	}
+}
+
+func TestGetPollingMousePosUsesPressSnapshotForPendingClick(t *testing.T) {
+	resetMouseButtonStates()
+	beginMouseInputFrame()
+
+	prevProvider := mouseButtonSnapshotProvider
+	mouseButtonSnapshotProvider = func() (float64, float64, bool) {
+		return 12, -34, true
+	}
+	defer func() {
+		mouseButtonSnapshotProvider = prevProvider
+	}()
+
+	setMouseButtonPressed(1, true)
+	setMouseButtonPressed(1, false)
+
+	x, y, ok := GetPollingMousePos()
+	if !ok || x != 12 || y != -34 {
+		t.Fatalf("GetPollingMousePos() = (%v, %v, %v), want (12, -34, true)", x, y, ok)
+	}
+
+	if !IsMouseButtonPressedForPolling(1) {
+		t.Fatal("expected pending click to be visible to polling")
+	}
+
+	if _, _, ok := GetPollingMousePos(); !ok {
+		t.Fatal("expected snapshot to remain visible while the observed frame is still active")
+	}
+
+	beginMouseInputFrame()
+	if IsMouseButtonPressedForPolling(1) {
+		t.Fatal("expected pending click to clear after the observed frame advances")
+	}
+	if _, _, ok := GetPollingMousePos(); ok {
+		t.Fatal("expected snapshot to clear after the observed frame advances")
+	}
+}
+
+func TestGetMouseButtonPressSnapshotUsesStickyWindow(t *testing.T) {
+	resetMouseButtonStates()
+	beginMouseInputFrame()
+
+	prevProvider := mouseButtonSnapshotProvider
+	mouseButtonSnapshotProvider = func() (float64, float64, bool) {
+		return 12, -34, true
+	}
+	defer func() {
+		mouseButtonSnapshotProvider = prevProvider
+	}()
+
+	setMouseButtonPressed(1, true)
+	setMouseButtonPressed(1, false)
+
+	beginMouseInputFrame()
+	x, y, ok := GetMouseButtonPressSnapshot(1)
+	if !ok || x != 12 || y != -34 {
+		t.Fatalf("GetMouseButtonPressSnapshot(1) = (%v, %v, %v), want (12, -34, true)", x, y, ok)
+	}
+
+	beginMouseInputFrame()
+	if _, _, ok := GetMouseButtonPressSnapshot(1); ok {
+		t.Fatal("expected sticky click snapshot to expire with the sticky pressed state")
+	}
+}
+
+func TestGetPollingMousePosDoesNotOverrideHeldMousePosition(t *testing.T) {
+	resetMouseButtonStates()
+	beginMouseInputFrame()
+
+	prevProvider := mouseButtonSnapshotProvider
+	mouseButtonSnapshotProvider = func() (float64, float64, bool) {
+		return 12, -34, true
+	}
+	defer func() {
+		mouseButtonSnapshotProvider = prevProvider
+	}()
+
+	setMouseButtonPressed(1, true)
+	if _, _, ok := GetPollingMousePos(); ok {
+		t.Fatal("expected held mouse press to keep using live cursor position")
+	}
+}

--- a/runtime_events.go
+++ b/runtime_events.go
@@ -358,7 +358,10 @@ func (p *scriptEventRegistry) doWhenSwipe(direction Direction, this threadObj) {
 }
 
 func (p *scriptEventRegistry) doWhenClick(this threadObj) {
-	p.dispatchAsync(coreevent.BucketClick, false, this, func(ev *eventSink) {
+	// Click handlers often mutate selection state that the current frame reads
+	// immediately afterwards, so start them promptly to keep input ordering
+	// closer to Scratch's behavior under rapid pointer interactions.
+	p.dispatchAsync(coreevent.BucketClick, true, this, func(ev *eventSink) {
 		coreevent.If0(isDebugEventEnabled, func() {
 			spxlog.Debug("OnClick: %s", nameOf(this))
 		})()

--- a/runtime_events_test.go
+++ b/runtime_events_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/goplus/spbase/mathf"
+	coreevent "github.com/goplus/spx/v2/internal/core/event"
 	"github.com/goplus/spx/v2/internal/engine"
 	"github.com/goplus/spx/v2/internal/enginewrap"
 	pkgengine "github.com/goplus/spx/v2/pkg/spx/pkg/engine"
@@ -201,5 +202,36 @@ func TestPointHitsClickTargetUsesClickQuery(t *testing.T) {
 	}
 	if got := mgr.lastIsTrigger[1]; !got {
 		t.Fatalf("pointHitsClickTarget used sensing query, want click query")
+	}
+}
+
+func TestDoWhenClickStartsHandlerPromptly(t *testing.T) {
+	var reg scriptEventRegistry
+	owner := &SpriteImpl{}
+	called := false
+	reg.manager.AddClick(coreevent.NewSink(owner, func() {
+		called = true
+	}, coreevent.MatchOwner(owner)))
+
+	prevHooks := scriptEventDispatchHooks
+	defer func() {
+		scriptEventDispatchHooks = prevHooks
+	}()
+
+	var gotStarts []bool
+	scriptEventDispatchHooks = coreevent.DispatchHooks{
+		Spawn: func(start bool, owner any, call func()) {
+			gotStarts = append(gotStarts, start)
+			call()
+		},
+	}
+
+	reg.doWhenClick(owner)
+
+	if !called {
+		t.Fatal("expected click handler to run")
+	}
+	if len(gotStarts) != 1 || !gotStarts[0] {
+		t.Fatalf("click dispatch start flags = %v, want [true]", gotStarts)
 	}
 }

--- a/runtime_loops.go
+++ b/runtime_loops.go
@@ -35,6 +35,9 @@ func (p *Game) eventLoop(me coroutine.Thread) int {
 func (p *Game) inputEventLoop(me coroutine.Thread) int {
 	return coreruntime.RunInputLoop(me, coreruntime.InputLoopConfig{
 		CurrentMousePos: func() mathf.Vec2 {
+			if x, y, ok := engine.GetMouseButtonPressSnapshot(MOUSE_BUTTON_LEFT); ok {
+				return mathf.Vec2{X: x, Y: y}
+			}
 			curMousePos := p.engine().InputMgr.GetGlobalMousePos()
 			return mathf.Vec2{X: float64(curMousePos.X), Y: float64(curMousePos.Y)}
 		},


### PR DESCRIPTION
## Summary

This PR improves mouse input reliability for short clicks and rapid pointer interactions.

- Keep quick mouse presses visible across script polling frames.
- Store the mouse position snapshot at press time.
- Use the press snapshot for click/input loops when the physical button was already released.
- Start click handlers promptly so click-side mutations are observable in the expected frame.

## Motivation

A very short press/release can happen between script frames, especially when scripts are busy or delayed. In that case polling code may miss `MousePressed`, or read the live cursor position after the pointer has already moved away.

This keeps Scratch-style click behavior stable by preserving the click state and position long enough for script polling and click dispatch to observe them.

## Test Plan

- `go test . ./internal/engine`