### PR TITLE
fix(ci): decouple runtime recipe from action updates

### DIFF
--- a/.github/scripts/build_runtime_pack.sh
+++ b/.github/scripts/build_runtime_pack.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+  echo "usage: build_runtime_pack.sh <engine-asset-directory> <output-zip>" >&2
+  exit 2
+fi
+
+engine_asset_directory="$1"
+output_zip="$2"
+
+if [ -z "${BUILDCTL:-}" ] || [ ! -x "$BUILDCTL" ]; then
+  echo "[error] BUILDCTL must name an executable buildctl binary" >&2
+  exit 1
+fi
+if [ ! -d "$engine_asset_directory" ]; then
+  echo "[error] Engine asset directory not found: $engine_asset_directory" >&2
+  exit 1
+fi
+
+"$BUILDCTL" engine download \
+  --runtime \
+  --skip-runtime-pack \
+  --asset-dir "$engine_asset_directory" \
+  --same-run-artifacts
+"$BUILDCTL" runtime export-pack
+
+gopath="$(go env GOPATH | tr -d '\r\n')"
+gopath="${gopath%%:*}"
+runtime_pack="$gopath/bin/spx-runtime-assets.zip"
+if [ ! -s "$runtime_pack" ]; then
+  echo "[error] Runtime asset bundle not found: $runtime_pack" >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "$output_zip")"
+cp "$runtime_pack" "$output_zip"
+unzip -t "$output_zip"
+echo "[info] Built runtime asset bundle: $output_zip"

