### PR TITLE
fix(runtime): unwrap Value before numeric compare

### DIFF
--- a/runtime_util.go
+++ b/runtime_util.go
@@ -59,8 +59,8 @@ func Contains(s, substr string) bool {
 // Values are compared numerically when both sides can be interpreted as numbers;
 // otherwise they are compared as case-insensitive strings.
 func Compare(v1, v2 any) int {
-	if n1, ok1 := scratchCompareNumber(v1); ok1 {
-		if n2, ok2 := scratchCompareNumber(v2); ok2 {
+	if n1, ok1 := toCompareNumber(v1); ok1 {
+		if n2, ok2 := toCompareNumber(v2); ok2 {
 			switch {
 			case n1 < n2:
 				return -1
@@ -89,19 +89,15 @@ func Equal(v1, v2 any) bool {
 	return Compare(v1, v2) == 0
 }
 
-func scratchCompareNumber(v any) (float64, bool) {
-	if isScratchWhitespace(v) {
+func toCompareNumber(v any) (float64, bool) {
+	v = fromObj(v)
+	if v == nil {
+		return 0, false
+	}
+	if s, ok := v.(string); ok && strings.TrimSpace(s) == "" {
 		return 0, false
 	}
 	return toFloat64Any(v)
-}
-
-func isScratchWhitespace(v any) bool {
-	if v == nil {
-		return true
-	}
-	s, ok := fromObj(v).(string)
-	return ok && strings.TrimSpace(s) == ""
 }
 
 // DeltaTime returns the time elapsed since the previous frame.

--- a/runtime_util_test.go
+++ b/runtime_util_test.go
@@ -141,6 +141,9 @@ func TestCompareAndEqual(t *testing.T) {
 		{name: "non numeric strings less", v1: "apple", v2: "Banana", compare: -1, equal: false},
 		{name: "whitespace uses string compare", v1: "", v2: "0", compare: -1, equal: false},
 		{name: "bool numeric compare", v1: true, v2: 1, compare: 0, equal: true},
+		{name: "wrapped numeric string compares numerically", v1: NewValue("01"), v2: 1, compare: 0, equal: true},
+		{name: "wrapped numeric string on right compares numerically", v1: 1, v2: NewValue("01"), compare: 0, equal: true},
+		{name: "wrapped bool compares numerically", v1: NewValue(true), v2: 1, compare: 0, equal: true},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- unwrap `Value` inputs before numeric comparison in `Compare`/`Equal`
- keep wrapped values aligned with Scratch comparison semantics instead of falling back to string comparison
- add regression coverage for wrapped numeric-string and bool comparisons

## Changes

- update `toCompareNumber` to call `fromObj(v)` before numeric conversion
- keep whitespace-only strings on the string-comparison path
- simplify the compare helper flow by inlining the whitespace check into `toCompareNumber`
- add tests for `Compare(NewValue("01"), 1)`, `Compare(1, NewValue("01"))`, and `Equal(NewValue(true), 1)`

## Why

Previously, whitespace detection unwrapped `Value`, but numeric conversion still received the wrapper itself. That made wrapped values like `NewValue("01")` and `NewValue(true)` fail numeric conversion and fall back to string comparison, producing different results from the same raw values.

## Testing

- `go test .`