### PR TITLE
fix(runtime): add scratch-style compare helpers

### DIFF
--- a/pkg/ispx/internal/pkg/github.com/goplus/spx/v2/export.go
+++ b/pkg/ispx/internal/pkg/github.com/goplus/spx/v2/export.go
@@ -130,8 +130,10 @@ func init() {
 		Vars: map[string]reflect.Value{},
 		Funcs: map[string]reflect.Value{
 			"CharAt":                     reflect.ValueOf(q.CharAt),
+			"Compare":                    reflect.ValueOf(q.Compare),
 			"Contains":                   reflect.ValueOf(q.Contains),
 			"DeltaTime":                  reflect.ValueOf(q.DeltaTime),
+			"Equal":                      reflect.ValueOf(q.Equal),
 			"Exit__0":                    reflect.ValueOf(q.Exit__0),
 			"Exit__1":                    reflect.ValueOf(q.Exit__1),
 			"Forever":                    reflect.ValueOf(q.Forever),

--- a/runtime_util.go
+++ b/runtime_util.go
@@ -53,6 +53,57 @@ func Contains(s, substr string) bool {
 	return strings.Contains(s, substr)
 }
 
+// Compare compares values using the same rules as Scratch's =, <, and >
+// operator blocks.
+//
+// Values are compared numerically when both sides can be interpreted as numbers;
+// otherwise they are compared as case-insensitive strings.
+func Compare(v1, v2 any) int {
+	if n1, ok1 := scratchCompareNumber(v1); ok1 {
+		if n2, ok2 := scratchCompareNumber(v2); ok2 {
+			switch {
+			case n1 < n2:
+				return -1
+			case n1 > n2:
+				return 1
+			default:
+				return 0
+			}
+		}
+	}
+
+	s1 := strings.ToLower(toString(v1))
+	s2 := strings.ToLower(toString(v2))
+	switch {
+	case s1 < s2:
+		return -1
+	case s1 > s2:
+		return 1
+	default:
+		return 0
+	}
+}
+
+// Equal reports whether two values match Scratch's = operator semantics.
+func Equal(v1, v2 any) bool {
+	return Compare(v1, v2) == 0
+}
+
+func scratchCompareNumber(v any) (float64, bool) {
+	if isScratchWhitespace(v) {
+		return 0, false
+	}
+	return toFloat64Any(v)
+}
+
+func isScratchWhitespace(v any) bool {
+	if v == nil {
+		return true
+	}
+	s, ok := fromObj(v).(string)
+	return ok && strings.TrimSpace(s) == ""
+}
+
 // DeltaTime returns the time elapsed since the previous frame.
 func DeltaTime() Seconds {
 	return itime.DeltaTime()

--- a/runtime_util_test.go
+++ b/runtime_util_test.go
@@ -127,6 +127,36 @@ func TestCharAt(t *testing.T) {
 	}
 }
 
+func TestCompareAndEqual(t *testing.T) {
+	tests := []struct {
+		name    string
+		v1      any
+		v2      any
+		compare int
+		equal   bool
+	}{
+		{name: "case insensitive strings", v1: "p", v2: "P", compare: 0, equal: true},
+		{name: "numeric strings", v1: "01", v2: "1", compare: 0, equal: true},
+		{name: "number and string", v1: 2, v2: "10", compare: -1, equal: false},
+		{name: "non numeric strings less", v1: "apple", v2: "Banana", compare: -1, equal: false},
+		{name: "whitespace uses string compare", v1: "", v2: "0", compare: -1, equal: false},
+		{name: "bool numeric compare", v1: true, v2: 1, compare: 0, equal: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotCompare := Compare(tt.v1, tt.v2)
+			if gotCompare != tt.compare {
+				t.Fatalf("Compare(%v, %v) = %d, want %d", tt.v1, tt.v2, gotCompare, tt.compare)
+			}
+			gotEqual := Equal(tt.v1, tt.v2)
+			if gotEqual != tt.equal {
+				t.Fatalf("Equal(%v, %v) = %v, want %v", tt.v1, tt.v2, gotEqual, tt.equal)
+			}
+		})
+	}
+}
+
 func TestPenColorParamFromString(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## Summary

- Add `Compare` and `Equal` runtime helpers that follow Scratch operator comparison semantics.
- Support numeric comparison when both values are number-like, otherwise fall back to case-insensitive string comparison.
- Export the helpers through the ixgo runtime package.
- Add tests for case-insensitive strings, numeric strings, mixed number/string values, whitespace, and bool numeric comparison.

## Tests

- `go test ./ -run 'TestCompareAndEqual|TestCharAt'`
- `go test ./pkg/ispx`
- `spx build --path .tmp/103746364`