### PR TITLE
fix(build): only set up macOS Vulkan SDK for iOS

### DIFF
--- a/internal/cmd/buildctl/engine/build.go
+++ b/internal/cmd/buildctl/engine/build.go
@@ -100,7 +100,7 @@ func prepareEngineBuildEnvironment(repoRoot, requestedPlatform string) (buildEnv
 	}
 
 	commandEnv := currentEnvMap()
-	if runtime.GOOS == "darwin" {
+	if runtime.GOOS == "darwin" && buildEnv.Platform == "ios" {
 		fmt.Fprintf(os.Stdout, "Installing macOS Vulkan SDK...\n")
 		if err := runStreamingCommand(buildEnv.EngineDir, filepath.Join("misc", "scripts", "install_vulkan_sdk_macos.sh")); err != nil {
 			return buildEnvironment{}, nil, err


### PR DESCRIPTION
Only iOS templates currently enable Vulkan, while desktop and web builds use vulkan=false. Avoid installing the Vulkan SDK for unrelated macOS builds and support SPX_SKIP_MACOS_VULKAN_SDK for preconfigured toolchains.