### PR TITLE
fix(runtime): harden coroutine wake-ups and shared state

### DIFF
--- a/internal/coroutine/lifecycle.go
+++ b/internal/coroutine/lifecycle.go
@@ -180,7 +180,6 @@ func (p *Coroutines) registerThread(th Thread) {
 
 func (p *Coroutines) unregisterThread(th Thread) {
 	p.threadsMu.Lock()
-	delete(p.suspended, th)
 	delete(p.allThreads, th)
 	p.threadsMu.Unlock()
 }

--- a/internal/coroutine/manager.go
+++ b/internal/coroutine/manager.go
@@ -43,9 +43,8 @@ type Coroutines struct {
 	runMu   sync.Mutex
 	current atomic.Pointer[threadImpl]
 
-	// threadsMu protects the thread registry and suspension map.
+	// threadsMu protects the thread registry.
 	threadsMu  sync.Mutex
-	suspended  map[Thread]bool
 	allThreads map[Thread]struct{}
 
 	// schedulerMu protects threadStates and the condition-variable predicate.
@@ -59,8 +58,10 @@ type Coroutines struct {
 	nextJobID    atomic.Int64
 	nextThreadID atomic.Int64
 
-	perfDebug   atomic.Bool
-	readGCStats func(*sdebug.GCStats)
+	perfDebug       atomic.Bool
+	readGCStats     func(*sdebug.GCStats)
+	statsMu         sync.RWMutex
+	lastUpdateStats UpdateJobsStats
 
 	// goroutineIDs contains the IDs of goroutines created by CreateAndStart.
 	goroutineIDs sync.Map // map[int64]struct{}
@@ -71,7 +72,6 @@ type Coroutines struct {
 func New(onPanic func(name, stack string)) *Coroutines {
 	p := &Coroutines{
 		onPanic:      onPanic,
-		suspended:    make(map[Thread]bool),
 		allThreads:   make(map[Thread]struct{}),
 		threadStates: make(map[Thread]threadState),
 		currentJobs:  NewQueue[*WaitJob](),

--- a/internal/coroutine/scheduler.go
+++ b/internal/coroutine/scheduler.go
@@ -16,8 +16,6 @@
 
 package coroutine
 
-import "runtime"
-
 type threadState uint8
 
 const (
@@ -45,18 +43,24 @@ func (p *Coroutines) Yield(me Thread) {
 	p.setCurrent(nil)
 	p.runMu.Unlock()
 
-	// Publish suspension before the handshake to preserve early wake-ups.
-	me.suspended.Store(true)
+	// Publish suspension before notifying yield waiters. Resume may have
+	// arrived before this point; consume that signal instead of blocking.
+	me.suspendMu.Lock()
+	if me.suspendState == suspendStateSignaled {
+		me.suspendState = suspendStateRunning
+	} else {
+		me.suspendState = suspendStateSuspended
+		me.suspended.Store(true)
+	}
 	for _, waiter := range me.finishYieldWaiters() {
 		p.markRunnableAndResume(waiter)
 	}
-	p.threadsMu.Lock()
-	p.suspended[me] = true
-	p.threadsMu.Unlock()
-
-	me.suspendMu.Lock()
-	for me.suspended.Load() && !p.isThreadCanceled(me) {
+	for me.suspendState == suspendStateSuspended && !p.isThreadCanceled(me) {
 		me.suspendCond.Wait()
+	}
+	if me.suspendState == suspendStateSuspended {
+		me.suspendState = suspendStateRunning
+		me.suspended.Store(false)
 	}
 	me.suspendMu.Unlock()
 
@@ -68,29 +72,22 @@ func (p *Coroutines) Yield(me Thread) {
 	}
 }
 
-// Resume waits for me to publish its suspended state, then wakes it. It returns
-// early if me is canceled before that state is published.
+// Resume wakes me if it is suspended. If Yield has not published suspension
+// yet, Resume records a signal for that Yield to consume without blocking.
 func (p *Coroutines) Resume(me Thread) {
-	for {
-		resumed := false
-		p.threadsMu.Lock()
-		if p.suspended[me] {
-			p.suspended[me] = false
-			resumed = true
-		}
-		p.threadsMu.Unlock()
+	me.suspendMu.Lock()
+	defer me.suspendMu.Unlock()
+	if p.isThreadCanceled(me) {
+		return
+	}
 
-		if resumed {
-			me.suspended.Store(false)
-			me.suspendMu.Lock()
-			me.suspendCond.Signal()
-			me.suspendMu.Unlock()
-			return
-		}
-		if p.isThreadCanceled(me) {
-			return
-		}
-		runtime.Gosched()
+	switch me.suspendState {
+	case suspendStateSuspended:
+		me.suspendState = suspendStateRunning
+		me.suspended.Store(false)
+		me.suspendCond.Signal()
+	case suspendStateRunning:
+		me.suspendState = suspendStateSignaled
 	}
 }
 

--- a/internal/coroutine/scheduler.go
+++ b/internal/coroutine/scheduler.go
@@ -52,9 +52,13 @@ func (p *Coroutines) Yield(me Thread) {
 		me.suspendState = suspendStateSuspended
 		me.suspended.Store(true)
 	}
+	me.suspendMu.Unlock()
+
 	for _, waiter := range me.finishYieldWaiters() {
 		p.markRunnableAndResume(waiter)
 	}
+
+	me.suspendMu.Lock()
 	for me.suspendState == suspendStateSuspended && !p.isThreadCanceled(me) {
 		me.suspendCond.Wait()
 	}

--- a/internal/coroutine/scheduler_test.go
+++ b/internal/coroutine/scheduler_test.go
@@ -240,6 +240,64 @@ func TestResumeBeforeYieldDoesNotBlockOrLoseWakeup(t *testing.T) {
 	}
 }
 
+func TestMutualYieldWaitersDoNotDeadlock(t *testing.T) {
+	co := New(nil)
+	a := co.newThread("a")
+	b := co.newThread("b")
+	co.registerThread(a)
+	co.registerThread(b)
+	a.yieldWaiters = map[Thread]struct{}{b: {}}
+	b.yieldWaiters = map[Thread]struct{}{a: {}}
+
+	// Keep A between releasing runMu and publishing its suspension. B can then
+	// publish its own suspension and try to wake A. Yield must not hold B's
+	// suspendMu during that wake-up, or A and B can deadlock on each other's
+	// suspendMu.
+	a.suspendMu.Lock()
+	aStarted := make(chan struct{})
+	bStarted := make(chan struct{})
+	done := make(chan struct{}, 2)
+	go func() {
+		co.runThread(a, func(me Thread) int {
+			close(aStarted)
+			co.Yield(me)
+			return 0
+		})
+		done <- struct{}{}
+	}()
+	<-aStarted
+	co.runMu.Lock()
+	co.runMu.Unlock()
+
+	go func() {
+		co.runThread(b, func(me Thread) int {
+			close(bStarted)
+			co.Yield(me)
+			return 0
+		})
+		done <- struct{}{}
+	}()
+	<-bStarted
+
+	deadline := time.Now().Add(time.Second)
+	for !b.suspended.Load() {
+		if time.Now().After(deadline) {
+			a.suspendMu.Unlock()
+			t.Fatal("B did not publish its suspended state")
+		}
+		runtime.Gosched()
+	}
+	a.suspendMu.Unlock()
+
+	for range 2 {
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatal("mutual yield waiters deadlocked")
+		}
+	}
+}
+
 func TestSchedResumesWithoutWaitingForUpdate(t *testing.T) {
 	co := New(nil)
 	done := make(chan struct{})

--- a/internal/coroutine/scheduler_test.go
+++ b/internal/coroutine/scheduler_test.go
@@ -33,7 +33,6 @@ func TestUpdateReadsGCStatsOnlyWhenPerfDebugEnabled(t *testing.T) {
 	originalReadGCStats := co.readGCStats
 	t.Cleanup(func() {
 		co.readGCStats = originalReadGCStats
-		lastUpdateStats = UpdateJobsStats{}
 	})
 
 	var calls int
@@ -56,6 +55,19 @@ func TestUpdateReadsGCStatsOnlyWhenPerfDebugEnabled(t *testing.T) {
 	}
 	if !co.GetLastUpdateStats().GCStatsEnabled {
 		t.Fatal("expected GC stats to be marked enabled when perf debug is on")
+	}
+}
+
+func TestLastUpdateStatsAreScopedToManager(t *testing.T) {
+	first := New(nil)
+	first.OnInited()
+	first.SetPerfDebug(true)
+	first.readGCStats = func(*sdebug.GCStats) {}
+	first.Update()
+
+	second := New(nil)
+	if second.GetLastUpdateStats().GCStatsEnabled {
+		t.Fatal("a new manager inherited update statistics from another manager")
 	}
 }
 
@@ -190,6 +202,41 @@ func TestYieldClearsCurrentWhileCoroutineIsSuspended(t *testing.T) {
 	case <-done:
 	case <-time.After(time.Second):
 		t.Fatal("coroutine did not finish after resume")
+	}
+}
+
+func TestResumeBeforeYieldDoesNotBlockOrLoseWakeup(t *testing.T) {
+	co := New(nil)
+	started := make(chan struct{})
+	proceed := make(chan struct{})
+	done := make(chan struct{})
+
+	th := co.Create("worker", func(me Thread) int {
+		close(started)
+		<-proceed
+		co.Yield(me)
+		close(done)
+		return 0
+	})
+	<-started
+
+	resumeDone := make(chan struct{})
+	go func() {
+		co.Resume(th)
+		close(resumeDone)
+	}()
+	select {
+	case <-resumeDone:
+	case <-time.After(time.Second):
+		close(proceed)
+		t.Fatal("Resume blocked while waiting for Yield to publish suspension")
+	}
+	close(proceed)
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Yield did not consume the earlier Resume signal")
 	}
 }
 

--- a/internal/coroutine/stats.go
+++ b/internal/coroutine/stats.go
@@ -37,11 +37,12 @@ type UpdateJobsStats struct {
 	LoopIterations int     // Number of update-loop iterations.
 }
 
-// GetLastUpdateStats returns the package-wide statistics from the most recent
+// GetLastUpdateStats returns this manager's statistics from its most recent
 // Update call. GCCount and GCPauses are meaningful only when GCStatsEnabled is
 // true.
-func (*Coroutines) GetLastUpdateStats() UpdateJobsStats {
-	return lastUpdateStats
+func (p *Coroutines) GetLastUpdateStats() UpdateJobsStats {
+	p.statsMu.RLock()
+	stats := p.lastUpdateStats
+	p.statsMu.RUnlock()
+	return stats
 }
-
-var lastUpdateStats UpdateJobsStats

--- a/internal/coroutine/thread.go
+++ b/internal/coroutine/thread.go
@@ -30,6 +30,14 @@ import (
 // implementing Name() also provide the thread's diagnostic name.
 type ThreadObj any
 
+type suspendState uint8
+
+const (
+	suspendStateRunning suspendState = iota
+	suspendStateSuspended
+	suspendStateSignaled
+)
+
 type threadImpl struct {
 	Obj ThreadObj
 
@@ -37,10 +45,11 @@ type threadImpl struct {
 	name  string
 	stack string
 
-	stopped     atomic.Bool
-	suspended   atomic.Bool
-	suspendMu   sync.Mutex
-	suspendCond *sync.Cond
+	stopped      atomic.Bool
+	suspended    atomic.Bool
+	suspendMu    sync.Mutex
+	suspendCond  *sync.Cond
+	suspendState suspendState
 
 	ctx        context.Context
 	cancelFunc context.CancelFunc

--- a/internal/coroutine/thread_test.go
+++ b/internal/coroutine/thread_test.go
@@ -83,11 +83,11 @@ func TestStopIfStopsActiveThread(t *testing.T) {
 		t.Fatal("coroutine did not start")
 	}
 
-	co.threadsMu.Lock()
-	_, suspended := co.suspended[th]
-	co.threadsMu.Unlock()
-	if suspended {
-		t.Fatal("test precondition failed: spinning thread should not be in suspended map")
+	th.suspendMu.Lock()
+	suspendState := th.suspendState
+	th.suspendMu.Unlock()
+	if suspendState == suspendStateSuspended {
+		t.Fatal("test precondition failed: spinning thread should not be suspended")
 	}
 
 	co.StopIf(func(candidate Thread) bool {

--- a/internal/coroutine/update.go
+++ b/internal/coroutine/update.go
@@ -39,7 +39,9 @@ func (p *Coroutines) Update() {
 	stats.GCStatsEnabled = gcStatsBefore != nil
 	p.runUpdateLoop(&stats, &state)
 	p.finishUpdate(&stats, start, gcStatsBefore)
-	lastUpdateStats = stats
+	p.statsMu.Lock()
+	p.lastUpdateStats = stats
+	p.statsMu.Unlock()
 }
 
 func (p *Coroutines) readGCStatsBeforeUpdate() *sdebug.GCStats {

--- a/internal/time/time.go
+++ b/internal/time/time.go
@@ -30,7 +30,7 @@ var (
 	deltaTime              float64
 	realDeltaTime          float64
 	fixedDeltaTimeBits     atomic.Uint64
-	timeScale              float64
+	timeScaleBits          atomic.Uint64
 	curFrame               atomic.Int64
 	setTimeScaleCallback   func(float64)
 	startTimestamp         stdtime.Time
@@ -63,14 +63,14 @@ func Frame() int64 {
 }
 
 func TimeScale() float64 {
-	return timeScale
+	return math.Float64frombits(timeScaleBits.Load())
 }
 
 func SetTimeScale(value float64) {
 	if setTimeScaleCallback != nil {
 		setTimeScaleCallback(value)
 	}
-	timeScale = value
+	timeScaleBits.Store(math.Float64bits(value))
 }
 
 func DeltaTime() float64 {
@@ -118,7 +118,7 @@ func Start(setTimeScaleCB func(float64)) {
 
 	realTimeSinceLevelLoad, timeSinceLevelLoad = 0, 0
 	deltaTime, realDeltaTime = 0, 0
-	timeScale = 1
+	timeScaleBits.Store(math.Float64bits(1))
 	curFrame.Store(0)
 	fps = DefaultFPS
 

--- a/internal/time/time_test.go
+++ b/internal/time/time_test.go
@@ -29,7 +29,7 @@ func resetStateForTest() {
 	deltaTime = 0
 	realDeltaTime = 0
 	fixedDeltaTimeBits.Store(0)
-	timeScale = 0
+	timeScaleBits.Store(0)
 	curFrame.Store(0)
 	setTimeScaleCallback = nil
 	startTimestamp = stdtime.Time{}
@@ -46,7 +46,7 @@ func TestStartInitializesTimeState(t *testing.T) {
 	timeSinceLevelLoad = 8
 	deltaTime = 7
 	realDeltaTime = 6
-	timeScale = 5
+	timeScaleBits.Store(math.Float64bits(5))
 	curFrame.Store(4)
 	fps = 3
 	timerBaseTime = 1
@@ -182,6 +182,27 @@ func TestFixedDeltaTimeSupportsConcurrentSessionChanges(t *testing.T) {
 			for i := 0; i < 1000; i++ {
 				_, _ = FixedDeltaTime()
 				_ = EffectiveLogicalDeltaTime(0.25)
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+func TestTimeScaleSupportsConcurrentAccess(t *testing.T) {
+	resetStateForTest()
+	var wg sync.WaitGroup
+	for range 4 {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 1000; i++ {
+				SetTimeScale(float64(i))
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 1000; i++ {
+				_ = TimeScale()
 			}
 		}()
 	}


### PR DESCRIPTION
## Summary

Improve coroutine scheduling and runtime state isolation:

- replace the `Resume` busy-wait loop with a suspend state machine
- preserve wake-ups that arrive before `Yield` publishes suspension
- make `timeScale` safe for concurrent access
- store update statistics per `Coroutines` instance
- protect update statistics from concurrent reads and writes

## Motivation

`Resume` previously used `runtime.Gosched()` to wait until the target coroutine
published its suspended state. This introduced unnecessary polling and made the
wake-up handshake dependent on goroutine scheduling timing.

The new `running` / `suspended` / `signaled` state machine records an early
wake-up and lets the following `Yield` consume it without blocking.

`timeScale` could also be read and written concurrently, while
`lastUpdateStats` was shared by all coroutine managers. Atomic time-scale access
and instance-owned statistics remove these data races and cross-instance
interference.

## Compatibility

This change does not modify engine frame counters, input-tick consumption,
fixed timestep handling, random seeding, or wait-job ordering.

Multiple early wake-ups are coalesced into one signal. Existing scheduler paths
use one wake-up per blocking operation.

## Tests

- `go test ./...`
- `go test -race -count=10 ./internal/coroutine ./internal/time`
- input recording/replay tests with the updated scheduler