### PR TITLE
ci: publish Web package only on explicit release

### DIFF
--- a/.github/workflows/publish_web_package.yml
+++ b/.github/workflows/publish_web_package.yml
@@ -1,9 +1,6 @@
 name: Publish Web Package
 
 on:
-  push:
-    branches:
-      - dev
   workflow_call:
     inputs:
       target:


### PR DESCRIPTION
## Summary

- stop publishing the Web npm package on every push to `dev`
- retain unified release publishing through `workflow_call`
- retain explicit development publishing through `workflow_dispatch`

## Root cause

The legacy `push` trigger ran `Publish Web Package` immediately after PR #1723 merged. The workflow then attempted to download the not-yet-published `runtime-v2.4.0` and failed with HTTP 404. Publishing now happens only when explicitly requested.

## Validation

- `actionlint .github/workflows/publish_web_package.yml`
- YAML parse
- `git diff --check`
- repository caller audit: the unified release workflow remains the only internal reusable caller