### PR TITLE
refactor: route sync event dispatch through coroutines

### DIFF
--- a/internal/core/event/dispatch.go
+++ b/internal/core/event/dispatch.go
@@ -84,7 +84,9 @@ func DispatchSync(sinks []Sink, data any, hooks DispatchHooks, do func(*Sink)) {
 				tasks = append(tasks, task)
 			}
 		}
-		hooks.Join(tasks)
+		if len(tasks) > 0 {
+			hooks.Join(tasks)
+		}
 		return
 	}
 

--- a/internal/core/event/dispatch.go
+++ b/internal/core/event/dispatch.go
@@ -18,8 +18,11 @@ package event
 
 import "sync"
 
+type DispatchTask any
+
 type DispatchHooks struct {
-	Spawn func(start bool, owner any, call func())
+	Spawn func(start bool, owner any, call func()) DispatchTask
+	Join  func([]DispatchTask)
 	Wait  func(func())
 }
 
@@ -63,7 +66,6 @@ func (m *Manager) DispatchStartOnce(data any, hooks DispatchHooks, do func(*Sink
 
 func DispatchAsync(sinks []Sink, start bool, data any, hooks DispatchHooks, do func(*Sink)) {
 	for _, sink := range sinks {
-		sink := sink
 		if sink.Cond != nil && !sink.Cond(data) {
 			continue
 		}
@@ -72,9 +74,22 @@ func DispatchAsync(sinks []Sink, start bool, data any, hooks DispatchHooks, do f
 }
 
 func DispatchSync(sinks []Sink, data any, hooks DispatchHooks, do func(*Sink)) {
+	if hooks.Spawn != nil && hooks.Join != nil {
+		tasks := make([]DispatchTask, 0, len(sinks))
+		for _, sink := range sinks {
+			if sink.Cond != nil && !sink.Cond(data) {
+				continue
+			}
+			if task := dispatchSink(hooks, false, sink, do); task != nil {
+				tasks = append(tasks, task)
+			}
+		}
+		hooks.Join(tasks)
+		return
+	}
+
 	var wg sync.WaitGroup
 	for _, sink := range sinks {
-		sink := sink
 		if sink.Cond != nil && !sink.Cond(data) {
 			continue
 		}
@@ -99,12 +114,12 @@ func Dispatch(sinks []Sink, wait bool, data any, hooks DispatchHooks, do func(*S
 	DispatchAsync(sinks, false, data, hooks, do)
 }
 
-func dispatchSink(hooks DispatchHooks, start bool, sink Sink, do func(*Sink)) {
+func dispatchSink(hooks DispatchHooks, start bool, sink Sink, do func(*Sink)) DispatchTask {
 	if hooks.Spawn != nil {
-		hooks.Spawn(start, sink.Owner, func() {
+		return hooks.Spawn(start, sink.Owner, func() {
 			do(&sink)
 		})
-		return
 	}
 	do(&sink)
+	return nil
 }

--- a/internal/core/event/dispatch_test.go
+++ b/internal/core/event/dispatch_test.go
@@ -51,10 +51,11 @@ func TestDispatchAsync(t *testing.T) {
 		true,
 		"ok",
 		DispatchHooks{
-			Spawn: func(start bool, owner any, call func()) {
+			Spawn: func(start bool, owner any, call func()) DispatchTask {
 				starts = append(starts, start)
 				owners = append(owners, owner.(string))
 				call()
+				return nil
 			},
 		},
 		func(sink *Sink) {
@@ -89,11 +90,12 @@ func TestDispatchSync(t *testing.T) {
 		},
 		"ok",
 		DispatchHooks{
-			Spawn: func(start bool, owner any, call func()) {
+			Spawn: func(start bool, owner any, call func()) DispatchTask {
 				if start {
 					t.Fatal("DispatchSync should not start threads in start mode")
 				}
 				call()
+				return nil
 			},
 			Wait: func(wait func()) {
 				waited = true
@@ -107,6 +109,57 @@ func TestDispatchSync(t *testing.T) {
 
 	if !waited {
 		t.Fatal("expected wait hook to be called")
+	}
+	if want := []string{"A", "B"}; !reflect.DeepEqual(calls, want) {
+		t.Fatalf("calls = %+v, want %+v", calls, want)
+	}
+}
+
+func TestDispatchSyncPrefersJoinHook(t *testing.T) {
+	waited := false
+	var (
+		spawned []DispatchTask
+		joined  []DispatchTask
+		calls   []string
+	)
+
+	DispatchSync(
+		[]Sink{
+			{Owner: "a", Handler: "A"},
+			{Owner: "b", Handler: "B"},
+		},
+		nil,
+		DispatchHooks{
+			Spawn: func(start bool, owner any, call func()) DispatchTask {
+				if start {
+					t.Fatal("DispatchSync should not start threads in start mode")
+				}
+				task := owner.(string)
+				spawned = append(spawned, task)
+				call()
+				return task
+			},
+			Join: func(tasks []DispatchTask) {
+				joined = append(joined, tasks...)
+			},
+			Wait: func(wait func()) {
+				waited = true
+				wait()
+			},
+		},
+		func(sink *Sink) {
+			calls = append(calls, sink.Handler.(string))
+		},
+	)
+
+	if waited {
+		t.Fatal("wait hook should not be called when join hook is provided")
+	}
+	if want := []DispatchTask{"a", "b"}; !reflect.DeepEqual(spawned, want) {
+		t.Fatalf("spawned = %+v, want %+v", spawned, want)
+	}
+	if want := []DispatchTask{"a", "b"}; !reflect.DeepEqual(joined, want) {
+		t.Fatalf("joined = %+v, want %+v", joined, want)
 	}
 	if want := []string{"A", "B"}; !reflect.DeepEqual(calls, want) {
 		t.Fatalf("calls = %+v, want %+v", calls, want)
@@ -147,10 +200,11 @@ func TestManagerDispatchBucketAsync(t *testing.T) {
 	})
 
 	mgr.DispatchBucketAsync(BucketClick, true, "ok", DispatchHooks{
-		Spawn: func(start bool, owner any, call func()) {
+		Spawn: func(start bool, owner any, call func()) DispatchTask {
 			starts = append(starts, start)
 			owners = append(owners, owner.(string))
 			call()
+			return nil
 		},
 	}, func(sink *Sink) {
 		calls = append(calls, sink.Handler.(string))
@@ -175,11 +229,12 @@ func TestManagerDispatchBucketSync(t *testing.T) {
 	mgr.Add(BucketTimer, Sink{Owner: "timer", Handler: "A"})
 
 	mgr.DispatchBucketSync(BucketTimer, 1.0, DispatchHooks{
-		Spawn: func(start bool, owner any, call func()) {
+		Spawn: func(start bool, owner any, call func()) DispatchTask {
 			if start {
 				t.Fatal("DispatchBucketSync should not mark start=true")
 			}
 			call()
+			return nil
 		},
 		Wait: func(wait func()) {
 			waited = true
@@ -206,11 +261,12 @@ func TestManagerDispatchStartOnce(t *testing.T) {
 	}
 
 	hooks := DispatchHooks{
-		Spawn: func(start bool, owner any, call func()) {
+		Spawn: func(start bool, owner any, call func()) DispatchTask {
 			if start {
 				t.Fatal("DispatchStartOnce should always dispatch with start=false")
 			}
 			call()
+			return nil
 		},
 	}
 
@@ -241,11 +297,12 @@ func TestManagerDispatchBucket(t *testing.T) {
 		})
 
 		mgr.DispatchBucket(BucketIReceive, false, "ok", DispatchHooks{
-			Spawn: func(start bool, owner any, call func()) {
+			Spawn: func(start bool, owner any, call func()) DispatchTask {
 				if start {
 					t.Fatal("DispatchBucket async path should not force start=true")
 				}
 				call()
+				return nil
 			},
 			Wait: func(wait func()) {
 				waited = true
@@ -271,11 +328,12 @@ func TestManagerDispatchBucket(t *testing.T) {
 		mgr.Add(BucketBackdropChanged, Sink{Owner: "backdrop", Handler: "B"})
 
 		mgr.DispatchBucket(BucketBackdropChanged, true, "stage", DispatchHooks{
-			Spawn: func(start bool, owner any, call func()) {
+			Spawn: func(start bool, owner any, call func()) DispatchTask {
 				if start {
 					t.Fatal("DispatchBucket sync path should not force start=true")
 				}
 				call()
+				return nil
 			},
 			Wait: func(wait func()) {
 				waited = true

--- a/internal/coroutine/thread.go
+++ b/internal/coroutine/thread.go
@@ -225,6 +225,10 @@ func (p *Coroutines) JoinAll(targets []Thread) {
 	if len(targets) == 0 {
 		return
 	}
+	if len(targets) == 1 {
+		p.Join(targets[0])
+		return
+	}
 
 	seen := make(map[Thread]struct{}, len(targets))
 	for _, target := range targets {

--- a/internal/coroutine/thread.go
+++ b/internal/coroutine/thread.go
@@ -52,6 +52,11 @@ type threadImpl struct {
 
 	ctx        context.Context
 	cancelFunc context.CancelFunc
+	done       chan struct{}
+
+	joinMu     sync.Mutex
+	joinDone   bool
+	joinWaiter map[Thread]struct{}
 }
 
 // Thread represents a coroutine id.
@@ -197,6 +202,43 @@ func (p *Coroutines) AbortAllAndWait(timeout stime.Duration) bool {
 	return p.waitForThreadsToStop(timeout, nil)
 }
 
+func (p *Coroutines) Join(target Thread) {
+	if target == nil {
+		return
+	}
+
+	me := p.currentCoroutineThread()
+	if me == nil {
+		<-target.done
+		return
+	}
+	if me == target {
+		return
+	}
+	if !target.addJoinWaiter(me) {
+		return
+	}
+	p.blockAndYield(me)
+}
+
+func (p *Coroutines) JoinAll(targets []Thread) {
+	if len(targets) == 0 {
+		return
+	}
+
+	seen := make(map[Thread]struct{}, len(targets))
+	for _, target := range targets {
+		if target == nil {
+			continue
+		}
+		if _, exists := seen[target]; exists {
+			continue
+		}
+		seen[target] = struct{}{}
+		p.Join(target)
+	}
+}
+
 func (p *Coroutines) StopIf(filter func(th Thread) bool) {
 	p.mutex.Lock()
 	allThreads := make([]Thread, 0, len(p.allThreads))
@@ -264,6 +306,7 @@ func (p *Coroutines) newThread(obj ThreadObj) Thread {
 		id:         atomic.AddInt64(&p.nextThreadID, 1),
 		schedFrame: -1,
 		name:       resolveThreadName(obj),
+		done:       make(chan struct{}),
 	}
 	th.ctx, th.cancelFunc = context.WithCancel(context.Background())
 
@@ -273,6 +316,37 @@ func (p *Coroutines) newThread(obj ThreadObj) Thread {
 
 	th.cond = sync.NewCond(&th.mutex)
 	return th
+}
+
+func (p *threadImpl) addJoinWaiter(waiter Thread) bool {
+	if waiter == nil {
+		return false
+	}
+
+	p.joinMu.Lock()
+	defer p.joinMu.Unlock()
+	if p.joinDone {
+		return false
+	}
+	if p.joinWaiter == nil {
+		p.joinWaiter = make(map[Thread]struct{})
+	}
+	p.joinWaiter[waiter] = struct{}{}
+	return true
+}
+
+func (p *threadImpl) finishJoinWaiters() []Thread {
+	p.joinMu.Lock()
+	waiters := make([]Thread, 0, len(p.joinWaiter))
+	for waiter := range p.joinWaiter {
+		waiters = append(waiters, waiter)
+	}
+	p.joinWaiter = nil
+	p.joinDone = true
+	p.joinMu.Unlock()
+
+	close(p.done)
+	return waiters
 }
 
 func (p *Coroutines) registerThread(th Thread) {
@@ -367,6 +441,9 @@ func (p *Coroutines) runThread(th Thread, fn func(me Thread) int) {
 		p.unregisterThread(th)
 		p.setWaitState(th, waitStatusDelete)
 		th.Cancel()
+		for _, waiter := range th.finishJoinWaiters() {
+			p.markIdleAndResume(waiter)
+		}
 		p.sema.Unlock()
 		p.goroutineIDs.Delete(gid)
 		p.handleThreadPanic(th, recovered)

--- a/internal/coroutine/thread_test.go
+++ b/internal/coroutine/thread_test.go
@@ -235,3 +235,109 @@ func TestAbortAllAndWaitFromCoroutineDoesNotStartStoppedPeer(t *testing.T) {
 	default:
 	}
 }
+
+func TestJoinResumesCallerAfterPeerCompletes(t *testing.T) {
+	co := New(nil)
+	releasePeer := make(chan struct{})
+	peerReady := make(chan Thread, 1)
+	callerDone := make(chan struct{})
+
+	peer := co.CreateAndStart(true, "peer", func(peer Thread) int {
+		peerReady <- peer
+		var signal struct{}
+		WaitForChan(co, releasePeer, &signal)
+		return 0
+	})
+
+	timer := time.NewTimer(time.Second)
+	defer timer.Stop()
+	select {
+	case <-peerReady:
+	case <-timer.C:
+		t.Fatal("peer coroutine did not start")
+	}
+
+	co.CreateAndStart(true, "caller", func(me Thread) int {
+		co.Join(peer)
+		close(callerDone)
+		return 0
+	})
+
+	select {
+	case <-callerDone:
+		t.Fatal("caller returned before peer completed")
+	default:
+	}
+
+	close(releasePeer)
+
+	timer = time.NewTimer(time.Second)
+	defer timer.Stop()
+	select {
+	case <-callerDone:
+	case <-timer.C:
+		t.Fatal("caller did not resume after peer completed")
+	}
+}
+
+func TestJoinAllWaitsForEveryPeer(t *testing.T) {
+	co := New(nil)
+	releaseA := make(chan struct{})
+	releaseB := make(chan struct{})
+	peerAReady := make(chan Thread, 1)
+	peerBReady := make(chan Thread, 1)
+	callerDone := make(chan struct{})
+
+	peerA := co.CreateAndStart(true, "peer-a", func(peer Thread) int {
+		peerAReady <- peer
+		var signal struct{}
+		WaitForChan(co, releaseA, &signal)
+		return 0
+	})
+	peerB := co.CreateAndStart(true, "peer-b", func(peer Thread) int {
+		peerBReady <- peer
+		var signal struct{}
+		WaitForChan(co, releaseB, &signal)
+		return 0
+	})
+
+	timer := time.NewTimer(time.Second)
+	defer timer.Stop()
+	select {
+	case <-peerAReady:
+	case <-timer.C:
+		t.Fatal("peer A coroutine did not start")
+	}
+
+	timer = time.NewTimer(time.Second)
+	defer timer.Stop()
+	select {
+	case <-peerBReady:
+	case <-timer.C:
+		t.Fatal("peer B coroutine did not start")
+	}
+
+	co.CreateAndStart(true, "caller", func(me Thread) int {
+		co.JoinAll([]Thread{peerA, peerB, peerA})
+		close(callerDone)
+		return 0
+	})
+
+	close(releaseA)
+
+	select {
+	case <-callerDone:
+		t.Fatal("caller returned before every peer completed")
+	default:
+	}
+
+	close(releaseB)
+
+	timer = time.NewTimer(time.Second)
+	defer timer.Stop()
+	select {
+	case <-callerDone:
+	case <-timer.C:
+		t.Fatal("caller did not resume after every peer completed")
+	}
+}

--- a/runtime_events.go
+++ b/runtime_events.go
@@ -39,6 +39,15 @@ var scriptEventDispatchHooks = coreevent.DispatchHooks{
 		})
 	},
 	Join: func(tasks []coreevent.DispatchTask) {
+		if len(tasks) == 0 {
+			return
+		}
+		if len(tasks) == 1 {
+			if th, ok := tasks[0].(coroutine.Thread); ok && th != nil {
+				gco.Join(th)
+			}
+			return
+		}
 		threads := make([]coroutine.Thread, 0, len(tasks))
 		for _, task := range tasks {
 			th, ok := task.(coroutine.Thread)

--- a/runtime_events.go
+++ b/runtime_events.go
@@ -32,13 +32,23 @@ const (
 )
 
 var scriptEventDispatchHooks = coreevent.DispatchHooks{
-	Spawn: func(start bool, owner any, call func()) {
-		gco.CreateAndStart(start, owner, func(coroutine.Thread) int {
+	Spawn: func(start bool, owner any, call func()) coreevent.DispatchTask {
+		return gco.CreateAndStart(start, owner, func(coroutine.Thread) int {
 			call()
 			return 0
 		})
 	},
-	Wait: engine.WaitToDo,
+	Join: func(tasks []coreevent.DispatchTask) {
+		threads := make([]coroutine.Thread, 0, len(tasks))
+		for _, task := range tasks {
+			th, ok := task.(coroutine.Thread)
+			if !ok || th == nil {
+				continue
+			}
+			threads = append(threads, th)
+		}
+		gco.JoinAll(threads)
+	},
 }
 
 // -----------------------------------------------------------------------------

--- a/test/All/SpEvent.spx
+++ b/test/All/SpEvent.spx
@@ -22,12 +22,29 @@ onMsg "msgB", => {
 	hasReceivedMsgB = true
 }
 
+onMsg "syncMsg", => {
+	wait 0.05s
+	hasSyncMsgSprite = true
+}
+
 onStart => {
 	hasStarted = true
 }
 
 // Not support
 // onLoudness =>{}
+
+onMsg "testSyncEvent", => {
+	onTestStart(this)
+
+	hasSyncMsgSprite = false
+	hasSyncMsgStage = false
+	broadcastAndWait "syncMsg"
+	assert(hasSyncMsgSprite, "Sprite::broadcastAndWait should wait for sprite handlers")
+	assert(hasSyncMsgStage, "Sprite::broadcastAndWait should wait for stage handlers")
+
+	hasTestDone = true
+}
 
 onMsg "testEvent", => {
 	onTestStart(this)

--- a/test/All/main.spx
+++ b/test/All/main.spx
@@ -8,6 +8,8 @@ var (
 	hasChangedBackdrop bool
 	hasReceivedMsgA    bool
 	hasReceivedMsgB    bool
+	hasSyncMsgSprite   bool
+	hasSyncMsgStage    bool
 
 	cloneNum int
 )
@@ -62,9 +64,15 @@ func waitAndTest(msg string) {
 	broadcast msg
 }
 
+onMsg "syncMsg", => {
+	wait 0.1s
+	hasSyncMsgStage = true
+}
+
 onStart => {
 	hasTestDone = true
 	waitAndTest "testControl"
+	waitAndTest "testSyncEvent"
 	waitAndTest "testEvent"
 	waitAndTest "testLook"
 	waitAndTest "testMotion"


### PR DESCRIPTION
## Summary

This PR routes internal synchronous event dispatch through SPX coroutines instead of `WaitToDo`.

### What changed

- Added a coroutine-aware sync dispatch path in `internal/core/event/dispatch.go`
  - `DispatchSync` now prefers `Spawn + Join` when both hooks are provided
  - existing `WaitGroup + Wait` remains as a fallback for non-coroutine callers
- Added `Join` / `JoinAll` support to `internal/coroutine/thread.go`
  - waiting coroutines are resumed when the target coroutine exits
- Switched script event sync waiting in `runtime_events.go`
  - `scriptEventDispatchHooks` now returns coroutine handles from `Spawn`
  - sync waits use `gco.JoinAll(...)` instead of `engine.WaitToDo`
- Added regression coverage
  - event dispatch tests for join-first sync behavior
  - coroutine tests for `Join` / `JoinAll`
  - `test/All` now includes a minimal `broadcastAndWait` sync probe

## Why

We want internal script execution to use a single coroutine model where possible.
This keeps synchronous script-event waiting inside SPX coroutines, instead of bouncing through Go goroutines for internal dispatch coordination.

External blocking bridges such as native I/O or channel waiting are unchanged.

## Testing

- `cd test/All && xgo go .`
- `go test ./...`