### PR TITLE
fix(godot): eliminate SPX C++ shadow warnings

### DIFF
--- a/godot_modules/spx/spx_audio.cpp
+++ b/godot_modules/spx/spx_audio.cpp
@@ -47,9 +47,9 @@ AudioStreamPlayer2D *SpxAudio::_get_aid_audio(GdInt aid) {
 	return nullptr;
 }
 
-void SpxAudio::on_create(GdInt id, Node *root) {
-	this->root = root;
-	this->id = id;
+void SpxAudio::on_create(GdInt p_id, Node *p_root) {
+	root = p_root;
+	id = p_id;
 	bus_name = SpxAudioBusPool::STR_BUS_SFX;
 	owns_dedicated_bus = false;
 }

--- a/godot_modules/spx/spx_audio.h
+++ b/godot_modules/spx/spx_audio.h
@@ -56,7 +56,7 @@ private:
 	AudioStreamPlayer2D *_get_aid_audio(GdInt aid);
 
 public:
-	void on_create(GdInt id, Node *root);
+	void on_create(GdInt p_id, Node *p_root);
 	void on_destroy();
 	void on_update(float delta);
 	void on_reset(int reset_code);

--- a/godot_modules/spx/spx_audio_mgr.cpp
+++ b/godot_modules/spx/spx_audio_mgr.cpp
@@ -171,15 +171,15 @@ GdInt SpxAudioMgr::play(GdObj obj, GdString path) {
 }
 
 GdInt SpxAudioMgr::play_with_attenuation(GdObj obj, GdString path, GdObj owner_id, GdFloat attenuation, GdFloat max_distance) {
-	Node *owner = nullptr;
+	Node *audio_owner = nullptr;
 	if (owner_id == -1) {
-		owner = static_cast<Node *>(cameraMgr->get_camera());
+		audio_owner = static_cast<Node *>(cameraMgr->get_camera());
 	} else {
-		owner = static_cast<Node *>(spriteMgr->get_sprite(owner_id));
+		audio_owner = static_cast<Node *>(spriteMgr->get_sprite(owner_id));
 	}
 
-	if (owner == nullptr) {
-		owner = static_cast<Node *>(root);
+	if (audio_owner == nullptr) {
+		audio_owner = static_cast<Node *>(root);
 	}
 
 	SpxAudio *audio = get_object(obj);
@@ -195,7 +195,7 @@ GdInt SpxAudioMgr::play_with_attenuation(GdObj obj, GdString path, GdObj owner_i
 		aid_audios[aid] = audio;
 	}
 
-	audio->play(aid, path, owner, attenuation, max_distance);
+	audio->play(aid, path, audio_owner, attenuation, max_distance);
 	return aid;
 }
 

--- a/godot_modules/spx/spx_object_guard.h
+++ b/godot_modules/spx/spx_object_guard.h
@@ -267,7 +267,7 @@ public:
  */
 #define SPX_AUDIO_GUARD_VOID(aid, context_name)                                  \
 	SpxObjectGuard<AudioStreamPlayer2D, SpxAudio> audio(aid, context_name, this, \
-			[](SpxAudio *mgr, GdInt id) { return mgr->_get_aid_audio(id); });    \
+			[](SpxAudio *mgr, GdInt audio_id) { return mgr->_get_aid_audio(audio_id); }); \
 	if (!audio)                                                                  \
 		return;
 
@@ -284,7 +284,7 @@ public:
  */
 #define SPX_AUDIO_GUARD_RETURN(aid, context_name, return_val)                    \
 	SpxObjectGuard<AudioStreamPlayer2D, SpxAudio> audio(aid, context_name, this, \
-			[](SpxAudio *mgr, GdInt id) { return mgr->_get_aid_audio(id); });    \
+			[](SpxAudio *mgr, GdInt audio_id) { return mgr->_get_aid_audio(audio_id); }); \
 	if (!audio)                                                                  \
 		return return_val;
 

--- a/godot_modules/spx/spx_pen.cpp
+++ b/godot_modules/spx/spx_pen.cpp
@@ -42,9 +42,9 @@ GdObj SpxPen::get_id() {
 	return id;
 }
 
