### PR TITLE
fix(codegen): trim trailing whitespace from generated Godot JS

### DIFF
--- a/internal/cmd/codegen/generate/webffi/generate.go
+++ b/internal/cmd/codegen/generate/webffi/generate.go
@@ -194,6 +194,7 @@ func GenerateJsEngineJsFile(projectPath, godotPath string, ast clang.CHeaderFile
 	if err != nil {
 		return err
 	}
+	output := trimTrailingWhitespace(b.Bytes())
 
 	headerFileName := filepath.Join(godotPath, "platform", "web", "js", "engine", "gdspx.js")
 	err = os.MkdirAll(filepath.Dir(headerFileName), os.ModePerm)
@@ -206,8 +207,16 @@ func GenerateJsEngineJsFile(projectPath, godotPath string, ast clang.CHeaderFile
 	}
 	defer f.Close()
 
-	_, err = f.Write(b.Bytes())
+	_, err = f.Write(output)
 	return err
+}
+
+func trimTrailingWhitespace(src []byte) []byte {
+	lines := bytes.Split(src, []byte("\n"))
+	for i, line := range lines {
+		lines[i] = bytes.TrimRight(line, " \t")
+	}
+	return bytes.Join(lines, []byte("\n"))
 }
 
 func getManagerFuncName(function *clang.TypedefFunction) string {

--- a/internal/cmd/codegen/generate/webffi/generate_test.go
+++ b/internal/cmd/codegen/generate/webffi/generate_test.go
@@ -17,12 +17,33 @@
 package webffi
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/goplus/spx/v2/internal/cmd/codegen/gdextensionparser/clang"
 	"github.com/goplus/spx/v2/internal/cmd/codegen/generate/common"
 	"github.com/stretchr/testify/require"
 )
+
+func TestGenerateJsEngineJsFileTrimsTrailingWhitespace(t *testing.T) {
+	function := &clang.TypedefFunction{
+		Name:       "GDExtensionSpxTestDoThing",
+		ReturnType: clang.PrimativeType{Name: "void"},
+	}
+	ast := clang.CHeaderFileAST{
+		Expr: []clang.Expr{{Function: function}},
+	}
+	godotPath := t.TempDir()
+
+	require.NoError(t, GenerateJsEngineJsFile("", godotPath, ast))
+	body, err := os.ReadFile(filepath.Join(godotPath, "platform", "web", "js", "engine", "gdspx.js"))
+	require.NoError(t, err)
+	for _, line := range strings.Split(string(body), "\n") {
+		require.Equal(t, strings.TrimRight(line, " \t"), line)
+	}
+}
 
 func TestGetJsFuncArgsFlattensGdObj(t *testing.T) {
 	function := &clang.TypedefFunction{


### PR DESCRIPTION
## What changed

- Trim trailing spaces and tabs from every line after rendering the generated Godot Web bridge.
- Add an integration-style regression test that generates `gdspx.js` and verifies every output line is clean.

## Why

The JavaScript template and Go-generated function bodies can both introduce trailing whitespace. As a result, `make generate` reproduced 1,156 lines with trailing spaces or tabs in `godot/platform/web/js/engine/gdspx.js`, and newly generated bridge methods could fail `git diff --check`.

Formatting the complete rendered output in the Go generator fixes both sources without changing JavaScript behavior.

## Impact

`make generate` now produces a clean, stable Godot Web bridge. The generated code differs only by removal of trailing whitespace.

## Validation

- `go test ./...` from `internal/cmd/codegen`
- `GODOT_SRC=/Users/mac/qiniu/godot-codegen-format make generate`
- Confirmed the generated `gdspx.js` contains zero lines with trailing spaces or tabs
- `git diff --check`
