### PR TITLE
feat: support configurable runtime username

### DIFF
--- a/game_api_test.go
+++ b/game_api_test.go
@@ -22,6 +22,7 @@ import (
 
 	internalaudio "github.com/goplus/spx/v2/internal/audio"
 	internalengine "github.com/goplus/spx/v2/internal/engine"
+	spxapi "github.com/goplus/spx/v2/pkg/spx"
 )
 
 type fakeAudioBackend struct {
@@ -125,10 +126,15 @@ func TestGameClearSoundEffectsAllocatesWhenUnused(t *testing.T) {
 	}
 }
 
-func TestGameUsernameReturnsEmptyString(t *testing.T) {
+func TestGameUsernameReturnsConfiguredUsername(t *testing.T) {
+	previous := spxapi.Username()
+	t.Cleanup(func() { spxapi.SetUsername(previous) })
+
+	spxapi.SetUsername("scratch-user")
+
 	var g Game
-	if got := g.Username(); got != "" {
-		t.Fatalf("Username = %q, want empty string", got)
+	if got := g.Username(); got != "scratch-user" {
+		t.Fatalf("Game.Username() = %q, want %q", got, "scratch-user")
 	}
 }
 

--- a/game_stage.go
+++ b/game_stage.go
@@ -26,6 +26,7 @@ import (
 	spxlog "github.com/goplus/spx/v2/internal/log"
 	itime "github.com/goplus/spx/v2/internal/time"
 	"github.com/goplus/spx/v2/internal/ui"
+	spxapi "github.com/goplus/spx/v2/pkg/spx"
 )
 
 // -----------------------------------------------------------------------------
@@ -146,7 +147,7 @@ func (p *Game) getMousePos() (x, y float64) {
 }
 
 func (p *Game) Username() string {
-	return ""
+	return spxapi.Username()
 }
 
 func (p *Game) WaitNextFrame() Seconds {

--- a/pkg/ispx/internal/pkg/github.com/goplus/spx/v2/export.go
+++ b/pkg/ispx/internal/pkg/github.com/goplus/spx/v2/export.go
@@ -68,6 +68,7 @@ func init() {
 			"github.com/goplus/spx/v2/internal/time":            "time",
 			"github.com/goplus/spx/v2/internal/tools":           "tools",
 			"github.com/goplus/spx/v2/internal/ui":              "ui",
+			"github.com/goplus/spx/v2/pkg/spx":                  "spx",
 			"github.com/goplus/spx/v2/pkg/spx/pkg/engine":       "engine",
 			"maps":      "maps",
 			"math":      "math",

--- a/pkg/ispx/internal/pkg/github.com/goplus/spx/v2/pkg/spx/export.go
+++ b/pkg/ispx/internal/pkg/github.com/goplus/spx/v2/pkg/spx/export.go
@@ -33,7 +33,8 @@ func init() {
 		Deps: map[string]string{
 			"context": "context",
 			"github.com/goplus/spx/v2/internal/engine": "engine",
-			"time": "time",
+			"sync/atomic": "atomic",
+			"time":        "time",
 		},
 		Interfaces: map[string]reflect.Type{},
 		NamedTypes: map[string]reflect.Type{},
@@ -45,6 +46,8 @@ func init() {
 			"Go":                 reflect.ValueOf(q.Go),
 			"IsAbortThreadError": reflect.ValueOf(q.IsAbortThreadError),
 			"IsInCoroutine":      reflect.ValueOf(q.IsInCoroutine),
+			"SetUsername":        reflect.ValueOf(q.SetUsername),
+			"Username":           reflect.ValueOf(q.Username),
 			"Wait":               reflect.ValueOf(q.Wait),
 			"WaitNextFrame":      reflect.ValueOf(q.WaitNextFrame),
 		},

--- a/pkg/spx/environment.go
+++ b/pkg/spx/environment.go
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2021 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package spx
+
+import "sync/atomic"
+
+var username atomic.Pointer[string]
+
+// SetUsername sets the username exposed to the running project. An empty
+// username represents an anonymous user.
+func SetUsername(name string) {
+	username.Store(&name)
+}
+
+// Username returns the configured username. It returns an empty string when no
+// username has been configured.
+func Username() string {
+	name := username.Load()
+	if name == nil {
+		return ""
+	}
+	return *name
+}

--- a/pkg/spx/environment_test.go
+++ b/pkg/spx/environment_test.go
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2021 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package spx
+
+import "testing"
+
+func TestUsername(t *testing.T) {
+	previous := Username()
+	t.Cleanup(func() { SetUsername(previous) })
+
+	SetUsername("scratch-user")
+	if got := Username(); got != "scratch-user" {
+		t.Fatalf("Username() = %q, want %q", got, "scratch-user")
+	}
+
+	SetUsername("")
+	if got := Username(); got != "" {
+		t.Fatalf("Username() = %q, want empty string", got)
+	}
+}


### PR DESCRIPTION
## Summary

- add concurrency-safe `SetUsername` and `Username` APIs to the runtime environment layer in `pkg/spx`
- make `Game.Username()` return the configured runtime username
- expose the new APIs to interpreted projects through the generated ispx package registry
- cover configured and anonymous username behavior with unit tests

## Motivation

Scratch projects can read the current username, but SPX currently always returns an empty string. Builder/ispx needs a supported way to inject the logged-in username before running a project.

This implementation keeps the mutable state private instead of exposing a package-level variable. It uses atomic storage so runtime reads and host updates do not introduce a data race, while an empty string continues to represent an anonymous user.

The environment-specific API lives in `pkg/spx`, which is already available to builder/ispx and leaves room for additional host-provided environment values in the future.

## Validation

- `go test ./pkg/spx . ./pkg/ispx/...`
- `go test -race ./pkg/spx .`
- `go test ./...`

Closes #1688.
