### PR TITLE
fix: normalize empty ask dialog behavior

### DIFF
--- a/bubble.go
+++ b/bubble.go
@@ -24,6 +24,13 @@ import (
 	"github.com/goplus/spx/v2/internal/ui"
 )
 
+func dialogText(msg any) string {
+	if msgStr, ok := msg.(string); ok {
+		return msgStr
+	}
+	return fmt.Sprint(msg)
+}
+
 // -------------------------------------------------------------------------------------
 // Common Bubble System - Shared functionality for Say/Think/Quote bubbles
 // -------------------------------------------------------------------------------------
@@ -134,10 +141,7 @@ func (p *SpriteImpl) newBubbleBase() bubbleBase {
 }
 
 func (p *SpriteImpl) sayOrThink(msg any, style int) {
-	msgStr, ok := msg.(string)
-	if !ok {
-		msgStr = fmt.Sprint(msg)
-	}
+	msgStr := dialogText(msg)
 	if msgStr == "" {
 		p.doStopText()
 		return

--- a/game_stage.go
+++ b/game_stage.go
@@ -17,7 +17,6 @@
 package spx
 
 import (
-	"fmt"
 	"math/rand"
 	"reflect"
 	"time"
@@ -180,14 +179,7 @@ func (p *Game) Dayssince2000() float64 {
 // Dialog
 // -----------------------------------------------------------------------------
 func (p *Game) Ask(msg any) {
-	msgStr, ok := msg.(string)
-	if !ok {
-		msgStr = fmt.Sprint(msg)
-	}
-	if msgStr == "" {
-		spxlog.Warn("Ask: message should not be empty")
-		return
-	}
+	msgStr := dialogText(msg)
 	p.ask(false, msgStr, func(answer string) {})
 }
 

--- a/internal/ui/ui_ask.go
+++ b/internal/ui/ui_ask.go
@@ -73,8 +73,9 @@ func (pself *UiAsk) Show(isSprite bool, question string, onCheck func(string)) {
 	// UiAsk prefab can auto scale to match window scale
 	// mgr.UiMgr.SetScale(pself.GetId(), mathf.NewVec2(windowScale, windowScale))
 	pself.OnCheck = onCheck
-	mgr.UiMgr.SetVisible(pself.askBody.GetId(), !isSprite)
-	if !isSprite {
+	showQuestion := !isSprite && question != ""
+	mgr.UiMgr.SetVisible(pself.askBody.GetId(), showQuestion)
+	if showQuestion {
 		mgr.UiMgr.SetText(pself.askLabel.GetId(), question)
 	}
 	mgr.UiMgr.SetText(pself.input.GetId(), "")

--- a/sprite_bubble.go
+++ b/sprite_bubble.go
@@ -17,8 +17,6 @@
 package spx
 
 import (
-	"fmt"
-
 	"github.com/goplus/spx/v2/internal/ui"
 
 	spxlog "github.com/goplus/spx/v2/internal/log"
@@ -32,15 +30,8 @@ func (p *SpriteImpl) Ask(msg any) {
 	if isDebugInstrEnabled() {
 		spxlog.Debug("Ask: sprite=%s, msg=%v", p.name, msg)
 	}
-	msgStr, ok := msg.(string)
-	if !ok {
-		msgStr = fmt.Sprint(msg)
-	}
-	if msgStr == "" {
-		spxlog.Warn("Ask: message should not be empty")
-		return
-	}
-	p.Say__0(msgStr)
+	msgStr := dialogText(msg)
+	p.sayOrThink(msgStr, ui.StyleSay)
 	p.g.ask(true, msgStr, func(answer string) {
 		p.doStopText()
 	})


### PR DESCRIPTION
## Summary

Normalize `Ask("")` behavior for both stage and sprites, and remove duplicated dialog text conversion logic.

## Changes

- allow `Game.Ask("")` without warning or early return
- make `Sprite.Ask("")` clear any existing speech bubble instead of leaving stale text visible
- hide the stage question body when the ask text is empty, so empty asks behave like silent prompts
- extract shared `dialogText` conversion helper to keep dialog message handling consistent

## Why

Projects in the current workspace already use `ask ""` as a valid pattern. Before this change, stage and sprite asks behaved differently, and sprite asks could leave an old bubble on screen. This makes empty asks a supported and consistent flow.

## Testing

- `go test ./...`