### PR TITLE
test: add coordinate system regression demo

### DIFF
--- a/test/CoordinateSystem/README.md
+++ b/test/CoordinateSystem/README.md
@@ -1,0 +1,30 @@
+# SPX coordinate-system regression demo
+
+This demo exercises the coordinate ownership introduced by:
+
+- goplus/spx#1702
+- goplus/godot#327
+- goplus/spx#1703
+
+Expected behavior:
+
+1. The stage center is SPX `(0, 0)`, `+X` points right, and `+Y` points up.
+2. The black cross is the sprite's logical root. Pressing `Space` cycles the
+   same SVG through three costume centers. The selected colored anchor must
+   stay on the black cross while the rendered SVG moves around it.
+   The SVG source dimensions are declared explicitly as `120 × 80`, so each
+   center is interpreted in the same source-image pixel coordinate space.
+3. `R` rotates around the logical root. `F` flips left/right around the same
+   root. `N` restores normal rotation.
+4. `P` draws a cyan pen segment in SPX `+Y`, so the segment must go upward.
+5. `S` stamps the current rendered costume and then moves the live sprite to
+   the right. The stamp must remain exactly where the rendered costume was.
+6. Arrow keys move both the logical root and its rendering together. `C`
+   resets the demo and `E` clears pen drawings and stamps.
+
+Run with the native SPX runtime:
+
+```sh
+cd test/CoordinateSystem
+spx runnative
+```

--- a/test/CoordinateSystem/RootMarker.spx
+++ b/test/CoordinateSystem/RootMarker.spx
@@ -1,0 +1,2 @@
+// The marker is a separate sprite at Subject's logical SPX position. It must
+// not inherit Subject's costume render offset, rotation, or horizontal flip.

--- a/test/CoordinateSystem/Subject.spx
+++ b/test/CoordinateSystem/Subject.spx
@@ -1,0 +1,143 @@
+import "fmt"
+import "math"
+
+const coordinateStep = 40.0
+
+var (
+	expectedX = 0.0
+	expectedY = 100.0
+	flipped   bool
+)
+
+func syncLogicalRoot() {
+	RootMarker.SetXYpos xpos, ypos
+}
+
+func acceptLogicalPosition() {
+	// Motion can be clamped by the stage fence. Use the resulting logical SPX
+	// position as the baseline for later costume/rotation invariants.
+	expectedX, expectedY = xpos, ypos
+}
+
+func verifyLogicalPosition(action string) {
+	if math.Abs(xpos-expectedX) > 0.001 || math.Abs(ypos-expectedY) > 0.001 {
+		msg := fmt.Sprintf("FAIL %s: got (%.1f, %.1f), want (%.1f, %.1f)", action, xpos, ypos, expectedX, expectedY)
+		println msg
+		say msg
+		return
+	}
+	println fmt.Sprintf("PASS %s: logical SPX position = (%.1f, %.1f)", action, xpos, ypos)
+}
+
+func reportState(action string) {
+	verifyLogicalPosition action
+	syncLogicalRoot
+	say fmt.Sprintf("%s\nanchor=%s\nSPX=(%.0f, %.0f)", action, costumeName, xpos, ypos)
+}
+
+func resetCoordinateDemo() {
+	expectedX, expectedY = 0, 100
+	setXYpos expectedX, expectedY
+	setRotationStyle Normal
+	setHeading 90
+	setCostume 0
+	flipped = false
+	reportState "reset"
+}
+
+onStart => {
+	setPenSize 4
+	setPenColor HSB(52, 80, 90)
+	resetCoordinateDemo
+
+	// Exercise each asset-space center once. Only RenderRoot should move.
+	for i := 0; i < 3; i++ {
+		setCostume i
+		reportState "startup center conversion"
+		wait 0.8s
+	}
+	setCostume 0
+	reportState "ready"
+}
+
+onClick => {
+	setCostume Next
+	reportState "click: next costume center"
+}
+
+onKey KeySpace, => {
+	setCostume Next
+	reportState "next costume center"
+}
+
+onKey KeyUp, => {
+	changeYpos coordinateStep
+	acceptLogicalPosition
+	reportState "move +Y"
+}
+
+onKey KeyDown, => {
+	changeYpos -coordinateStep
+	acceptLogicalPosition
+	reportState "move -Y"
+}
+
+onKey KeyLeft, => {
+	changeXpos -coordinateStep
+	acceptLogicalPosition
+	reportState "move -X"
+}
+
+onKey KeyRight, => {
+	changeXpos coordinateStep
+	acceptLogicalPosition
+	reportState "move +X"
+}
+
+onKey KeyR, => {
+	setRotationStyle Normal
+	turn 30
+	reportState "rotate around logical root"
+}
+
+onKey KeyF, => {
+	setRotationStyle LeftRight
+	if flipped {
+		setHeading 90
+	} else {
+		setHeading -90
+	}
+	flipped = !flipped
+	reportState "flip around logical root"
+}
+
+onKey KeyN, => {
+	setRotationStyle Normal
+	setHeading 90
+	flipped = false
+	reportState "normal rotation"
+}
+
+onKey KeyP, => {
+	penDown
+	changeYpos 80
+	penUp
+	acceptLogicalPosition
+	reportState "pen moved +Y"
+}
+
+onKey KeyS, => {
+	stamp
+	changeXpos 140
+	acceptLogicalPosition
+	reportState "stamp then move +X"
+}
+
+onKey KeyC, => {
+	resetCoordinateDemo
+}
+
+onKey KeyE, => {
+	eraseAll
+	reportState "erase pen and stamps"
+}

