### PR TITLE
fix(runtime): keep cloned sprites above their source

### DIFF
--- a/game_load_test.go
+++ b/game_load_test.go
@@ -560,6 +560,61 @@ func TestCloneSpriteAwakesBeforeMain(t *testing.T) {
 	}
 }
 
+func TestCloneSpriteInsertsImmediatelyAfterSource(t *testing.T) {
+	var game Game
+	game.initShapeMgr()
+	setupCloneSpriteMgr(t)
+
+	back := newCloneAwakeOrderSprite(&game, "Back")
+	source := newCloneAwakeOrderSprite(&game, "Source")
+	front := newCloneAwakeOrderSprite(&game, "Front")
+	game.addShape(spriteOf(back))
+	game.addShape(spriteOf(source))
+	game.addShape(spriteOf(front))
+
+	var cloned *cloneAwakeOrderSprite
+	platform.RunOnMainThread(func() {
+		doClone(source, nil, false, func(sprite *SpriteImpl) {
+			var ok bool
+			cloned, ok = sprite.sprite.(*cloneAwakeOrderSprite)
+			if !ok {
+				t.Fatalf("clone sprite type = %T, want *cloneAwakeOrderSprite", sprite.sprite)
+			}
+		})
+	})
+
+	if cloned == nil {
+		t.Fatal("clone callback did not capture cloned sprite")
+	}
+
+	shapes := game.getAllShapes()
+	if got := len(shapes); got != 4 {
+		t.Fatalf("shape count = %d, want 4", got)
+	}
+	if shapes[0] != spriteOf(back) {
+		t.Fatalf("shape[0] = %v, want back sprite", shapes[0])
+	}
+	if shapes[1] != spriteOf(source) {
+		t.Fatalf("shape[1] = %v, want source sprite", shapes[1])
+	}
+	if shapes[2] != spriteOf(cloned) {
+		t.Fatalf("shape[2] = %v, want cloned sprite", shapes[2])
+	}
+	if shapes[3] != spriteOf(front) {
+		t.Fatalf("shape[3] = %v, want front sprite", shapes[3])
+	}
+
+	if got, want := source.runtimeState.Layer, 2; got != want {
+		t.Fatalf("source layer = %d, want %d", got, want)
+	}
+	if got, want := cloned.runtimeState.Layer, 3; got != want {
+		t.Fatalf("clone layer = %d, want %d", got, want)
+	}
+	if got, want := front.runtimeState.Layer, 4; got != want {
+		t.Fatalf("front layer = %d, want %d", got, want)
+	}
+}
+
 func TestCloneSpritePreservesUserStateAfterMainRegistration(t *testing.T) {
 	var game Game
 	game.initShapeMgr()

--- a/shape_manager.go
+++ b/shape_manager.go
@@ -127,8 +127,8 @@ func (s *shapeManager) addShape(child Shape) {
 	s.add(child)
 }
 
-// addClonedShape inserts a cloned shape immediately after its source.
-// This preserves rendering order and ensures clones appear behind their source.
+// addClonedShape inserts a cloned shape immediately after its source so the
+// clone renders in front of the original while preserving nearby layer order.
 func (s *shapeManager) addClonedShape(src, clone Shape) {
 	idx := s.findShapeIndex(src)
 	if idx < 0 {
@@ -137,7 +137,7 @@ func (s *shapeManager) addClonedShape(src, clone Shape) {
 		return
 	}
 
-	s.items = sliceutil.InsertAt(s.items, idx, clone)
+	s.items = sliceutil.InsertAt(s.items, idx+1, clone)
 	s.updateRenderLayers()
 }
 


### PR DESCRIPTION
## Summary

Fix clone render ordering so cloned sprites are inserted immediately after their source sprite instead of before it.

## Changes

- update `shapeManager.addClonedShape` to insert clones after the source sprite
- keep clone rendering above the original while preserving nearby layer order
- add a regression test covering clone insertion order and assigned runtime layers

## Why

Cloned sprites could end up hidden behind their source or surrounding sprites because the runtime inserted them at the wrong position in the render list.

## Testing

- `go test ./... -run 'TestCloneSprite(AwakesBeforeMain|InsertsImmediatelyAfterSource|PreservesUserStateAfterMainRegistration|PreservesAllTopLevelUserFields)'`