### PR TITLE
fix(runtime): warn on main execution timeout

### DIFF
--- a/game_run.go
+++ b/game_run.go
@@ -19,6 +19,7 @@ package spx
 import (
 	"errors"
 	"reflect"
+	"runtime"
 	"time"
 
 	coreproject "github.com/goplus/spx/v2/internal/core/project"
@@ -96,11 +97,12 @@ func XGot_Game_Reload(game Gamer, index any) (err error) {
 // Scheduling
 // -----------------------------------------------------------------------------
 func SchedNow() int {
+	now := time.Now()
 	err := coreruntime.SchedNow(
 		coreruntime.ScheduleState{
 			IsSchedInMain:   isSchedInMainState(),
 			MainSchedTime:   mainSchedTime(),
-			Now:             time.Now(),
+			Now:             now,
 			MainExecTimeout: time.Second * mainExecTimeoutSec,
 		},
 		coreruntime.SchedulerHooks{
@@ -111,6 +113,9 @@ func SchedNow() int {
 			},
 		},
 	)
+	if handleMainExecutionTimeout(err) {
+		return 0
+	}
 	if err != nil && !errors.Is(err, coreruntime.ErrLoopExecutionTimedOut) {
 		engine.Panic(err.Error())
 	}
@@ -139,10 +144,33 @@ func Sched() int {
 			},
 		},
 	)
+	if handleMainExecutionTimeout(err) {
+		return 0
+	}
 	if err != nil {
 		engine.Panic(err.Error())
 	}
 	return 0
+}
+
+func handleMainExecutionTimeout(err error) bool {
+	if !errors.Is(err, coreruntime.ErrMainExecutionTimedOut) {
+		return false
+	}
+	spxlog.Warn("%s\n%s", coreruntime.MainExecutionTimedOutMsg, debug.GetStackTrace())
+	// Demote long-running top-level Main code to regular coroutine scheduling
+	// after the first timeout so it keeps running without repeated panics.
+	setSchedInMain(false)
+	setMainSchedTime(time.Time{})
+	if engine.IsInCoroutine() {
+		me := gco.Current()
+		if me != nil {
+			gco.Sched(me)
+		}
+	} else {
+		runtime.Gosched()
+	}
+	return true
 }
 
 func Forever(call func()) {

--- a/game_run_test.go
+++ b/game_run_test.go
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2021 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package spx
+
+import (
+	"testing"
+	"time"
+
+	"github.com/goplus/spx/v2/internal/engine"
+)
+
+func TestSchedNowWarnsInsteadOfPanickingOnMainExecutionTimeout(t *testing.T) {
+	originalGame := engine.GetGame()
+	t.Cleanup(func() {
+		engine.SetGame(originalGame)
+	})
+
+	var g Game
+	g.initGame(nil)
+
+	setSchedInMain(true)
+	setMainSchedTime(time.Now().Add(-2 * time.Duration(mainExecTimeoutSec) * time.Second))
+
+	SchedNow()
+
+	if isSchedInMainState() {
+		t.Fatal("SchedNow should demote timed-out Main execution instead of keeping the main timeout state")
+	}
+	if !mainSchedTime().IsZero() {
+		t.Fatalf("mainSchedTime = %v, want zero after timed-out Main demotion", mainSchedTime())
+	}
+}
+
+func TestSchedWarnsInsteadOfPanickingOnMainExecutionTimeout(t *testing.T) {
+	originalGame := engine.GetGame()
+	t.Cleanup(func() {
+		engine.SetGame(originalGame)
+	})
+
+	var g Game
+	g.initGame(nil)
+
+	setSchedInMain(true)
+	setMainSchedTime(time.Now().Add(-2 * time.Duration(mainExecTimeoutSec) * time.Second))
+
+	Sched()
+
+	if isSchedInMainState() {
+		t.Fatal("Sched should demote timed-out Main execution instead of keeping the main timeout state")
+	}
+	if !mainSchedTime().IsZero() {
+		t.Fatalf("mainSchedTime = %v, want zero after timed-out Main demotion", mainSchedTime())
+	}
+}

--- a/pkg/ispx/internal/pkg/github.com/goplus/spx/v2/export.go
+++ b/pkg/ispx/internal/pkg/github.com/goplus/spx/v2/export.go
@@ -75,6 +75,7 @@ func init() {
 			"os":        "os",
 			"path":      "path",
 			"reflect":   "reflect",
+			"runtime":   "runtime",
 			"slices":    "slices",
 			"strconv":   "strconv",
 			"strings":   "strings",


### PR DESCRIPTION
## Summary
- change `Main execution timed out` from runtime panic to warning
- handle the timeout consistently in both `SchedNow` and `Sched`
- demote timed-out top-level `Main` execution to normal coroutine scheduling so long-running control-flow scripts can continue

## Why
Top-level `Main` scripts can now legally contain long-running control flow such as `repeatUntil` with frame yields.
On Web this was still being treated as a fatal `Main` timeout and stopped execution.

## Changes
- add shared handling for `ErrMainExecutionTimedOut`
- log a warning with stack instead of calling `engine.Panic`
- clear `IsSchedInMain` / `MainSchedTime` after the first timeout
- add regression tests for both `SchedNow` and `Sched`

## Testing
- `go test ./...`