### PR TITLE
ci: add explicit development npm publishing

### DIFF
--- a/.github/scripts/release_workflow_test.py
+++ b/.github/scripts/release_workflow_test.py
@@ -4,11 +4,15 @@ import json
 import os
 import re
 import subprocess
+import tempfile
 import unittest
 from pathlib import Path
 
 
 WORKFLOW_PATH = Path(__file__).resolve().parents[1] / "workflows" / "release.yml"
+WEB_PACKAGE_WORKFLOW_PATH = (
+    Path(__file__).resolve().parents[1] / "workflows" / "publish_web_package.yml"
+)
 
 
 def job_blocks(text):
@@ -36,6 +40,8 @@ def job_needs(block):
     for index, line in enumerate(lines):
         if match := re.fullmatch(r"    needs: \[([^]]*)\]", line):
             return tuple(value.strip() for value in match.group(1).split(","))
+        if match := re.fullmatch(r"    needs: ([a-z0-9-]+)", line):
+            return (match.group(1),)
         if line == "    needs:":
             values = []
             for item in lines[index + 1 :]:
@@ -80,21 +86,53 @@ def step_script(block, name):
     return "\n".join(body)
 
 
+def workflow_dispatch_input_block(text, name):
+    lines = text.splitlines()
+    try:
+        start = lines.index(f"      {name}:")
+    except ValueError as exc:
+        raise AssertionError(f"missing workflow_dispatch input {name!r}") from exc
+
+    body = [lines[start]]
+    for line in lines[start + 1 :]:
+        if re.fullmatch(r"      [a-z0-9_]+:", line):
+            break
+        if line and not line.startswith("        "):
+            break
+        body.append(line)
+    return "\n".join(body)
+
+
 class ReleaseWorkflowTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.jobs = job_blocks(WORKFLOW_PATH.read_text(encoding="utf-8"))