-void SpxPen::on_create(GdInt id, Node *root) {
-	this->id = id;
-	surface = static_cast<SpxPenSurface *>(root);
+void SpxPen::on_create(GdInt p_id, Node *p_root) {
+	id = p_id;
+	surface = static_cast<SpxPenSurface *>(p_root);
 	is_pen_down = false;
 	has_last_draw_pos = false;
 	needs_start_cap = true;

--- a/godot_modules/spx/spx_pen.h
+++ b/godot_modules/spx/spx_pen.h
@@ -70,7 +70,7 @@ private:
 	Ref<Texture2D> _resolve_stamp_texture(const String &texture_path);
 
 public:
-	void on_create(GdInt id, Node *root);
+	void on_create(GdInt p_id, Node *p_root);
 	void on_destroy();
 	void on_update(float delta);
 	void on_reset(int reset_code);

--- a/godot_modules/spx/spx_sprite_mgr.h
+++ b/godot_modules/spx/spx_sprite_mgr.h
@@ -53,12 +53,12 @@ public:
 	TriggerPair() :
 			id1(0), id2(0) {}
 
-	TriggerPair(GdObj id1, GdObj id2) {
-		this->id1 = id1;
-		this->id2 = id2;
-		if (id1 > id2) {
-			this->id1 = id2;
-			this->id2 = id1;
+	TriggerPair(GdObj p_id1, GdObj p_id2) {
+		id1 = p_id1;
+		id2 = p_id2;
+		if (p_id1 > p_id2) {
+			id1 = p_id2;
+			id2 = p_id1;
 		}
 	}
 	bool operator<(const TriggerPair &p_other) const {

--- a/godot_modules/spx/spx_sprite_physics.cpp
+++ b/godot_modules/spx/spx_sprite_physics.cpp
@@ -132,25 +132,25 @@ void SpxSprite::_physics_process(double p_delta) {
 }
 
 void SpxSprite::_handle_dynamic_physics(double p_delta) {
-	Vector2 velocity = get_velocity();
+	Vector2 current_velocity = get_velocity();
 
 	if (use_gravity && !is_on_floor()) {
-		velocity.y += _gravity * p_delta * gravity_scale * SpxPhysicsDefine::get_global_gravity();
+		current_velocity.y += _gravity * p_delta * gravity_scale * SpxPhysicsDefine::get_global_gravity();
 	}
 
 	float safe_mass = Math::is_zero_approx(mass_value) ? 1.0f : mass_value;
-	velocity += applied_forces * p_delta / safe_mass;
-	velocity += external_forces * p_delta;
+	current_velocity += applied_forces * p_delta / safe_mass;
+	current_velocity += external_forces * p_delta;
 
 	if (drag_value > 0.0f) {
-		velocity = velocity.move_toward(Vector2(), drag_value * velocity.length() * p_delta * SpxPhysicsDefine::get_global_air_drag());
+		current_velocity = current_velocity.move_toward(Vector2(), drag_value * current_velocity.length() * p_delta * SpxPhysicsDefine::get_global_air_drag());
 	}
 
-	if (is_on_floor() && Math::abs(velocity.x) > 0.0f) {
-		velocity.x = Math::move_toward(double(velocity.x), 0.0, p_delta * friction_value * SpxPhysicsDefine::get_global_friction());
+	if (is_on_floor() && Math::abs(current_velocity.x) > 0.0f) {
+		current_velocity.x = Math::move_toward(double(current_velocity.x), 0.0, p_delta * friction_value * SpxPhysicsDefine::get_global_friction());
 	}
 
-	set_velocity(velocity);
+	set_velocity(current_velocity);
 	applied_forces = Vector2();
 }
 
@@ -164,9 +164,9 @@ void SpxSprite::_handle_static_physics(double /* p_delta */) {
 }
 
 void SpxSprite::_handle_no_physics(double p_delta) {
-	Vector2 velocity = get_velocity();
-	if (velocity != Vector2()) {
-		set_global_position(get_global_position() + velocity * p_delta);
+	Vector2 current_velocity = get_velocity();
+	if (current_velocity != Vector2()) {
+		set_global_position(get_global_position() + current_velocity * p_delta);
 	}
 
 	external_forces = Vector2();

--- a/godot_modules/spx/spx_ui_binding.cpp
+++ b/godot_modules/spx/spx_ui_binding.cpp
@@ -53,14 +53,14 @@ Error SpxUiBinding::_connect_pressed_first(Control *p_control) {
 
 	const StringName pressed_signal = SNAME("pressed");
 	const Callable binding_callable = callable_mp(this, &SpxUiBinding::_on_pressed);
-	List<Object::Connection> connections;
-	button->get_signal_connection_list(pressed_signal, &connections);
+	List<Object::Connection> signal_connections;
+	button->get_signal_connection_list(pressed_signal, &signal_connections);
 
 	// BaseButton used to invoke the SPX callback immediately before emitting
 	// "pressed". Preserve that observable ordering when moving the callback to
 	// a standard signal, including for connections restored from PackedScene.
 	Vector<PreservedConnection> preserved;
-	for (const Object::Connection &connection : connections) {
+	for (const Object::Connection &connection : signal_connections) {
 		PreservedConnection item;
 		item.callable = connection.callable;
 		item.flags = connection.flags;


### PR DESCRIPTION
## Summary

Fix C++ `-Wshadow` warnings emitted while compiling the SPX Godot module.

## Changes

- Rename shadowing parameters in audio and pen initialization.
- Rename shadowing lambda parameters in audio guard macros.
- Rename `TriggerPair` constructor parameters.
- Rename shadowing local variables in audio manager, sprite physics, and UI binding.

These changes only affect local identifiers and preserve existing behavior and interfaces.

## Verification

- `git diff --check`
- `make build-editor`
- Confirmed SPX module compilation succeeds without the reported `-Wshadow` warnings.