### PR TITLE
fix(runtime): preserve ZOrder while releasing bootstrap after initial Main yield

### DIFF
--- a/game_load.go
+++ b/game_load.go
@@ -222,7 +222,7 @@ func (p *Game) runSpriteCallbacks(inits []Sprite, proj *coreproject.ProjectConfi
 		},
 	})
 	queueBootstrap(func() {
-		p.runBootstrapSpriteMainBatch(inits)
+		p.runBootstrapSpriteMainsUntilYield(inits)
 	})
 	queueBootstrap(onLoaded)
 }

--- a/game_load_test.go
+++ b/game_load_test.go
@@ -55,12 +55,6 @@ type bootstrapAwakeOrderSprite struct {
 	sawPeerAwake bool
 }
 
-type bootstrapConcurrentMainSprite struct {
-	SpriteImpl
-	waitFor  <-chan struct{}
-	signalTo chan<- struct{}
-}
-
 type cloneAwakeOrderSprite struct {
 	SpriteImpl
 	sawAwakeInMain *bool
@@ -135,19 +129,6 @@ func (s *bootstrapAwakeOrderSprite) Main() {
 	s.sawSelfAwake = s.spriteState.IsAwakened
 	if s.peer != nil {
 		s.sawPeerAwake = s.peer.spriteState.IsAwakened
-	}
-}
-
-func (s *bootstrapConcurrentMainSprite) Main() {
-	if s.signalTo != nil {
-		select {
-		case s.signalTo <- struct{}{}:
-		default:
-		}
-	}
-	if s.waitFor != nil {
-		var signal struct{}
-		engine.WaitForChan(s.waitFor, &signal)
 	}
 }
 
@@ -278,16 +259,6 @@ func newCollisionLayerOrderSprite(g *Game, name string, onMain func()) *collisio
 
 func newBootstrapAwakeOrderSprite(g *Game, name string) *bootstrapAwakeOrderSprite {
 	sprite := &bootstrapAwakeOrderSprite{}
-	sprite.g = g
-	sprite.name = name
-	sprite.sprite = sprite
-	sprite.scriptEventBindings.init(&g.scriptEvents, &sprite.SpriteImpl)
-	sprite.components.initComponents(&sprite.SpriteImpl, &coreproject.SpriteConfig{})
-	return sprite
-}
-
-func newBootstrapConcurrentMainSprite(g *Game, name string, waitFor <-chan struct{}, signalTo chan<- struct{}) *bootstrapConcurrentMainSprite {
-	sprite := &bootstrapConcurrentMainSprite{waitFor: waitFor, signalTo: signalTo}
 	sprite.g = g
 	sprite.name = name
 	sprite.sprite = sprite
@@ -539,14 +510,24 @@ func TestRunSpriteCallbacksAwakesAllSpritesBeforeMain(t *testing.T) {
 	}
 }
 
-func TestRunSpriteCallbacksRunsSpriteMainsConcurrently(t *testing.T) {
+func TestRunSpriteCallbacksRunsSpriteMainsInZOrderUntilFirstYield(t *testing.T) {
 	setupBootstrapScheduler(t)
 
 	var game Game
 
-	ready := make(chan struct{}, 1)
-	spriteA := newBootstrapConcurrentMainSprite(&game, "SpriteA", ready, nil)
-	spriteB := newBootstrapConcurrentMainSprite(&game, "SpriteB", nil, ready)
+	blocked := make(chan struct{})
+	defer close(blocked)
+
+	var spriteASeenThreadCount int64
+	var spriteBSeenThreadCount int64
+	spriteA := newCollisionLayerOrderSprite(&game, "SpriteA", func() {
+		spriteASeenThreadCount = gco.LastThreadID()
+		var signal struct{}
+		engine.WaitForChan(blocked, &signal)
+	})
+	spriteB := newCollisionLayerOrderSprite(&game, "SpriteB", func() {
+		spriteBSeenThreadCount = gco.LastThreadID()
+	})
 
 	generation := game.currentBootstrapGeneration()
 	game.runSpriteCallbacks(
@@ -557,6 +538,106 @@ func TestRunSpriteCallbacksRunsSpriteMainsConcurrently(t *testing.T) {
 	)
 
 	runBootstrapTasksWithScheduler(t, &game, generation)
+
+	if spriteASeenThreadCount != 1 {
+		t.Fatalf("SpriteA saw %d created threads before its first yield, want 1", spriteASeenThreadCount)
+	}
+	if spriteBSeenThreadCount != 2 {
+		t.Fatalf("SpriteB saw %d created threads before its first yield, want 2", spriteBSeenThreadCount)
+	}
+}
+
+func TestRunBootstrapMainUntilYieldReleasesFollowingBootstrapTasks(t *testing.T) {
+	setupBootstrapScheduler(t)
+
+	var game Game
+	blocked := make(chan struct{})
+	defer close(blocked)
+
+	stageStarted := make(chan struct{})
+	stageResumed := make(chan struct{})
+	followingTaskRan := make(chan struct{})
+	generation := game.currentBootstrapGeneration()
+	game.deferBootstrapFor(generation, func() {
+		game.runBootstrapMainUntilYield(&game, func() {
+			close(stageStarted)
+			var signal struct{}
+			engine.WaitForChan(blocked, &signal)
+			close(stageResumed)
+		})
+	})
+	game.deferBootstrapFor(generation, func() {
+		close(followingTaskRan)
+	})
+
+	runBootstrapTasksWithScheduler(t, &game, generation)
+
+	select {
+	case <-stageStarted:
+	default:
+		t.Fatal("stage Main did not start")
+	}
+	select {
+	case <-followingTaskRan:
+	default:
+		t.Fatal("following bootstrap task did not run after stage Main yielded")
+	}
+	select {
+	case <-stageResumed:
+		t.Fatal("stage Main resumed before its wait was released")
+	default:
+	}
+}
+
+func TestRunSpriteCallbacksAllowsOnStartAfterMainFirstYield(t *testing.T) {
+	setupBootstrapScheduler(t)
+
+	var game Game
+	game.initRuntimeState()
+	game.events = make(chan event, eventBufferSize)
+
+	blocked := make(chan struct{})
+	defer close(blocked)
+
+	started := make(chan struct{})
+	var spriteA *collisionLayerOrderSprite
+	spriteA = newCollisionLayerOrderSprite(&game, "SpriteA", func() {
+		spriteA.OnStart(func() {
+			close(started)
+		})
+		var signal struct{}
+		engine.WaitForChan(blocked, &signal)
+	})
+	spriteB := newCollisionLayerOrderSprite(&game, "SpriteB", nil)
+
+	generation := game.currentBootstrapGeneration()
+	game.runSpriteCallbacks(
+		[]Sprite{spriteA, spriteB},
+		&coreproject.ProjectConfig{},
+		reflect.ValueOf(&game).Elem(),
+		generation,
+	)
+
+	runBootstrapTasksWithScheduler(t, &game, generation)
+
+	game.dispatchStartEventIfNeeded()
+
+	timer := time.NewTimer(time.Second)
+	defer timer.Stop()
+	var ev event
+	select {
+	case ev = <-game.events:
+	case <-timer.C:
+		t.Fatal("start event was not queued after bootstrap completed")
+	}
+
+	game.handleEvent(ev)
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("OnStart did not run after Main yielded once")
+	}
 }
 
 func TestInitRuntimeProxyAppliesCostumeBeforeAwake(t *testing.T) {

--- a/internal/coroutine/coro.go
+++ b/internal/coroutine/coro.go
@@ -156,6 +156,7 @@ func (p *Coroutines) Yield(me Thread) {
 	p.sema.Unlock()
 	// Set atomic suspended flag first
 	me.suspended.Store(true)
+	me.markYieldedOrDone()
 	// Then update the map for backward compatibility
 	p.mutex.Lock()
 	p.suspended[me] = true

--- a/internal/coroutine/thread.go
+++ b/internal/coroutine/thread.go
@@ -57,6 +57,9 @@ type threadImpl struct {
 	joinMu     sync.Mutex
 	joinDone   bool
 	joinWaiter map[Thread]struct{}
+
+	yieldedOrDoneOnce sync.Once
+	yieldedOrDone     chan struct{}
 }
 
 // Thread represents a coroutine id.
@@ -259,6 +262,52 @@ func (p *Coroutines) JoinAll(targets []Thread) {
 	}
 }
 
+func (p *Coroutines) JoinYieldedOrDone(target Thread) {
+	if target == nil {
+		return
+	}
+
+	me := p.currentCoroutineThread()
+	if me == nil {
+		<-target.yieldedOrDone
+		return
+	}
+	if me == target {
+		return
+	}
+
+	select {
+	case <-target.yieldedOrDone:
+		return
+	default:
+	}
+
+	var signal struct{}
+	WaitForChan(p, target.yieldedOrDone, &signal)
+}
+
+func (p *Coroutines) JoinYieldedOrDoneAll(targets []Thread) {
+	if len(targets) == 0 {
+		return
+	}
+	if len(targets) == 1 {
+		p.JoinYieldedOrDone(targets[0])
+		return
+	}
+
+	seen := make(map[Thread]struct{}, len(targets))
+	for _, target := range targets {
+		if target == nil {
+			continue
+		}
+		if _, exists := seen[target]; exists {
+			continue
+		}
+		seen[target] = struct{}{}
+		p.JoinYieldedOrDone(target)
+	}
+}
+
 func (p *Coroutines) StopIf(filter func(th Thread) bool) {
 	p.mutex.Lock()
 	allThreads := make([]Thread, 0, len(p.allThreads))
@@ -321,12 +370,13 @@ func resolveThreadName(obj ThreadObj) string {
 
 func (p *Coroutines) newThread(obj ThreadObj) Thread {
 	th := &threadImpl{
-		Obj:        obj,
-		frame:      p.frame,
-		id:         atomic.AddInt64(&p.nextThreadID, 1),
-		schedFrame: -1,
-		name:       resolveThreadName(obj),
-		done:       make(chan struct{}),
+		Obj:           obj,
+		frame:         p.frame,
+		id:            atomic.AddInt64(&p.nextThreadID, 1),
+		schedFrame:    -1,
+		name:          resolveThreadName(obj),
+		done:          make(chan struct{}),
+		yieldedOrDone: make(chan struct{}),
 	}
 	th.ctx, th.cancelFunc = context.WithCancel(context.Background())
 
@@ -336,6 +386,12 @@ func (p *Coroutines) newThread(obj ThreadObj) Thread {
 
 	th.cond = sync.NewCond(&th.mutex)
 	return th
+}
+
+func (p *threadImpl) markYieldedOrDone() {
+	p.yieldedOrDoneOnce.Do(func() {
+		close(p.yieldedOrDone)
+	})
 }
 
 func (p *threadImpl) addJoinWaiter(waiter Thread) bool {
@@ -461,6 +517,7 @@ func (p *Coroutines) runThread(th Thread, fn func(me Thread) int) {
 		p.unregisterThread(th)
 		p.setWaitState(th, waitStatusDelete)
 		th.Cancel()
+		th.markYieldedOrDone()
 		for _, waiter := range th.finishJoinWaiters() {
 			p.markIdleAndResume(waiter)
 		}

--- a/internal/coroutine/thread_test.go
+++ b/internal/coroutine/thread_test.go
@@ -344,6 +344,82 @@ func TestJoinAllWaitsForEveryPeer(t *testing.T) {
 	}
 }
 
+func TestJoinYieldedOrDoneResumesCallerAfterPeerFirstYield(t *testing.T) {
+	co := New(nil)
+	releasePeer := make(chan struct{})
+	peerReady := make(chan Thread, 1)
+	callerDone := make(chan struct{})
+
+	peer := co.CreateAndStart(true, "peer", func(peer Thread) int {
+		peerReady <- peer
+		var signal struct{}
+		WaitForChan(co, releasePeer, &signal)
+		return 0
+	})
+
+	timer := time.NewTimer(time.Second)
+	defer timer.Stop()
+	select {
+	case <-peerReady:
+	case <-timer.C:
+		t.Fatal("peer coroutine did not start")
+	}
+
+	co.CreateAndStart(true, "caller", func(me Thread) int {
+		co.JoinYieldedOrDone(peer)
+		close(callerDone)
+		return 0
+	})
+
+	timer = time.NewTimer(time.Second)
+	defer timer.Stop()
+	select {
+	case <-callerDone:
+	case <-timer.C:
+		t.Fatal("caller did not resume after peer reached its first yield")
+	}
+
+	select {
+	case <-releasePeer:
+		t.Fatal("releasePeer should remain controlled by the test")
+	default:
+	}
+	close(releasePeer)
+}
+
+func TestJoinYieldedOrDoneReturnsWhenPeerExitsWithoutYield(t *testing.T) {
+	co := New(nil)
+	peerReady := make(chan Thread, 1)
+	callerDone := make(chan struct{})
+
+	peer := co.CreateAndStart(true, "peer", func(peer Thread) int {
+		peerReady <- peer
+		return 0
+	})
+
+	timer := time.NewTimer(time.Second)
+	defer timer.Stop()
+	select {
+	case <-peerReady:
+	case <-timer.C:
+		t.Fatal("peer coroutine did not start")
+	}
+
+	co.CreateAndStart(true, "caller", func(me Thread) int {
+		co.JoinYieldedOrDone(peer)
+		close(callerDone)
+		return 0
+	})
+
+	timer = time.NewTimer(time.Second)
+	defer timer.Stop()
+	select {
+	case <-callerDone:
+	case <-timer.C:
+		t.Fatal("caller did not resume after peer returned without yielding")
+	}
+}
+
 func TestCreateAndStartFromCoroutineYieldsCallerWhenStarted(t *testing.T) {
 	co := New(nil)
 	co.OnInited()

--- a/runtime_engine.go
+++ b/runtime_engine.go
@@ -39,7 +39,7 @@ func (p *Game) OnEngineStart() {
 			defer engine.CheckPanic()
 			if me, ok := p.gamer.(interface{ MainEntry() }); ok {
 				p.deferBootstrapFor(generation, func() {
-					runMain(me.MainEntry)
+					p.runBootstrapMainUntilYield(p, me.MainEntry)
 				})
 			}
 			if !p.lifecycleState.IsRunned.Load() {
@@ -107,30 +107,35 @@ func runMain(call func()) {
 	coreruntime.RunMain(call, time.Now(), setSchedInMain, setMainSchedTime)
 }
 
-func (p *Game) runBootstrapSpriteMainBatch(inits []Sprite) {
+func (p *Game) runBootstrapMainUntilYield(owner coroutine.ThreadObj, mainFn func()) {
+	if mainFn == nil {
+		return
+	}
+
+	thread := gco.CreateAndStart(false, owner, func(coroutine.Thread) int {
+		runMain(mainFn)
+		return 0
+	})
+	gco.JoinYieldedOrDone(thread)
+}
+
+func (p *Game) runBootstrapSpriteMainsUntilYield(inits []Sprite) {
 	if len(inits) == 0 {
 		return
 	}
 
-	threads := make([]coroutine.Thread, 0, len(inits))
+	// Advance initial sprite Mains in load/Z-order until each reaches its first
+	// yield (or return) before continuing bootstrap. This preserves deterministic
+	// pre-yield setup while still releasing startup once a long-running Main
+	// yields for the first time.
 	for _, ini := range inits {
 		spr := spriteOf(ini)
 		if spr == nil {
 			continue
 		}
 
-		mainFn := ini.Main
-		thread := gco.CreateAndStart(false, spr.pthis, func(coroutine.Thread) int {
-			runMain(mainFn)
-			return 0
-		})
-		if thread != nil {
-			threads = append(threads, thread)
-		}
+		p.runBootstrapMainUntilYield(spr.pthis, ini.Main)
 	}
-	// Keep bootstrap Main behavior aligned with the old awake dispatch:
-	// start every initial sprite Main first, then wait for the batch.
-	gco.JoinAll(threads)
 }
 
 func (p *Game) deferBootstrap(call func()) {


### PR DESCRIPTION
### 背景

`468db071` 之前，初始 Sprite Main 按 ZOrder 串行执行，但必须等待前一个 Main 完整结束，导致长运行 Main 阻塞后续 Sprite、OnLoaded 和 onStart。

`468db071` 将全部 Main 批量创建为协程，解决了部分互相等待问题，但失去了首次 yield 前的 ZOrder 初始化确定性。

### 修复

按 ZOrder 逐个创建初始 Sprite Main，并等待当前 Main 首次 yield 或结束后再启动下一个 Main。

### 效果

- 保留 `468db071` 之前的确定性初始化顺序。
- 不再等待 Main 完整结束，避免长运行 Main 卡住 onStart。
- 首次 yield 前的跨 Sprite 共享状态读写可推导。
- 首次 yield 后仍保持正常协程并发语义。