### PR TITLE
fix(coroutine): yield caller on eager start

### DIFF
--- a/game_load_test.go
+++ b/game_load_test.go
@@ -146,7 +146,8 @@ func (s *bootstrapConcurrentMainSprite) Main() {
 		}
 	}
 	if s.waitFor != nil {
-		<-s.waitFor
+		var signal struct{}
+		engine.WaitForChan(s.waitFor, &signal)
 	}
 }
 
@@ -539,6 +540,8 @@ func TestRunSpriteCallbacksAwakesAllSpritesBeforeMain(t *testing.T) {
 }
 
 func TestRunSpriteCallbacksRunsSpriteMainsConcurrently(t *testing.T) {
+	setupBootstrapScheduler(t)
+
 	var game Game
 
 	ready := make(chan struct{}, 1)
@@ -553,22 +556,7 @@ func TestRunSpriteCallbacksRunsSpriteMainsConcurrently(t *testing.T) {
 		generation,
 	)
 
-	done := make(chan struct{})
-	go func() {
-		game.runBootstrapTasksFor(generation)
-		close(done)
-	}()
-
-	select {
-	case <-done:
-	case <-time.After(200 * time.Millisecond):
-		select {
-		case ready <- struct{}{}:
-		default:
-		}
-		<-done
-		t.Fatal("runBootstrapTasksFor blocked on earlier sprite Main, want batched concurrent execution")
-	}
+	runBootstrapTasksWithScheduler(t, &game, generation)
 }
 
 func TestInitRuntimeProxyAppliesCostumeBeforeAwake(t *testing.T) {

--- a/internal/coroutine/thread.go
+++ b/internal/coroutine/thread.go
@@ -163,6 +163,14 @@ func (p *Coroutines) CreateAndStart(start bool, obj ThreadObj, fn func(me Thread
 	}()
 
 	if start {
+		// When the scheduler is already active, yield the current coroutine once so
+		// eagerly started peers can begin running even on single-threaded runtimes.
+		if p.hasInited {
+			if caller := p.currentCoroutineThread(); caller != nil {
+				p.WaitYield(caller)
+				return th
+			}
+		}
 		runtime.Gosched()
 	}
 	return th

--- a/internal/coroutine/thread_test.go
+++ b/internal/coroutine/thread_test.go
@@ -20,6 +20,8 @@ import (
 	"runtime"
 	"testing"
 	"time"
+
+	"github.com/goplus/spx/v2/internal/engine/platform"
 )
 
 type namedThreadObj struct{}
@@ -339,5 +341,56 @@ func TestJoinAllWaitsForEveryPeer(t *testing.T) {
 	case <-callerDone:
 	case <-timer.C:
 		t.Fatal("caller did not resume after every peer completed")
+	}
+}
+
+func TestCreateAndStartFromCoroutineYieldsCallerWhenStarted(t *testing.T) {
+	co := New(nil)
+	co.OnInited()
+
+	peerStarted := make(chan struct{}, 1)
+	observed := make(chan bool, 1)
+	done := make(chan struct{})
+
+	co.CreateAndStart(true, "caller", func(me Thread) int {
+		co.CreateAndStart(true, "peer", func(peer Thread) int {
+			close(peerStarted)
+			return 0
+		})
+
+		select {
+		case <-peerStarted:
+			observed <- true
+		default:
+			observed <- false
+		}
+		close(done)
+		return 0
+	})
+
+	deadline := time.Now().Add(time.Second)
+	for {
+		select {
+		case <-done:
+			select {
+			case got := <-observed:
+				if !got {
+					t.Fatal("CreateAndStart(true) returned before the eagerly started peer ran")
+				}
+			default:
+				t.Fatal("caller completed without recording eager-start observation")
+			}
+			return
+		default:
+		}
+
+		if time.Now().After(deadline) {
+			t.Fatal("caller did not finish while pumping the scheduler")
+		}
+
+		platform.RunOnMainThread(func() {
+			co.Update()
+		})
+		time.Sleep(time.Millisecond)
 	}
 }


### PR DESCRIPTION
## Summary

This fixes a web-only coroutine scheduling gap that could delay eagerly started child coroutines until after the caller had already continued running.

In cases like clone `onCloned` startup work, desktop scheduling often masked the issue, while single-threaded web/wasm execution could leave initialization incomplete long enough for later logic to observe partially populated state.

## What changed

- make `CreateAndStart(true)` yield the current coroutine once when the scheduler is already active
- keep the old `runtime.Gosched()` fallback for non-coroutine callers
- add a coroutine regression test that verifies eagerly started peers begin running before the caller resumes
- update the bootstrap concurrency test to wait through the coroutine scheduler instead of blocking on a raw channel receive

## Why

`start=true` previously relied on `runtime.Gosched()` alone, which does not reliably give a newly created coroutine a chance to run on web/wasm.

That made startup paths depending on timely child execution, such as clone initialization, timing-sensitive and could surface as Match3 startup crashes on web.

## Testing

- `go test ./...`

## Related

- fixes Match3 web startup behavior discussed in https://github.com/goplus/spx/issues/1657