### PR TITLE
fix(audio): clean up completed playback IDs

### DIFF
--- a/godot_modules/spx/spx_audio.cpp
+++ b/godot_modules/spx/spx_audio.cpp
@@ -112,9 +112,12 @@ void SpxAudio::on_reset(int reset_code) {
 	owns_dedicated_bus = false;
 }
 
-void SpxAudio::play(GdInt aid, GdString path, Node *owner, GdFloat attenuation, GdFloat max_distance) {
+bool SpxAudio::play(GdInt aid, GdString path, Node *owner, GdFloat attenuation, GdFloat max_distance) {
 	auto path_str = SpxStr(path);
 	Ref<AudioStream> stream = resMgr->load_audio(path_str);
+	if (stream.is_null()) {
+		return false;
+	}
 	auto audio = memnew(AudioStreamPlayer2D);
 	if (owner != nullptr) {
 		owner->add_child(audio);
@@ -130,6 +133,11 @@ void SpxAudio::play(GdInt aid, GdString path, Node *owner, GdFloat attenuation, 
 	audio->set_pitch_scale(get_pitch());
 	audios.push_back(audio);
 	aid_audios[aid] = audio;
+	return true;
+}
+
+bool SpxAudio::has_audio(GdInt aid) const {
+	return aid_audios.has(aid);
 }
 
 GdBool SpxAudio::is_playing(GdInt aid) {

--- a/godot_modules/spx/spx_audio.h
+++ b/godot_modules/spx/spx_audio.h
@@ -70,7 +70,8 @@ public:
 	void set_volume(GdFloat volume);
 	GdFloat get_volume();
 
-	void play(GdInt aid, GdString path, Node *owner = nullptr, GdFloat attenuation = 1.0f, GdFloat max_distance = 2000.0f);
+	bool play(GdInt aid, GdString path, Node *owner = nullptr, GdFloat attenuation = 1.0f, GdFloat max_distance = 2000.0f);
+	bool has_audio(GdInt aid) const;
 	void pause(GdInt aid);
 	void resume(GdInt aid);
 	void stop(GdInt aid);

--- a/godot_modules/spx/spx_audio_mgr.cpp
+++ b/godot_modules/spx/spx_audio_mgr.cpp
@@ -58,6 +58,19 @@ void SpxAudioMgr::on_awake() {
 void SpxAudioMgr::on_update(float delta) {
 	SpxBaseMgr::on_update(delta);
 	_update_all(delta);
+
+	// SpxAudio removes finished players during its update. Mirror that cleanup in
+	// the manager so subsequent queries do not resolve a stale aid to the owner.
+	MutexLock aid_lock(aid_mutex);
+	Vector<GdInt> finished_aids;
+	for (const auto &[aid, audio] : aid_audios) {
+		if (audio == nullptr || !audio->has_audio(aid)) {
+			finished_aids.push_back(aid);
+		}
+	}
+	for (const GdInt &aid : finished_aids) {
+		aid_audios.erase(aid);
+	}
 }
 
 void SpxAudioMgr::on_reset(int reset_code) {
@@ -192,10 +205,14 @@ GdInt SpxAudioMgr::play_with_attenuation(GdObj obj, GdString path, GdObj owner_i
 	{
 		MutexLock aid_lock(aid_mutex);
 		aid = ++g_audio_id;
+	}
+	if (!audio->play(aid, path, audio_owner, attenuation, max_distance)) {
+		return 0;
+	}
+	{
+		MutexLock aid_lock(aid_mutex);
 		aid_audios[aid] = audio;
 	}
-
-	audio->play(aid, path, audio_owner, attenuation, max_distance);
 	return aid;
 }
 
@@ -206,6 +223,11 @@ GdBool SpxAudioMgr::is_playing(GdInt aid) {
 		audio = _get_aid_audio(aid);
 	}
 	if (audio == nullptr) {
+		return false;
+	}
+	if (!audio->has_audio(aid)) {
+		MutexLock aid_lock(aid_mutex);
+		aid_audios.erase(aid);
 		return false;
 	}
 	return audio->is_playing(aid);


### PR DESCRIPTION
## Background

When audio playback finishes, `SpxAudio::on_update` removes the player and
clears its local `aid_audios` entry. However, the corresponding entry remains
in `SpxAudioMgr::aid_audios`.

A subsequent `is_playing` call resolves the stale manager entry and triggers:

Try to access property of a null object in is_playing

Additionally, when `load_audio()` returns an invalid stream, the previous
implementation still creates a player and registers its playback ID, which can
lead to the same warning after the player stops.

## Changes

- Synchronize completed playback ID cleanup with `SpxAudioMgr::aid_audios`
- Return `false` from `is_playing` for stale IDs without triggering an object
  guard warning
- Avoid creating a player when `load_audio()` returns an invalid stream
- Return `0` from `play_with_attenuation()` when audio loading fails
- Preserve mutex protection when allocating playback IDs

## Expected Behavior

- Calling `is_playing` for completed playback returns `false`
- Completed playback no longer produces null-object warnings
- Invalid audio resources do not create or register players

## Verification

- `git diff --check`
- `GODOT_SRC=/Users/mac/qiniu/godot make build-editor`
- Editor build completed successfully
- Built version: `4.4.1.stable.custom_build.32e5a3f32`