### PR TITLE
fix(ci): make release publish gates fail closed

### DIFF
--- a/.github/scripts/release_workflow_test.py
+++ b/.github/scripts/release_workflow_test.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+
+import json
+import os
+import re
+import subprocess
+import unittest
+from pathlib import Path
+
+
+WORKFLOW_PATH = Path(__file__).resolve().parents[1] / "workflows" / "release.yml"
+
+
+def job_blocks(text):
+    lines = text.splitlines()
+    try:
+        jobs_line = lines.index("jobs:")
+    except ValueError as exc:
+        raise AssertionError("release workflow has no top-level jobs mapping") from exc
+
+    starts = [
+        (index, match.group(1))
+        for index, line in enumerate(lines[jobs_line + 1 :], jobs_line + 1)
+        if (match := re.fullmatch(r"  ([a-z0-9-]+):", line))
+    ]
+    return {
+        name: "\n".join(lines[start : starts[position + 1][0]])
+        if position + 1 < len(starts)
+        else "\n".join(lines[start:])
+        for position, (start, name) in enumerate(starts)
+    }
+
+
+def job_needs(block):
+    lines = block.splitlines()
+    for index, line in enumerate(lines):
+        if match := re.fullmatch(r"    needs: \[([^]]*)\]", line):
+            return tuple(value.strip() for value in match.group(1).split(","))
+        if line == "    needs:":
+            values = []
+            for item in lines[index + 1 :]:
+                if not (match := re.fullmatch(r"      - ([a-z0-9-]+)", item)):
+                    break
+                values.append(match.group(1))
+            return tuple(values)
+    return ()
+
+
+def job_condition(block):
+    lines = block.splitlines()
+    for index, line in enumerate(lines):
+        if not (match := re.fullmatch(r"    if: ?(.*)", line)):
+            continue
+        if match.group(1) not in (">-", "|", ""):
+            value = match.group(1)
+        else:
+            parts = []
+            for item in lines[index + 1 :]:
+                if not item.startswith("      "):
+                    break
+                parts.append(item.strip())
+            value = " ".join(parts)
+        return "".join(value.replace("${{", "").replace("}}", "").split())
+    return ""
+
+
+def step_script(block, name):
+    lines = block.splitlines()
+    try:
+        start = lines.index(f"      - name: {name}")
+        run_line = lines.index("        run: |", start + 1)
+    except ValueError as exc:
+        raise AssertionError(f"missing literal run script for step {name!r}") from exc
+
+    body = []
+    for line in lines[run_line + 1 :]:
+        if line and not line.startswith("          "):
+            break
+        body.append(line[10:] if line else line)
+    return "\n".join(body)
+
+
+class ReleaseWorkflowTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.jobs = job_blocks(WORKFLOW_PATH.read_text(encoding="utf-8"))
+
+    def test_job_scheduling_contract(self):
+        needs = {
+            "runtime-ready": ("setup", "static-checks", "godot-runtime-build", "runtime-assets-build"),
+            "assemble": ("setup", "runtime-ready", "web-build", "macos-build", "windows-build", "linux-build"),
+            "publish-runtime": ("setup", "assemble"),
+            "publish-spx": ("setup", "assemble", "publish-runtime"),
+            "publish-web-package": ("setup", "publish-spx"),
+            "finalize-spx": ("setup", "publish-spx", "publish-web-package"),
+        }
+        conditions = {
+            "runtime-ready": (
+                "!cancelled()&&needs.setup.result=='success'&&needs.static-checks.result=='success'&&"
+                "((needs.setup.outputs.runtime_state=='ready'&&needs.godot-runtime-build.result=='skipped'&&"
+                "needs.runtime-assets-build.result=='skipped')||(needs.setup.outputs.runtime_state=='missing'&&"
+                "needs.godot-runtime-build.result=='success'&&needs.runtime-assets-build.result=='success'))"
+            ),
+            "assemble": (
+                "!cancelled()&&needs.setup.result=='success'&&needs.runtime-ready.result=='success'&&"
+                "(needs.setup.outputs.run_web!='true'||needs.web-build.result=='success')&&"
+                "(needs.setup.outputs.run_macos!='true'||needs.macos-build.result=='success')&&"
+                "(needs.setup.outputs.run_windows!='true'||needs.windows-build.result=='success')&&"
+                "(needs.setup.outputs.run_linux!='true'||needs.linux-build.result=='success')"
+            ),
+            "publish-runtime": "!cancelled()&&inputs.operation!='dry-run'&&needs.assemble.result=='success'",
+            "publish-spx": "!cancelled()&&inputs.operation=='publish-release'&&needs.publish-runtime.result=='success'",
+            "publish-web-package": "!cancelled()&&inputs.operation=='publish-release'&&needs.publish-spx.result=='success'",
+            "finalize-spx": "!cancelled()&&inputs.operation=='publish-release'&&needs.publish-web-package.result=='success'",
+        }
+        for platform in ("web", "macos", "windows", "linux"):
+            job = f"{platform}-build"
+            needs[job] = ("setup", "runtime-ready")
+            conditions[job] = (
+                "!cancelled()&&needs.runtime-ready.result=='success'&&"
+                f"needs.setup.outputs.run_{platform}=='true'"
+            )
+
+        for job, expected in conditions.items():
+            with self.subTest(job=job):
+                self.assertEqual(job_needs(self.jobs[job]), needs[job])
+                self.assertEqual(job_condition(self.jobs[job]), expected)
+
+    def test_release_gate_is_operation_aware_and_fail_closed(self):
+        block = self.jobs["release-gate"]
+        terminal_jobs = (
+            "setup",
+            "assemble",
+            "publish-runtime",
+            "publish-spx",
+            "publish-web-package",
+            "finalize-spx",
+        )
+        self.assertEqual(job_needs(block), terminal_jobs)
+        self.assertEqual(job_condition(block), "!cancelled()")
+        self.assertIn("          OPERATION: ${{ inputs.operation }}", block)
+        self.assertIn("          NEEDS_JSON: ${{ toJSON(needs) }}", block)
+
+        script = step_script(block, "Require the selected operation's terminal jobs")
+        cases = (
+            ("dry-run", {"setup": "success", "assemble": "success"}, True),
+            ("publish-runtime", {"setup": "success", "assemble": "success", "publish-runtime": "success"}, True),
+            ("publish-release", {job: "success" for job in terminal_jobs}, True),
+            ("dry-run", {"setup": "success", "assemble": "skipped"}, False),
+            ("publish-runtime", {"setup": "success", "assemble": "success", "publish-runtime": "skipped"}, False),
+            ("publish-release", {"setup": "success", "assemble": "success", "publish-runtime": "success", "publish-spx": "success", "publish-web-package": "skipped"}, False),
+            ("unknown", {}, False),
+        )
+        for operation, results, succeeds in cases:
+            with self.subTest(operation=operation, results=results):
+                needs_json = {
+                    job: {"result": results.get(job, "skipped")}
+                    for job in terminal_jobs
+                }
+                completed = subprocess.run(
+                    ["bash", "-euo", "pipefail", "-c", script],
+                    env={
+                        **os.environ,
+                        "OPERATION": operation,
+                        "NEEDS_JSON": json.dumps(needs_json),
+                    },
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+                self.assertEqual(completed.returncode == 0, succeeds, completed.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -327,7 +327,7 @@ jobs:
     needs: [setup, static-checks, godot-runtime-build, runtime-assets-build]
     if: >-
       ${{
-        always() &&
+        !cancelled() &&
         needs.setup.result == 'success' &&
         needs.static-checks.result == 'success' &&
         (
@@ -351,7 +351,7 @@ jobs:
   web-build:
     name: Build Web packages
     needs: [setup, runtime-ready]
-    if: needs.setup.outputs.run_web == 'true'
+    if: ${{ !cancelled() && needs.runtime-ready.result == 'success' && needs.setup.outputs.run_web == 'true' }}
     uses: ./.github/workflows/release_web.yml
     with:
       engine_artifacts: ${{ needs.setup.outputs.runtime_state == 'missing' }}
@@ -359,7 +359,7 @@ jobs:
   macos-build:
     name: Package macOS
     needs: [setup, runtime-ready]
-    if: needs.setup.outputs.run_macos == 'true'
+    if: ${{ !cancelled() && needs.runtime-ready.result == 'success' && needs.setup.outputs.run_macos == 'true' }}
     uses: ./.github/workflows/release_macos.yml
     with:
       engine_artifacts: ${{ needs.setup.outputs.runtime_state == 'missing' }}
@@ -367,7 +367,7 @@ jobs:
   windows-build:
     name: Package Windows
     needs: [setup, runtime-ready]
-    if: needs.setup.outputs.run_windows == 'true'
+    if: ${{ !cancelled() && needs.runtime-ready.result == 'success' && needs.setup.outputs.run_windows == 'true' }}
     uses: ./.github/workflows/release_windows.yml
     with:
       engine_artifacts: ${{ needs.setup.outputs.runtime_state == 'missing' }}
@@ -375,7 +375,7 @@ jobs:
   linux-build:
     name: Package Linux
     needs: [setup, runtime-ready]
-    if: needs.setup.outputs.run_linux == 'true'
+    if: ${{ !cancelled() && needs.runtime-ready.result == 'success' && needs.setup.outputs.run_linux == 'true' }}
     uses: ./.github/workflows/release_linux.yml
     with:
       engine_artifacts: ${{ needs.setup.outputs.runtime_state == 'missing' }}
@@ -391,7 +391,7 @@ jobs:
       - linux-build
     if: >-
       ${{
-        always() &&
+        !cancelled() &&
         needs.setup.result == 'success' &&
         needs.runtime-ready.result == 'success' &&
         (needs.setup.outputs.run_web != 'true' || needs.web-build.result == 'success') &&
@@ -598,7 +598,7 @@ jobs:
   publish-runtime:
     name: Publish runtime release
     needs: [setup, assemble]
-    if: inputs.operation != 'dry-run' && needs.assemble.result == 'success'
+    if: ${{ !cancelled() && inputs.operation != 'dry-run' && needs.assemble.result == 'success' }}
     runs-on: ubuntu-22.04
     permissions:
       contents: write
@@ -672,7 +672,7 @@ jobs:
   publish-spx:
     name: Prepare SPX release draft
     needs: [setup, assemble, publish-runtime]
-    if: inputs.operation == 'publish-release' && needs.publish-runtime.result == 'success'
+    if: ${{ !cancelled() && inputs.operation == 'publish-release' && needs.publish-runtime.result == 'success' }}
     runs-on: ubuntu-22.04
     permissions:
       contents: write
@@ -725,7 +725,7 @@ jobs:
   publish-web-package:
     name: Publish npm package
     needs: [setup, publish-spx]
-    if: inputs.operation == 'publish-release' && needs.publish-spx.result == 'success'
+    if: ${{ !cancelled() && inputs.operation == 'publish-release' && needs.publish-spx.result == 'success' }}
     permissions:
       contents: read
       id-token: write
@@ -738,7 +738,7 @@ jobs:
   finalize-spx:
     name: Finalize SPX release
     needs: [setup, publish-spx, publish-web-package]
-    if: inputs.operation == 'publish-release' && needs.publish-spx.result == 'success' && needs.publish-web-package.result == 'success'
+    if: ${{ !cancelled() && inputs.operation == 'publish-release' && needs.publish-web-package.result == 'success' }}
     runs-on: ubuntu-22.04
     permissions:
       contents: write
@@ -750,3 +750,46 @@ jobs:
           RELEASE_TAG: ${{ needs.setup.outputs.release_tag }}
           REPOSITORY: ${{ needs.setup.outputs.release_repository }}
         run: gh release edit "$RELEASE_TAG" --repo "$REPOSITORY" --draft=false
+
+  release-gate:
+    name: Verify release operation completed
+    needs:
+      - setup
+      - assemble
+      - publish-runtime
+      - publish-spx
+      - publish-web-package
+      - finalize-spx
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Require the selected operation's terminal jobs
+        shell: bash
+        env:
+          OPERATION: ${{ inputs.operation }}
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          set -euo pipefail
+
+          required=(setup assemble)
+          case "$OPERATION" in
+            dry-run)
+              ;;
+            publish-runtime)
+              required+=(publish-runtime)
+              ;;
+            publish-release)
+              required+=(publish-runtime publish-spx publish-web-package finalize-spx)
+              ;;
+            *)
+              echo "[error] Unsupported release operation: $OPERATION" >&2
+              exit 1
+              ;;
+          esac
+          for job in "${required[@]}"; do
+            result="$(jq -r --arg job "$job" '.[$job].result // "missing"' <<<"$NEEDS_JSON")"
+            if [ "$result" != success ]; then
+              echo "[error] Required job did not succeed: $job ($result)" >&2
+              exit 1
+            fi
+          done

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -46,6 +46,7 @@ jobs:
           go test -v .github/scripts/runtime_resolution.go .github/scripts/runtime_resolution_test.go
           go test -v .github/scripts/runtime_version.go .github/scripts/runtime_version_test.go
           PYTHONDONTWRITEBYTECODE=1 python3 .github/scripts/runtime_build_contract_test.py
+          PYTHONDONTWRITEBYTECODE=1 python3 .github/scripts/release_workflow_test.py
           PYTHONDONTWRITEBYTECODE=1 python3 .github/scripts/release_bump_test.py
           go run .github/scripts/runtime_pack_source_digest.go HEAD >/dev/null
           go run .github/scripts/runtime_build_recipe_digest.go HEAD >/dev/null


### PR DESCRIPTION
## What changed

- make every release DAG boundary explicitly evaluate after expected skipped dependencies while stopping on cancellation
- keep the publish chain fail-closed through its immediate successful predecessor
- add an operation-aware terminal gate so a skipped publish job cannot leave a green workflow
- add data-driven workflow contract tests, including executable positive and negative gate matrices

## Root cause

The `publish-runtime` job had no status function in its job-level condition. During `publish-runtime`, product jobs are intentionally skipped; GitHub propagated that skipped ancestor through the dependency chain and skipped the publish job even though `assemble` succeeded. The workflow therefore concluded successfully without creating `runtime-v2.4.0`.

The same propagation would also affect product and publish jobs when reusing an already published runtime.

## Impact

The staged release flow now distinguishes an intentionally skipped optional job from a required terminal job. `dry-run`, `publish-runtime`, and `publish-release` each require their own terminal success set.

This orchestration-only change does not alter the Godot module tree, runtime pack source digest, or runtime build recipe digest.

## Validation

- `actionlint .github/workflows/release.yml .github/workflows/static_checks.yml`
- `python3 .github/scripts/release_workflow_test.py`
- existing runtime/release Python tests
- `go test $(go list ./... | grep -v /internal/webffi)`
- `cd cmd/ispx && go test ./...`
- `git diff --check`
