### PR TITLE
feat(runtime): add condition event trigger

### DIFF
--- a/game.go
+++ b/game.go
@@ -106,6 +106,7 @@ type Game struct {
 	bootstrapMu             sync.Mutex
 	bootstrapGen            uint64
 	bootstrapStarted        bool
+	startScheduled          bool
 	pendingBootstrap        []func()
 	sprCollisionInfos       map[string]*spriteCollisionInfo
 	sprCollisionData        []*spriteCollisionData
@@ -247,6 +248,7 @@ func (p *Game) getSpriteProtoByName(name string, g reflect.Value) Sprite {
 
 func (p *Game) reset() {
 	p.lifecycleState.IsRunned.Store(false)
+	p.resetBootstrapState()
 
 	p.releaseGameAudio()
 	p.EraseAll()
@@ -259,13 +261,10 @@ func (p *Game) reset() {
 
 	p.Stop(AllOtherScripts)
 
-	p.lifecycleState.StartFlag = sync.Once{}
 	p.lifecycleState.RunOnce = sync.Once{}
 	p.lifecycleState.OncePathFinder = sync.Once{}
-	p.lifecycleState.StartDispatched.Store(false)
 	p.sprs = make(map[string]Sprite)
 
-	p.resetBootstrapState()
 	engine.ResetFrameRuntime()
 	p.abortInputSession("game reset")
 	p.resetCollisionLayerState()

--- a/game_load_test.go
+++ b/game_load_test.go
@@ -611,6 +611,7 @@ func TestRunSpriteCallbacksAllowsOnStartAfterMainFirstYield(t *testing.T) {
 
 	runBootstrapTasksWithScheduler(t, &game, generation)
 
+	game.markBootstrapDoneFor(generation)
 	game.dispatchStartEventIfNeeded()
 	gco.Update()
 

--- a/internal/core/event/api.go
+++ b/internal/core/event/api.go
@@ -28,6 +28,7 @@ type IEventSinks interface {
 	OnBackdrop__0(onBackdrop func(name BackdropName))
 	OnBackdrop__1(name BackdropName, onBackdrop func())
 	OnClick(onClick func())
+	OnCond(condition func() bool, onCondition func())
 	OnKey__0(key Key, onKey func())
 	OnKey__1(keys []Key, onKey func(Key))
 	OnKey__2(keys []Key, onKey func())

--- a/internal/core/event/manager.go
+++ b/internal/core/event/manager.go
@@ -41,6 +41,7 @@ const (
 	BucketTouchEnd
 	BucketClick
 	BucketTimer
+	BucketCondition
 
 	bucketCount
 )
@@ -181,6 +182,10 @@ func (m *Manager) AddTimer(sink Sink) {
 	m.Add(BucketTimer, sink)
 }
 
+func (m *Manager) AddCondition(sink Sink) {
+	m.Add(BucketCondition, sink)
+}
+
 func (m *Manager) Snapshot(bucket Bucket) []Sink {
 	m.mu.RLock()
 	out := readOnlySnapshot(m.buckets[bucket])
@@ -244,4 +249,8 @@ func (m *Manager) SnapshotClick() []Sink {
 
 func (m *Manager) SnapshotTimer() []Sink {
 	return m.Snapshot(BucketTimer)
+}
+
+func (m *Manager) SnapshotCondition() []Sink {
+	return m.Snapshot(BucketCondition)
 }

--- a/internal/core/event/manager_test.go
+++ b/internal/core/event/manager_test.go
@@ -22,6 +22,7 @@ func TestManagerReset(t *testing.T) {
 	var mgr Manager
 	mgr.Add(BucketStart, Sink{Owner: "game", Handler: func() {}})
 	mgr.Add(BucketTimer, Sink{Owner: "sprite", Handler: func() {}})
+	mgr.Add(BucketCondition, Sink{Owner: "sprite", Handler: func() {}})
 
 	mgr.Reset()
 
@@ -31,6 +32,9 @@ func TestManagerReset(t *testing.T) {
 	if got := mgr.Snapshot(BucketTimer); len(got) != 0 {
 		t.Fatalf("BucketTimer len = %d, want 0", len(got))
 	}
+	if got := mgr.Snapshot(BucketCondition); len(got) != 0 {
+		t.Fatalf("BucketCondition len = %d, want 0", len(got))
+	}
 }
 
 func TestManagerDeleteOwner(t *testing.T) {
@@ -38,6 +42,7 @@ func TestManagerDeleteOwner(t *testing.T) {
 	mgr.Add(BucketStart, Sink{Owner: "keep", Handler: func() {}})
 	mgr.Add(BucketClick, Sink{Owner: "drop", Handler: func() {}})
 	mgr.Add(BucketTimer, Sink{Owner: "drop", Handler: func() {}})
+	mgr.Add(BucketCondition, Sink{Owner: "drop", Handler: func() {}})
 
 	mgr.DeleteOwner("drop")
 
@@ -49,6 +54,9 @@ func TestManagerDeleteOwner(t *testing.T) {
 	}
 	if got := mgr.Snapshot(BucketTimer); len(got) != 0 {
 		t.Fatalf("BucketTimer len = %d, want 0", len(got))
+	}
+	if got := mgr.Snapshot(BucketCondition); len(got) != 0 {
+		t.Fatalf("BucketCondition len = %d, want 0", len(got))
 	}
 }
 
@@ -110,12 +118,16 @@ func TestManagerConvenienceMethods(t *testing.T) {
 	var mgr Manager
 	mgr.AddClick(Sink{Owner: "click", Handler: func() {}})
 	mgr.AddTimer(Sink{Owner: "timer", Handler: func() {}})
+	mgr.AddCondition(Sink{Owner: "condition", Handler: func() {}})
 
 	if got := mgr.SnapshotClick(); len(got) != 1 || got[0].Owner != "click" {
 		t.Fatalf("SnapshotClick = %+v, want click sink", got)
 	}
 	if got := mgr.SnapshotTimer(); len(got) != 1 || got[0].Owner != "timer" {
 		t.Fatalf("SnapshotTimer = %+v, want timer sink", got)
+	}
+	if got := mgr.SnapshotCondition(); len(got) != 1 || got[0].Owner != "condition" {
+		t.Fatalf("SnapshotCondition = %+v, want condition sink", got)
 	}
 }
 

--- a/internal/core/event/sink.go
+++ b/internal/core/event/sink.go
@@ -67,3 +67,15 @@ func MatchApproxFloat(want, tolerance float64) func(any) bool {
 		return ok && math.Abs(got-want) < tolerance
 	}
 }
+
+// MatchRisingEdge reports whether condition changed from false to true.
+// The initial state is false, and condition is evaluated once per invocation.
+func MatchRisingEdge(condition func() bool) func(any) bool {
+	wasTrue := false
+	return func(any) bool {
+		isTrue := condition()
+		fire := isTrue && !wasTrue
+		wasTrue = isTrue
+		return fire
+	}
+}

--- a/internal/core/event/sink_test.go
+++ b/internal/core/event/sink_test.go
@@ -43,3 +43,38 @@ func TestSinkMatchers(t *testing.T) {
 		t.Fatal("MatchApproxFloat mismatch")
 	}
 }
+
+func TestMatchRisingEdge(t *testing.T) {
+	values := []bool{false, false, true, true, false, true}
+	index := 0
+	edge := MatchRisingEdge(func() bool {
+		value := values[index]
+		index++
+		return value
+	})
+
+	var fired []int
+	for i := range values {
+		if edge(nil) {
+			fired = append(fired, i)
+		}
+	}
+
+	want := []int{2, 5}
+	if len(fired) != len(want) || fired[0] != want[0] || fired[1] != want[1] {
+		t.Fatalf("fired = %v, want %v", fired, want)
+	}
+	if index != len(values) {
+		t.Fatalf("test evaluated %d times, want %d", index, len(values))
+	}
+}
+
+func TestMatchRisingEdgeInitiallyTrue(t *testing.T) {
+	edge := MatchRisingEdge(func() bool { return true })
+	if !edge(nil) {
+		t.Fatal("initial true condition did not fire")
+	}
+	if edge(nil) {
+		t.Fatal("condition fired again while remaining true")
+	}
+}

--- a/internal/core/runtime/loop.go
+++ b/internal/core/runtime/loop.go
@@ -172,6 +172,7 @@ type LogicFrameConfig[T any] struct {
 	FlushCompletedAnimations func(T, []string) []string
 	NextTimer                func() (float64, bool)
 	FireTimer                func(float64)
+	PollConditions           func()
 }
 
 func ProcessLogicFrame[T any](cfg LogicFrameConfig[T]) ([]string, []string) {
@@ -192,6 +193,9 @@ func ProcessLogicFrame[T any](cfg LogicFrameConfig[T]) ([]string, []string) {
 		}
 		cfg.FireTimer(targetTimer)
 	}
+	if cfg.PollConditions != nil {
+		cfg.PollConditions()
+	}
 	return tempAudios, tempAnimations
 }
 
@@ -201,6 +205,7 @@ type LogicLoopConfig[T any] struct {
 	FlushCompletedAnimations func(T, []string) []string
 	NextTimer                func() (float64, bool)
 	FireTimer                func(float64)
+	PollConditions           func()
 	ShowDebugPanel           func()
 }
 
@@ -217,6 +222,7 @@ func RunLogicLoop[T any](me coroutine.Thread, cfg LogicLoopConfig[T]) int {
 			FlushCompletedAnimations: cfg.FlushCompletedAnimations,
 			NextTimer:                cfg.NextTimer,
 			FireTimer:                cfg.FireTimer,
+			PollConditions:           cfg.PollConditions,
 		})
 		engine.WaitNextFrame()
 		cfg.ShowDebugPanel()

--- a/internal/core/runtime/runtime_test.go
+++ b/internal/core/runtime/runtime_test.go
@@ -314,6 +314,7 @@ func TestHandleLeftButtonDownBlockedTargetGate(t *testing.T) {
 
 func TestProcessLogicFrame(t *testing.T) {
 	var fired []float64
+	pollCount := 0
 	nextTimers := []float64{2.5, 3}
 	nextTimerIndex := 0
 	audios, animations := ProcessLogicFrame(LogicFrameConfig[int]{
@@ -334,7 +335,8 @@ func TestProcessLogicFrame(t *testing.T) {
 			nextTimerIndex++
 			return timer, true
 		},
-		FireTimer: func(v float64) { fired = append(fired, v) },
+		FireTimer:      func(v float64) { fired = append(fired, v) },
+		PollConditions: func() { pollCount++ },
 	})
 
 	if len(audios) != 3 {
@@ -345,6 +347,9 @@ func TestProcessLogicFrame(t *testing.T) {
 	}
 	if len(fired) != 2 || fired[0] != 2.5 || fired[1] != 3 {
 		t.Fatalf("unexpected fired timers: %+v", fired)
+	}
+	if pollCount != 1 {
+		t.Fatalf("pollCount = %d, want 1", pollCount)
 	}
 }
 

--- a/internal/core/state/game.go
+++ b/internal/core/state/game.go
@@ -27,7 +27,6 @@ import (
 )
 
 type GameLifecycleState struct {
-	StartFlag       sync.Once
 	RunOnce         sync.Once
 	OncePathFinder  sync.Once
 	BootstrapDone   atomic.Bool

--- a/runtime.go
+++ b/runtime.go
@@ -35,7 +35,9 @@ type event any
 // -----------------------------------------------------------------------------
 // Event Payloads
 // -----------------------------------------------------------------------------
-type eventStart struct{}
+type eventStart struct {
+	generation uint64
+}
 
 type eventKeyDown struct {
 	Key Key

--- a/runtime_bootstrap_test.go
+++ b/runtime_bootstrap_test.go
@@ -109,3 +109,22 @@ func TestGameRunBootstrapTasksStopsDrainingAfterReset(t *testing.T) {
 		}
 	}
 }
+
+func TestGameBootstrapCompletionIgnoresStaleGeneration(t *testing.T) {
+	var game Game
+	stale := game.currentBootstrapGeneration()
+
+	game.lifecycleState.BootstrapDone.Store(true)
+	game.lifecycleState.StartDispatched.Store(true)
+	game.resetBootstrapState()
+
+	if game.markBootstrapDoneFor(stale) {
+		t.Fatal("stale bootstrap generation was marked done")
+	}
+	if game.markStartDispatchedFor(stale) {
+		t.Fatal("stale bootstrap generation was marked started")
+	}
+	if game.lifecycleState.BootstrapDone.Load() || game.lifecycleState.StartDispatched.Load() {
+		t.Fatal("stale generation reopened lifecycle gates")
+	}
+}

--- a/runtime_engine.go
+++ b/runtime_engine.go
@@ -198,9 +198,11 @@ func (p *Game) resetBootstrapState() {
 	p.bootstrapMu.Lock()
 	p.bootstrapGen++
 	p.bootstrapStarted = false
+	p.startScheduled = false
 	p.pendingBootstrap = nil
-	p.bootstrapMu.Unlock()
 	p.lifecycleState.BootstrapDone.Store(false)
+	p.lifecycleState.StartDispatched.Store(false)
+	p.bootstrapMu.Unlock()
 }
 
 func (p *Game) runBootstrapTasks() {
@@ -243,6 +245,45 @@ func (p *Game) isBootstrapGenerationCurrent(generation uint64) bool {
 	return generation == p.bootstrapGen
 }
 
+func (p *Game) markBootstrapDoneFor(generation uint64) bool {
+	p.bootstrapMu.Lock()
+	defer p.bootstrapMu.Unlock()
+	if generation != p.bootstrapGen {
+		return false
+	}
+	p.lifecycleState.BootstrapDone.Store(true)
+	return true
+}
+
+func (p *Game) scheduleStartEvent() *eventStart {
+	p.bootstrapMu.Lock()
+	defer p.bootstrapMu.Unlock()
+	if !p.lifecycleState.BootstrapDone.Load() || p.lifecycleState.StartDispatched.Load() || p.startScheduled {
+		return nil
+	}
+	p.startScheduled = true
+	return &eventStart{generation: p.bootstrapGen}
+}
+
+func (p *Game) takeStartSinksFor(generation uint64) ([]eventSink, bool) {
+	p.bootstrapMu.Lock()
+	defer p.bootstrapMu.Unlock()
+	if generation != p.bootstrapGen {
+		return nil, false
+	}
+	return p.scriptEvents.manager.SnapshotStartOnce(), true
+}
+
+func (p *Game) markStartDispatchedFor(generation uint64) bool {
+	p.bootstrapMu.Lock()
+	defer p.bootstrapMu.Unlock()
+	if generation != p.bootstrapGen {
+		return false
+	}
+	p.lifecycleState.StartDispatched.Store(true)
+	return true
+}
+
 func (p *Game) claimBootstrapPhaseFor(generation uint64) (hasTasks, ok bool) {
 	p.bootstrapMu.Lock()
 	defer p.bootstrapMu.Unlock()
@@ -260,16 +301,13 @@ func (p *Game) startBootstrapPhaseFor(generation uint64) {
 			return
 		}
 		if !hasTasks {
-			p.lifecycleState.BootstrapDone.Store(true)
+			p.markBootstrapDoneFor(generation)
 			return
 		}
 
-		p.lifecycleState.BootstrapDone.Store(false)
 		gco.CreateAndStart(false, p, func(coroutine.Thread) int {
 			p.runBootstrapTasksFor(generation)
-			if p.isBootstrapGenerationCurrent(generation) {
-				p.lifecycleState.BootstrapDone.Store(true)
-			}
+			p.markBootstrapDoneFor(generation)
 			return 0
 		})
 	})

--- a/runtime_events.go
+++ b/runtime_events.go
@@ -113,6 +113,19 @@ func (p *scriptEventBindings) OnClick(onClick func()) {
 	p.scriptEventRegistry.manager.AddClick(coreevent.NewSink(pthis, onClick, coreevent.MatchOwner(pthis)))
 }
 
+// OnCond runs the handler on each false-to-true transition.
+// condition is polled after startup and must be fast and non-blocking.
+func (p *scriptEventBindings) OnCond(condition func() bool, onCondition func()) {
+	if condition == nil || onCondition == nil {
+		return
+	}
+	p.scriptEventRegistry.manager.AddCondition(coreevent.NewSink(
+		p.pthis,
+		onCondition,
+		coreevent.MatchRisingEdge(condition),
+	))
+}
+
 func (p *scriptEventBindings) OnAnyKey(onKey func(key Key)) {
 	p.scriptEventRegistry.manager.AddKeyPressed(coreevent.NewSink(p.pthis, onKey))
 }
@@ -343,8 +356,12 @@ func (p *Game) handleEvent(ev event) {
 		p.scriptEvents.doWhenKeyPressed(e.Key)
 	case *eventStart:
 		runStartPhase := func() {
-			p.scriptEvents.doWhenStart()
-			p.lifecycleState.StartDispatched.Store(true)
+			sinks, ok := p.takeStartSinksFor(e.generation)
+			if !ok {
+				return
+			}
+			p.scriptEvents.doWhenStart(sinks)
+			p.markStartDispatchedFor(e.generation)
 		}
 		if gco != nil && !gco.IsInCoroutine() {
 			// Keep OnStart handlers in one coroutine phase and advance them in
@@ -373,8 +390,7 @@ func (p *Game) fireEvent(ev event) {
 // -----------------------------------------------------------------------------
 // Event Dispatch
 // -----------------------------------------------------------------------------
-func (p *scriptEventRegistry) doWhenStart() {
-	sinks := p.manager.SnapshotStartOnce()
+func (p *scriptEventRegistry) doWhenStart(sinks []eventSink) {
 	if len(sinks) == 0 {
 		return
 	}
@@ -416,6 +432,15 @@ func (p *scriptEventRegistry) doWhenAwake(this threadObj) {
 func (p *scriptEventRegistry) doWhenTimer(time float64) {
 	p.dispatchAsync(coreevent.BucketTimer, false, time, func(ev *eventSink) {
 		ev.Handler.(func(float64))(time)
+	})
+}
+
+func (p *scriptEventRegistry) doWhenCondition() {
+	p.dispatchAsync(coreevent.BucketCondition, false, nil, func(ev *eventSink) {
+		coreevent.If0(isDebugEventEnabled, func() {
+			spxlog.Debug("OnCond: %s", nameOf(ev.Owner))
+		})()
+		ev.Handler.(func())()
 	})
 }
 

--- a/runtime_events_test.go
+++ b/runtime_events_test.go
@@ -18,6 +18,7 @@ package spx
 
 import (
 	"reflect"
+	"runtime"
 	"testing"
 	"time"
 
@@ -29,17 +30,38 @@ import (
 	pkgengine "github.com/goplus/spx/v3/pkg/spx/pkg/engine"
 )
 
-func TestStartHandlersRegisterAbsoluteEngineFrames(t *testing.T) {
+func setupRuntimeEventScheduler(t *testing.T) *coroutine.Coroutines {
+	t.Helper()
+
 	co := coroutine.New(nil)
 	co.OnInited()
 	original := gco
 	gco = co
 	engine.SetCoroutines(co)
 	t.Cleanup(func() {
-		co.AbortAllAndWait(time.Second)
+		if !co.AbortAllAndWait(time.Second) {
+			t.Error("coroutines did not stop")
+		}
 		gco = original
 		engine.SetCoroutines(original)
 	})
+	return co
+}
+
+func updateRuntimeEventSchedulerUntil(t *testing.T, co *coroutine.Coroutines, done func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for !done() {
+		if time.Now().After(deadline) {
+			t.Fatal("coroutine scheduler did not reach the expected state")
+		}
+		co.Update()
+		runtime.Gosched()
+	}
+}
+
+func TestStartHandlersRegisterAbsoluteEngineFrames(t *testing.T) {
+	co := setupRuntimeEventScheduler(t)
 
 	var game Game
 	game.scriptEventBindings.init(&game.scriptEvents, &game)
@@ -58,7 +80,7 @@ func TestStartHandlersRegisterAbsoluteEngineFrames(t *testing.T) {
 		AtFrame(base+1, func() { callbacks = append(callbacks, "second") })
 	})
 
-	game.handleEvent(&eventStart{})
+	game.handleEvent(&eventStart{generation: game.currentBootstrapGeneration()})
 	co.Update()
 	if !game.lifecycleState.StartDispatched.Load() {
 		t.Fatal("start event was not marked dispatched")
@@ -74,20 +96,11 @@ func TestStartHandlersRegisterAbsoluteEngineFrames(t *testing.T) {
 }
 
 func TestOnStartReachesCoroutineBoundaryBeforePostBootstrapFrames(t *testing.T) {
-	co := coroutine.New(nil)
-	co.OnInited()
-	original := gco
-	gco = co
-	engine.SetCoroutines(co)
-	t.Cleanup(func() {
-		co.AbortAllAndWait(time.Second)
-		gco = original
-		engine.SetCoroutines(original)
-	})
+	co := setupRuntimeEventScheduler(t)
 
 	var game Game
 	game.scriptEventBindings.init(&game.scriptEvents, &game)
-	game.lifecycleState.BootstrapDone.Store(true)
+	game.markBootstrapDoneFor(game.currentBootstrapGeneration())
 	engine.SetGame(&game)
 	defer engine.SetGame(nil)
 	engine.ResetFrameRuntime()
@@ -111,6 +124,253 @@ func TestOnStartReachesCoroutineBoundaryBeforePostBootstrapFrames(t *testing.T) 
 
 	if want := []string{"start", "frame"}; !reflect.DeepEqual(phases, want) {
 		t.Fatalf("frame/start phases = %v, want %v", phases, want)
+	}
+}
+
+func TestOnCondRisingEdgeAndOwnerIsolation(t *testing.T) {
+	co := setupRuntimeEventScheduler(t)
+
+	var registry scriptEventRegistry
+	var left, right scriptEventBindings
+	left.init(&registry, "left")
+	right.init(&registry, "right")
+
+	var (
+		leftValue, rightValue bool
+		leftEvaluations       int
+		rightEvaluations      int
+		calls                 []string
+	)
+	left.OnCond(func() bool {
+		leftEvaluations++
+		return leftValue
+	}, func() {
+		calls = append(calls, "left")
+	})
+	right.OnCond(func() bool {
+		rightEvaluations++
+		return rightValue
+	}, func() {
+		calls = append(calls, "right")
+	})
+
+	states := [][2]bool{
+		{false, false},
+		{true, false},
+		{true, true},
+		{false, true},
+		{true, false},
+	}
+	for _, state := range states {
+		leftValue, rightValue = state[0], state[1]
+		registry.doWhenCondition()
+		co.Update()
+	}
+
+	if want := []string{"left", "right", "left"}; !reflect.DeepEqual(calls, want) {
+		t.Fatalf("condition calls = %v, want %v", calls, want)
+	}
+	if leftEvaluations != len(states) || rightEvaluations != len(states) {
+		t.Fatalf("condition evaluations = %d/%d, want %d/%d", leftEvaluations, rightEvaluations, len(states), len(states))
+	}
+
+	left.doDeleteClone()
+	leftValue = false
+	rightValue = false
+	registry.doWhenCondition()
+	leftValue = true
+	registry.doWhenCondition()
+	co.Update()
+	if leftEvaluations != len(states) {
+		t.Fatalf("deleted owner evaluated %d times, want %d", leftEvaluations, len(states))
+	}
+	if want := []string{"left", "right", "left"}; !reflect.DeepEqual(calls, want) {
+		t.Fatalf("calls after owner deletion = %v, want %v", calls, want)
+	}
+}
+
+func TestOnCondIgnoresNilCallbacks(t *testing.T) {
+	var game Game
+	game.scriptEventBindings.init(&game.scriptEvents, &game)
+	game.OnCond(nil, func() {})
+	game.OnCond(func() bool { return true }, nil)
+
+	if got := game.scriptEvents.manager.SnapshotCondition(); len(got) != 0 {
+		t.Fatalf("condition sinks = %d, want 0", len(got))
+	}
+}
+
+func TestOnCondStartsAfterOnStartPhase(t *testing.T) {
+	co := setupRuntimeEventScheduler(t)
+
+	var game Game
+	game.scriptEventBindings.init(&game.scriptEvents, &game)
+	var order []string
+	evaluations := 0
+	game.OnCond(func() bool {
+		evaluations++
+		order = append(order, "evaluate")
+		return true
+	}, func() {
+		order = append(order, "condition")
+	})
+	game.OnStart(func() {
+		order = append(order, "start")
+	})
+
+	game.pollConditions()
+	if evaluations != 0 {
+		t.Fatalf("condition evaluated %d times during bootstrap, want 0", evaluations)
+	}
+
+	game.markBootstrapDoneFor(game.currentBootstrapGeneration())
+	game.pollConditions()
+	if evaluations != 0 {
+		t.Fatalf("condition evaluated %d times before OnStart, want 0", evaluations)
+	}
+
+	game.runScriptFramePhase()
+	updateRuntimeEventSchedulerUntil(t, co, game.lifecycleState.StartDispatched.Load)
+	if want := []string{"start"}; !reflect.DeepEqual(order, want) {
+		t.Fatalf("order before condition polling = %v, want %v", order, want)
+	}
+
+	game.pollConditions()
+	co.Update()
+	if evaluations != 1 {
+		t.Fatalf("condition evaluated %d times after OnStart, want 1", evaluations)
+	}
+	if want := []string{"start", "evaluate", "condition"}; !reflect.DeepEqual(order, want) {
+		t.Fatalf("startup order = %v, want %v", order, want)
+	}
+
+	game.pollConditions()
+	co.Update()
+	if evaluations != 2 {
+		t.Fatalf("condition evaluated %d times after two polls, want 2", evaluations)
+	}
+	if want := []string{"start", "evaluate", "condition", "evaluate"}; !reflect.DeepEqual(order, want) {
+		t.Fatalf("sustained-true order = %v, want %v", order, want)
+	}
+}
+
+func TestOnCondObservesTopLevelAndOnStartInitialization(t *testing.T) {
+	co := setupRuntimeEventScheduler(t)
+
+	var game Game
+	game.scriptEventBindings.init(&game.scriptEvents, &game)
+	var order []string
+	ready := false
+	topLevelBlocked := make(chan struct{})
+	onStartBlocked := make(chan struct{})
+
+	generation := game.currentBootstrapGeneration()
+	game.deferBootstrapFor(generation, func() {
+		game.runBootstrapMainUntilYield(&game, func() {
+			order = append(order, "top-level")
+			game.OnCond(func() bool {
+				order = append(order, "evaluate")
+				return ready
+			}, func() {
+				order = append(order, "condition")
+			})
+			game.OnStart(func() {
+				ready = true
+				order = append(order, "start")
+				var signal struct{}
+				engine.WaitForChan(onStartBlocked, &signal)
+				order = append(order, "start-resumed")
+			})
+
+			var signal struct{}
+			engine.WaitForChan(topLevelBlocked, &signal)
+			order = append(order, "top-level-resumed")
+		})
+	})
+
+	game.runBootstrapTasksFor(generation)
+	if want := []string{"top-level"}; !reflect.DeepEqual(order, want) {
+		t.Fatalf("order after top-level first yield = %v, want %v", order, want)
+	}
+	game.pollConditions()
+	if want := []string{"top-level"}; !reflect.DeepEqual(order, want) {
+		t.Fatalf("condition ran before OnStart: %v", order)
+	}
+
+	game.markBootstrapDoneFor(generation)
+	game.runScriptFramePhase()
+	updateRuntimeEventSchedulerUntil(t, co, game.lifecycleState.StartDispatched.Load)
+	if want := []string{"top-level", "start"}; !reflect.DeepEqual(order, want) {
+		t.Fatalf("order after OnStart = %v, want %v", order, want)
+	}
+
+	game.pollConditions()
+	co.Update()
+	if want := []string{"top-level", "start", "evaluate", "condition"}; !reflect.DeepEqual(order, want) {
+		t.Fatalf("startup order = %v, want %v", order, want)
+	}
+
+	close(topLevelBlocked)
+	close(onStartBlocked)
+	co.Update()
+}
+
+func TestOnStartIgnoresStaleBootstrapGeneration(t *testing.T) {
+	co := setupRuntimeEventScheduler(t)
+
+	var game Game
+	game.scriptEventBindings.init(&game.scriptEvents, &game)
+	stale := game.currentBootstrapGeneration()
+	game.resetBootstrapState()
+
+	calls := 0
+	game.OnStart(func() { calls++ })
+	game.handleEvent(&eventStart{generation: stale})
+	co.Update()
+	if calls != 0 || game.lifecycleState.StartDispatched.Load() {
+		t.Fatal("stale start event affected the current lifecycle")
+	}
+
+	game.handleEvent(&eventStart{generation: game.currentBootstrapGeneration()})
+	updateRuntimeEventSchedulerUntil(t, co, game.lifecycleState.StartDispatched.Load)
+	if calls != 1 {
+		t.Fatalf("current start calls = %d, want 1", calls)
+	}
+}
+
+func TestOnStartCompletionDoesNotCrossReset(t *testing.T) {
+	co := setupRuntimeEventScheduler(t)
+
+	var game Game
+	game.scriptEventBindings.init(&game.scriptEvents, &game)
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	game.OnStart(func() {
+		close(entered)
+		<-release
+	})
+
+	game.handleEvent(&eventStart{generation: game.currentBootstrapGeneration()})
+	select {
+	case <-entered:
+	case <-time.After(time.Second):
+		t.Fatal("OnStart did not begin")
+	}
+
+	game.resetBootstrapState()
+	game.scriptEvents.manager.Reset()
+	close(release)
+	co.Update()
+	if game.lifecycleState.StartDispatched.Load() {
+		t.Fatal("stale OnStart completion reopened the start gate")
+	}
+
+	calls := 0
+	game.OnStart(func() { calls++ })
+	game.handleEvent(&eventStart{generation: game.currentBootstrapGeneration()})
+	updateRuntimeEventSchedulerUntil(t, co, game.lifecycleState.StartDispatched.Load)
+	if calls != 1 {
+		t.Fatalf("new lifecycle start calls = %d, want 1", calls)
 	}
 }
 

--- a/runtime_loops.go
+++ b/runtime_loops.go
@@ -81,6 +81,15 @@ func (p *Game) logicLoop(me coroutine.Thread) int {
 		FireTimer: func(targetTimer float64) {
 			p.fireEvent(&eventTimer{Time: targetTimer})
 		},
+		PollConditions: p.pollConditions,
 		ShowDebugPanel: p.showDebugPanel,
 	})
+}
+
+func (p *Game) pollConditions() {
+	// Startup code and OnStart handlers reach their first yield before this opens.
+	if !p.lifecycleState.StartDispatched.Load() {
+		return
+	}
+	p.scriptEvents.doWhenCondition()
 }

--- a/runtime_sync.go
+++ b/runtime_sync.go
@@ -25,12 +25,9 @@ import (
 
 // dispatchStartEventIfNeeded fires the start event once after bootstrap completes.
 func (p *Game) dispatchStartEventIfNeeded() {
-	coreruntime.SyncOnce(&p.lifecycleState.StartFlag, func() {
-		// Handle start directly in the engine update phase. Routing it through the
-		// generic event channel can let its helper goroutine resume only after the
-		// coroutine update has already decided it is idle.
-		p.handleEvent(&eventStart{})
-	})
+	if ev := p.scheduleStartEvent(); ev != nil {
+		p.handleEvent(ev)
+	}
 }
 
 // updateSpriteProxies activates pending shapes, batches dirty sprite proxy changes,

--- a/test/All/SpEvent.spx
+++ b/test/All/SpEvent.spx
@@ -1,6 +1,28 @@
+import "fmt"
+
 var (
-	hasStarted bool
+	hasStarted        bool
+	score             = 0
+	scoreReachedCount int
 )
+
+func triggerScoreCondition(expectedCount int) {
+	score = 0
+	for score < 3 {
+		score++
+		waitNextFrame
+	}
+	for scoreReachedCount < expectedCount {
+		waitNextFrame
+	}
+	assert(scoreReachedCount == expectedCount,
+		"Sprite::OnCond trigger count = %d, want %d", scoreReachedCount, expectedCount)
+}
+
+onCond score >= 3, => {
+	scoreReachedCount++
+	say fmt.Sprintf("Condition trigger count: %d", scoreReachedCount)
+}
 
 onKey KeyY, => {
 	hasInputKey = true
@@ -50,7 +72,7 @@ onMsg "testEvent", => {
 	onTestStart(this)
 
 	// 1. Sprite::onKey
-	say "Please presse key 'y' "
+	say "Please press key 'y'"
 	for !hasInputKey {
 		waitNextFrame
 	}
@@ -62,9 +84,16 @@ onMsg "testEvent", => {
 	}
 	say ""
 
-	// 3. Sprite::onStart
+	// 3. Sprite::onStart, onCond
 	wait 0.1s
 	assert(hasStarted, "Sprite::OnStart")
+
+	triggerScoreCondition 1
+	wait 1
+	assert(scoreReachedCount == 1, "Sprite::OnCond should not repeat while true")
+
+	triggerScoreCondition 2
+	wait 1
 
 	// 4. Sprite::onBackdrop
 	setBackdrop "backdrop2"


### PR DESCRIPTION
## Summary

This PR adds `OnCond(condition, onCondition)` for condition-based script events.

Conditions are polled by the existing logic loop, and handlers are dispatched through the existing event system when the condition changes from false to true.

XGo usage:

```go
onCond score >= 3, => {
    triggerCount++
    say fmt.Sprintf("Condition trigger count: %d", triggerCount)
}
```

## Behavior

- Evaluate each registered condition once per logic-frame poll.
- Trigger when the condition changes from false to true.
- Treat the initial state as false, so an initially true condition triggers once.
- Do not trigger repeatedly while the condition remains true.
- Rearm after the condition becomes false.
- Allow subsequent false-to-true transitions to trigger again.
- Ignore registrations with a nil condition or handler.
- Dispatch handlers asynchronously through the existing event infrastructure.

Conditions run synchronously in the logic loop and should remain fast and non-blocking.

## Startup ordering

Condition polling starts only after:

1. Top-level game and sprite startup code reaches its first yield or returns.
2. Every `OnStart` handler reaches its first yield or returns.

This allows conditions to observe startup initialization without requiring long-running top-level or `OnStart` scripts to finish completely.

## Lifecycle handling

Bootstrap and start dispatch are associated with the current bootstrap generation.

After reset or reload:

- stale bootstrap tasks cannot mark the new lifecycle as ready;
- stale `OnStart` work cannot reopen the condition polling gate;
- condition registrations and rising-edge state are cleared through the existing event-manager lifecycle;
- owner deletion removes the owner's condition handlers.

## Implementation

- Add a dedicated condition bucket to the event manager.
- Add `MatchRisingEdge` to keep transition state with each registration.
- Poll conditions from the runtime logic loop.
- Reuse the existing event ownership, snapshot, reset, deletion, and asynchronous dispatch mechanisms.
- Avoid maintaining a separate per-frame condition-state map.
- Make start scheduling generation-aware so work from an old lifecycle cannot affect a new one.

## Tests

Added coverage for:

- initially false and initially true conditions;
- sustained-true suppression;
- false-to-true retriggering;
- independent state across event owners;
- owner deletion and manager reset;
- nil callbacks;
- logic-loop polling;
- polling only after the `OnStart` boundary;
- conditions registered by top-level code;
- state initialized by `OnStart`;
- stale bootstrap and `OnStart` completion after reset.

`test/All/SpEvent.spx` drives the same condition through two false-to-true cycles. It verifies that the condition fires once while remaining true and fires again after returning to false.

The example displays `Condition trigger count: 1` and `Condition trigger count: 2` so each trigger is visible.

## Validation

```bash
go test ./...
go test -race ./internal/core/event ./internal/core/runtime .
go vet ./...

cd test/All
xgo fmt SpEvent.spx
xgo build ./...
```

Refs #1696