### PR TITLE
fix: audio playback lifetime and pitch effect

### DIFF
--- a/game_api_test.go
+++ b/game_api_test.go
@@ -98,8 +98,8 @@ func TestGameClearSoundEffectsResetsPanAndPitch(t *testing.T) {
 	if backend.pan != 0 {
 		t.Fatalf("pan = %v, want 0", backend.pan)
 	}
-	if backend.pitch != 0 {
-		t.Fatalf("pitch = %v, want 0", backend.pitch)
+	if backend.pitch != 1 {
+		t.Fatalf("pitch = %v, want 1", backend.pitch)
 	}
 }
 
@@ -120,8 +120,8 @@ func TestGameClearSoundEffectsAllocatesWhenUnused(t *testing.T) {
 	if backend.pan != 0 {
 		t.Fatalf("pan = %v, want 0", backend.pan)
 	}
-	if backend.pitch != 0 {
-		t.Fatalf("pitch = %v, want 0", backend.pitch)
+	if backend.pitch != 1 {
+		t.Fatalf("pitch = %v, want 1", backend.pitch)
 	}
 }
 

--- a/internal/audio/manager.go
+++ b/internal/audio/manager.go
@@ -16,7 +16,13 @@
 
 package audio
 
-import "github.com/goplus/spx/v2/internal/engine"
+import (
+	"math"
+
+	"github.com/goplus/spx/v2/internal/engine"
+)
+
+const scratchPitchStepsPerOctave = 120
 
 type Backend interface {
 	CreateAudio() engine.Object
@@ -38,13 +44,25 @@ type Backend interface {
 }
 
 type Manager struct {
-	backend  Backend
-	path2ids map[string][]int64
+	backend        Backend
+	path2ids       map[string][]int64
+	obj2ids        map[engine.Object][]int64
+	playbacks      map[int64]playbackInfo
+	pendingDestroy map[engine.Object]struct{}
+}
+
+type playbackInfo struct {
+	path     string
+	soundObj engine.Object
+	loop     bool
 }
 
 func (m *Manager) Init(backend Backend) {
 	m.backend = backend
 	m.path2ids = make(map[string][]int64)
+	m.obj2ids = make(map[engine.Object][]int64)
+	m.playbacks = make(map[int64]playbackInfo)
+	m.pendingDestroy = make(map[engine.Object]struct{})
 }
 
 func (m *Manager) AllocSound() engine.Object {
@@ -55,7 +73,18 @@ func (m *Manager) ReleaseSound(soundObj engine.Object) {
 	if soundObj == 0 {
 		return
 	}
-	m.backend.DestroyAudio(soundObj)
+	_, wasPending := m.pendingDestroy[soundObj]
+	m.preparePlaybacksForRelease(soundObj)
+	if len(m.obj2ids[soundObj]) == 0 {
+		if _, pending := m.pendingDestroy[soundObj]; pending {
+			delete(m.pendingDestroy, soundObj)
+			m.backend.DestroyAudio(soundObj)
+		} else if !wasPending {
+			m.backend.DestroyAudio(soundObj)
+		}
+		return
+	}
+	m.pendingDestroy[soundObj] = struct{}{}
 }
 
 func (m *Manager) Pause(path string) {
@@ -73,8 +102,10 @@ func (m *Manager) Resume(path string) {
 }
 
 func (m *Manager) Stop(path string) {
-	for _, id := range m.path2ids[path] {
+	ids := append([]int64(nil), m.path2ids[path]...)
+	for _, id := range ids {
 		m.backend.Stop(id)
+		m.dropPlaybackTracking(id)
 	}
 	delete(m.path2ids, path)
 }
@@ -133,6 +164,10 @@ func (m *Manager) Play(
 
 	ids := m.pruneDeadIDs(path)
 	curID := m.backend.PlayWithAttenuation(soundObj, engine.ToAssetPath(path), owner, attenuation, maxDistance)
+	if curID == 0 {
+		return 0
+	}
+	m.trackPlayback(curID, path, soundObj, isLoop)
 	ids = append(ids, curID)
 	m.path2ids[path] = ids
 	if isLoop {
@@ -148,7 +183,28 @@ func (m *Manager) Play(
 
 func (m *Manager) StopAll() {
 	m.path2ids = make(map[string][]int64)
+	m.obj2ids = make(map[engine.Object][]int64)
+	m.playbacks = make(map[int64]playbackInfo)
 	m.backend.StopAll()
+	for soundObj := range m.pendingDestroy {
+		m.backend.DestroyAudio(soundObj)
+	}
+	m.pendingDestroy = make(map[engine.Object]struct{})
+}
+
+func (m *Manager) Update() {
+	if m.backend == nil || len(m.path2ids) == 0 && len(m.pendingDestroy) == 0 {
+		return
+	}
+	for path := range m.path2ids {
+		m.pruneDeadIDs(path)
+	}
+	for soundObj := range m.pendingDestroy {
+		if len(m.obj2ids[soundObj]) == 0 {
+			delete(m.pendingDestroy, soundObj)
+			m.backend.DestroyAudio(soundObj)
+		}
+	}
 }
 
 func (m *Manager) GetPan(soundObj engine.Object) float64 {
@@ -164,15 +220,26 @@ func (m *Manager) ChangePan(soundObj engine.Object, delta float64) {
 }
 
 func (m *Manager) GetPitch(soundObj engine.Object) float64 {
-	return m.backend.GetPitch(soundObj) * 100
+	return pitchScaleToScratchEffect(m.backend.GetPitch(soundObj))
 }
 
 func (m *Manager) SetPitch(soundObj engine.Object, value float64) {
-	m.backend.SetPitch(soundObj, value/100)
+	m.backend.SetPitch(soundObj, scratchPitchEffectToScale(value))
 }
 
 func (m *Manager) ChangePitch(soundObj engine.Object, delta float64) {
 	m.SetPitch(soundObj, m.GetPitch(soundObj)+delta)
+}
+
+func scratchPitchEffectToScale(value float64) float64 {
+	return math.Pow(2, value/scratchPitchStepsPerOctave)
+}
+
+func pitchScaleToScratchEffect(scale float64) float64 {
+	if scale <= 0 {
+		return 0
+	}
+	return scratchPitchStepsPerOctave * math.Log2(scale)
 }
 
 func (m *Manager) GetVolume(soundObj engine.Object) float64 {
@@ -202,7 +269,9 @@ func (m *Manager) pruneDeadIDs(path string) []int64 {
 	for _, id := range ids {
 		if m.backend.IsPlaying(id) {
 			live = append(live, id)
+			continue
 		}
+		m.dropPlaybackTracking(id)
 	}
 	if len(live) == 0 {
 		delete(m.path2ids, path)
@@ -213,18 +282,88 @@ func (m *Manager) pruneDeadIDs(path string) []int64 {
 }
 
 func (m *Manager) removeID(target int64) {
-	for path, ids := range m.path2ids {
+	info, ok := m.playbacks[target]
+	if ok {
+		ids := m.path2ids[info.path]
 		for i, id := range ids {
 			if id != target {
 				continue
 			}
 			ids = append(ids[:i], ids[i+1:]...)
 			if len(ids) == 0 {
-				delete(m.path2ids, path)
+				delete(m.path2ids, info.path)
 			} else {
-				m.path2ids[path] = ids
+				m.path2ids[info.path] = ids
 			}
-			return
+			break
 		}
+	}
+	m.dropPlaybackTracking(target)
+}
+
+func (m *Manager) trackPlayback(id int64, path string, soundObj engine.Object, loop bool) {
+	if id == 0 {
+		return
+	}
+	m.playbacks[id] = playbackInfo{
+		path:     path,
+		soundObj: soundObj,
+		loop:     loop,
+	}
+	m.obj2ids[soundObj] = append(m.obj2ids[soundObj], id)
+}
+
+func (m *Manager) dropPlaybackTracking(id int64) {
+	info, ok := m.playbacks[id]
+	if !ok {
+		return
+	}
+	delete(m.playbacks, id)
+	m.dropSoundPlaybackID(info.soundObj, id)
+	if len(m.obj2ids[info.soundObj]) == 0 {
+		if _, pending := m.pendingDestroy[info.soundObj]; pending {
+			delete(m.pendingDestroy, info.soundObj)
+			m.backend.DestroyAudio(info.soundObj)
+		}
+	}
+}
+
+func (m *Manager) dropSoundPlaybackID(soundObj engine.Object, id int64) {
+	ids := m.obj2ids[soundObj]
+	for i, playbackID := range ids {
+		if playbackID != id {
+			continue
+		}
+		ids = append(ids[:i], ids[i+1:]...)
+		if len(ids) == 0 {
+			delete(m.obj2ids, soundObj)
+		} else {
+			m.obj2ids[soundObj] = ids
+		}
+		break
+	}
+}
+
+func (m *Manager) preparePlaybacksForRelease(soundObj engine.Object) {
+	ids := m.obj2ids[soundObj]
+	if len(ids) == 0 {
+		delete(m.obj2ids, soundObj)
+		return
+	}
+	for _, id := range append([]int64(nil), ids...) {
+		info, ok := m.playbacks[id]
+		if !ok {
+			m.dropSoundPlaybackID(soundObj, id)
+			continue
+		}
+		if info.loop {
+			m.backend.Stop(id)
+			m.removeID(id)
+			continue
+		}
+		if m.backend.IsPlaying(id) {
+			continue
+		}
+		m.removeID(id)
 	}
 }

--- a/internal/audio/manager_test.go
+++ b/internal/audio/manager_test.go
@@ -17,6 +17,7 @@
 package audio
 
 import (
+	"math"
 	"testing"
 
 	"github.com/goplus/spx/v2/internal/engine"
@@ -31,6 +32,7 @@ type fakeBackend struct {
 	restarts    []int64
 	loops       []loopCall
 	volumes     []float64
+	destroys    []engine.Object
 	lastDestroy engine.Object
 	pan         float64
 	pitch       float64
@@ -56,6 +58,7 @@ func (f *fakeBackend) CreateAudio() engine.Object {
 
 func (f *fakeBackend) DestroyAudio(obj engine.Object) {
 	f.lastDestroy = obj
+	f.destroys = append(f.destroys, obj)
 }
 
 func (f *fakeBackend) SetPitch(obj engine.Object, pitch float64) {
@@ -261,32 +264,59 @@ func TestManagerRestartIDPrunesStalePlayback(t *testing.T) {
 }
 
 func TestManagerVolumeAndEffects(t *testing.T) {
-	backend := &fakeBackend{pan: 0.25, pitch: 1.5, volume: 0.8}
+	backend := &fakeBackend{pan: 0.25, pitch: 2, volume: 0.8}
 	var mgr Manager
 	mgr.Init(backend)
 
 	if got := mgr.GetPan(1); got != 25 {
 		t.Fatalf("GetPan = %v, want 25", got)
 	}
-	if got := mgr.GetPitch(1); got != 150 {
-		t.Fatalf("GetPitch = %v, want 150", got)
+	if got := mgr.GetPitch(1); !almostEqual(got, 120) {
+		t.Fatalf("GetPitch = %v, want 120", got)
 	}
 	if got := mgr.GetVolume(1); got != 80 {
 		t.Fatalf("GetVolume = %v, want 80", got)
 	}
 
 	mgr.SetPan(1, 40)
-	mgr.SetPitch(1, 125)
+	mgr.SetPitch(1, 120)
 	mgr.SetVolume(1, -5)
 
 	if backend.pan != 0.4 {
 		t.Fatalf("SetPan backend = %v, want 0.4", backend.pan)
 	}
-	if backend.pitch != 1.25 {
-		t.Fatalf("SetPitch backend = %v, want 1.25", backend.pitch)
+	if !almostEqual(backend.pitch, 2) {
+		t.Fatalf("SetPitch backend = %v, want 2", backend.pitch)
 	}
 	if got := backend.volumes[len(backend.volumes)-1]; got != 0.01 {
 		t.Fatalf("SetVolume backend = %v, want 0.01", got)
+	}
+}
+
+func TestManagerPitchEffectUsesScratchScale(t *testing.T) {
+	backend := &fakeBackend{}
+	var mgr Manager
+	mgr.Init(backend)
+
+	mgr.SetPitch(1, 0)
+	if !almostEqual(backend.pitch, 1) {
+		t.Fatalf("SetPitch(0) backend = %v, want 1", backend.pitch)
+	}
+
+	mgr.SetPitch(1, 10)
+	want := math.Pow(2, 1.0/12)
+	if !almostEqual(backend.pitch, want) {
+		t.Fatalf("SetPitch(10) backend = %v, want %v", backend.pitch, want)
+	}
+
+	backend.pitch = want
+	if got := mgr.GetPitch(1); !almostEqual(got, 10) {
+		t.Fatalf("GetPitch = %v, want 10", got)
+	}
+
+	backend.pitch = 0
+	if got := mgr.GetPitch(1); got != 0 {
+		t.Fatalf("GetPitch with non-positive backend scale = %v, want 0", got)
 	}
 }
 
@@ -303,4 +333,163 @@ func TestManagerAllocAndRelease(t *testing.T) {
 	if backend.lastDestroy != 13 {
 		t.Fatalf("ReleaseSound destroyed = %d, want 13", backend.lastDestroy)
 	}
+}
+
+func TestManagerReleaseSoundDefersDestroyUntilPlaybackStops(t *testing.T) {
+	backend := &fakeBackend{}
+	var mgr Manager
+	mgr.Init(backend)
+
+	id := mgr.Play(13, "sounds/a.wav", false, false, 0, 0, 0)
+
+	mgr.ReleaseSound(13)
+	if len(backend.destroys) != 0 {
+		t.Fatalf("DestroyAudio calls = %+v, want none while playback %d is live", backend.destroys, id)
+	}
+
+	backend.playing[id] = false
+	mgr.Update()
+
+	if len(backend.destroys) != 1 || backend.destroys[0] != 13 {
+		t.Fatalf("DestroyAudio calls = %+v, want [13] after playback stops", backend.destroys)
+	}
+	assertManagerNoTracking(t, &mgr)
+}
+
+func TestManagerReleaseSoundDoesNotDestroyPendingSoundTwice(t *testing.T) {
+	backend := &fakeBackend{}
+	var mgr Manager
+	mgr.Init(backend)
+
+	id := mgr.Play(13, "sounds/a.wav", false, false, 0, 0, 0)
+
+	mgr.ReleaseSound(13)
+	backend.playing[id] = false
+	mgr.ReleaseSound(13)
+	mgr.Update()
+
+	if len(backend.destroys) != 1 || backend.destroys[0] != 13 {
+		t.Fatalf("DestroyAudio calls = %+v, want exactly [13]", backend.destroys)
+	}
+	assertManagerNoTracking(t, &mgr)
+}
+
+func TestManagerReleaseSoundStopsLoopedPlaybackBeforeDestroy(t *testing.T) {
+	backend := &fakeBackend{}
+	var mgr Manager
+	mgr.Init(backend)
+
+	id := mgr.Play(13, "sounds/loop.wav", true, false, 0, 0, 0)
+
+	mgr.ReleaseSound(13)
+
+	if len(backend.stops) != 1 || backend.stops[0] != id {
+		t.Fatalf("Stop calls = %+v, want [%d]", backend.stops, id)
+	}
+	if len(backend.destroys) != 1 || backend.destroys[0] != 13 {
+		t.Fatalf("DestroyAudio calls = %+v, want [13] after loop playback stops", backend.destroys)
+	}
+	assertManagerNoTracking(t, &mgr)
+}
+
+func TestManagerReleaseSoundStopsLoopsAndDefersOneShots(t *testing.T) {
+	backend := &fakeBackend{}
+	var mgr Manager
+	mgr.Init(backend)
+
+	loopID := mgr.Play(13, "sounds/loop.wav", true, false, 0, 0, 0)
+	oneShotID := mgr.Play(13, "sounds/hit.wav", false, false, 0, 0, 0)
+
+	mgr.ReleaseSound(13)
+
+	if len(backend.stops) != 1 || backend.stops[0] != loopID {
+		t.Fatalf("Stop calls = %+v, want only loop playback %d stopped", backend.stops, loopID)
+	}
+	if len(backend.destroys) != 0 {
+		t.Fatalf("DestroyAudio calls = %+v, want none while one-shot playback %d is live", backend.destroys, oneShotID)
+	}
+	if _, ok := mgr.playbacks[loopID]; ok {
+		t.Fatalf("loop playback %d still tracked after release", loopID)
+	}
+	if _, ok := mgr.playbacks[oneShotID]; !ok {
+		t.Fatalf("one-shot playback %d not tracked while still playing", oneShotID)
+	}
+
+	backend.playing[oneShotID] = false
+	mgr.Update()
+
+	if len(backend.destroys) != 1 || backend.destroys[0] != 13 {
+		t.Fatalf("DestroyAudio calls = %+v, want [13] after one-shot playback stops", backend.destroys)
+	}
+	assertManagerNoTracking(t, &mgr)
+}
+
+func TestManagerStopPathDestroysPendingReleasedSound(t *testing.T) {
+	backend := &fakeBackend{}
+	var mgr Manager
+	mgr.Init(backend)
+
+	id := mgr.Play(13, "sounds/a.wav", false, false, 0, 0, 0)
+	mgr.ReleaseSound(13)
+
+	mgr.Stop("sounds/a.wav")
+
+	if len(backend.stops) != 1 || backend.stops[0] != id {
+		t.Fatalf("Stop calls = %+v, want [%d]", backend.stops, id)
+	}
+	if len(backend.destroys) != 1 || backend.destroys[0] != 13 {
+		t.Fatalf("DestroyAudio calls = %+v, want [13] after Stop", backend.destroys)
+	}
+	assertManagerNoTracking(t, &mgr)
+}
+
+func TestManagerStopIDDestroysPendingReleasedSound(t *testing.T) {
+	backend := &fakeBackend{}
+	var mgr Manager
+	mgr.Init(backend)
+
+	id := mgr.Play(13, "sounds/a.wav", false, false, 0, 0, 0)
+	mgr.ReleaseSound(13)
+
+	mgr.StopID(id)
+
+	if len(backend.stops) != 1 || backend.stops[0] != id {
+		t.Fatalf("Stop calls = %+v, want [%d]", backend.stops, id)
+	}
+	if len(backend.destroys) != 1 || backend.destroys[0] != 13 {
+		t.Fatalf("DestroyAudio calls = %+v, want [13] after StopID", backend.destroys)
+	}
+	assertManagerNoTracking(t, &mgr)
+}
+
+func TestManagerStopAllDestroysPendingReleasedSounds(t *testing.T) {
+	backend := &fakeBackend{}
+	var mgr Manager
+	mgr.Init(backend)
+
+	mgr.Play(13, "sounds/a.wav", false, false, 0, 0, 0)
+	mgr.ReleaseSound(13)
+	mgr.StopAll()
+
+	if len(backend.destroys) != 1 || backend.destroys[0] != 13 {
+		t.Fatalf("DestroyAudio calls = %+v, want [13] after StopAll", backend.destroys)
+	}
+	assertManagerNoTracking(t, &mgr)
+}
+
+func assertManagerNoTracking(t *testing.T, mgr *Manager) {
+	t.Helper()
+	if len(mgr.path2ids) != 0 || len(mgr.obj2ids) != 0 || len(mgr.playbacks) != 0 || len(mgr.pendingDestroy) != 0 {
+		t.Fatalf(
+			"manager tracking not cleared: path2ids=%+v obj2ids=%+v playbacks=%+v pendingDestroy=%+v",
+			mgr.path2ids,
+			mgr.obj2ids,
+			mgr.playbacks,
+			mgr.pendingDestroy,
+		)
+	}
+}
+
+func almostEqual(got, want float64) bool {
+	return math.Abs(got-want) < 1e-9
 }

--- a/runtime_engine.go
+++ b/runtime_engine.go
@@ -65,6 +65,7 @@ func (p *Game) OnEngineUpdate(delta float64) {
 	if !p.lifecycleState.IsRunned.Load() {
 		return
 	}
+	p.soundMgr.Update()
 	if p.lifecycleState.BootstrapDone.Load() {
 		p.dispatchStartEventIfNeeded()
 	}

--- a/test/All/SpSound.spx
+++ b/test/All/SpSound.spx
@@ -33,12 +33,12 @@ onMsg "testSound", => {
 	assertFloat(volume(), 100, "Sprite::Volume")
 
 	// 7. Game::ChangeGraphicEffect
-	say "test change sound effect : pitch (150)"
-	changeSoundEffect SoundPitchEffect, 50 // pitch 150
+	say "test change sound effect : pitch effect (50)"
+	changeSoundEffect SoundPitchEffect, 50 // pitch effect 50
 	playAndWait "sound1"
 	// 8. Game::SetGraphicEffect
-	say "test set sound effect : pitch (150)"
-	setSoundEffect SoundPitchEffect, 50 // pitch 50
+	say "test set sound effect : pitch effect (50)"
+	setSoundEffect SoundPitchEffect, 50 // pitch effect 50
 	playAndWait "sound1"
 	// 9. Game::ClearSoundEffects
 	say "test clear sound effect : pitch (0)"


### PR DESCRIPTION
## Summary

- Defer sprite sound object destruction until active one-shot playbacks finish, so short sounds are not cut off when clones are destroyed.
- Stop looped playbacks when releasing a sound object to avoid leaked playback tracking.
- Track playback metadata by ID and clean `path2ids`, `obj2ids`, `playbacks`, and `pendingDestroy` across stop/update/stop-all paths.
- Match Scratch pitch effect semantics using `pitch_scale = 2^(effect/120)` and reset pitch to scale `1`.

## Validation

- `go test ./internal/audio`
- `go test .`
- `go test ./...`
- `git diff --check`
- `cd .tmp/715491086 && xgo go -t .`
- `cd .tmp/715491086 && spx build`