### PR TITLE
chore(release): add v2.0.4 release mapping

### DIFF
--- a/internal/release/release_meta.go
+++ b/internal/release/release_meta.go
@@ -54,6 +54,7 @@ var releaseVersionMappings = []releaseVersionMapping{
 	{"v2.0.1", "2.2.1"},
 	{"v2.0.2", "2.2.2"},
 	{"v2.0.3", "2.2.3"},
+	{"v2.0.4", "2.2.4"},
 }
 
 func newReleaseMeta(mapping releaseVersionMapping) ReleaseMeta {

--- a/internal/release/release_meta_test.go
+++ b/internal/release/release_meta_test.go
@@ -40,14 +40,14 @@ func TestReleaseMetaForRuntimeVersionMapped(t *testing.T) {
 
 func TestDefaultReleaseMetaUsesLatestSPXVersionForRuntimeAssets(t *testing.T) {
 	meta := DefaultReleaseMeta()
-	if meta.SPXVersion != "v2.0.3" {
-		t.Fatalf("spx version = %q, want %q", meta.SPXVersion, "v2.0.3")
+	if meta.SPXVersion != "v2.0.4" {
+		t.Fatalf("spx version = %q, want %q", meta.SPXVersion, "v2.0.4")
 	}
-	if meta.Runtime.Version != "2.2.3" {
-		t.Fatalf("runtime version = %q, want %q", meta.Runtime.Version, "2.2.3")
+	if meta.Runtime.Version != "2.2.4" {
+		t.Fatalf("runtime version = %q, want %q", meta.Runtime.Version, "2.2.4")
 	}
-	if got := meta.RuntimeAssetDownloadURL(RuntimeAssetZipName); got != SpxReleaseURLBase+"v2.0.3/"+RuntimeAssetZipName {
-		t.Fatalf("runtime asset download url = %q, want %q", got, SpxReleaseURLBase+"v2.0.3/"+RuntimeAssetZipName)
+	if got := meta.RuntimeAssetDownloadURL(RuntimeAssetZipName); got != SpxReleaseURLBase+"v2.0.4/"+RuntimeAssetZipName {
+		t.Fatalf("runtime asset download url = %q, want %q", got, SpxReleaseURLBase+"v2.0.4/"+RuntimeAssetZipName)
 	}
 }
 


### PR DESCRIPTION
## Summary

- add the SPX `v2.0.4` to runtime `2.2.4` release mapping
- update the default release metadata test to reflect the latest release mapping

## Testing

- go test ./internal/release/...