### PR TITLE
refactor: simplify deterministic frame capture flow

### DIFF
--- a/cmd/ispx/web/runner.html
+++ b/cmd/ispx/web/runner.html
@@ -234,14 +234,6 @@
 			return gameApp.getRecordedVideo()
 		}
 
-		let spxCaptureHost = null
-
-		window.spxSetCaptureHost = (host) => {
-			spxCaptureHost = host || null
-		}
-
-		window.spxGetCaptureHost = () => spxCaptureHost
-
 		// Captures the current game screen and returns its binary data as a Blob.
 		window.getScreenshot = async () => {
 			let gameCanvas = document.getElementById('game-canvas')
@@ -260,139 +252,141 @@
 			})
 		}
 
-		function normalizeCaptureFilename(name, check) {
-			let fileName = typeof name === 'string' ? name.trim() : ''
-			if (!fileName) {
-				fileName = check ? 'capture-check.png' : 'capture.png'
-			}
-			fileName = fileName.replace(/[\\/:*?"<>|\u0000-\u001F]+/g, '_')
-			if (!/\.png$/i.test(fileName)) {
-				fileName += '.png'
-			}
-			return fileName
-		}
-
-		function normalizeCaptureRequest(request) {
-			if (!request || typeof request !== 'object' || Array.isArray(request)) {
-				throw new Error('spx: capture request must be an object')
-			}
-			const check = request.check === true || request.intent === 'check'
-			const intent = check ? 'check' : 'snapshot'
-			return {
-				name: typeof request.name === 'string' ? request.name : '',
-				filename: normalizeCaptureFilename(request.name, check),
-				intent,
-				check,
-				frame: Number.isFinite(request.frame) ? request.frame : null,
-				sequence: Number.isFinite(request.sequence) ? request.sequence : null,
-			}
-		}
-
-		function notifyCaptureEvent(detail) {
-			const event = new CustomEvent('spxCaptureScreenshot', { detail })
-			window.dispatchEvent(event)
-			if (window.parent && window.parent !== window) {
-				try {
-					window.parent.dispatchEvent(new CustomEvent('spxCaptureScreenshot', { detail }))
-				} catch (error) {
-					console.warn('Failed to notify parent capture event', error)
+		const spxCaptureBridge = {
+			host: null,
+			setHost(host) {
+				this.host = host || null
+			},
+			getHost() {
+				return this.host
+			},
+			normalizeFilename(name, check) {
+				let fileName = typeof name === 'string' ? name.trim() : ''
+				if (!fileName) {
+					fileName = check ? 'capture-check.png' : 'capture.png'
 				}
-			}
-		}
-
-		function downloadBlob(blob, filename) {
-			const url = URL.createObjectURL(blob)
-			const anchor = document.createElement('a')
-			anchor.href = url
-			anchor.download = filename
-			document.body.appendChild(anchor)
-			anchor.click()
-			document.body.removeChild(anchor)
-			setTimeout(() => URL.revokeObjectURL(url), 0)
-		}
-
-		function dispatchCaptureToHost(request, blob) {
-			if (!spxCaptureHost) {
-				return { handled: false, completion: null }
-			}
-			let result = null
-			if (typeof spxCaptureHost === 'function') {
-				result = spxCaptureHost(request, blob)
-			} else if (typeof spxCaptureHost.handleCapture === 'function') {
-				result = spxCaptureHost.handleCapture(request, blob)
-			} else {
-				throw new Error('spx: capture host must be a function or expose handleCapture(request, blob)')
-			}
-			if (result && typeof result.then === 'function') {
-				return { handled: true, completion: result }
-			}
-			return { handled: true, completion: Promise.resolve(result) }
-		}
-
-		function notifyCaptureSuccess(request, blob, destination) {
-			notifyCaptureEvent({
-				ok: true,
-				name: request.name,
-				filename: request.filename,
-				intent: request.intent,
-				check: request.check,
-				frame: request.frame,
-				sequence: request.sequence,
-				destination,
-				size: blob.size,
-				type: blob.type || 'image/png',
-			})
-		}
-
-		function notifyCaptureFailure(request, error) {
-			const message = error instanceof Error ? error.message : `${error}`
-			console.error('spx: capture bridge failed', error)
-			notifyCaptureEvent({
-				ok: false,
-				error: message,
-				name: request ? request.name : '',
-				filename: request ? request.filename : '',
-				intent: request ? request.intent : 'snapshot',
-				check: request ? request.check : false,
-				frame: request ? request.frame : null,
-				sequence: request ? request.sequence : null,
-			})
-		}
-
-		window.__spxHandleCaptureRequest = (request) => {
-			if (typeof window.getScreenshot !== 'function') {
-				return { error: 'spx: getScreenshot is not configured' }
-			}
-
-			const normalizedRequest = normalizeCaptureRequest(request)
-			if (normalizedRequest.check && !spxCaptureHost) {
-				console.warn('CaptureForCheck currently uses download-only fallback on web:', normalizedRequest.filename)
-			}
-
-			window.getScreenshot().then((blob) => {
-				if (!blob) {
-					const error = new Error(`spx: failed to capture screenshot ${normalizedRequest.filename}`)
-					console.error(error)
-					notifyCaptureFailure(normalizedRequest, error)
-					return
+				fileName = fileName.replace(/[\\/:*?"<>|\u0000-\u001F]+/g, '_')
+				if (!/\.png$/i.test(fileName)) {
+					fileName += '.png'
 				}
-				const dispatch = dispatchCaptureToHost(normalizedRequest, blob)
-				if (!dispatch.handled) {
-					downloadBlob(blob, normalizedRequest.filename)
-					notifyCaptureSuccess(normalizedRequest, blob, 'download')
-					return
+				return fileName
+			},
+			normalizeRequest(request) {
+				if (!request || typeof request !== 'object' || Array.isArray(request)) {
+					throw new Error('spx: capture request must be an object')
 				}
-				dispatch.completion.then(() => {
-					notifyCaptureSuccess(normalizedRequest, blob, 'host')
-				}).catch((error) => {
-					notifyCaptureFailure(normalizedRequest, error)
+				const check = request.check === true || request.intent === 'check'
+				return {
+					name: typeof request.name === 'string' ? request.name : '',
+					filename: this.normalizeFilename(request.name, check),
+					intent: check ? 'check' : 'snapshot',
+					check,
+					frame: Number.isFinite(request.frame) ? request.frame : null,
+					sequence: Number.isFinite(request.sequence) ? request.sequence : null,
+				}
+			},
+			notify(detail) {
+				const event = new CustomEvent('spxCaptureScreenshot', { detail })
+				window.dispatchEvent(event)
+				if (window.parent && window.parent !== window) {
+					try {
+						window.parent.dispatchEvent(new CustomEvent('spxCaptureScreenshot', { detail }))
+					} catch (error) {
+						console.warn('Failed to notify parent capture event', error)
+					}
+				}
+			},
+			downloadBlob(blob, filename) {
+				const url = URL.createObjectURL(blob)
+				const anchor = document.createElement('a')
+				anchor.href = url
+				anchor.download = filename
+				document.body.appendChild(anchor)
+				anchor.click()
+				document.body.removeChild(anchor)
+				setTimeout(() => URL.revokeObjectURL(url), 0)
+			},
+			dispatchToHost(request, blob) {
+				if (!this.host) {
+					return { handled: false, completion: null }
+				}
+				let result = null
+				if (typeof this.host === 'function') {
+					result = this.host(request, blob)
+				} else if (typeof this.host.handleCapture === 'function') {
+					result = this.host.handleCapture(request, blob)
+				} else {
+					throw new Error('spx: capture host must be a function or expose handleCapture(request, blob)')
+				}
+				if (result && typeof result.then === 'function') {
+					return { handled: true, completion: result }
+				}
+				return { handled: true, completion: Promise.resolve(result) }
+			},
+			notifySuccess(request, blob, destination) {
+				this.notify({
+					ok: true,
+					name: request.name,
+					filename: request.filename,
+					intent: request.intent,
+					check: request.check,
+					frame: request.frame,
+					sequence: request.sequence,
+					destination,
+					size: blob.size,
+					type: blob.type || 'image/png',
 				})
-			}).catch((error) => {
-				notifyCaptureFailure(normalizedRequest, error)
-			})
+			},
+			notifyFailure(request, error) {
+				const message = error instanceof Error ? error.message : `${error}`
+				console.error('spx: capture bridge failed', error)
+				this.notify({
+					ok: false,
+					error: message,
+					name: request ? request.name : '',
+					filename: request ? request.filename : '',
+					intent: request ? request.intent : 'snapshot',
+					check: request ? request.check : false,
+					frame: request ? request.frame : null,
+					sequence: request ? request.sequence : null,
+				})
+			},
+			async completeCapture(request) {
+				const blob = await window.getScreenshot()
+				if (!blob) {
+					throw new Error(`spx: failed to capture screenshot ${request.filename}`)
+				}
 
-			return { ok: true, pending: true }
+				const dispatch = this.dispatchToHost(request, blob)
+				if (!dispatch.handled) {
+					this.downloadBlob(blob, request.filename)
+					this.notifySuccess(request, blob, 'download')
+					return
+				}
+
+				await dispatch.completion
+				this.notifySuccess(request, blob, 'host')
+			},
+			handleRequest(request) {
+				if (typeof window.getScreenshot !== 'function') {
+					return { error: 'spx: getScreenshot is not configured' }
+				}
+
+				const normalizedRequest = this.normalizeRequest(request)
+				if (normalizedRequest.check && !this.host) {
+					console.warn('CaptureForCheck currently uses download-only fallback on web:', normalizedRequest.filename)
+				}
+
+				this.completeCapture(normalizedRequest).catch((error) => {
+					this.notifyFailure(normalizedRequest, error)
+				})
+				return { ok: true, pending: true }
+			},
 		}
+
+		window.spxSetCaptureHost = (host) => spxCaptureBridge.setHost(host)
+		window.spxGetCaptureHost = () => spxCaptureBridge.getHost()
+		window.__spxHandleCaptureRequest = (request) => spxCaptureBridge.handleRequest(request)
 
 		window.downloadRecordedVideo = (filename) => {
 			if (gameApp == null) {

--- a/cmd/spx/template/platform/web/index.html
+++ b/cmd/spx/template/platform/web/index.html
@@ -306,11 +306,13 @@
 
 		const iframe = document.getElementById('runnerFrame');
 		let enlarged = false;
-		let captureRootHandle = null
-		let activeCaptureProject = null
-		let activeCaptureSession = null
-		let captureCompareRefreshTimer = 0
-		let capturePreviewUrls = []
+		const captureState = {
+			rootHandle: null,
+			project: null,
+			session: null,
+			refreshTimer: 0,
+			previewUrls: [],
+		}
 
 		runnerWindow = iframe.contentWindow;
 
@@ -321,8 +323,8 @@
 		}
 
 		function revokeCapturePreviewUrls() {
-			capturePreviewUrls.forEach((url) => URL.revokeObjectURL(url))
-			capturePreviewUrls = []
+			captureState.previewUrls.forEach((url) => URL.revokeObjectURL(url))
+			captureState.previewUrls = []
 		}
 
 		function setCaptureCompareEmpty(message, summary = message) {
@@ -332,11 +334,11 @@
 		}
 
 		function scheduleCaptureCompareRefresh() {
-			if (captureCompareRefreshTimer) {
-				clearTimeout(captureCompareRefreshTimer)
+			if (captureState.refreshTimer) {
+				clearTimeout(captureState.refreshTimer)
 			}
-			captureCompareRefreshTimer = window.setTimeout(() => {
-				captureCompareRefreshTimer = 0
+			captureState.refreshTimer = window.setTimeout(() => {
+				captureState.refreshTimer = 0
 				refreshCaptureCompare().catch((error) => {
 					console.error('Failed to refresh capture compare', error)
 					setCaptureCompareEmpty('Failed to read capture files. Check browser console for details.')
@@ -353,8 +355,8 @@
 				mode: 'readwrite',
 				id: 'spx-capture-root',
 			}
-			if (captureRootHandle) {
-				options.startIn = captureRootHandle
+			if (captureState.rootHandle) {
+				options.startIn = captureState.rootHandle
 				return options
 			}
 			options.startIn = 'downloads'
@@ -419,8 +421,8 @@
 		}
 
 		function resetActiveCaptureSession(project) {
-			activeCaptureProject = project
-			activeCaptureSession = {
+			captureState.project = project
+			captureState.session = {
 				projectKey: project.projectKey,
 				deterministic: project.deterministic,
 				runTimestamp: formatCaptureTimestamp(),
@@ -453,17 +455,17 @@
 		}
 
 		async function ensureCaptureTarget() {
-			if (!captureRootHandle || !activeCaptureSession) {
+			if (!captureState.rootHandle || !captureState.session) {
 				return null
 			}
-			if (!activeCaptureSession.targetPromise) {
-				activeCaptureSession.targetPromise = (async () => {
-					const snapshotsDir = await captureRootHandle.getDirectoryHandle('spx-snapshots', { create: true })
-					const projectDir = await snapshotsDir.getDirectoryHandle(activeCaptureSession.projectKey, { create: true })
-					if (!activeCaptureSession.deterministic) {
+			if (!captureState.session.targetPromise) {
+				captureState.session.targetPromise = (async () => {
+					const snapshotsDir = await captureState.rootHandle.getDirectoryHandle('spx-snapshots', { create: true })
+					const projectDir = await snapshotsDir.getDirectoryHandle(captureState.session.projectKey, { create: true })
+					if (!captureState.session.deterministic) {
 						const runsDir = await projectDir.getDirectoryHandle('runs', { create: true })
-						const runDir = await runsDir.getDirectoryHandle(activeCaptureSession.runTimestamp, { create: true })
-						return { directory: runDir, destination: `runs/${activeCaptureSession.runTimestamp}` }
+						const runDir = await runsDir.getDirectoryHandle(captureState.session.runTimestamp, { create: true })
+						return { directory: runDir, destination: `runs/${captureState.session.runTimestamp}` }
 					}
 
 					const hasBaseline = await fileExists(projectDir, '.baseline.ready')
@@ -473,11 +475,11 @@
 					}
 
 					const runsDir = await projectDir.getDirectoryHandle('runs', { create: true })
-					const runDir = await runsDir.getDirectoryHandle(activeCaptureSession.runTimestamp, { create: true })
-					return { directory: runDir, destination: `runs/${activeCaptureSession.runTimestamp}` }
+					const runDir = await runsDir.getDirectoryHandle(captureState.session.runTimestamp, { create: true })
+					return { directory: runDir, destination: `runs/${captureState.session.runTimestamp}` }
 				})()
 			}
-			return activeCaptureSession.targetPromise
+			return captureState.session.targetPromise
 		}
 
 		async function markBaselineReady(projectDir) {
@@ -485,7 +487,7 @@
 			const writer = await marker.createWritable()
 			await writer.write(JSON.stringify({
 				createdAt: new Date().toISOString(),
-				projectKey: activeCaptureSession ? activeCaptureSession.projectKey : '',
+				projectKey: captureState.session ? captureState.session.projectKey : '',
 			}, null, 2))
 			await writer.close()
 		}
@@ -517,7 +519,7 @@
 			for (const entry of entries) {
 				const file = await entry.getFile()
 				const url = URL.createObjectURL(file)
-				capturePreviewUrls.push(url)
+				captureState.previewUrls.push(url)
 				files.set(entry.name, {
 					name: entry.name,
 					file,
@@ -825,24 +827,24 @@
 		}
 
 		async function refreshCaptureCompare() {
-			if (!captureRootHandle) {
+			if (!captureState.rootHandle) {
 				setCaptureCompareEmpty('Select CaptureDir to browse baseline and run images.')
 				return
 			}
-			if (!activeCaptureProject) {
+			if (!captureState.project) {
 				setCaptureCompareEmpty('Start a project to load capture metadata.')
 				return
 			}
 
-			const snapshotsDir = await getOptionalDirectoryHandle(captureRootHandle, 'spx-snapshots')
+			const snapshotsDir = await getOptionalDirectoryHandle(captureState.rootHandle, 'spx-snapshots')
 			if (!snapshotsDir) {
-				setCaptureCompareEmpty('No spx-snapshots folder found in the selected directory.', `${activeCaptureProject.projectKey} · no snapshots yet`)
+				setCaptureCompareEmpty('No spx-snapshots folder found in the selected directory.', `${captureState.project.projectKey} · no snapshots yet`)
 				return
 			}
 
-			const projectDir = await getOptionalDirectoryHandle(snapshotsDir, activeCaptureProject.projectKey)
+			const projectDir = await getOptionalDirectoryHandle(snapshotsDir, captureState.project.projectKey)
 			if (!projectDir) {
-				setCaptureCompareEmpty(`No snapshots yet for ${activeCaptureProject.projectKey}.`, `${activeCaptureProject.projectKey} · waiting for first capture`)
+				setCaptureCompareEmpty(`No snapshots yet for ${captureState.project.projectKey}.`, `${captureState.project.projectKey} · waiting for first capture`)
 				return
 			}
 
@@ -851,10 +853,10 @@
 			let runDir = null
 
 			const runsDir = await getOptionalDirectoryHandle(projectDir, 'runs')
-			if (runsDir && activeCaptureSession) {
-				runDir = await getOptionalDirectoryHandle(runsDir, activeCaptureSession.runTimestamp)
+			if (runsDir && captureState.session) {
+				runDir = await getOptionalDirectoryHandle(runsDir, captureState.session.runTimestamp)
 				if (runDir) {
-					runLabel = `run ${activeCaptureSession.runTimestamp}`
+					runLabel = `run ${captureState.session.runTimestamp}`
 				}
 			}
 			if (!runDir) {
@@ -873,7 +875,7 @@
 				...runFiles.keys(),
 			])).sort((left, right) => left.localeCompare(right))
 			const comparisons = await buildCaptureComparisons(names, baselineFiles, runFiles)
-			renderCaptureCompare(activeCaptureProject.projectKey, runLabel, comparisons)
+			renderCaptureCompare(captureState.project.projectKey, runLabel, comparisons)
 		}
 
 		function createFileSystemCaptureHost() {
@@ -893,7 +895,7 @@
 						target.writeBaselineMarker = false
 					}
 					console.log('[spx capture saved]', {
-						projectKey: activeCaptureSession ? activeCaptureSession.projectKey : '',
+						projectKey: captureState.session ? captureState.session.projectKey : '',
 						destination: target.destination,
 						filename,
 						request,
@@ -907,7 +909,7 @@
 			if (typeof runnerWindow.spxSetCaptureHost !== 'function') {
 				return false
 			}
-			if (!captureRootHandle) {
+			if (!captureState.rootHandle) {
 				runnerWindow.spxSetCaptureHost(null)
 				return true
 			}
@@ -921,8 +923,8 @@
 				return
 			}
 			try {
-				captureRootHandle = await window.showDirectoryPicker(buildCaptureDirectoryPickerOptions())
-				const handleName = captureRootHandle && captureRootHandle.name ? captureRootHandle.name : 'selected'
+				captureState.rootHandle = await window.showDirectoryPicker(buildCaptureDirectoryPickerOptions())
+				const handleName = captureState.rootHandle && captureState.rootHandle.name ? captureState.rootHandle.name : 'selected'
 				updateCaptureStatus(`CaptureDir: ${handleName}`)
 				installCaptureHostIfReady()
 				scheduleCaptureCompareRefresh()
@@ -1051,8 +1053,8 @@
 			let unzipped = fflate.unzipSync(new Uint8Array(zipped))
 			resetActiveCaptureSession(parseCaptureProject(unzipped))
 			configureAIInteraction(unzipped)
-			if (captureRootHandle) {
-				updateCaptureStatus(`CaptureDir: ${captureRootHandle.name} -> ${activeCaptureSession.projectKey}`)
+			if (captureState.rootHandle) {
+				updateCaptureStatus(`CaptureDir: ${captureState.rootHandle.name} -> ${captureState.session.projectKey}`)
 			}
 			let files = {}
 			Object.entries(unzipped).forEach(([path, data]) => {

--- a/internal/engine/frame_runtime.go
+++ b/internal/engine/frame_runtime.go
@@ -50,14 +50,16 @@ func (req CaptureRequest) IsCheck() bool {
 
 type CaptureHandler func(CaptureRequest) error
 
-var frameRuntime struct {
-	mu                    sync.Mutex
-	callbackSeq           uint64
-	captureSeq            uint64
-	pendingFrameCallbacks []frameCallback
-	pendingCaptures       []CaptureRequest
-	captureHandler        CaptureHandler
+type frameRuntimeState struct {
+	mu          sync.Mutex
+	callbackSeq uint64
+	captureSeq  uint64
+	callbacks   []frameCallback
+	captures    []CaptureRequest
+	handler     CaptureHandler
 }
+
+var frameRuntime frameRuntimeState
 
 // CurrentFrame returns the current engine frame number.
 func CurrentFrame() int64 {
@@ -73,36 +75,39 @@ func ScheduleFrame(frame int64, fn func()) {
 		fn()
 		return
 	}
-
-	frameRuntime.mu.Lock()
-	frameRuntime.callbackSeq++
-	frameRuntime.pendingFrameCallbacks = append(frameRuntime.pendingFrameCallbacks, frameCallback{
-		frame: frame,
-		seq:   frameRuntime.callbackSeq,
-		fn:    fn,
-	})
-	frameRuntime.mu.Unlock()
+	frameRuntime.schedule(frame, fn)
 }
 
 // RunFrameCallbacks runs all callbacks due at or before frame.
 func RunFrameCallbacks(frame int64) {
-	callbacks := drainDueFrameCallbacks(frame)
+	callbacks := frameRuntime.drainDueCallbacks(frame)
 	for _, cb := range callbacks {
 		cb.fn()
 	}
 }
 
-func drainDueFrameCallbacks(frame int64) []frameCallback {
-	frameRuntime.mu.Lock()
-	defer frameRuntime.mu.Unlock()
+func (rt *frameRuntimeState) schedule(frame int64, fn func()) {
+	rt.mu.Lock()
+	rt.callbackSeq++
+	rt.callbacks = append(rt.callbacks, frameCallback{
+		frame: frame,
+		seq:   rt.callbackSeq,
+		fn:    fn,
+	})
+	rt.mu.Unlock()
+}
 
-	if len(frameRuntime.pendingFrameCallbacks) == 0 {
+func (rt *frameRuntimeState) drainDueCallbacks(frame int64) []frameCallback {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+
+	if len(rt.callbacks) == 0 {
 		return nil
 	}
 
-	due := make([]frameCallback, 0, len(frameRuntime.pendingFrameCallbacks))
-	future := frameRuntime.pendingFrameCallbacks[:0]
-	for _, cb := range frameRuntime.pendingFrameCallbacks {
+	due := make([]frameCallback, 0, len(rt.callbacks))
+	future := rt.callbacks[:0]
+	for _, cb := range rt.callbacks {
 		if cb.frame <= frame {
 			due = append(due, cb)
 			continue
@@ -110,8 +115,8 @@ func drainDueFrameCallbacks(frame int64) []frameCallback {
 		future = append(future, cb)
 	}
 
-	clear(frameRuntime.pendingFrameCallbacks[len(future):])
-	frameRuntime.pendingFrameCallbacks = future
+	clear(rt.callbacks[len(future):])
+	rt.callbacks = future
 
 	sort.SliceStable(due, func(i, j int) bool {
 		if due[i].frame == due[j].frame {
@@ -124,37 +129,17 @@ func drainDueFrameCallbacks(frame int64) []frameCallback {
 
 // SetCaptureHandler installs the screenshot backend used by EnqueueCapture.
 func SetCaptureHandler(handler CaptureHandler) {
-	frameRuntime.mu.Lock()
-	frameRuntime.captureHandler = handler
-	frameRuntime.mu.Unlock()
+	frameRuntime.setCaptureHandler(handler)
 }
 
 // EnqueueCapture queues a screenshot request for the end of the current frame.
 func EnqueueCapture(name string, intent CaptureIntent) error {
-	frameRuntime.mu.Lock()
-	req := CaptureRequest{
-		Name:     name,
-		Intent:   intent,
-		Frame:    CurrentFrame(),
-		Sequence: frameRuntime.captureSeq + 1,
-	}
-	frameRuntime.captureSeq++
-	if GetGame() == nil {
-		handler := frameRuntime.captureHandler
-		frameRuntime.mu.Unlock()
-		if handler == nil {
-			return fmt.Errorf("spx: capture backend is not configured")
-		}
-		return handler(req)
-	}
-	frameRuntime.pendingCaptures = append(frameRuntime.pendingCaptures, req)
-	frameRuntime.mu.Unlock()
-	return nil
+	return frameRuntime.enqueueCapture(name, intent, CurrentFrame(), GetGame() == nil)
 }
 
 // FlushCaptures flushes screenshot requests queued during the frame.
 func FlushCaptures() error {
-	captures := drainPendingCaptures()
+	captures := frameRuntime.drainCaptures()
 	for _, capture := range captures {
 		if err := dispatchCapture(capture); err != nil {
 			return err
@@ -163,22 +148,55 @@ func FlushCaptures() error {
 	return nil
 }
 
-func drainPendingCaptures() []CaptureRequest {
-	frameRuntime.mu.Lock()
-	defer frameRuntime.mu.Unlock()
-	if len(frameRuntime.pendingCaptures) == 0 {
+func (rt *frameRuntimeState) setCaptureHandler(handler CaptureHandler) {
+	rt.mu.Lock()
+	rt.handler = handler
+	rt.mu.Unlock()
+}
+
+func (rt *frameRuntimeState) enqueueCapture(name string, intent CaptureIntent, frame int64, immediate bool) error {
+	rt.mu.Lock()
+	req := rt.nextCaptureRequest(name, intent, frame)
+	if !immediate {
+		rt.captures = append(rt.captures, req)
+		rt.mu.Unlock()
 		return nil
 	}
-	captures := append([]CaptureRequest(nil), frameRuntime.pendingCaptures...)
-	clear(frameRuntime.pendingCaptures)
-	frameRuntime.pendingCaptures = frameRuntime.pendingCaptures[:0]
+	handler := rt.handler
+	rt.mu.Unlock()
+	return callCaptureHandler(handler, req)
+}
+
+func (rt *frameRuntimeState) nextCaptureRequest(name string, intent CaptureIntent, frame int64) CaptureRequest {
+	rt.captureSeq++
+	return CaptureRequest{
+		Name:     name,
+		Intent:   intent,
+		Frame:    frame,
+		Sequence: rt.captureSeq,
+	}
+}
+
+func (rt *frameRuntimeState) drainCaptures() []CaptureRequest {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	if len(rt.captures) == 0 {
+		return nil
+	}
+	captures := append([]CaptureRequest(nil), rt.captures...)
+	clear(rt.captures)
+	rt.captures = rt.captures[:0]
 	return captures
 }
 
 func dispatchCapture(req CaptureRequest) error {
 	frameRuntime.mu.Lock()
-	handler := frameRuntime.captureHandler
+	handler := frameRuntime.handler
 	frameRuntime.mu.Unlock()
+	return callCaptureHandler(handler, req)
+}
+
+func callCaptureHandler(handler CaptureHandler, req CaptureRequest) error {
 	if handler == nil {
 		return fmt.Errorf("spx: capture backend is not configured")
 	}
@@ -187,12 +205,16 @@ func dispatchCapture(req CaptureRequest) error {
 
 // ResetFrameRuntime clears frame-scoped callbacks and capture requests.
 func ResetFrameRuntime() {
-	frameRuntime.mu.Lock()
-	clear(frameRuntime.pendingFrameCallbacks)
-	frameRuntime.pendingFrameCallbacks = nil
-	frameRuntime.callbackSeq = 0
-	clear(frameRuntime.pendingCaptures)
-	frameRuntime.pendingCaptures = nil
-	frameRuntime.captureSeq = 0
-	frameRuntime.mu.Unlock()
+	frameRuntime.reset()
+}
+
+func (rt *frameRuntimeState) reset() {
+	rt.mu.Lock()
+	clear(rt.callbacks)
+	rt.callbacks = nil
+	rt.callbackSeq = 0
+	clear(rt.captures)
+	rt.captures = nil
+	rt.captureSeq = 0
+	rt.mu.Unlock()
 }

--- a/runtime_frame.go
+++ b/runtime_frame.go
@@ -66,22 +66,18 @@ func SetCaptureHandler(handler CaptureRequestHandler) {
 }
 
 func requestCaptureAfter(name string, intent CaptureIntent, fn func() error) {
-	if err := runCaptureAction(fn); err != nil {
+	if err := runCaptureBody(fn); err != nil {
 		engine.Panic(err)
 		return
 	}
-	if err := enqueueCapture(name, intent); err != nil {
+	if err := engine.EnqueueCapture(name, intent); err != nil {
 		engine.Panic(err)
 	}
 }
 
-func runCaptureAction(fn func() error) error {
+func runCaptureBody(fn func() error) error {
 	if fn == nil {
 		return nil
 	}
 	return fn()
-}
-
-func enqueueCapture(name string, intent CaptureIntent) error {
-	return engine.EnqueueCapture(name, engine.CaptureIntent(intent))
 }

--- a/runtime_frame_noop_test.go
+++ b/runtime_frame_noop_test.go
@@ -31,7 +31,7 @@ func TestCaptureDefaultsToNoopHandlerOnNative(t *testing.T) {
 
 	SetCaptureHandler(ignoreCaptureRequest)
 
-	if err := enqueueCapture("step_001.png", CaptureIntentSnapshot); err != nil {
+	if err := engine.EnqueueCapture("step_001.png", CaptureIntentSnapshot); err != nil {
 		t.Fatalf("enqueueCapture returned error on native platform: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

This PR refactors the deterministic frame capture implementation introduced in #1663 without changing behavior.

## What changed

- simplify `internal/engine/frame_runtime.go` by grouping frame callback and capture queue state into a clearer runtime state type
- remove redundant capture wrapper helpers in `runtime_frame.go`
- reorganize the web capture bridge in `cmd/ispx/web/runner.html` into a single `spxCaptureBridge` object
- group web snapshot UI runtime state in `cmd/spx/template/platform/web/index.html` under `captureState`
- keep existing capture flow, bridge protocol, and snapshot/check behavior unchanged

## Why

The previous implementation worked, but the logic was spread across several flat helpers and state variables. This refactor keeps the deterministic capture feature the same while making the code easier to follow, maintain, and extend.

## Testing

- `go test ./internal/engine ./...`