--- a/.github/scripts/runtime_resolution.go
+++ b/.github/scripts/runtime_resolution.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -23,6 +24,11 @@ const (
 	runtimeStateReady   = "ready"
 	runtimeStateMissing = "missing"
 	maxGitHubBodySize   = 8 << 20
+
+	legacyRuntimeVersion        = "2.4.0"
+	legacyRuntimeManifestSHA256 = "c52c6d7c6986e4d5226f845fc1e6b89a29b361464abe36baba1128b266b66ae0"
+	legacyRuntimeRecipeSHA256   = "730b4b5f3ceac73d9ddf29d852b3e8a68f245feb7d0acbcffa7e2c4321b736b3"
+	semanticRuntimeRecipeSHA256 = "d6b43b2ad86d0b856c5ad0a7acfbe37486989a3f3e0664299c7a5c00034e643c"
 )
 
 type runtimeResolutionConfig struct {
@@ -144,6 +150,7 @@ func resolveRuntime(ctx context.Context, config runtimeResolutionConfig) (runtim
 	if status != http.StatusOK {
 		return runtimeResolution{}, runtimeConflict(tag, "download manifest: HTTP %d %s", status, http.StatusText(status))
 	}
+	manifestDigest := fmt.Sprintf("%x", sha256.Sum256(body))
 	manifest, err := release.ParseRuntimeManifest(body)
 	if err != nil {
 		return runtimeResolution{}, runtimeConflict(tag, "parse manifest: %v", err)
@@ -151,7 +158,7 @@ func resolveRuntime(ctx context.Context, config runtimeResolutionConfig) (runtim
 	if err := manifest.ValidateForLock(lock); err != nil {
 		return runtimeResolution{}, runtimeConflict(tag, "%v", err)
 	}
-	if err := verifyCurrentRuntimeProvenance(config, lock, manifest); err != nil {
+	if err := verifyCurrentRuntimeProvenance(config, lock, manifest, manifestDigest); err != nil {
 		return runtimeResolution{}, runtimeConflict(tag, "%v", err)
 	}
 
@@ -261,7 +268,7 @@ func verifyPublishedAssetNames(lock release.RuntimeLock, assets []gitHubAsset) (
 	return manifestURL, nil
 }
 
-func verifyCurrentRuntimeProvenance(config runtimeResolutionConfig, lock release.RuntimeLock, manifest release.RuntimeManifest) error {
+func verifyCurrentRuntimeProvenance(config runtimeResolutionConfig, lock release.RuntimeLock, manifest release.RuntimeManifest, manifestDigest string) error {
 	repoRoot := filepath.Clean(config.RepoRoot)
 	revision := strings.TrimSpace(config.Revision)
 	if revision == "" {
@@ -286,10 +293,24 @@ func verifyCurrentRuntimeProvenance(config runtimeResolutionConfig, lock release
 	if err != nil {
 		return err
 	}
-	if manifest.Provenance.BuildRecipeSHA256 != buildRecipeDigest {
+	if !runtimeBuildRecipeCompatible(lock.RuntimeVersion, manifestDigest, manifest.Provenance.BuildRecipeSHA256, buildRecipeDigest) {
 		return fmt.Errorf("runtime build recipe digest = %s, current %s requires %s; bump runtime_version", manifest.Provenance.BuildRecipeSHA256, revision, buildRecipeDigest)
 	}
 	return nil
+}
+
+// runtimeBuildRecipeCompatible contains the one-time migration bridge for the
+// already-published runtime-v2.4.0 manifest. That manifest used a recipe hash
+// which included CI transport files. The replacement hash covers only the
+// extracted pack builder and semantic buildctl inputs. Every field is exact so
+// a later semantic change still requires a new runtime version.
+func runtimeBuildRecipeCompatible(runtimeVersion, manifestDigest, publishedDigest, currentDigest string) bool {
+	if runtimeVersion == legacyRuntimeVersion {
+		return manifestDigest == legacyRuntimeManifestSHA256 &&
+			publishedDigest == legacyRuntimeRecipeSHA256 &&
+			currentDigest == semanticRuntimeRecipeSHA256
+	}
+	return publishedDigest == currentDigest
 }
 
 func gitRevision(repoRoot, revision string) (string, error) {

--- a/.github/scripts/runtime_resolution_test.go
+++ b/.github/scripts/runtime_resolution_test.go
@@ -108,6 +108,78 @@ func TestResolveRuntimeRejectsPublishedProvenanceConflict(t *testing.T) {
 	}
 }
 
+func TestRuntimeBuildRecipeCompatibilityIsExact(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		runtimeVersion  string
+		manifestDigest  string
+		publishedDigest string
+		currentDigest   string
+		want            bool
+	}{
+		{
+			name:            "future identical recipe",
+			runtimeVersion:  "9.9.9",
+			manifestDigest:  "unused",
+			publishedDigest: "same",
+			currentDigest:   "same",
+			want:            true,
+		},
+		{
+			name:            "v2.4 migration",
+			runtimeVersion:  legacyRuntimeVersion,
+			manifestDigest:  legacyRuntimeManifestSHA256,
+			publishedDigest: legacyRuntimeRecipeSHA256,
+			currentDigest:   semanticRuntimeRecipeSHA256,
+			want:            true,
+		},
+		{
+			name:            "v2.4 cannot bypass manifest root",
+			runtimeVersion:  legacyRuntimeVersion,
+			manifestDigest:  strings.Repeat("0", 64),
+			publishedDigest: semanticRuntimeRecipeSHA256,
+			currentDigest:   semanticRuntimeRecipeSHA256,
+		},
+		{
+			name:            "different manifest",
+			runtimeVersion:  legacyRuntimeVersion,
+			manifestDigest:  strings.Repeat("0", 64),
+			publishedDigest: legacyRuntimeRecipeSHA256,
+			currentDigest:   semanticRuntimeRecipeSHA256,
+		},
+		{
+			name:            "different semantic recipe",
+			runtimeVersion:  legacyRuntimeVersion,
+			manifestDigest:  legacyRuntimeManifestSHA256,
+			publishedDigest: legacyRuntimeRecipeSHA256,
+			currentDigest:   strings.Repeat("0", 64),
+		},
+		{
+			name:            "different runtime",
+			runtimeVersion:  "2.4.1",
+			manifestDigest:  legacyRuntimeManifestSHA256,
+			publishedDigest: legacyRuntimeRecipeSHA256,
+			currentDigest:   semanticRuntimeRecipeSHA256,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			got := runtimeBuildRecipeCompatible(
+				test.runtimeVersion,
+				test.manifestDigest,
+				test.publishedDigest,
+				test.currentDigest,
+			)
+			if got != test.want {
+				t.Fatalf("runtimeBuildRecipeCompatible() = %t, want %t", got, test.want)
+			}
+		})
+	}
+}
+
 func TestResolveRuntimeRejectsIncompletePublishedAssetSet(t *testing.T) {
 	fixture := newRuntimeResolutionFixture(t)
 	server, _ := fixture.server(t, http.StatusOK, false, fixture.manifest, func(assets *[]gitHubAsset) {
@@ -198,9 +270,20 @@ type runtimeResolutionFixture struct {
 func newRuntimeResolutionFixture(t *testing.T) runtimeResolutionFixture {
 	t.Helper()
 	repoRoot := gitOutput(t, ".", "rev-parse", "--show-toplevel")
-	lockPath := filepath.Join(repoRoot, "internal", "release", "runtime.lock.json")
-	lock, err := loadRuntimeResolutionLock(lockPath)
+	currentLockPath := filepath.Join(repoRoot, "internal", "release", "runtime.lock.json")
+	lock, err := loadRuntimeResolutionLock(currentLockPath)
 	if err != nil {
+		t.Fatal(err)
+	}
+	// Resolver fixtures exercise the normal exact-digest path. The published
+	// v2.4.0 identity is reserved for the explicit immutable migration tests.
+	lock.RuntimeVersion = "9.9.9"
+	lockData, err := lock.JSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	lockPath := filepath.Join(t.TempDir(), "runtime.lock.json")
+	if err := os.WriteFile(lockPath, lockData, 0o600); err != nil {
 		t.Fatal(err)
 	}
 	moduleTree := gitOutput(t, repoRoot, "rev-parse", "--verify", "HEAD:"+lock.Module.Path)

--- a/.github/workflows/release_runtime_assets.yml
+++ b/.github/workflows/release_runtime_assets.yml
@@ -33,39 +33,16 @@ jobs:
       - name: Build local buildctl
         uses: ./.github/actions/setup-buildctl
 
-      - name: Prepare host export assets
-        run: |
-          set -euo pipefail
-          "$BUILDCTL" engine download \
-            --runtime \
-            --skip-runtime-pack \
-            --asset-dir runtime-assets \
-            --same-run-artifacts
-
       - name: Build runtime asset bundle
-        id: build_runtime_assets
         run: |
-          set -euo pipefail
-
-          "$BUILDCTL" runtime export-pack
-
-          GOPATH_DIR="$(go env GOPATH | tr -d '\r\n')"
-          ASSET_ZIP="${GOPATH_DIR}/bin/spx-runtime-assets.zip"
-
-          if [ ! -f "$ASSET_ZIP" ]; then
-            echo "[error] Runtime asset bundle not found: $ASSET_ZIP" >&2
-            exit 1
-          fi
-
-          echo "[info] Built runtime asset bundle: $ASSET_ZIP"
-          echo "asset-zip=$ASSET_ZIP" >> "$GITHUB_OUTPUT"
-
-      - name: Verify runtime asset bundle
-        run: unzip -t "${{ steps.build_runtime_assets.outputs.asset-zip }}"
+          bash .github/scripts/build_runtime_pack.sh \
+            runtime-assets \
+            dist/spx-runtime-assets.zip
 
       - name: Upload runtime asset bundle
         uses: actions/upload-artifact@v7
         with:
           name: runtime-spx-assets
-          path: ${{ steps.build_runtime_assets.outputs.asset-zip }}
+          path: dist/spx-runtime-assets.zip
+          if-no-files-found: error
           retention-days: 14

--- a/docs/en/dev/engine/release.md
+++ b/docs/en/dev/engine/release.md
@@ -23,6 +23,8 @@ SPX and Godot Actions both invoke `.github/scripts/runtime_build_contract.py` fr
 
 The manifest records `module_tree`, `runtime_pack_source_sha256`, and `build_recipe_sha256` independently. The full lock SHA is also part of the runtime-release reuse contract, so changing the ABI, required assets, repository/manifest, Godot ref/version/commit, module path, or any toolchain field rejects reuse. Godot SCons caches use a narrower identity: changing only a version, release metadata, an asset list, or documentation does not recompile Godot, although it may require a new runtime-release identity. Documentation itself is outside both runtime digests.
 
+The pack build recipe covers only `.github/scripts/build_runtime_pack.sh` and the buildctl implementation that can affect the output. Workflow layout and external checkout/upload/download Action versions are CI transport and stay outside this digest, so Dependabot updates to those Actions do not require a runtime bump. Changes to the pack script or relevant buildctl code still reject reuse of the old runtime.
+
 ## Freeze order
 
 1. Select the exact Godot candidate commit and the durable branch or tag that will own it, such as `spx4.4.1`. Before that commit reaches the canonical ref, an unpublished runtime may pin it for an exact-SHA dry-run only:

--- a/docs/zh/dev/engine/release.md
+++ b/docs/zh/dev/engine/release.md
@@ -23,6 +23,8 @@ SPX 与 Godot Actions 都调用所选 SPX commit 中的 `.github/scripts/runtime
 
 manifest 分别记录 `module_tree`、`runtime_pack_source_sha256` 和 `build_recipe_sha256`。完整 lock SHA 也是 runtime release 的复用契约，因此 ABI、required assets、repository/manifest、Godot ref/version/commit、module path 或任一工具链字段变化都会拒绝复用旧 runtime。Godot SCons cache 使用更窄的独立身份；只改版本号、release 元数据、资产清单或文档不会重新编译 Godot，但可能要求新的 runtime release 身份。文档本身不进入这两类 runtime digest。
 
+pack build recipe 只覆盖 `.github/scripts/build_runtime_pack.sh` 与实际参与生成产物的 buildctl 实现。workflow 排版、checkout/upload/download 等外部 Action 版本属于 CI 运输层，不进入该摘要；Dependabot 升级这些 Action 不需要提升 runtime 版本。修改 pack 脚本或相关 buildctl 代码仍会严格拒绝复用旧 runtime。
+
 ## 冻结顺序
 
 1. 先选定精确的 Godot candidate commit，以及最终承载它的持久 branch/tag（例如 `spx4.4.1`）。在该 commit 进入 canonical ref 之前，只允许为尚未发布的 runtime 固定它并执行 exact-SHA dry-run：

--- a/internal/release/release_meta.go
+++ b/internal/release/release_meta.go
@@ -23,13 +23,6 @@ import (
 )
 
 const (
-	// RuntimeTag is the filename prefix for the runtime binary/pck files.
-	RuntimeTag = "gdspxrt"
-
-	// RuntimeAssetZipName is the standard runtime pack name. SPX v2.0.0 used
-	// an older versioned filename, which is retained in its release metadata.
-	RuntimeAssetZipName = "spx-runtime-assets.zip"
-
 	legacyEngineRepository  = "goplus/godot"
 	legacyRuntimeRepository = "goplus/spx"
 )

--- a/internal/release/runtime_asset.go
+++ b/internal/release/runtime_asset.go
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2021 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package release
+
+const (
+	// RuntimeTag is the filename prefix for the runtime binary/pck files.
+	RuntimeTag = "gdspxrt"
+
+	// RuntimeAssetZipName is the standard runtime pack name. SPX v2.0.0 used
+	// an older versioned filename, which is retained in its release metadata.
+	RuntimeAssetZipName = "spx-runtime-assets.zip"
+)

--- a/internal/release/runtime_pack_source.go
+++ b/internal/release/runtime_pack_source.go
@@ -41,10 +41,9 @@ func runtimePackSourceTreeSHA256(tree []byte) (string, error) {
 	return selectedTreeSHA256(tree, "runtime pack source", isRuntimePackSourcePath)
 }
 
-// RuntimeBuildRecipeSHA256 returns a stable digest of the tracked release and
-// buildctl inputs that orchestrate runtime pack generation. Recipe inputs are
-// kept separate from RuntimePackSourceSHA256 and from the Godot module tree so
-// changing orchestration cannot masquerade as an engine source change.
+// RuntimeBuildRecipeSHA256 returns a stable digest of the implementation that
+// can change runtime-pack bytes. CI transport details such as workflow layout
+// and external Action versions are deliberately excluded.
 func RuntimeBuildRecipeSHA256(repoRoot, revision string) (string, error) {
 	return trackedTreeSHA256(repoRoot, revision, "runtime build recipe", isRuntimeBuildRecipePath)
 }
@@ -54,8 +53,8 @@ func runtimeBuildRecipeTreeSHA256(tree []byte) (string, error) {
 }
 
 var runtimeBuildRecipeFiles = map[string]struct{}{
+	".github/scripts/build_runtime_pack.sh":              {},
 	".github/scripts/runtime_build_contract.py":          {},
-	".github/workflows/release_runtime_assets.yml":       {},
 	"cmd/internal/macos_go_toolchain.sh":                 {},
 	"internal/cmd/buildctl/main.go":                      {},
 	"internal/cmd/buildctl/root.go":                      {},
@@ -71,12 +70,12 @@ var runtimeBuildRecipeFiles = map[string]struct{}{
 	"internal/cmd/buildctl/shared/repo.go":               {},
 	"internal/cmd/buildctl/shared/runner.go":             {},
 	"internal/cmd/buildctl/shared/validate.go":           {},
+	"internal/release/runtime_asset.go":                  {},
 	"internal/release/runtime_lock.go":                   {},
 	"internal/release/runtime_manifest.go":               {},
 }
 
 var runtimeBuildRecipePrefixes = []string{
-	".github/actions/deps/",
 	".github/actions/setup-buildctl/",
 	"internal/base/fileutil/",
 }

--- a/internal/release/runtime_pack_source_test.go
+++ b/internal/release/runtime_pack_source_test.go
@@ -99,7 +99,9 @@ func TestRuntimeBuildRecipePathSeparatesRecipeFromSources(t *testing.T) {
 		path string
 		want bool
 	}{
-		{".github/actions/deps/action.yml", true},
+		{".github/actions/deps/action.yml", false},
+		{".github/actions/setup-buildctl/action.yml", true},
+		{".github/scripts/build_runtime_pack.sh", true},
 		{".github/scripts/runtime_build_contract.py", true},
 		{".github/scripts/runtime_build_contract_test.py", false},
 		{".github/scripts/runtime_lock_snapshot.py", false},
@@ -108,7 +110,7 @@ func TestRuntimeBuildRecipePathSeparatesRecipeFromSources(t *testing.T) {
 		{".github/scripts/runtime_asset_manifest.go", false},
 		{".github/scripts/runtime_build_recipe_digest.go", false},
 		{".github/scripts/runtime_pack_source_digest.go", false},
-		{".github/workflows/release_runtime_assets.yml", true},
+		{".github/workflows/release_runtime_assets.yml", false},
 		{".github/workflows/release.yml", false},
 		{"internal/cmd/buildctl/main.go", true},
 		{"internal/cmd/buildctl/simple_cmd.go", false},
@@ -123,6 +125,7 @@ func TestRuntimeBuildRecipePathSeparatesRecipeFromSources(t *testing.T) {
 		{"internal/cmd/buildctl/engine/common.go", false},
 		{"internal/cmd/buildctl/engine/download.go", true},
 		{"internal/cmd/buildctl/engine/build.go", false},
+		{"internal/release/runtime_asset.go", true},
 		{"internal/release/runtime.lock.json", false},
 		{"internal/release/runtime_lock.go", true},
 		{"internal/release/runtime_manifest.go", true},
@@ -178,16 +181,39 @@ func TestRuntimeBuildRecipeFilesExist(t *testing.T) {
 	}
 }
 
+func TestRuntimePackWorkflowDelegatesSemanticBuild(t *testing.T) {
+	t.Parallel()
+
+	_, testFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("cannot locate runtime_pack_source_test.go")
+	}
+	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(testFile), "../.."))
+	workflow, err := os.ReadFile(filepath.Join(repoRoot, ".github/workflows/release_runtime_assets.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	workflowText := string(workflow)
+	if !strings.Contains(workflowText, "bash .github/scripts/build_runtime_pack.sh") {
+		t.Fatal("runtime asset workflow does not call the semantic pack builder")
+	}
+	for _, duplicatedCommand := range []string{"\"$BUILDCTL\" engine download", "\"$BUILDCTL\" runtime export-pack"} {
+		if strings.Contains(workflowText, duplicatedCommand) {
+			t.Fatalf("runtime asset workflow duplicates semantic command %q", duplicatedCommand)
+		}
+	}
+}
+
 func TestRuntimeBuildRecipeIgnoresReleaseMappings(t *testing.T) {
 	t.Parallel()
 
-	const workflowEntry = "100644 blob 1111111111111111111111111111111111111111\t.github/workflows/release_runtime_assets.yml"
+	const recipeEntry = "100644 blob 1111111111111111111111111111111111111111\t.github/scripts/build_runtime_pack.sh"
 	before := []byte(strings.Join([]string{
-		workflowEntry,
+		recipeEntry,
 		"100644 blob 2222222222222222222222222222222222222222\tinternal/release/release_meta.go",
 	}, "\x00") + "\x00")
 	after := []byte(strings.Join([]string{
-		workflowEntry,
+		recipeEntry,
 		"100644 blob 3333333333333333333333333333333333333333\tinternal/release/release_meta.go",
 	}, "\x00") + "\x00")
 
@@ -201,6 +227,34 @@ func TestRuntimeBuildRecipeIgnoresReleaseMappings(t *testing.T) {
 	}
 	if beforeDigest != afterDigest {
 		t.Fatalf("release mapping changed runtime build recipe: %s != %s", beforeDigest, afterDigest)
+	}
+}
+
+func TestRuntimeBuildRecipeIgnoresCITransport(t *testing.T) {
+	t.Parallel()
+
+	semanticEntry := "100644 blob 1111111111111111111111111111111111111111\t.github/scripts/build_runtime_pack.sh"
+	before := []byte(strings.Join([]string{
+		semanticEntry,
+		"100644 blob 2222222222222222222222222222222222222222\t.github/actions/deps/action.yml",
+		"100644 blob 3333333333333333333333333333333333333333\t.github/workflows/release_runtime_assets.yml",
+	}, "\x00") + "\x00")
+	after := []byte(strings.Join([]string{
+		semanticEntry,
+		"100644 blob 4444444444444444444444444444444444444444\t.github/actions/deps/action.yml",
+		"100644 blob 5555555555555555555555555555555555555555\t.github/workflows/release_runtime_assets.yml",
+	}, "\x00") + "\x00")
+
+	beforeDigest, err := runtimeBuildRecipeTreeSHA256(before)
+	if err != nil {
+		t.Fatal(err)
+	}
+	afterDigest, err := runtimeBuildRecipeTreeSHA256(after)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if beforeDigest != afterDigest {
+		t.Fatalf("CI transport changed runtime build recipe: %s != %s", beforeDigest, afterDigest)
 	}
 }
 


### PR DESCRIPTION
## Summary

- extract runtime-pack generation into a single semantic build script
- exclude CI workflow layout and external Action versions from the runtime recipe digest
- add an exact compatibility bridge for the published `runtime-v2.4.0`
- keep genuine pack script and buildctl changes fail-closed

## Root cause

Dependabot PR #1722 upgraded GitHub Actions used by the release workflows.

Although the SPX module tree and runtime-pack source were unchanged, `release_runtime_assets.yml` was included in the runtime build-recipe digest. Updating checkout/download/upload Actions therefore changed the digest from `730b4b5f…736b3` to `10d7b21f…dc79cb`, causing the published runtime resolver to reject `runtime-v2.4.0`.

Failed run: https://github.com/goplus/spx/actions/runs/31765669399/job/94660940507

## Changes

- move `engine download`, `runtime export-pack`, and ZIP verification into `.github/scripts/build_runtime_pack.sh`
- make `release_runtime_assets.yml` delegate to that script
- exclude workflow and external Action transport from the semantic recipe
- move runtime asset constants into a narrow recipe-owned file
- accept the legacy v2.4.0 recipe only when all identities match exactly:
  - runtime version
  - immutable manifest SHA-256
  - published legacy recipe digest
  - current semantic recipe digest

No wildcard or transitive compatibility is introduced.

## Impact

Dependabot upgrades to checkout/upload/download Actions no longer require a new runtime version.

Changes to the runtime-pack script or relevant buildctl implementation still invalidate the recipe and require a runtime bump.

The existing release flow remains unchanged:

`dry-run → publish-runtime → publish-release`

## Validation

- full root Go test suite, excluding `internal/webffi`
- `cmd/ispx` test suite
- `internal/release` race tests
- runtime resolver tests
- release workflow/build-contract/bump tests
- runtime lock snapshot validation
- actionlint
- shell syntax and functional runtime-pack script checks
- live resolver verification against public `runtime-v2.4.0`

The committed semantic recipe digest is `d6b43b2a…4e643c`, and the live resolver reports `ready`.