### PR TITLE
fix: keep hidden sprite bounds and clamp edge bounce

### DIFF
--- a/component_transform.go
+++ b/component_transform.go
@@ -320,6 +320,9 @@ func (t *transformComponent) fixWorldRange(x, y float64) (float64, float64) {
 	if rect == nil {
 		return x, y
 	}
+	if t.sprite.g.displayState.WorldWidth <= 0 || t.sprite.g.displayState.WorldHeight <= 0 {
+		return x, y
+	}
 
 	worldLeft, worldTop, worldRight, worldBottom := t.sprite.g.worldBounds()
 
@@ -328,8 +331,8 @@ func (t *transformComponent) fixWorldRange(x, y float64) (float64, float64) {
 	bottomOffset := t.y - rect.Position.Y
 	topOffset := rect.Position.Y + rect.Size.Y - t.y
 
-	x = mathf.Clamp(x, float64(worldLeft)-rightOffset, float64(worldRight)+leftOffset)
-	y = mathf.Clamp(y, float64(worldBottom)-topOffset, float64(worldTop)+bottomOffset)
+	x = mathf.Clamp(x, float64(worldLeft)+leftOffset, float64(worldRight)-rightOffset)
+	y = mathf.Clamp(y, float64(worldBottom)+bottomOffset, float64(worldTop)-topOffset)
 
 	return x, y
 }
@@ -416,6 +419,8 @@ func (t *transformComponent) BounceOffEdge(area string) {
 
 	newDirection := engine.RadToDeg(math.Atan2(dy, dx)) + 90
 	t.direction = normalizeDirection(newDirection)
+
+	t.moveTo(t.x, t.y)
 }
 
 // ============================================================================

--- a/sprite_query.go
+++ b/sprite_query.go
@@ -19,7 +19,7 @@ package spx
 import "github.com/goplus/spbase/mathf"
 
 func (p *SpriteImpl) bounds() *mathf.Rect2 {
-	if !p.spriteState.IsVisible {
+	if len(p.costumes) == 0 || p.costumeIndex < 0 || p.costumeIndex >= len(p.costumes) {
 		return nil
 	}
 


### PR DESCRIPTION
## Summary
- keep sprite bounds available even when the sprite is hidden
- fix world boundary clamp math so sprite positions stay inside valid bounds
- clamp sprite position after `BounceOffEdge`
- safely skip boundary clamping when world size or costume data is not initialized

## Why
Hidden sprites still need valid bounds for edge/collision related behavior.
This change also fixes incorrect clamp direction math and avoids regressions in paths where world/costume state is not fully initialized yet.

## Testing
- go test ./...