### PR TITLE
fix: clear graphic effects on stop all

### DIFF
--- a/runtime_events.go
+++ b/runtime_events.go
@@ -172,6 +172,12 @@ func (p *scriptEventBindings) OnBackdrop__1(name BackdropName, onBackdrop func()
 }
 
 func (p *scriptEventBindings) Stop(kind StopKind) {
+	if kind == AllStop {
+		if game := activeGame(); game != nil {
+			game.resetGraphicEffectsOnStopAll()
+		}
+	}
+
 	current := gco.Current()
 	filter, abort := coreevent.ResolveStop(
 		kind,
@@ -186,6 +192,21 @@ func (p *scriptEventBindings) Stop(kind StopKind) {
 	}
 	if abort {
 		gco.Abort()
+	}
+}
+
+// Scratch clears graphic effects for the stage and every sprite when a
+// project-wide stop is triggered, including the `stop all` control block.
+func (p *Game) resetGraphicEffectsOnStopAll() {
+	p.baseObj.clearGraphicEffects()
+
+	shapes := append([]Shape(nil), p.getAllShapes()...)
+	for _, item := range shapes {
+		sprite, ok := item.(*SpriteImpl)
+		if !ok {
+			continue
+		}
+		sprite.clearGraphicEffects()
 	}
 }
 

--- a/runtime_events_test.go
+++ b/runtime_events_test.go
@@ -203,3 +203,36 @@ func TestPointHitsClickTargetUsesClickQuery(t *testing.T) {
 		t.Fatalf("pointHitsClickTarget used sensing query, want click query")
 	}
 }
+
+func TestResetGraphicEffectsOnStopAllClearsGraphicEffects(t *testing.T) {
+	var g Game
+	g.initShapeMgr()
+	g.greffUniforms = map[EffectKind]float64{GhostEffect: 100}
+
+	left := &SpriteImpl{g: &g, name: "left"}
+	left.greffUniforms = map[EffectKind]float64{GhostEffect: 100}
+
+	right := &SpriteImpl{g: &g, name: "right"}
+	right.greffUniforms = map[EffectKind]float64{
+		GhostEffect:      50,
+		BrightnessEffect: 25,
+	}
+
+	g.addShape(left)
+	g.addShape(right)
+
+	g.resetGraphicEffectsOnStopAll()
+
+	if got := g.greffUniforms[GhostEffect]; got != 0 {
+		t.Fatalf("stage ghost effect = %v, want 0 after stop all reset", got)
+	}
+	if got := left.greffUniforms[GhostEffect]; got != 0 {
+		t.Fatalf("left ghost effect = %v, want 0 after stop all reset", got)
+	}
+	if got := right.greffUniforms[GhostEffect]; got != 0 {
+		t.Fatalf("right ghost effect = %v, want 0 after stop all reset", got)
+	}
+	if got := right.greffUniforms[BrightnessEffect]; got != 0 {
+		t.Fatalf("right brightness effect = %v, want 0 after stop all reset", got)
+	}
+}


### PR DESCRIPTION
## Summary
- align `stop all` behavior with Scratch VM by clearing stage and sprite graphic effects
- keep other stop kinds unchanged so only project-wide stop resets visual effects
- add a regression test covering ghost and brightness effect reset on `stop all`

## Testing
- `go test -v . -run 'TestResetGraphicEffectsOnStopAllClearsGraphicEffects|TestFindClickTargetKeepsTopmostSpriteWithoutClickHandler|TestFindClickTargetKeepsTopmostClickableSprite|TestFindClickTargetSkipsFullyGhostedSpriteEvenWithClickHandler|TestTouchPointUsesScratchSensingQuery|TestPointHitsClickTargetUsesClickQuery' -count=1 -timeout 30s`