### PR TITLE
fix: disable GDExtensions during Godot imports

### DIFF
--- a/cmd/spx/internal/command/env.go
+++ b/cmd/spx/internal/command/env.go
@@ -211,7 +211,8 @@ func (cmd *CmdTool) runProjectImport() error {
 
 func (cmd *CmdTool) newProjectImportCommand() (*exec.Cmd, context.Context, time.Duration, context.CancelFunc) {
 	timeout := cmd.projectImportTimeout()
-	args := []string{"--headless", "--path", cmd.ProjectDir, "--import"}
+	// Avoid loading project GDExtensions during resource import.
+	args := []string{"--headless", "--path", cmd.ProjectDir, "--import", "--recovery-mode"}
 	if timeout <= 0 {
 		return exec.Command(cmd.CmdPath, args...), context.Background(), 0, func() {}
 	}

--- a/cmd/spx/internal/command/env_test.go
+++ b/cmd/spx/internal/command/env_test.go
@@ -117,6 +117,7 @@ func TestShouldReimport(t *testing.T) {
 		want        bool
 	}{
 		{name: "skips buildweb", cmdName: "buildweb", want: false},
+		{name: "reimports web template export", cmdName: "exporttemplateweb", want: true},
 		{name: "reimports exportweb when cache missing", cmdName: "exportweb", want: true},
 		{name: "skips runtime mode", cmdName: "runweb", runtimeMode: true, want: false},
 		{name: "skips pure engine mode", cmdName: "build", tags: "pure_engine", want: false},
@@ -144,6 +145,19 @@ func TestShouldReimport(t *testing.T) {
 				t.Fatalf("ShouldReimport() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestProjectImportUsesRecoveryMode(t *testing.T) {
+	t.Setenv(projectImportTimeoutEnvVar, "0")
+	cmd := CmdTool{CmdPath: "godot", ProjectDir: "/tmp/spx-project"}
+	execCmd, _, _, cancel := cmd.newProjectImportCommand()
+	defer cancel()
+
+	got := strings.Join(execCmd.Args[1:], " ")
+	want := "--headless --path /tmp/spx-project --import --recovery-mode"
+	if got != want {
+		t.Fatalf("project import args = %q, want %q", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary

- run Godot resource imports in recovery mode
- avoid loading project GDExtensions during the import process
- keep resource pre-import enabled for all applicable export targets
- add regression coverage for the import arguments

## Motivation

Godot resource imports can intermittently crash during editor shutdown after
loading the project's Go GDExtension. This is not Web-specific because multiple
export targets share the same project import path.

Resource importing does not require project GDExtensions. Godot recovery mode
keeps them unloaded while preserving the normal resource import process.

## Testing

- `go test ./cmd/spx/internal/command`
- repeated fresh-project `exporttemplateweb` runs successfully