--- a/test/CoordinateSystem/assets/coordinate-grid.svg
+++ b/test/CoordinateSystem/assets/coordinate-grid.svg
@@ -1,0 +1,42 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#f8fafc"/>
+  <g stroke="#dbe4ee" stroke-width="1">
+    <path d="M40 0V480M80 0V480M120 0V480M160 0V480M200 0V480M240 0V480M280 0V480M360 0V480M400 0V480M440 0V480M480 0V480M520 0V480M560 0V480M600 0V480"/>
+    <path d="M0 40H640M0 80H640M0 120H640M0 160H640M0 200H640M0 280H640M0 320H640M0 360H640M0 400H640M0 440H640"/>
+  </g>
+
+  <g stroke="#334155" stroke-width="2">
+    <path d="M24 240H616"/>
+    <path d="M320 456V24"/>
+  </g>
+  <g fill="#334155">
+    <path d="M616 240l-12-6v12z"/>
+    <path d="M320 24l-6 12h12z"/>
+  </g>
+
+  <g font-family="'default'" fill="#334155">
+    <text x="588" y="228" font-size="15" font-weight="700">+X</text>
+    <text x="331" y="35" font-size="15" font-weight="700">+Y</text>
+    <text x="331" y="462" font-size="13">-Y</text>
+    <text x="326" y="258" font-size="12">SPX (0, 0)</text>
+    <text x="331" y="132" font-size="12" fill="#64748b">start: (0, 100)</text>
+  </g>
+
+  <g transform="translate(18 16)" font-family="'default'">
+    <rect width="274" height="92" rx="10" fill="#ffffff" stroke="#cbd5e1"/>
+    <text x="12" y="21" font-size="13" font-weight="700" fill="#0f172a">Coordinate regression controls</text>
+    <text x="12" y="40" font-size="11" fill="#475569">Space/click: center · Arrows: logical position</text>
+    <text x="12" y="57" font-size="11" fill="#475569">R/F/N: rotate/flip/normal · P: pen +Y</text>
+    <text x="12" y="74" font-size="11" fill="#475569">S: stamp+move · C: reset · E: erase</text>
+  </g>
+
+  <g transform="translate(420 16)" font-family="'default'">
+    <rect width="202" height="92" rx="10" fill="#ffffff" stroke="#cbd5e1"/>
+    <text x="12" y="21" font-size="13" font-weight="700" fill="#0f172a">Costume center</text>
+    <circle cx="17" cy="40" r="5" fill="#8b5cf6"/><text x="29" y="44" font-size="11" fill="#475569">geometric (60, 40)</text>
+    <circle cx="17" cy="58" r="5" fill="#f97316"/><text x="29" y="62" font-size="11" fill="#475569">asset (20, 20)</text>
+    <circle cx="17" cy="76" r="5" fill="#22c55e"/><text x="29" y="80" font-size="11" fill="#475569">asset (100, 60)</text>
+  </g>
+
+  <circle cx="320" cy="140" r="15" fill="none" stroke="#94a3b8" stroke-width="2" stroke-dasharray="4 3"/>
+</svg>

--- a/test/CoordinateSystem/assets/index.json
+++ b/test/CoordinateSystem/assets/index.json
@@ -1,0 +1,28 @@
+{
+  "run": {
+    "title": "SPX Coordinate System",
+    "width": 640,
+    "height": 480
+  },
+  "backdrops": [
+    {
+      "name": "coordinate-grid",
+      "path": "coordinate-grid.svg"
+    }
+  ],
+  "backdropIndex": 0,
+  "zorder": [
+    {
+      "type": "sprite",
+      "target": "Subject",
+      "x": 0,
+      "y": 100
+    },
+    {
+      "type": "sprite",
+      "target": "RootMarker",
+      "x": 0,
+      "y": 100
+    }
+  ]
+}

