### PR TITLE
fix(runtime): align bootstrap sprite startup timing

### DIFF
--- a/game_load.go
+++ b/game_load.go
@@ -195,6 +195,9 @@ func (p *Game) runSpriteCallbacks(inits []Sprite, proj *coreproject.ProjectConfi
 	if loader, ok := g.Addr().Interface().(interface{ OnLoaded() }); ok {
 		onLoaded = loader.OnLoaded
 	}
+	queueBootstrap := func(call func()) {
+		p.deferBootstrapFor(generation, call)
+	}
 	cameraTarget := ""
 	if proj.Camera != nil {
 		cameraTarget = proj.Camera.On
@@ -207,31 +210,21 @@ func (p *Game) runSpriteCallbacks(inits []Sprite, proj *coreproject.ProjectConfi
 	coreproject.RunSpriteInitializers(coreproject.SpriteInitConfig[Sprite]{
 		Items: inits,
 		Setup: func(items []Sprite) {
-			p.deferBootstrapFor(generation, func() {
+			queueBootstrap(func() {
 				p.setupCollisionData(items)
 			})
 		},
 		BeforeMain: func(ini Sprite) {
 			spr := spriteOf(ini)
 			if spr != nil {
-				p.deferBootstrapFor(generation, func() {
-					spr.awake()
-				})
+				queueBootstrap(spr.awake)
 			}
 		},
-		RunMain: func(ini Sprite) {
-			p.deferBootstrapFor(generation, func() {
-				runMain(ini.Main)
-			})
-		},
-		OnLoaded: func() {
-			p.deferBootstrapFor(generation, func() {
-				if onLoaded != nil {
-					onLoaded()
-				}
-			})
-		},
 	})
+	queueBootstrap(func() {
+		p.runBootstrapSpriteMainBatch(inits)
+	})
+	queueBootstrap(onLoaded)
 }
 
 // -----------------------------------------------------------------------------

--- a/game_load_test.go
+++ b/game_load_test.go
@@ -23,6 +23,8 @@ import (
 
 	"github.com/goplus/spbase/mathf"
 	coreproject "github.com/goplus/spx/v2/internal/core/project"
+	"github.com/goplus/spx/v2/internal/coroutine"
+	"github.com/goplus/spx/v2/internal/engine"
 	"github.com/goplus/spx/v2/internal/engine/platform"
 	"github.com/goplus/spx/v2/internal/enginewrap"
 	pkgengine "github.com/goplus/spx/v2/pkg/spx/pkg/engine"
@@ -51,6 +53,12 @@ type bootstrapAwakeOrderSprite struct {
 	peer         *bootstrapAwakeOrderSprite
 	sawSelfAwake bool
 	sawPeerAwake bool
+}
+
+type bootstrapConcurrentMainSprite struct {
+	SpriteImpl
+	waitFor  <-chan struct{}
+	signalTo chan<- struct{}
 }
 
 type cloneAwakeOrderSprite struct {
@@ -127,6 +135,18 @@ func (s *bootstrapAwakeOrderSprite) Main() {
 	s.sawSelfAwake = s.spriteState.IsAwakened
 	if s.peer != nil {
 		s.sawPeerAwake = s.peer.spriteState.IsAwakened
+	}
+}
+
+func (s *bootstrapConcurrentMainSprite) Main() {
+	if s.signalTo != nil {
+		select {
+		case s.signalTo <- struct{}{}:
+		default:
+		}
+	}
+	if s.waitFor != nil {
+		<-s.waitFor
 	}
 }
 
@@ -265,6 +285,16 @@ func newBootstrapAwakeOrderSprite(g *Game, name string) *bootstrapAwakeOrderSpri
 	return sprite
 }
 
+func newBootstrapConcurrentMainSprite(g *Game, name string, waitFor <-chan struct{}, signalTo chan<- struct{}) *bootstrapConcurrentMainSprite {
+	sprite := &bootstrapConcurrentMainSprite{waitFor: waitFor, signalTo: signalTo}
+	sprite.g = g
+	sprite.name = name
+	sprite.sprite = sprite
+	sprite.scriptEventBindings.init(&g.scriptEvents, &sprite.SpriteImpl)
+	sprite.components.initComponents(&sprite.SpriteImpl, &coreproject.SpriteConfig{})
+	return sprite
+}
+
 func newCloneAwakeOrderSprite(g *Game, name string) *cloneAwakeOrderSprite {
 	sawAwake := false
 	onCloned := false
@@ -328,6 +358,50 @@ func setupCloneSpriteMgr(t *testing.T) {
 	t.Cleanup(func() {
 		pkgengine.SpriteMgr = original
 	})
+}
+
+func setupBootstrapScheduler(t *testing.T) {
+	t.Helper()
+
+	co := coroutine.New(nil)
+	co.OnInited()
+
+	original := gco
+	gco = co
+	engine.SetCoroutines(co)
+	t.Cleanup(func() {
+		co.AbortAllAndWait(time.Second)
+		gco = original
+		engine.SetCoroutines(original)
+	})
+}
+
+func runBootstrapTasksWithScheduler(t *testing.T, game *Game, generation uint64) {
+	t.Helper()
+
+	done := make(chan struct{})
+	go func() {
+		game.runBootstrapTasksFor(generation)
+		close(done)
+	}()
+
+	deadline := time.Now().Add(time.Second)
+	for {
+		select {
+		case <-done:
+			return
+		default:
+		}
+
+		if time.Now().After(deadline) {
+			t.Fatal("bootstrap tasks did not finish while pumping scheduler")
+		}
+
+		platform.RunOnMainThread(func() {
+			gco.Update()
+		})
+		time.Sleep(time.Millisecond)
+	}
 }
 
 func TestRunSpriteCallbacksKeepsManualCameraFollowLast(t *testing.T) {
@@ -399,6 +473,8 @@ func TestRefreshCollisionLayersUsesCurrentTargetsFromSetupCollisionData(t *testi
 }
 
 func TestRunSpriteCallbacksRefreshesCollisionLayersRegisteredInMain(t *testing.T) {
+	setupBootstrapScheduler(t)
+
 	game := &collisionLayerOrderGame{}
 	game.initShapeMgr()
 	game.isAutoSetCollisionLayer = true
@@ -424,9 +500,7 @@ func TestRunSpriteCallbacksRefreshesCollisionLayersRegisteredInMain(t *testing.T
 			generation,
 		)
 	})
-	platform.RunOnMainThread(func() {
-		game.runBootstrapTasksFor(generation)
-	})
+	runBootstrapTasksWithScheduler(t, &game.Game, generation)
 
 	if got := game.sprCollisionInfos["SpriteA"].Mask; got != game.sprCollisionInfos["SpriteB"].Layer {
 		t.Fatalf("SpriteA collision mask = %d, want %d", got, game.sprCollisionInfos["SpriteB"].Layer)
@@ -461,6 +535,39 @@ func TestRunSpriteCallbacksAwakesAllSpritesBeforeMain(t *testing.T) {
 	}
 	if got := game.scriptEvents.manager.SnapshotAwake(); len(got) != 0 {
 		t.Fatalf("SnapshotAwake len = %d, want 0 for initial sprites", len(got))
+	}
+}
+
+func TestRunSpriteCallbacksRunsSpriteMainsConcurrently(t *testing.T) {
+	var game Game
+
+	ready := make(chan struct{}, 1)
+	spriteA := newBootstrapConcurrentMainSprite(&game, "SpriteA", ready, nil)
+	spriteB := newBootstrapConcurrentMainSprite(&game, "SpriteB", nil, ready)
+
+	generation := game.currentBootstrapGeneration()
+	game.runSpriteCallbacks(
+		[]Sprite{spriteA, spriteB},
+		&coreproject.ProjectConfig{},
+		reflect.ValueOf(&game).Elem(),
+		generation,
+	)
+
+	done := make(chan struct{})
+	go func() {
+		game.runBootstrapTasksFor(generation)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(200 * time.Millisecond):
+		select {
+		case ready <- struct{}{}:
+		default:
+		}
+		<-done
+		t.Fatal("runBootstrapTasksFor blocked on earlier sprite Main, want batched concurrent execution")
 	}
 }
 

--- a/internal/core/project/load.go
+++ b/internal/core/project/load.go
@@ -25,8 +25,6 @@ type SpriteInitConfig[T any] struct {
 	Items      []T
 	Setup      func([]T)
 	BeforeMain func(T)
-	RunMain    func(T)
-	OnLoaded   func()
 }
 
 func WalkZOrder(
@@ -60,14 +58,6 @@ func RunSpriteInitializers[T any](cfg SpriteInitConfig[T]) {
 		if cfg.BeforeMain != nil {
 			cfg.BeforeMain(item)
 		}
-	}
-	for _, item := range cfg.Items {
-		if cfg.RunMain != nil {
-			cfg.RunMain(item)
-		}
-	}
-	if cfg.OnLoaded != nil {
-		cfg.OnLoaded()
 	}
 }
 

--- a/internal/core/project/project_test.go
+++ b/internal/core/project/project_test.go
@@ -858,14 +858,8 @@ func TestRunSpriteInitializers(t *testing.T) {
 		BeforeMain: func(item string) {
 			got = append(got, "before:"+item)
 		},
-		RunMain: func(item string) {
-			got = append(got, "main:"+item)
-		},
-		OnLoaded: func() {
-			got = append(got, "loaded")
-		},
 	})
-	want := []string{"setup", "before:a", "before:b", "main:a", "main:b", "loaded"}
+	want := []string{"setup", "before:a", "before:b"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("RunSpriteInitializers got %v, want %v", got, want)
 	}

--- a/runtime_engine.go
+++ b/runtime_engine.go
@@ -78,9 +78,11 @@ func (p *Game) OnEngineUpdate(delta float64) {
 }
 
 func (p *Game) OnEngineRender(delta float64) {
-	if !p.lifecycleState.StartDispatched.Load() {
+	if !p.lifecycleState.IsRunned.Load() {
 		return
 	}
+	// Initial sprite Main hooks can move and collide during bootstrap, so
+	// trigger pairs must be drained before the start event is dispatched.
 	p.processPhysicsTriggers()
 }
 
@@ -103,6 +105,32 @@ func (p *Game) runLoop(cfg *Config) (err error) {
 
 func runMain(call func()) {
 	coreruntime.RunMain(call, time.Now(), setSchedInMain, setMainSchedTime)
+}
+
+func (p *Game) runBootstrapSpriteMainBatch(inits []Sprite) {
+	if len(inits) == 0 {
+		return
+	}
+
+	threads := make([]coroutine.Thread, 0, len(inits))
+	for _, ini := range inits {
+		spr := spriteOf(ini)
+		if spr == nil {
+			continue
+		}
+
+		mainFn := ini.Main
+		thread := gco.CreateAndStart(false, spr.pthis, func(coroutine.Thread) int {
+			runMain(mainFn)
+			return 0
+		})
+		if thread != nil {
+			threads = append(threads, thread)
+		}
+	}
+	// Keep bootstrap Main behavior aligned with the old awake dispatch:
+	// start every initial sprite Main first, then wait for the batch.
+	gco.JoinAll(threads)
 }
 
 func (p *Game) deferBootstrap(call func()) {


### PR DESCRIPTION
## Summary

Fixes startup timing regressions where top-level sprite scripts could run serially and physics trigger events created during bootstrap could be delayed until after startup.

Changes:
- Runs initial sprite `Main` callbacks as a bootstrap batch after collision data setup and sprite awake.
- Allows physics trigger processing once the game is running, including during bootstrap, so collisions produced by initial movement are consumed immediately.
- Removes unused `RunMain` / `OnLoaded` hooks from `SpriteInitConfig` now that sprite main startup is handled explicitly by runtime.
- Adds regression coverage for bootstrap sprite main batching, awake-before-main ordering, and collision layer registration inside sprite `Main`.

## Testing

- `go test ./... -count=1 -timeout=120s`