### PR TITLE
fix(web): keep audio bus indices synchronized

### DIFF
--- a/godot_modules/spx/web/js/libs/library_godot_audio.js
+++ b/godot_modules/spx/web/js/libs/library_godot_audio.js
@@ -988,8 +988,13 @@ class Bus {
 			return;
 		}
 		const buses = GodotAudio.buses.filter((_, i) => i !== fromIndex);
-		// Inserts at index.
-		buses.splice(toIndex - 1, 0, movedBus);
+		if (toIndex === -1) {
+			buses.push(movedBus);
+		} else if (toIndex < fromIndex) {
+			buses.splice(toIndex, 0, movedBus);
+		} else {
+			buses.splice(toIndex - 1, 0, movedBus);
+		}
 		GodotAudio.buses = buses;
 	}
 
@@ -1000,7 +1005,10 @@ class Bus {
 	 */
 	static addAt(index) {
 		const newBus = GodotAudio.Bus.create();
-		if (index !== newBus.getId()) {
+		// AudioServer uses -1 for append. The new bus is already appended by
+		// create(), so moving it with a negative splice index would reorder the
+		// registry and desynchronize every subsequent C++/JavaScript bus index.
+		if (index !== -1 && index !== newBus.getId()) {
 			GodotAudio.Bus.move(newBus.getId(), index);
 		}
 	}

--- a/internal/cmd/codegen/generate/webffi/generate_test.go
+++ b/internal/cmd/codegen/generate/webffi/generate_test.go
@@ -297,5 +297,7 @@ func TestRepositoryWebBridgeKeepsCrossCompilationABIStable(t *testing.T) {
 	require.Contains(t, audioLibrary, "positionWorker['onMessage']")
 	require.Contains(t, audioLibrary, "'inputLength': input.length")
 	require.Contains(t, audioLibrary, "event['type']")
+	require.Contains(t, audioLibrary, "if (index !== -1 && index !== newBus.getId())")
+	require.Contains(t, audioLibrary, "if (toIndex === -1) {\n\t\t\tbuses.push(movedBus);")
 	require.NotContains(t, audioLibrary, "positionWorker.onMessage")
 }


### PR DESCRIPTION
## Summary

- Treat `-1` as append when adding Web audio buses.
- Align JavaScript bus movement semantics with Godot's `AudioServer`.
- Add regression checks for Web audio bus index synchronization.

## Root cause

Commit `c2226ea2` introduced the external Web audio implementation together with dynamically created SPX audio buses.

`Bus.addAt(-1)` created a bus at the end, then incorrectly moved it using a negative `splice` index. This reordered the JavaScript bus registry while the C++ `AudioServer` retained the correct order.

As a result, `Master`, `Sfx`, and subsequent buses used different indices across C++ and JavaScript. Updating bus sends could form an audio routing cycle and disconnect `Master` from the browser output, causing complete silence on Web.

## Verification

- `go test ./generate/webffi`
- `GODOT_SRC=/Users/mac/qiniu/godot make build-web MODE=normal`
- Re-exported the affected project with `spx exportweb`
- Verified in Chrome with a Web Audio analyser:
  - Before: RMS `0`, peak `0`
  - After: max RMS `0.312`, peak `0.825`
  - `AudioContext` remained `running` with no audio errors

The existing SVG and null-object warnings are unrelated and are not changed by this PR.