### PR TITLE
feat: expose warp function metadata

### DIFF
--- a/game.go
+++ b/game.go
@@ -40,7 +40,8 @@ const (
 )
 
 const (
-	Gop_sched = "Sched,SchedNow"
+	Gop_sched    = "Sched,SchedNow"
+	Gop_wrapCall = "Warp"
 )
 
 var (

--- a/pkg/ispx/internal/pkg/github.com/goplus/spx/v2/export.go
+++ b/pkg/ispx/internal/pkg/github.com/goplus/spx/v2/export.go
@@ -337,6 +337,7 @@ func init() {
 		UntypedConsts: map[string]ixgo.UntypedConst{
 			"All":                          {Typ: "untyped int", Value: constant.MakeInt64(int64(q.All))},
 			"Gop_sched":                    {Typ: "untyped string", Value: constant.MakeString(string(q.Gop_sched))},
+			"Gop_wrapCall":                 {Typ: "untyped string", Value: constant.MakeString(string(q.Gop_wrapCall))},
 			"XGoPackage":                   {Typ: "untyped bool", Value: constant.MakeBool(bool(q.XGoPackage))},
 			"XGoo_SpriteImpl_GlideWith":    {Typ: "untyped string", Value: constant.MakeString(string(q.XGoo_SpriteImpl_GlideWith))},
 			"XGoo_SpriteImpl_QuoteWith":    {Typ: "untyped string", Value: constant.MakeString(string(q.XGoo_SpriteImpl_QuoteWith))},


### PR DESCRIPTION
## Summary
- Add `Gop_wrapCall = "Warp"` metadata for SPX.
- Export `Gop_wrapCall` through the ispx package registry so xgo can opt into `Warp func` lowering.

## Companion
Requires the xgo compiler support for `Warp func` declarations.

## Related
Updates https://github.com/goplus/xgo/issues/2756

## Tests
- `go test ./pkg/ispx`