+        cls.workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+        cls.jobs = job_blocks(cls.workflow)
+        cls.web_package_workflow = WEB_PACKAGE_WORKFLOW_PATH.read_text(encoding="utf-8")
+        cls.web_package_jobs = job_blocks(cls.web_package_workflow)
+
+    def test_publish_dev_input_contract(self):
+        release_tag = workflow_dispatch_input_block(self.workflow, "release_tag")
+        self.assertIn("        required: false", release_tag)
+        self.assertIn("        default: ''", release_tag)
+
+        operation = workflow_dispatch_input_block(self.workflow, "operation")
+        self.assertIn("          - publish-dev-npm", operation)
 
     def test_job_scheduling_contract(self):
         needs = {
+            "setup": (),
             "runtime-ready": ("setup", "static-checks", "godot-runtime-build", "runtime-assets-build"),
             "assemble": ("setup", "runtime-ready", "web-build", "macos-build", "windows-build", "linux-build"),
             "publish-runtime": ("setup", "assemble"),
             "publish-spx": ("setup", "assemble", "publish-runtime"),
             "publish-web-package": ("setup", "publish-spx"),
             "finalize-spx": ("setup", "publish-spx", "publish-web-package"),
+            "dev-npm-guard": (),
+            "publish-dev-web-package": ("dev-npm-guard",),
         }
         conditions = {
+            "setup": "inputs.operation!='publish-dev-npm'",
             "runtime-ready": (
                 "!cancelled()&&needs.setup.result=='success'&&needs.static-checks.result=='success'&&"
                 "((needs.setup.outputs.runtime_state=='ready'&&needs.godot-runtime-build.result=='skipped'&&"
@@ -112,6 +150,11 @@ class ReleaseWorkflowTest(unittest.TestCase):
             "publish-spx": "!cancelled()&&inputs.operation=='publish-release'&&needs.publish-runtime.result=='success'",
             "publish-web-package": "!cancelled()&&inputs.operation=='publish-release'&&needs.publish-spx.result=='success'",
             "finalize-spx": "!cancelled()&&inputs.operation=='publish-release'&&needs.publish-web-package.result=='success'",
+            "dev-npm-guard": "inputs.operation=='publish-dev-npm'",
+            "publish-dev-web-package": (
+                "!cancelled()&&inputs.operation=='publish-dev-npm'&&"
+                "needs.dev-npm-guard.result=='success'"
+            ),
         }
         for platform in ("web", "macos", "windows", "linux"):
             job = f"{platform}-build"
@@ -126,6 +169,208 @@ class ReleaseWorkflowTest(unittest.TestCase):
                 self.assertEqual(job_needs(self.jobs[job]), needs[job])
                 self.assertEqual(job_condition(self.jobs[job]), expected)
 
+    def test_publish_dev_uses_exact_sha_and_oidc(self):
+        block = self.jobs["publish-dev-web-package"]
+        self.assertIn("    uses: ./.github/workflows/publish_web_package.yml", block)
+        self.assertIn("      target: ${{ github.sha }}", block)
+        self.assertIn("      release_version: ''", block)
+        self.assertIn("      release_artifact: ''", block)
+        self.assertIn("      contents: read", block)
+        self.assertIn("      id-token: write", block)
+
+        guard = step_script(
+            self.jobs["dev-npm-guard"], "Require the canonical dev branch"
+        )
+        cases = (
+            ("goplus/spx", "refs/heads/dev", "", True),
+            ("someone/spx", "refs/heads/dev", "", False),
+            ("goplus/spx", "refs/heads/release/v3.2.0", "", False),
+            ("goplus/spx", "refs/heads/dev", "v3.2.0", False),
+        )
+        for repository, ref, release_tag, succeeds in cases:
+            with self.subTest(repository=repository, ref=ref, release_tag=release_tag):
+                completed = subprocess.run(
+                    ["bash", "-euo", "pipefail", "-c", guard],
+                    cwd=WORKFLOW_PATH.parents[2],
+                    env={
+                        **os.environ,
+                        "CURRENT_REF": ref,
+                        "CURRENT_REPOSITORY": repository,
+                        "RELEASE_TAG_INPUT": release_tag,
+                    },
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+                self.assertEqual(completed.returncode == 0, succeeds, completed.stderr)
+
+    def test_web_package_is_reusable_only_and_rejects_release_tags(self):
+        self.assertNotIn("  workflow_dispatch:", self.web_package_workflow)
+        self.assertIn(
+            "permissions:\n  contents: read\n  id-token: write",
+            self.web_package_workflow,
+        )
+        block = self.web_package_jobs["build"]
+
+        validate_target = step_script(block, "Validate publication target")
+        for target, release_version, release_artifact, succeeds in (
+            ("a" * 40, "", "", True),
+            ("a" * 40, "3.2.0", "web-release", True),
+            ("a" * 40, "3.2.0", "", False),
+            ("a" * 40, "", "web-release", False),
+            ("dev", "", "", False),
+            ("refs/heads/dev", "", "", False),
+            ("A" * 40, "", "", False),
+        ):
+            with self.subTest(
+                target=target,
+                release_version=release_version,
+                release_artifact=release_artifact,
+            ):
+                completed = subprocess.run(
+                    ["bash", "-euo", "pipefail", "-c", validate_target],
+                    env={
+                        **os.environ,
+                        "RELEASE_ARTIFACT": release_artifact,
+                        "RELEASE_VERSION": release_version,
+                        "TARGET": target,
+                    },
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+                self.assertEqual(completed.returncode == 0, succeeds, completed.stderr)
+
+        verify_source = step_script(block, "Verify checked-out publication source")
+        with tempfile.TemporaryDirectory() as repository:
+            for command in (
+                ("git", "init", "--quiet"),
+                ("git", "config", "user.name", "SPX release test"),
+                ("git", "config", "user.email", "release-test@example.invalid"),
+                ("git", "config", "commit.gpgSign", "false"),
+                ("git", "config", "tag.gpgSign", "false"),
+                ("git", "commit", "--allow-empty", "--quiet", "-m", "test"),
+                ("git", "tag", "v3.2.0"),
+            ):
+                subprocess.run(command, cwd=repository, check=True)
+            target = subprocess.run(
+                ("git", "rev-parse", "HEAD"),
+                cwd=repository,
+                capture_output=True,
+                text=True,
+                check=True,
+            ).stdout.strip()
+
+            tagged = subprocess.run(
+                ["bash", "-euo", "pipefail", "-c", verify_source],
+                cwd=repository,
+                env={
+                    **os.environ,
+                    "IS_DEVELOPMENT": "true",
+                    "TARGET": target,
+                },
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertNotEqual(tagged.returncode, 0, tagged.stdout)
+
+            wrong_sha = subprocess.run(
+                ["bash", "-euo", "pipefail", "-c", verify_source],
+                cwd=repository,
+                env={
+                    **os.environ,
+                    "IS_DEVELOPMENT": "false",
+                    "TARGET": "b" * 40,
+                },
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertNotEqual(wrong_sha.returncode, 0, wrong_sha.stdout)
+            self.assertIn("instead of publication target", wrong_sha.stderr)
+
+            subprocess.run(
+                ("git", "tag", "--delete", "v3.2.0"),
+                cwd=repository,
+                capture_output=True,
+                check=True,
+            )
+            untagged = subprocess.run(
+                ["bash", "-euo", "pipefail", "-c", verify_source],
+                cwd=repository,
+                env={
+                    **os.environ,
+                    "IS_DEVELOPMENT": "true",
+                    "TARGET": target,
+                },
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(untagged.returncode, 0, untagged.stderr)
+
+        publish = step_script(block, "Publish web package to npm")
+        with tempfile.TemporaryDirectory() as workspace:
+            workspace_path = Path(workspace)
+            scripts_path = workspace_path / ".github" / "scripts"
+            scripts_path.mkdir(parents=True)
+            prepare = scripts_path / "prepare_spx_web_package.sh"
+            prepare.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+            prepare.chmod(0o755)
+
+            fake_bin = workspace_path / "fake-bin"
+            fake_bin.mkdir()
+            fake_npm = fake_bin / "npm"
+            fake_npm.write_text(
+                """#!/bin/sh
+set -eu
+case "$1:$3" in
+  pack:*)
+    printf '%s\\n' '[{"filename":"spx.tgz","integrity":"sha512-local"}]'
+    ;;
+  view:version)
+    printf '%s\\n' "$MOCK_VERSION"
+    ;;
+  view:dist.integrity)
+    printf '%s\\n' 'sha512-local'
+    ;;
+  view:dist-tags)
+    printf '{"dev":"%s"}\\n' "$MOCK_DIST_TAG"
+    ;;
+  *)
+    exit 99
+    ;;
+esac
+""",
+                encoding="utf-8",
+            )
+            fake_npm.chmod(0o755)
+
+            version = "3.2.1-0.20260814000000-aaaaaaaaaaaa"
+            for remote_dist_tag, succeeds in ((version, True), ("older", False)):
+                with self.subTest(remote_dist_tag=remote_dist_tag):
+                    completed = subprocess.run(
+                        ["bash", "-euo", "pipefail", "-c", publish],
+                        cwd=workspace,
+                        env={
+                            **os.environ,
+                            "IS_RELEASE": "false",
+                            "MOCK_DIST_TAG": remote_dist_tag,
+                            "MOCK_VERSION": version,
+                            "PATH": f"{fake_bin}:{os.environ['PATH']}",
+                            "SPX_VERSION": f"v{version}",
+                        },
+                        capture_output=True,
+                        text=True,
+                        check=False,
+                    )
+                    self.assertEqual(
+                        completed.returncode == 0,
+                        succeeds,
+                        completed.stderr,
+                    )
+
     def test_release_gate_is_operation_aware_and_fail_closed(self):
         block = self.jobs["release-gate"]
         terminal_jobs = (
@@ -135,6 +380,8 @@ class ReleaseWorkflowTest(unittest.TestCase):
             "publish-spx",
             "publish-web-package",
             "finalize-spx",
+            "dev-npm-guard",
+            "publish-dev-web-package",
         )
         self.assertEqual(job_needs(block), terminal_jobs)
         self.assertEqual(job_condition(block), "!cancelled()")
@@ -145,10 +392,13 @@ class ReleaseWorkflowTest(unittest.TestCase):
         cases = (
             ("dry-run", {"setup": "success", "assemble": "success"}, True),
             ("publish-runtime", {"setup": "success", "assemble": "success", "publish-runtime": "success"}, True),
-            ("publish-release", {job: "success" for job in terminal_jobs}, True),
+            ("publish-release", {job: "success" for job in terminal_jobs[:6]}, True),
+            ("publish-dev-npm", {"dev-npm-guard": "success", "publish-dev-web-package": "success"}, True),
             ("dry-run", {"setup": "success", "assemble": "skipped"}, False),
             ("publish-runtime", {"setup": "success", "assemble": "success", "publish-runtime": "skipped"}, False),
             ("publish-release", {"setup": "success", "assemble": "success", "publish-runtime": "success", "publish-spx": "success", "publish-web-package": "skipped"}, False),
+            ("publish-dev-npm", {"dev-npm-guard": "skipped", "publish-dev-web-package": "skipped"}, False),
+            ("publish-dev-npm", {"dev-npm-guard": "success", "publish-dev-web-package": "failure"}, False),
             ("unknown", {}, False),
         )
         for operation, results, succeeds in cases:

--- a/.github/workflows/publish_web_package.yml
+++ b/.github/workflows/publish_web_package.yml
@@ -17,19 +17,13 @@ on:
         required: false
         default: ''
         type: string
-  workflow_dispatch:
-    inputs:
-      target:
-        description: Branch name or full commit SHA to build
-        required: true
-        type: string
 
 permissions:
   contents: read
   id-token: write
 
 concurrency:
-  group: web-package-${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call') && inputs.target || github.sha }}
+  group: web-package-${{ inputs.target }}
   cancel-in-progress: false
 
 jobs:
@@ -37,22 +31,19 @@ jobs:
     name: Publish web package
     runs-on: ubuntu-latest
     steps:
-      - name: Validate dispatch target
-        if: github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call'
+      - name: Validate publication target
         env:
+          RELEASE_ARTIFACT: ${{ inputs.release_artifact }}
+          RELEASE_VERSION: ${{ inputs.release_version }}
           TARGET: ${{ inputs.target }}
         run: |
-          if [[ "${TARGET}" =~ ^[0-9a-f]{40}$ ]]; then
-            exit 0
-          fi
-
-          if [[ "${TARGET}" == refs/* ]]; then
-            echo "[error] Dispatch target must be a branch name or full commit SHA" >&2
+          if [[ ! "${TARGET}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "[error] Publication target must be a full lowercase commit SHA, not ${TARGET}" >&2
             exit 1
           fi
-
-          if ! git check-ref-format --branch "${TARGET}" >/dev/null 2>&1; then
-            echo "[error] Invalid workflow_dispatch target: ${TARGET}" >&2
+          if { [ -z "$RELEASE_VERSION" ] && [ -n "$RELEASE_ARTIFACT" ]; } || \
+            { [ -n "$RELEASE_VERSION" ] && [ -z "$RELEASE_ARTIFACT" ]; }; then
+            echo "[error] release_version and release_artifact must both be empty or both be set" >&2
             exit 1
           fi
 
@@ -61,7 +52,28 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
-          ref: ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call') && inputs.target || github.sha }}
+          persist-credentials: false
+          ref: ${{ inputs.target }}
+
+      - name: Verify checked-out publication source
+        env:
+          IS_DEVELOPMENT: ${{ inputs.release_version == '' }}
+          TARGET: ${{ inputs.target }}
+        run: |
+          set -euo pipefail
+
+          current_sha="$(git rev-parse HEAD)"
+          if [ "$current_sha" != "$TARGET" ]; then
+            echo "[error] Checked out $current_sha instead of publication target $TARGET" >&2
+            exit 1
+          fi
+          if [ "$IS_DEVELOPMENT" = true ]; then
+            release_tag="$(git tag --points-at HEAD --list 'v3.*' | sed -n '1p')"
+            if [ -n "$release_tag" ]; then
+              echo "[error] Refusing to publish development npm from exact release tag $release_tag" >&2
+              exit 1
+            fi
+          fi
 
       - name: Download verified release Web bundle
         if: inputs.release_artifact != ''
@@ -133,9 +145,6 @@ jobs:
             if [[ "${npm_package_version}" == *-* ]]; then
               npm_dist_tag="next"
             fi
-          elif git tag --points-at HEAD --list "v${npm_package_version}" | grep -qx "v${npm_package_version}"; then
-            echo "[info] v${npm_package_version} is an exact tag; leave npm publishing to the unified release workflow"
-            exit 0
           fi
 
           ./.github/scripts/prepare_spx_web_package.sh \
@@ -153,6 +162,11 @@ jobs:
             remote_integrity="$(npm view "@xgo-pkgs/spx@${npm_package_version}" dist.integrity)"
             if [ "$remote_integrity" != "$local_integrity" ]; then
               echo "[error] Existing npm package integrity $remote_integrity does not match $local_integrity" >&2
+              exit 1
+            fi
+            remote_dist_tag="$(npm view @xgo-pkgs/spx dist-tags --json | jq -r --arg tag "$npm_dist_tag" '.[$tag] // ""')"
+            if [ "$remote_dist_tag" != "$npm_package_version" ]; then
+              echo "[error] Existing npm package is not selected by dist-tag $npm_dist_tag (found $remote_dist_tag)" >&2
               exit 1
             fi
             echo "[info] Identical @xgo-pkgs/spx@${npm_package_version} already exists"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,16 +4,17 @@ on:
   workflow_dispatch:
     inputs:
       release_tag:
-        description: 'SPX release tag declared by this commit (for example, v3.x.y)'
-        required: true
+        description: 'SPX release tag declared by this commit; required except for publish-dev-npm'
+        required: false
+        default: ''
         type: string
       platforms:
-        description: 'SPX packages: all or comma-separated web,macos,windows,linux; ignored by publish-runtime'
+        description: 'SPX packages: all or comma-separated web,macos,windows,linux; ignored by publish-runtime and publish-dev-npm'
         required: true
         default: 'all'
         type: string
       operation:
-        description: 'Validate artifacts, publish only runtime-v*, or publish the complete SPX release'
+        description: 'Validate or publish a release, or publish a development npm package'
         required: true
         default: 'dry-run'
         type: choice
@@ -21,6 +22,7 @@ on:
           - dry-run
           - publish-runtime
           - publish-release
+          - publish-dev-npm
 
 permissions:
   contents: read
@@ -32,6 +34,7 @@ concurrency:
 jobs:
   setup:
     name: Validate locked release inputs
+    if: ${{ inputs.operation != 'publish-dev-npm' }}
     runs-on: ubuntu-22.04
     outputs:
       release_tag: ${{ steps.release.outputs.release_tag }}
@@ -735,6 +738,50 @@ jobs:
       release_version: ${{ needs.setup.outputs.version }}
       release_artifact: web-release
 
+  dev-npm-guard:
+    name: Validate development npm target
+    if: ${{ inputs.operation == 'publish-dev-npm' }}
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out publication target
+        uses: actions/checkout@v6
+
+      - name: Require the canonical dev branch
+        shell: bash
+        env:
+          CURRENT_REF: ${{ github.ref }}
+          CURRENT_REPOSITORY: ${{ github.repository }}
+          RELEASE_TAG_INPUT: ${{ inputs.release_tag }}
+        run: |
+          set -euo pipefail
+
+          expected_repository="$(jq -er .release_repository internal/release/runtime.lock.json)"
+          if [ "$CURRENT_REPOSITORY" != "$expected_repository" ]; then
+            echo "[error] Development npm publishing is locked to $expected_repository, not $CURRENT_REPOSITORY" >&2
+            exit 1
+          fi
+          if [ "$CURRENT_REF" != refs/heads/dev ]; then
+            echo "[error] Development npm publishing requires refs/heads/dev, not $CURRENT_REF" >&2
+            exit 1
+          fi
+          if [ -n "$RELEASE_TAG_INPUT" ]; then
+            echo "[error] release_tag must be empty for publish-dev-npm" >&2
+            exit 1
+          fi
+
+  publish-dev-web-package:
+    name: Publish development npm package
+    needs: dev-npm-guard
+    if: ${{ !cancelled() && inputs.operation == 'publish-dev-npm' && needs.dev-npm-guard.result == 'success' }}
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/publish_web_package.yml
+    with:
+      target: ${{ github.sha }}
+      release_version: ''
+      release_artifact: ''
+
   finalize-spx:
     name: Finalize SPX release
     needs: [setup, publish-spx, publish-web-package]
@@ -760,6 +807,8 @@ jobs:
       - publish-spx
       - publish-web-package
       - finalize-spx
+      - dev-npm-guard
+      - publish-dev-web-package
     if: ${{ !cancelled() }}
     runs-on: ubuntu-22.04
     steps:
@@ -771,15 +820,19 @@ jobs:
         run: |
           set -euo pipefail
 
-          required=(setup assemble)
+          required=()
           case "$OPERATION" in
             dry-run)
+              required+=(setup assemble)
               ;;
             publish-runtime)
-              required+=(publish-runtime)
+              required+=(setup assemble publish-runtime)
               ;;
             publish-release)
-              required+=(publish-runtime publish-spx publish-web-package finalize-spx)
+              required+=(setup assemble publish-runtime publish-spx publish-web-package finalize-spx)
+              ;;
+            publish-dev-npm)
+              required+=(dev-npm-guard publish-dev-web-package)
               ;;
             *)
               echo "[error] Unsupported release operation: $OPERATION" >&2

--- a/docs/en/dev/engine/release.md
+++ b/docs/en/dev/engine/release.md
@@ -91,6 +91,21 @@ Use a frozen release branch in `goplus/spx` for the bootstrap operations:
 
 The runtime manifest, `SHA256SUMS`, and the lock's required asset set must match exactly. A public tag with different provenance or assets fails rather than being overwritten. An unpublished runtime/SPX draft tag must target the current `GITHUB_SHA`; a public runtime may target the candidate commit from the previous stage, but only an identical full reuse contract allows the final SPX commit to consume it. The SPX tag always targets the final commit. If the merge changes any runtime identity input, the final run rejects reuse; freeze again and bump `runtime_version` instead.
 
+## Development npm package
+
+`publish-dev-npm` is an independent on-demand operation, not a fourth stage of the production release. It is restricted to the canonical `goplus/spx` `dev` branch; leave `release_tag` empty and note that `platforms` is ignored:
+
+```sh
+gh workflow run release.yml \
+  --repo goplus/spx \
+  --ref dev \
+  -f operation=publish-dev-npm
+```
+
+The operation pins the exact commit SHA captured by the dispatch, builds the Web normal bundle, computes a pseudo-version, and publishes it under the npm `dev` dist-tag. It does not build the release runtime or platform products and does not create a GitHub Release. The Web build still downloads the public runtime selected by the lock, so that runtime release must already be public and complete; otherwise dependency setup fails. A target SHA carrying an exact production `v3.*` tag fails closed. Development npm publication shares the `spx-release` concurrency group with production releases so different SHAs and production/development publication cannot race over dist-tags.
+
+Do not restore publication on every push to `dev`. Explicit publication avoids repeated failures while a newly advanced runtime lock has no public runtime and avoids creating an irreversible npm version for every merge. Configure the npm Trusted Publisher with organization `goplus`, repository `spx`, workflow filename `release.yml`, and no environment. Production and development packages then use the same top-level OIDC identity. `publish_web_package.yml` is reusable-only and must not be dispatched directly.
+
 ## Maintaining later versions
 
 - If only SPX products change and both runtime artifact classes remain identical, an SPX-only mapping may retain the current runtime, but the release dry-run must first prove that the public runtime's complete provenance is reusable. `bump-release` deliberately does not make this reuse decision locally.

--- a/docs/zh/dev/engine/release.md
+++ b/docs/zh/dev/engine/release.md
@@ -91,6 +91,21 @@ canonical-ref ancestry 规则刻意只用于 release。普通 runner 与 module-
 
 runtime manifest、`SHA256SUMS` 和 lock 的 required asset 集合必须完全一致；已公开 tag 的来源或资产不同会直接失败，不能覆盖。未公开的 runtime/SPX draft tag 必须指向当前 `GITHUB_SHA`；已公开 runtime 可来自前一阶段的 candidate commit，但只有完整复用契约一致时才能用于最终 SPX commit。SPX tag 始终指向最终 commit。如果合并修改了任一 runtime 身份输入，最终运行会拒绝复用，此时必须重新冻结并提升 `runtime_version`。
 
+## 开发版 npm 包
+
+`publish-dev-npm` 是独立的按需操作，不属于上述三阶段正式发版。它只允许从 canonical `goplus/spx` 的 `dev` 分支触发；`release_tag` 必须留空，`platforms` 会被忽略：
+
+```sh
+gh workflow run release.yml \
+  --repo goplus/spx \
+  --ref dev \
+  -f operation=publish-dev-npm
+```
+
+该操作固定使用 dispatch 捕获的精确 commit SHA，构建 Web normal 包，计算 pseudo-version，并发布到 npm `dev` dist-tag。它不会构建 release runtime、平台产品包或创建 GitHub Release；Web 构建仍会下载 lock 对应的公开 runtime，因此该 runtime release 必须已经公开且完整，否则依赖准备会失败。如果目标 SHA 恰好已有正式 `v3.*` tag，则会 fail closed。开发版 npm 与正式发布共用 `spx-release` 并发组，避免不同 SHA 或正式/开发发布同时竞争 dist-tag。
+
+不要恢复 `dev` 每次 push 自动发布。显式操作可以避免 runtime lock 已推进但对应 runtime 尚未公开时反复失败，也避免为每次合入产生不可撤销的 npm 版本。npm Trusted Publisher 应固定为 organization `goplus`、repository `spx`、workflow filename `release.yml`，environment 留空；正式版与开发版都通过该顶层 workflow 的 OIDC 身份发布。`publish_web_package.yml` 只是 reusable workflow，不应单独触发。
+
 ## 后续版本维护
 
 - 仅 SPX 产品变化且 runtime 两类产物均未变化时，可以用 SPX-only mapping 保留 current runtime，但必须先由 release dry-run 证明公开 runtime 的完整 provenance 可复用；`bump-release` 不会在本地擅自做这个复用决定。


### PR DESCRIPTION
## Summary

- Add an explicit `publish-dev-npm` operation to the unified Release workflow.
- Restrict development npm publication to the canonical `goplus/spx` `dev` branch.
- Pin publication to the exact workflow-dispatch commit SHA.
- Make `publish_web_package.yml` reusable-only so production and development packages share the `release.yml` Trusted Publisher identity.
- Add fail-closed guards for release tags, invalid input modes, checkout identity, npm integrity, and dist-tag mismatches.
- Document the development npm workflow in English and Chinese.
- Extend release workflow contract tests with executable positive and negative cases.

## Motivation

npm trusted publishing validates the top-level calling workflow when publication happens through a reusable workflow.

Production packages are called from `release.yml`, while the previous standalone development path used `publish_web_package.yml`, resulting in incompatible OIDC identities.

Routing both production and development publication through `release.yml` allows npm to use a single Trusted Publisher configuration. Explicit dispatch also avoids publishing an immutable npm version for every `dev` push and prevents concurrent runs from moving the `dev` dist-tag out of order.

## Usage

After this change is merged:

```bash
gh workflow run release.yml -R goplus/spx \
  --ref dev \
  -f operation=publish-dev-npm
```

Do not provide `release_tag`. The `platforms` input is ignored for this operation.

## Behavior

The operation:

- requires the canonical `goplus/spx` repository;
- requires `refs/heads/dev`;
- requires an empty `release_tag`;
- builds the Web normal bundle from the exact dispatch SHA;
- computes a pseudo-version and publishes it under the npm `dev` dist-tag;
- requires the locked public runtime to be available;
- does not build release runtime artifacts or platform products;
- does not create a GitHub Release;
- fails if the target has an exact `v3.*` release tag;
- shares the `spx-release` concurrency group with production publication.

## npm Trusted Publisher

The npm Trusted Publisher should remain configured as:

- Organization: `goplus`
- Repository: `spx`
- Workflow: `release.yml`
- Environment: empty

No static npm token or VM password is used.

## Validation

- `actionlint` passed for both modified workflows.
- `release_workflow_test.py`: 5 tests passed.
- Runtime build contract tests: 35 tests passed.
- Release bump tests: 8 tests passed.
- Runtime manifest, resolution, and version Go tests passed.
- SPX/Godot preflight passed.
- `git diff --check` passed.