### PR TITLE
fix(pen): sync canvas with stage geometry

### DIFF
--- a/component_pen_test.go
+++ b/component_pen_test.go
@@ -10,6 +10,9 @@ import (
 )
 
 type spyPenMgr struct {
+	canvasWidth          int64
+	canvasHeight         int64
+	canvasCalls          int
 	createCalls          int
 	moveCalls            int
 	penDownCalls         int
@@ -35,6 +38,13 @@ func (*penTestSprite) Main() {}
 
 func (s *spyPenMgr) DestroyAllPens() {
 	s.events = append(s.events, "erase")
+}
+
+func (s *spyPenMgr) SetCanvasSize(width, height int64) {
+	s.canvasCalls++
+	s.canvasWidth = width
+	s.canvasHeight = height
+	s.events = append(s.events, "canvas")
 }
 
 func (s *spyPenMgr) CreatePen() engine.Object {

--- a/game_load.go
+++ b/game_load.go
@@ -149,6 +149,21 @@ func (p *Game) setupPlatformAndCamera(proj *coreproject.ProjectConfig) {
 	p.setupBackdrop()
 }
 
+func (p *Game) syncPenCanvasToWorld() {
+	width := int64(p.displayState.WorldWidth)
+	height := int64(p.displayState.WorldHeight)
+	p.penCommandBarrier(func() {
+		p.engine().PenMgr.SetCanvasSize(width, height)
+	})
+}
+
+func (p *Game) applyStageGeometry() {
+	if p.camera != nil {
+		p.camera.setLimits()
+	}
+	p.syncPenCanvasToWorld()
+}
+
 // -----------------------------------------------------------------------------
 // Sprite Setup
 // -----------------------------------------------------------------------------
@@ -220,11 +235,16 @@ func (p *Game) runSpriteCallbacks(inits []Sprite, proj *coreproject.ProjectConfi
 // Stage Items
 // -----------------------------------------------------------------------------
 func (p *Game) setupAudioAndTilemap(proj *coreproject.ProjectConfig) {
-	p.tilemapMgr.parseTilemap()
+	p.applyTilemap()
 	p.audioState.SoundObj = p.soundMgr.AllocSound()
 	if proj.Bgm != "" {
 		p.Play__1(proj.Bgm, true)
 	}
+}
+
+func (p *Game) applyTilemap() {
+	p.tilemapMgr.parseTilemap()
+	p.applyStageGeometry()
 }
 
 func (p *Game) endLoad(g reflect.Value, proj *coreproject.ProjectConfig, generation uint64) (err error) {

--- a/game_load_window_test.go
+++ b/game_load_window_test.go
@@ -1,9 +1,12 @@
 package spx
 
 import (
+	"reflect"
 	"testing"
 
+	"github.com/goplus/spbase/mathf"
 	coreproject "github.com/goplus/spx/v3/internal/core/project"
+	internalengine "github.com/goplus/spx/v3/internal/engine"
 )
 
 func TestSetupWorldAndWindowClampsBackdropWindowToWorld(t *testing.T) {
@@ -38,5 +41,34 @@ func TestSetupWorldAndWindowClampsBackdropWindowToWorld(t *testing.T) {
 	}
 	if game.displayState.MapMode != coreproject.MapModeRepeat {
 		t.Fatalf("map mode = %d, want %d", game.displayState.MapMode, coreproject.MapModeRepeat)
+	}
+}
+
+func TestSyncPenCanvasToWorldUsesLogicalStageSize(t *testing.T) {
+	spy := setupSpyPenMgr(t)
+	game := &Game{}
+	game.displayState.WorldWidth = 640
+	game.displayState.WorldHeight = 480
+	game.displayState.WindowWidth = 480
+	game.displayState.WindowHeight = 360
+
+	game.syncPenCanvasToWorld()
+
+	if spy.canvasCalls != 1 || spy.canvasWidth != 640 || spy.canvasHeight != 480 {
+		t.Fatalf("pen canvas calls/size = %d/%dx%d, want 1/640x480", spy.canvasCalls, spy.canvasWidth, spy.canvasHeight)
+	}
+}
+
+func TestSyncPenCanvasToWorldFlushesPendingCommandsFirst(t *testing.T) {
+	spy := setupSpyPenMgr(t)
+	game := &Game{penSyncBuffer: internalengine.NewPenSyncBuffer(1)}
+	game.displayState.WorldWidth = 640
+	game.displayState.WorldHeight = 480
+	game.queuePenMove(1, mathf.NewVec2(10, 20))
+
+	game.syncPenCanvasToWorld()
+
+	if want := []string{"batch", "canvas"}; !reflect.DeepEqual(spy.events, want) {
+		t.Fatalf("events = %v, want %v", spy.events, want)
 	}
 }

--- a/internal/enginewrap/sync.gen.go
+++ b/internal/enginewrap/sync.gen.go
@@ -521,6 +521,11 @@ func (*penMgrImpl) DestroyAllPens() {
 		gdx.PenMgr.DestroyAllPens()
 	})
 }
+func (*penMgrImpl) SetCanvasSize(width int64, height int64) {
+	callInMainThread(func() {
+		gdx.PenMgr.SetCanvasSize(width, height)
+	})
+}
 func (*penMgrImpl) CreatePen() gdx.Object {
 	var _ret1 gdx.Object
 	callInMainThread(func() {

--- a/internal/enginewrap/sync_pure.gen.go
+++ b/internal/enginewrap/sync_pure.gen.go
@@ -281,7 +281,8 @@ func (*navigationMgrImpl) FindPath(p_from Vec2, p_to Vec2, with_jump bool) gdx.A
 }
 
 // IPenMgr
-func (*penMgrImpl) DestroyAllPens() {}
+func (*penMgrImpl) DestroyAllPens()                         {}
+func (*penMgrImpl) SetCanvasSize(width int64, height int64) {}
 func (*penMgrImpl) CreatePen() gdx.Object {
 	return 0
 }

--- a/internal/gdengine/binding/native/ffi.gen.go
+++ b/internal/gdengine/binding/native/ffi.gen.go
@@ -96,6 +96,7 @@ type GDExtensionInterface struct {
 	SpxNavigationSetObstacle                    GDExtensionSpxNavigationSetObstacle
 	SpxNavigationFindPath                       GDExtensionSpxNavigationFindPath
 	SpxPenDestroyAllPens                        GDExtensionSpxPenDestroyAllPens
+	SpxPenSetCanvasSize                         GDExtensionSpxPenSetCanvasSize
 	SpxPenCreatePen                             GDExtensionSpxPenCreatePen
 	SpxPenDestroyPen                            GDExtensionSpxPenDestroyPen
 	SpxPenBatchUpdateCommands                   GDExtensionSpxPenBatchUpdateCommands
@@ -430,6 +431,7 @@ func (x *GDExtensionInterface) resolveAPIFunctions() {
 	x.SpxNavigationSetObstacle = (GDExtensionSpxNavigationSetObstacle)(resolveCFunc("spx_navigation_set_obstacle"))
 	x.SpxNavigationFindPath = (GDExtensionSpxNavigationFindPath)(resolveCFunc("spx_navigation_find_path"))
 	x.SpxPenDestroyAllPens = (GDExtensionSpxPenDestroyAllPens)(resolveCFunc("spx_pen_destroy_all_pens"))
+	x.SpxPenSetCanvasSize = (GDExtensionSpxPenSetCanvasSize)(resolveCFunc("spx_pen_set_canvas_size"))
 	x.SpxPenCreatePen = (GDExtensionSpxPenCreatePen)(resolveCFunc("spx_pen_create_pen"))
 	x.SpxPenDestroyPen = (GDExtensionSpxPenDestroyPen)(resolveCFunc("spx_pen_destroy_pen"))
 	x.SpxPenBatchUpdateCommands = (GDExtensionSpxPenBatchUpdateCommands)(resolveCFunc("spx_pen_batch_update_commands"))

--- a/internal/gdengine/binding/native/ffi_wrapper.gen.go
+++ b/internal/gdengine/binding/native/ffi_wrapper.gen.go
@@ -161,6 +161,7 @@ type GDExtensionSpxNavigationSetupPathFinder C.GDExtensionSpxNavigationSetupPath
 type GDExtensionSpxNavigationSetObstacle C.GDExtensionSpxNavigationSetObstacle
 type GDExtensionSpxNavigationFindPath C.GDExtensionSpxNavigationFindPath
 type GDExtensionSpxPenDestroyAllPens C.GDExtensionSpxPenDestroyAllPens
+type GDExtensionSpxPenSetCanvasSize C.GDExtensionSpxPenSetCanvasSize
 type GDExtensionSpxPenCreatePen C.GDExtensionSpxPenCreatePen
 type GDExtensionSpxPenDestroyPen C.GDExtensionSpxPenDestroyPen
 type GDExtensionSpxPenBatchUpdateCommands C.GDExtensionSpxPenBatchUpdateCommands
@@ -999,6 +1000,17 @@ func CallPenDestroyAllPens() {
 	arg0 := (C.GDExtensionSpxPenDestroyAllPens)(api.SpxPenDestroyAllPens)
 
 	C.cgo_callfn_GDExtensionSpxPenDestroyAllPens(arg0)
+}
+func CallPenSetCanvasSize(
+	width GdInt,
+	height GdInt,
+) {
+	arg0 := (C.GDExtensionSpxPenSetCanvasSize)(api.SpxPenSetCanvasSize)
+	arg1 := (C.GdInt)(width)
+	arg2 := (C.GdInt)(height)
+
+	C.cgo_callfn_GDExtensionSpxPenSetCanvasSize(arg0, arg1, arg2)
+
 }
 func CallPenCreatePen() GdObj {
 	arg0 := (C.GDExtensionSpxPenCreatePen)(api.SpxPenCreatePen)

--- a/internal/gdengine/binding/native/ffi_wrapper.gen.h
+++ b/internal/gdengine/binding/native/ffi_wrapper.gen.h
@@ -372,6 +372,12 @@ void cgo_callfn_GDExtensionSpxPenDestroyAllPens(const GDExtensionSpxPenDestroyAl
 	}
 	fn();
 }
+void cgo_callfn_GDExtensionSpxPenSetCanvasSize(const GDExtensionSpxPenSetCanvasSize fn, GdInt width, GdInt height) {
+	if (!fn) {
+		return;
+	}
+	fn(width, height);
+}
 void cgo_callfn_GDExtensionSpxPenCreatePen(const GDExtensionSpxPenCreatePen fn, GdObj* ret_val) {
 	if (!fn) {
 		return;

--- a/internal/gdengine/binding/native/gdextension_spx_ext.h
+++ b/internal/gdengine/binding/native/gdextension_spx_ext.h
@@ -283,6 +283,7 @@ typedef void (*GDExtensionSpxNavigationSetObstacle)(GdObj obj, GdBool enabled);
 typedef void (*GDExtensionSpxNavigationFindPath)(GdVec2 p_from, GdVec2 p_to, GdBool with_jump, GdArray *ret_value);
 // SpxPen
 typedef void (*GDExtensionSpxPenDestroyAllPens)();
+typedef void (*GDExtensionSpxPenSetCanvasSize)(GdInt width, GdInt height);
 typedef void (*GDExtensionSpxPenCreatePen)(GdObj *ret_value);
 typedef void (*GDExtensionSpxPenDestroyPen)(GdObj obj);
 typedef void (*GDExtensionSpxPenBatchUpdateCommands)(const float *buffer_data, int len);

--- a/internal/gdengine/binding/web/ffi.gen.go
+++ b/internal/gdengine/binding/web/ffi.gen.go
@@ -100,6 +100,7 @@ type GDExtensionInterface struct {
 	SpxNavigationSetObstacle                    js.Value
 	SpxNavigationFindPath                       js.Value
 	SpxPenDestroyAllPens                        js.Value
+	SpxPenSetCanvasSize                         js.Value
 	SpxPenCreatePen                             js.Value
 	SpxPenDestroyPen                            js.Value
 	SpxPenBatchUpdateCommands                   js.Value
@@ -434,6 +435,7 @@ func (x *GDExtensionInterface) resolveAPIFunctions() {
 	x.SpxNavigationSetObstacle = resolveJSFunc("gdspx_navigation_set_obstacle")
 	x.SpxNavigationFindPath = resolveJSFunc("gdspx_navigation_find_path")
 	x.SpxPenDestroyAllPens = resolveJSFunc("gdspx_pen_destroy_all_pens")
+	x.SpxPenSetCanvasSize = resolveJSFunc("gdspx_pen_set_canvas_size")
 	x.SpxPenCreatePen = resolveJSFunc("gdspx_pen_create_pen")
 	x.SpxPenDestroyPen = resolveJSFunc("gdspx_pen_destroy_pen")
 	x.SpxPenBatchUpdateCommands = resolveJSFunc("gdspx_pen_batch_update_commands")

--- a/internal/gdengine/impl/manager_native.gen.go
+++ b/internal/gdengine/impl/manager_native.gen.go
@@ -468,6 +468,11 @@ func (pself *navigationMgr) FindPath(p_from Vec2, p_to Vec2, with_jump bool) Arr
 func (pself *penMgr) DestroyAllPens() {
 	CallPenDestroyAllPens()
 }
+func (pself *penMgr) SetCanvasSize(width int64, height int64) {
+	arg0 := ToGdInt(width)
+	arg1 := ToGdInt(height)
+	CallPenSetCanvasSize(arg0, arg1)
+}
 func (pself *penMgr) CreatePen() Object {
 	retValue := CallPenCreatePen()
 	return ToObject(retValue)

--- a/internal/gdengine/impl/manager_web.gen.go
+++ b/internal/gdengine/impl/manager_web.gen.go
@@ -460,6 +460,11 @@ func (pself *navigationMgr) FindPath(p_from Vec2, p_to Vec2, with_jump bool) Arr
 func (pself *penMgr) DestroyAllPens() {
 	API.SpxPenDestroyAllPens.Invoke()
 }
+func (pself *penMgr) SetCanvasSize(width int64, height int64) {
+	arg0Low, arg0High := JsSplitGdInt(width)
+	arg1Low, arg1High := JsSplitGdInt(height)
+	API.SpxPenSetCanvasSize.Invoke(arg0Low, arg0High, arg1Low, arg1High)
+}
 func (pself *penMgr) CreatePen() Object {
 	_retValue := API.SpxPenCreatePen.Invoke()
 	return JsToGdObject(_retValue)

--- a/pkg/spx/pkg/engine/interface.gen.go
+++ b/pkg/spx/pkg/engine/interface.gen.go
@@ -127,6 +127,7 @@ type INavigationMgr interface {
 
 type IPenMgr interface {
 	DestroyAllPens()
+	SetCanvasSize(width int64, height int64)
 	CreatePen() Object
 	DestroyPen(obj Object)
 	BatchUpdateCommands(buffer []float32)

--- a/tilemap.go
+++ b/tilemap.go
@@ -231,7 +231,7 @@ func (p *Game) GetTile__1(x, y float64, layerIndex int64) string {
 func (p *Game) LoadTilemap(mapDir string) {
 	p.tilemapMgr.unloadMap()
 	p.tilemapMgr.loadMap(mapDir)
-	p.tilemapMgr.parseTilemap()
+	p.applyTilemap()
 }
 
 // UnloadTilemap unloads the currently loaded tilemap and cleans up resources.

--- a/tilemap_pen_test.go
+++ b/tilemap_pen_test.go
@@ -1,0 +1,136 @@
+package spx
+
+import (
+	"errors"
+	"io"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/goplus/spbase/mathf"
+	spxfs "github.com/goplus/spx/v3/fs"
+	internalaudio "github.com/goplus/spx/v3/internal/audio"
+	coreproject "github.com/goplus/spx/v3/internal/core/project"
+	internalengine "github.com/goplus/spx/v3/internal/engine"
+	gdx "github.com/goplus/spx/v3/pkg/spx/pkg/engine"
+)
+
+type penCanvasTestDir map[string]string
+
+func (d penCanvasTestDir) Open(name string) (io.ReadCloser, error) {
+	content, ok := d[name]
+	if !ok {
+		return nil, errors.New("file not found")
+	}
+	return io.NopCloser(strings.NewReader(content)), nil
+}
+
+func (penCanvasTestDir) Close() error { return nil }
+
+type penCanvasTilemapMgr struct {
+	gdx.ITilemapMgr
+	events *[]string
+}
+
+func (*penCanvasTilemapMgr) SetLayerIndex(int64) {}
+func (m *penCanvasTilemapMgr) PlaceTilesWithLayer(gdx.Array, string, int64) {
+	*m.events = append(*m.events, "tiles")
+}
+
+type penCanvasCameraMgr struct {
+	gdx.ICameraMgr
+	limits [4]int64
+	calls  int
+}
+
+func (m *penCanvasCameraMgr) SetCameraLimit(side, limit int64) {
+	m.calls++
+	m.limits[side] = limit
+}
+
+func (*penCanvasCameraMgr) SetCameraSmoothing(bool) {}
+
+type penCanvasAudioBackend struct {
+	internalaudio.Backend
+}
+
+func (*penCanvasAudioBackend) CreateAudio() gdx.Object { return 1 }
+
+func newPenCanvasTilemapTestGame(t *testing.T) (*Game, *spyPenMgr, *penCanvasCameraMgr, string) {
+	t.Helper()
+
+	spy := setupSpyPenMgr(t)
+	originalTilemapMgr := gdx.TilemapMgr
+	gdx.TilemapMgr = &penCanvasTilemapMgr{events: &spy.events}
+	t.Cleanup(func() {
+		gdx.TilemapMgr = originalTilemapMgr
+	})
+	originalCameraMgr := gdx.CameraMgr
+	cameraSpy := &penCanvasCameraMgr{}
+	gdx.CameraMgr = cameraSpy
+	t.Cleanup(func() {
+		gdx.CameraMgr = originalCameraMgr
+	})
+
+	const tilemapPath = "tilemaps/map1.json"
+	fs := penCanvasTestDir{
+		tilemapPath: `{
+			"tilemap": {
+				"tile_size": {"width": 32, "height": 16},
+				"tileset": {"sources": []},
+				"layers": [{"tile_data": [1, 2, 3, 0, 0, 1, 4, 5, 0, 0]}]
+			},
+			"decorators": [],
+			"sprites": []
+		}`,
+	}
+	game := &Game{fs: spxfs.Dir(fs)}
+	game.displayState.WorldWidth = 480
+	game.displayState.WorldHeight = 360
+	game.tilemapMgr.g = game
+	game.tilemapMgr.fs = fs
+	game.camera = &cameraImpl{g: game}
+	game.Camera = game.camera
+	game.soundMgr.Init(&penCanvasAudioBackend{})
+	return game, spy, cameraSpy, tilemapPath
+}
+
+func assertStageGeometryUsesTilemapWorld(t *testing.T, game *Game, penSpy *spyPenMgr, cameraSpy *penCanvasCameraMgr) {
+	t.Helper()
+
+	if game.displayState.WorldWidth != 96 || game.displayState.WorldHeight != 48 {
+		t.Fatalf("world size = %dx%d, want 96x48", game.displayState.WorldWidth, game.displayState.WorldHeight)
+	}
+	if penSpy.canvasCalls != 1 || penSpy.canvasWidth != 96 || penSpy.canvasHeight != 48 {
+		t.Fatalf("pen canvas calls/size = %d/%dx%d, want 1/96x48", penSpy.canvasCalls, penSpy.canvasWidth, penSpy.canvasHeight)
+	}
+	wantLimits := [4]int64{64, -80, 160, -32}
+	if cameraSpy.calls != 4 || cameraSpy.limits != wantLimits {
+		t.Fatalf("camera limit calls/values = %d/%v, want 4/%v", cameraSpy.calls, cameraSpy.limits, wantLimits)
+	}
+}
+
+func TestSetupAudioAndTilemapSyncsPenCanvasAfterWorldSize(t *testing.T) {
+	game, penSpy, cameraSpy, tilemapPath := newPenCanvasTilemapTestGame(t)
+	game.tilemapMgr.loadMap(tilemapPath)
+
+	game.setupAudioAndTilemap(&coreproject.ProjectConfig{})
+
+	assertStageGeometryUsesTilemapWorld(t, game, penSpy, cameraSpy)
+	if want := []string{"tiles", "canvas"}; !reflect.DeepEqual(penSpy.events, want) {
+		t.Fatalf("events = %v, want %v", penSpy.events, want)
+	}
+}
+
+func TestLoadTilemapSyncsPenCanvasAfterWorldSize(t *testing.T) {
+	game, penSpy, cameraSpy, tilemapPath := newPenCanvasTilemapTestGame(t)
+	game.penSyncBuffer = internalengine.NewPenSyncBuffer(1)
+	game.queuePenMove(1, mathf.NewVec2(10, 20))
+
+	game.LoadTilemap(tilemapPath)
+
+	assertStageGeometryUsesTilemapWorld(t, game, penSpy, cameraSpy)
+	if want := []string{"tiles", "batch", "canvas"}; !reflect.DeepEqual(penSpy.events, want) {
+		t.Fatalf("events = %v, want %v", penSpy.events, want)
+	}
+}


### PR DESCRIPTION
## Summary

- Synchronize the pen canvas with the final logical World size.
- Apply tilemap changes before updating pen canvas dimensions.
- Reapply camera limits after tilemap-derived world bounds change.
- Use a pen command barrier so pending commands are flushed before resizing.
- Cover both initial tilemap setup and dynamic `LoadTilemap`.

## Motivation

Pen rendering must follow the Scratch-style logical stage, not the physical window or viewport size. Previously, legacy tilemaps could update World dimensions after the pen canvas had already been initialized, causing stamps to be clipped.

## Tests

- `go test ./...`
- `go test -race . -run 'Test(SyncPenCanvasToWorld|SetupAudioAndTilemapSyncsPenCanvas|LoadTilemapSyncsPenCanvas)'`
- `git diff --check` in both repositories

## Dependency

Requires the Godot PR:
`fix/spx-pen-canvas-size` (`0344521bb9`).