### PR TITLE
fix(pen): initialize default color components

### DIFF
--- a/component_pen.go
+++ b/component_pen.go
@@ -53,12 +53,9 @@ type penComponent struct {
 func (p *penComponent) initialize(sprite *SpriteImpl, spriteCfg *coreproject.SpriteConfig) {
 	p.componentBase.initialize(sprite, spriteCfg)
 	// Always initialize with default pen values
-	p.penColor = mathf.NewColor(66, 133, 244, 255)
+	p.penColor = mathf.NewColorRGBAi(66, 133, 244, 255)
 	p.penWidth = 1
-	p.penHue = 0.6
-	p.penSaturation = 1
-	p.penBrightness = 1
-	p.penTransparency = 0
+	p.syncPenColorComponents()
 	p.penDown = false
 	p.penObj = nil
 }
@@ -187,13 +184,7 @@ func (p *penComponent) ChangePenColor(kind PenColorParam, delta float64) {
 // ============================================================================
 
 func (p *penComponent) setPenHue(value float64) {
-	nextValue := mathf.Clamp(value, 0, 100)
-	if p.penObj != nil && nearlyEqualPenValue(p.penHue, nextValue) {
-		return
-	}
-	p.checkOrCreatePen()
-	p.penHue = nextValue
-	p.applyPenHsvProperty()
+	p.setPenHsvComponent(&p.penHue, value)
 }
 
 func (p *penComponent) changePenHue(delta float64) {
@@ -201,13 +192,7 @@ func (p *penComponent) changePenHue(delta float64) {
 }
 
 func (p *penComponent) setPenSaturation(value float64) {
-	nextValue := mathf.Clamp(value, 0, 100)
-	if p.penObj != nil && nearlyEqualPenValue(p.penSaturation, nextValue) {
-		return
-	}
-	p.checkOrCreatePen()
-	p.penSaturation = nextValue
-	p.applyPenHsvProperty()
+	p.setPenHsvComponent(&p.penSaturation, value)
 }
 
 func (p *penComponent) changePenSaturation(delta float64) {
@@ -215,13 +200,7 @@ func (p *penComponent) changePenSaturation(delta float64) {
 }
 
 func (p *penComponent) setPenBrightness(value float64) {
-	nextValue := mathf.Clamp(value, 0, 100)
-	if p.penObj != nil && nearlyEqualPenValue(p.penBrightness, nextValue) {
-		return
-	}
-	p.checkOrCreatePen()
-	p.penBrightness = nextValue
-	p.applyPenHsvProperty()
+	p.setPenHsvComponent(&p.penBrightness, value)
 }
 
 func (p *penComponent) changePenBrightness(delta float64) {
@@ -229,13 +208,7 @@ func (p *penComponent) changePenBrightness(delta float64) {
 }
 
 func (p *penComponent) setPenTransparency(value float64) {
-	nextValue := mathf.Clamp(value, 0, 100)
-	if p.penObj != nil && nearlyEqualPenValue(p.penTransparency, nextValue) {
-		return
-	}
-	p.checkOrCreatePen()
-	p.penTransparency = nextValue
-	p.applyPenHsvProperty()
+	p.setPenHsvComponent(&p.penTransparency, value)
 }
 
 func (p *penComponent) changePenTransparency(delta float64) {
@@ -283,18 +256,32 @@ func (p *penComponent) getPenStampTransform() (rotationRadians float64, scale ma
 
 func (p *penComponent) applyPenColorProperty() {
 	p.checkOrCreatePen()
+	p.syncPenColorComponents()
+	p.updatePenColor()
+}
+
+func (p *penComponent) syncPenColorComponents() {
 	h, s, v := p.penColor.ToHSV()
 	p.penHue = hueToPercent(h)
 	p.penSaturation = normalizedToPercent(s)
 	p.penBrightness = normalizedToPercent(v)
 	p.penTransparency = normalizedToPercent(p.penColor.A)
-	p.updatePenColor()
 }
 
 func (p *penComponent) applyPenHsvProperty() {
 	p.penColor = mathf.NewColorHSV(percentToHue(p.penHue), percentToNormalized(p.penSaturation), percentToNormalized(p.penBrightness))
 	p.penColor.A = percentToNormalized(p.penTransparency)
 	p.updatePenColor()
+}
+
+func (p *penComponent) setPenHsvComponent(component *float64, value float64) {
+	nextValue := mathf.Clamp(value, 0, 100)
+	if p.penObj != nil && nearlyEqualPenValue(*component, nextValue) {
+		return
+	}
+	p.checkOrCreatePen()
+	*component = nextValue
+	p.applyPenHsvProperty()
 }
 
 func (p *penComponent) updatePenColor() {

--- a/component_pen_test.go
+++ b/component_pen_test.go
@@ -120,6 +120,22 @@ func setupSpyPenMgr(t *testing.T) *spyPenMgr {
 	return spy
 }
 
+func TestPenComponentInitializesDefaultColorComponents(t *testing.T) {
+	sprite := newPenTestSprite()
+	pen := sprite.pen()
+
+	wantColor := mathf.NewColorRGBAi(66, 133, 244, 255)
+	if !samePenColor(pen.penColor, wantColor) {
+		t.Fatalf("penColor = %v, want %v", pen.penColor, wantColor)
+	}
+
+	h, s, v := wantColor.ToHSV()
+	assertNearlyEqualPenValue(t, "penHue", pen.penHue, hueToPercent(h))
+	assertNearlyEqualPenValue(t, "penSaturation", pen.penSaturation, normalizedToPercent(s))
+	assertNearlyEqualPenValue(t, "penBrightness", pen.penBrightness, normalizedToPercent(v))
+	assertNearlyEqualPenValue(t, "penTransparency", pen.penTransparency, normalizedToPercent(wantColor.A))
+}
+
 func TestPenComponentRepeatedPenDownDrawsAtCurrentPosition(t *testing.T) {
 	spy := setupSpyPenMgr(t)
 	sprite := newPenTestSprite()
@@ -206,16 +222,31 @@ func TestPenComponentDefaultPenColorStillMaterializesPen(t *testing.T) {
 }
 
 func TestPenComponentDefaultHSVStillMaterializesPen(t *testing.T) {
-	spy := setupSpyPenMgr(t)
-	sprite := newPenTestSprite()
-
-	sprite.pen().SetPenColorParam(PenHue, sprite.pen().penHue)
-
-	if spy.createCalls != 1 {
-		t.Fatalf("CreatePen calls = %d, want 1", spy.createCalls)
+	tests := []struct {
+		name  string
+		kind  PenColorParam
+		value func(*penComponent) float64
+	}{
+		{name: "hue", kind: PenHue, value: func(p *penComponent) float64 { return p.penHue }},
+		{name: "saturation", kind: PenSaturation, value: func(p *penComponent) float64 { return p.penSaturation }},
+		{name: "brightness", kind: PenBrightness, value: func(p *penComponent) float64 { return p.penBrightness }},
+		{name: "transparency", kind: PenTransparency, value: func(p *penComponent) float64 { return p.penTransparency }},
 	}
-	if spy.setColorCalls != 1 {
-		t.Fatalf("SetPenColorTo calls = %d, want 1", spy.setColorCalls)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spy := setupSpyPenMgr(t)
+			sprite := newPenTestSprite()
+
+			sprite.pen().SetPenColorParam(tt.kind, tt.value(sprite.pen()))
+
+			if spy.createCalls != 1 {
+				t.Fatalf("CreatePen calls = %d, want 1", spy.createCalls)
+			}
+			if spy.setColorCalls != 1 {
+				t.Fatalf("SetPenColorTo calls = %d, want 1", spy.setColorCalls)
+			}
+		})
 	}
 }
 
@@ -308,5 +339,12 @@ func TestPenComponentStampSyncsNormalRotation(t *testing.T) {
 	wantRotation := engine.DegToRad(-45)
 	if spy.lastStampRotation != wantRotation {
 		t.Fatalf("PenStampWithTransform rotation = %v, want %v", spy.lastStampRotation, wantRotation)
+	}
+}
+
+func assertNearlyEqualPenValue(t *testing.T, name string, got, want float64) {
+	t.Helper()
+	if !nearlyEqualPenValue(got, want) {
+		t.Fatalf("%s = %v, want %v", name, got, want)
 	}
 }


### PR DESCRIPTION
Summary:
1. Keep repeated PenDown calls reaching the engine so the current position can draw a point.
2. Initialize the default pen color with normalized RGBA values via mathf.NewColorRGBAi.
3. Derive default hue, saturation, brightness, and transparency from the default color.
4. Consolidate HSV component setters through a shared helper.
5. Add tests for default color component initialization and all default HSV materialization paths.
Tests:
go test ./...