--- a/test/CoordinateSystem/assets/sprites/RootMarker/index.json
+++ b/test/CoordinateSystem/assets/sprites/RootMarker/index.json
@@ -1,0 +1,21 @@
+{
+  "costumes": [
+    {
+      "bitmapResolution": 1,
+      "imageWidth": 24,
+      "imageHeight": 24,
+      "name": "logical-root",
+      "path": "root-marker.svg",
+      "x": 12,
+      "y": 12
+    }
+  ],
+  "costumeIndex": 0,
+  "heading": 90,
+  "isDraggable": false,
+  "rotationStyle": "none",
+  "size": 1,
+  "visible": true,
+  "x": 0,
+  "y": 100
+}

--- a/test/CoordinateSystem/assets/sprites/RootMarker/root-marker.svg
+++ b/test/CoordinateSystem/assets/sprites/RootMarker/root-marker.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+  <circle cx="12" cy="12" r="9" fill="#ffffff" fill-opacity="0.88" stroke="#0f172a" stroke-width="2"/>
+  <path d="M12 1v22M1 12h22" stroke="#0f172a" stroke-width="2"/>
+  <circle cx="12" cy="12" r="2.5" fill="#ef4444" stroke="#ffffff" stroke-width="1"/>
+</svg>

--- a/test/CoordinateSystem/assets/sprites/Subject/index.json
+++ b/test/CoordinateSystem/assets/sprites/Subject/index.json
@@ -1,0 +1,42 @@
+{
+  "costumes": [
+    {
+      "bitmapResolution": 1,
+      "imageWidth": 120,
+      "imageHeight": 80,
+      "name": "geometric-center",
+      "path": "subject.svg",
+      "faceRight": 0,
+      "x": 60,
+      "y": 40
+    },
+    {
+      "bitmapResolution": 1,
+      "imageWidth": 120,
+      "imageHeight": 80,
+      "name": "asset-20-20",
+      "path": "subject.svg",
+      "faceRight": 0,
+      "x": 20,
+      "y": 20
+    },
+    {
+      "bitmapResolution": 1,
+      "imageWidth": 120,
+      "imageHeight": 80,
+      "name": "asset-100-60",
+      "path": "subject.svg",
+      "faceRight": 0,
+      "x": 100,
+      "y": 60
+    }
+  ],
+  "costumeIndex": 0,
+  "heading": 90,
+  "isDraggable": false,
+  "rotationStyle": "normal",
+  "size": 1,
+  "visible": true,
+  "x": 0,
+  "y": 100
+}

--- a/test/CoordinateSystem/assets/sprites/Subject/subject.svg
+++ b/test/CoordinateSystem/assets/sprites/Subject/subject.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="80" viewBox="0 0 120 80">
+  <rect x="5" y="5" width="110" height="70" rx="12" fill="#60a5fa" fill-opacity="0.78" stroke="#1d4ed8" stroke-width="3"/>
+  <path d="M28 40h53V27l27 13-27 13V40H28z" fill="#dbeafe" stroke="#1e40af" stroke-width="2" stroke-linejoin="round"/>
+
+  <circle cx="20" cy="20" r="7" fill="#f97316" stroke="#ffffff" stroke-width="2"/>
+  <circle cx="60" cy="40" r="7" fill="#8b5cf6" stroke="#ffffff" stroke-width="2"/>
+  <circle cx="100" cy="60" r="7" fill="#22c55e" stroke="#ffffff" stroke-width="2"/>
+
+  <g stroke="#0f172a" stroke-width="1.5" opacity="0.72">
+    <path d="M60 29v22M49 40h22"/>
+  </g>
+</svg>

--- a/test/CoordinateSystem/main.spx
+++ b/test/CoordinateSystem/main.spx
@@ -1,0 +1,4 @@
+onStart => {
+	println "CoordinateSystem demo ready"
+	println "Space: costume center | arrows: move | R/F/N: rotate/flip/reset | P: +Y pen | S: stamp | C: reset | E: erase"
+}


### PR DESCRIPTION
## Summary

- add a `CoordinateSystem` regression demo for the unified SPX/Godot coordinate conversion
- visualize the SPX origin, axis directions, and the sprite's independent logical root
- verify costume anchors at the geometric center and two off-center asset coordinates
- explicitly declare the SVG source size as `120 × 80` so costume centers use the correct asset pixel space
- exercise rotation, `LeftRight` flipping, movement, pen drawing, and stamping while checking logical-position invariants

## Impact

The demo provides an interactive regression fixture for the logical-root/render-node split. It makes anchor conversion and render-offset regressions visible without changing runtime behavior.

## Verification

```sh
cd test/CoordinateSystem
spx runnative
```

- startup anchor checks: PASS
- left/right flip round trip: PASS
- related SPX coordinate and render-offset tests: PASS
- JSON and SVG validation: PASS

Verified on macOS amd64 with the native Godot SPX runtime at `a9b06008a`.

## Related

- https://github.com/goplus/spx/issues/1702
- https://github.com/goplus/godot/pull/327
- https://github.com/goplus/spx/pull/1703
