### PR TITLE
refactor(cli): remove portable Go environment flag

### DIFF
--- a/cmd/spx/internal/command/args.go
+++ b/cmd/spx/internal/command/args.go
@@ -43,7 +43,6 @@ type ExtraArgs struct {
 	Build           *string
 	Mode            *string
 	Movie           *bool
-	GoEnv           *string
 	Verbose         *bool
 }
 
@@ -168,7 +167,6 @@ Examples:
     #CMDNAME init ./test/demo01           # Create a project at path ./test/demo01
     #CMDNAME run --path ./myproject       # Run project in interpreted mode
     #CMDNAME runnative --path ./myproject # Run project with the native PC runtime
-	#CMDNAME run --goenv=/path/to/goenv   # Run interpreted mode with a portable Go environment
     #CMDNAME build --servermode           # Build in server mode
     #CMDNAME runweb --debugweb            # Run web server with debug service
     #CMDNAME buildtinygo                  # Build TinyGo static library for ESP32
@@ -204,7 +202,6 @@ func (cmd *CmdTool) initializeFlags() *bool {
 	cmd.Args.Build = f.String("build", "normal", "build mode: normal or fast")
 	cmd.Args.Mode = f.String("mode", "none", "mode: none, worker, minigame")
 	cmd.Args.Movie = f.Bool("movie", false, "record movie mode")
-	cmd.Args.GoEnv = f.String("goenv", "", "portable Go environment directory")
 	cmd.Args.Verbose = f.Bool("v", false, "print verbose information")
 	return help
 }
@@ -217,7 +214,9 @@ func (cmd *CmdTool) parseCommandLineArgs(help *bool, ext ...string) error {
 	}
 
 	cmd.Args.CmdName = os.Args[1]
-	flag.CommandLine.Parse(os.Args[2:])
+	if err := flag.CommandLine.Parse(os.Args[2:]); err != nil {
+		return err
+	}
 
 	if *help {
 		cmd.ShowHelpInfo()

--- a/cmd/spx/internal/command/args_test.go
+++ b/cmd/spx/internal/command/args_test.go
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2021 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package command
+
+import (
+	"flag"
+	"io"
+	"os"
+	"testing"
+)
+
+func TestParseCommandLineArgsRejectsRemovedGoEnv(t *testing.T) {
+	originalFlags := flag.CommandLine
+	originalArgs := os.Args
+	flag.CommandLine = flag.NewFlagSet("spx", flag.ContinueOnError)
+	flag.CommandLine.SetOutput(io.Discard)
+	os.Args = []string{"spx", "run", "--goenv", "/tmp/goenv"}
+	t.Cleanup(func() {
+		flag.CommandLine = originalFlags
+		os.Args = originalArgs
+	})
+
+	cmd := &CmdTool{}
+	help := cmd.initializeFlags()
+	if err := cmd.parseCommandLineArgs(help); err == nil {
+		t.Fatal("legacy --goenv flag was accepted")
+	}
+}

--- a/cmd/spx/internal/command/cmd.go
+++ b/cmd/spx/internal/command/cmd.go
@@ -63,12 +63,6 @@ type CmdTool struct {
 	RuntimeCmdPath string
 
 	GoModTemplate string
-
-	// Portable Go.
-	GoEnvDir    string
-	GoRoot      string
-	GoPath      string
-	CustomGoEnv bool
 }
 
 // RunCmd runs the CLI.
@@ -118,13 +112,6 @@ func (cmd *CmdTool) RunCmd(projectName, fileSuffix, version string, fs embed.FS,
 
 	if cmd.handleSpecialCommands() {
 		return nil
-	}
-
-	if cmd.Args.GoEnv != nil && *cmd.Args.GoEnv != "" {
-		if err := cmd.setupPortableGoEnv(); err != nil {
-			logErrorf("Setting up portable Go environment: %v", err)
-			return fmt.Errorf("failed to setup portable Go environment: %w", err)
-		}
 	}
 
 	if isInterpretedRunCommand(cmd.Args.CmdName) {

--- a/cmd/spx/internal/command/env.go
+++ b/cmd/spx/internal/command/env.go
@@ -42,18 +42,6 @@ const defaultProjectImportTimeout = 10 * time.Minute
 var projectNameReplacer = strings.NewReplacer("_", "", " ", "", "\"", "", "\n", "", "\r", "")
 var spxModuleReplaceLinePattern = regexp.MustCompile(`^(\s*)(replace\s+)?github\.com/goplus/spx/v3\s*=>\s*(\S+)(\s*//.*)?$`)
 
-type envVar struct {
-	key   string
-	value string
-}
-
-type portableGoPaths struct {
-	goRootBinPath string
-	goBinaryPath  string
-	goCacheDir    string
-	goModCacheDir string
-}
-
 // CheckEnv validates the target directory.
 func (cmd *CmdTool) CheckEnv() error {
 	dir, err := filepath.Abs(cmd.TargetDir)
@@ -295,7 +283,7 @@ func (cmd *CmdTool) setupEnginePaths() error {
 		return nil
 	}
 
-	binPostfix, cmdPath, err := resolveAppPath(cmd.GoBinPath, envName, cmd.Version, cmd.CustomGoEnv)
+	binPostfix, cmdPath, err := resolveAppPath(cmd.GoBinPath, envName, cmd.Version)
 	if err != nil {
 		return fmt.Errorf("%s requires engine to be installed as a binary at %s: %w", envName, cmd.GoBinPath, err)
 	}
@@ -366,124 +354,6 @@ func (cmd *CmdTool) updateProjectName() error {
 
 func (cmd *CmdTool) usesPureEngine() bool {
 	return cmd.Args.Tags != nil && strings.Contains(*cmd.Args.Tags, "pure_engine")
-}
-
-// setupPortableGoEnv configures a portable Go toolchain.
-func (cmd *CmdTool) setupPortableGoEnv() error {
-	goPaths, err := cmd.resolvePortableGoEnvPaths()
-	if err != nil {
-		return err
-	}
-
-	if err := cmd.applyPortableGoEnv(goPaths); err != nil {
-		return err
-	}
-
-	printPortableGoEnv(cmd, goPaths)
-	return nil
-}
-
-func (cmd *CmdTool) resolvePortableGoEnvPaths() (portableGoPaths, error) {
-	goEnvDir, err := filepath.Abs(*cmd.Args.GoEnv)
-	if err != nil {
-		return portableGoPaths{}, fmt.Errorf("invalid goenv path: %w", err)
-	}
-
-	cmd.GoEnvDir = goEnvDir
-	cmd.CustomGoEnv = true
-
-	if _, err := os.Stat(goEnvDir); os.IsNotExist(err) {
-		return portableGoPaths{}, fmt.Errorf("goenv directory does not exist: %s", goEnvDir)
-	}
-
-	cmd.GoRoot = path.Join(goEnvDir, "gotoolchain", "go")
-	cmd.GoPath = filepath.Join(goEnvDir, "go")
-	if _, err := os.Stat(cmd.GoRoot); os.IsNotExist(err) {
-		//lint:ignore ST1005 This is a user-facing setup hint with complete sentences.
-		return portableGoPaths{}, fmt.Errorf("portable Go toolchain not found at the expected path: %s\n\nThis is expected to be provided by the SPX release package. If you are setting this up manually, please ensure the Go toolchain is extracted to '%s/gotoolchain/go'.", cmd.GoRoot, goEnvDir)
-	}
-
-	cmd.GoBinPath, err = filepath.Abs(filepath.Join(cmd.GoPath, "bin"))
-	if err != nil {
-		return portableGoPaths{}, fmt.Errorf("failed to resolve Go bin path: %w", err)
-	}
-	if _, err := os.Stat(cmd.GoBinPath); os.IsNotExist(err) {
-		return portableGoPaths{}, fmt.Errorf("go bin directory not found: %s", cmd.GoBinPath)
-	}
-
-	goPaths := portableGoPaths{
-		goRootBinPath: filepath.Join(cmd.GoRoot, "bin"),
-		goCacheDir:    filepath.Join(goEnvDir, ".cache", "build"),
-		goModCacheDir: filepath.Join(goEnvDir, ".cache", "mod"),
-	}
-	if _, err := os.Stat(goPaths.goRootBinPath); os.IsNotExist(err) {
-		return portableGoPaths{}, fmt.Errorf("go bin directory not found: %s", goPaths.goRootBinPath)
-	}
-
-	goPaths.goBinaryPath = goBinaryPath(goPaths.goRootBinPath)
-	if _, err := os.Stat(goPaths.goBinaryPath); os.IsNotExist(err) {
-		return portableGoPaths{}, fmt.Errorf("go executable not found: %s", goPaths.goBinaryPath)
-	}
-
-	if err := os.MkdirAll(goPaths.goCacheDir, 0o755); err != nil {
-		return portableGoPaths{}, fmt.Errorf("failed to create Go build cache directory: %w", err)
-	}
-	if err := os.MkdirAll(goPaths.goModCacheDir, 0o755); err != nil {
-		return portableGoPaths{}, fmt.Errorf("failed to create Go module cache directory: %w", err)
-	}
-
-	return goPaths, nil
-}
-
-func (cmd *CmdTool) applyPortableGoEnv(goPaths portableGoPaths) error {
-	pathEntries := []string{cmd.GoBinPath, goPaths.goRootBinPath}
-	if pathValue := os.Getenv("PATH"); pathValue != "" {
-		pathEntries = append(pathEntries, pathValue)
-	}
-	if err := setEnvVars(
-		envVar{key: "GOROOT", value: cmd.GoRoot},
-		envVar{key: "GOPATH", value: cmd.GoPath},
-		envVar{key: "GOTOOLCHAIN", value: ""},
-		envVar{key: "GOCACHE", value: goPaths.goCacheDir},
-		envVar{key: "GOMODCACHE", value: goPaths.goModCacheDir},
-		envVar{key: "PATH", value: strings.Join(pathEntries, string(os.PathListSeparator))},
-	); err != nil {
-		return err
-	}
-	return nil
-}
-
-func printPortableGoEnv(cmd *CmdTool, goPaths portableGoPaths) {
-	const portableGoEnvFormat = "" +
-		"using portable Go environment:\n" +
-		"  GOROOT: %s\n" +
-		"  GOPATH: %s\n" +
-		"  GoBinPath: %s (for gdspx, gdspxrt, etc.)\n" +
-		"  Go binary: %s\n" +
-		"  GOCACHE: %s\n" +
-		"  GOMODCACHE: %s\n"
-
-	fmt.Printf(portableGoEnvFormat,
-		cmd.GoRoot,
-		cmd.GoPath,
-		cmd.GoBinPath,
-		goPaths.goBinaryPath,
-		goPaths.goCacheDir,
-		goPaths.goModCacheDir,
-	)
-}
-
-func goBinaryPath(goRootBinPath string) string {
-	return filepath.Join(goRootBinPath, goBinaryName(runtime.GOOS))
-}
-
-func setEnvVars(vars ...envVar) error {
-	for _, env := range vars {
-		if err := os.Setenv(env.key, env.value); err != nil {
-			return fmt.Errorf("set %s: %w", env.key, err)
-		}
-	}
-	return nil
 }
 
 // setupPaths resolves paths.
@@ -684,7 +554,7 @@ func hasGoModuleDeclaration(content, modulePath string) bool {
 	return false
 }
 
-func resolveAppPath(gobinDir, tag, version string, customGoEnv bool) (string, string, error) {
+func resolveAppPath(gobinDir, tag, version string) (string, string, error) {
 	binPostfix := executableSuffix(runtime.GOOS)
 
 	tagName := tag + version
@@ -698,13 +568,9 @@ func resolveAppPath(gobinDir, tag, version string, customGoEnv bool) (string, st
 
 	cmdPath := path.Join(gobinDir, dstFileName)
 	info, err := os.Stat(cmdPath)
-	if os.IsNotExist(err) {
-		if customGoEnv {
-			return binPostfix, cmdPath, nil
-		}
-	} else if err != nil {
+	if err != nil && !os.IsNotExist(err) {
 		return binPostfix, "", err
-	} else if info.Mode()&0o111 == 0 {
+	} else if err == nil && info.Mode()&0o111 == 0 {
 		if err := os.Chmod(cmdPath, 0o755); err != nil {
 			return binPostfix, cmdPath, err
 		}

--- a/cmd/spx/internal/command/run_test.go
+++ b/cmd/spx/internal/command/run_test.go
@@ -17,7 +17,6 @@
 package command
 
 import (
-	"embed"
 	"errors"
 	"fmt"
 	"os"
@@ -464,59 +463,6 @@ func TestResolveInterpretedRuntimeAssetsFallsBackToExternalWhenEmbeddedUnavailab
 	}
 	if libPath != libPathWant {
 		t.Fatalf("shared library path = %s, want %s", libPath, libPathWant)
-	}
-}
-
-func TestRunCmdRunHonorsPortableGoEnv(t *testing.T) {
-	oldPrepareEmbeddedRuntimeAssets := prepareEmbeddedRuntimeAssets
-	prepareEmbeddedRuntimeAssets = func(string, ...string) (string, bool, error) {
-		return "", false, nil
-	}
-	t.Cleanup(func() {
-		prepareEmbeddedRuntimeAssets = oldPrepareEmbeddedRuntimeAssets
-	})
-
-	targetDir := t.TempDir()
-	goEnvDir := filepath.Join(t.TempDir(), "goenv")
-	goBinPath := filepath.Join(goEnvDir, "go", "bin")
-	goRootBinPath := filepath.Join(goEnvDir, "gotoolchain", "go", "bin")
-	logPath := filepath.Join(t.TempDir(), "runtime.log")
-	version := "9.9.9-test"
-
-	if err := os.MkdirAll(goBinPath, 0o755); err != nil {
-		t.Fatalf("mkdir go/bin: %v", err)
-	}
-	if err := os.MkdirAll(goRootBinPath, 0o755); err != nil {
-		t.Fatalf("mkdir gotoolchain/go/bin: %v", err)
-	}
-	writeTestRuntimeExecutable(t, filepath.Join(goRootBinPath, goBinaryName(runtime.GOOS)), filepath.Join(t.TempDir(), "go.log"))
-
-	runtimeName := "gdspxrt" + version + executableSuffix(runtime.GOOS)
-	writeTestRuntimeExecutable(t, filepath.Join(goBinPath, runtimeName), logPath)
-	if err := os.WriteFile(filepath.Join(goBinPath, runtimePackFileName(runtimeName)), []byte("runtime pack"), 0o644); err != nil {
-		t.Fatalf("write runtime pack: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(goBinPath, libraryFileName(envName, runtime.GOOS, runtime.GOARCH)), []byte("shared library"), 0o755); err != nil {
-		t.Fatalf("write shared library: %v", err)
-	}
-
-	rawArgs := os.Args
-	t.Cleanup(func() {
-		os.Args = rawArgs
-	})
-	os.Args = []string{"spx", "run", "--goenv", goEnvDir, "--path", targetDir}
-
-	cmd := CmdTool{}
-	if err := cmd.RunCmd("spx", "spx", version, embed.FS{}, "", "project"); err != nil {
-		t.Fatalf("RunCmd returned error: %v", err)
-	}
-
-	gotLog, err := os.ReadFile(logPath)
-	if err != nil {
-		t.Fatalf("read runtime log: %v", err)
-	}
-	if !strings.Contains(string(gotLog), filepath.Join(targetDir, ".temp")) {
-		t.Fatalf("runtime log = %q, want runtime temp dir under %s", string(gotLog), targetDir)
 	}
 }
 

--- a/docs/en/dev/game/cmd_spx.md
+++ b/docs/en/dev/game/cmd_spx.md
@@ -146,7 +146,6 @@ spx exportminiprogram
 | `--build` | Mini-game build mode: `normal` or `fast`; default is `normal`. |
 | `--mode` | Web build mode: `none`, `worker`, or `minigame`; default is `none`. |
 | `--movie` | Enable movie recording mode. |
-| `--goenv` | Use a portable Go environment directory. |
 | `-v` | Print verbose diagnostics. |
 
 ## Troubleshooting

--- a/docs/zh/dev/game/cmd_spx.md
+++ b/docs/zh/dev/game/cmd_spx.md
@@ -325,7 +325,6 @@ SPX 命令工具支持以下通用参数，可以与各种命令组合使用：
 | `--build <模式>` | 小游戏构建模式：`normal` 或 `fast`，默认 `normal` |
 | `--mode <模式>` | Web 构建模式：`none`、`worker` 或 `minigame`，默认 `none` |
 | `--movie` | 录制运行画面 |
-| `--goenv <目录>` | 指定便携 Go 环境目录 |
 | `-v` | 输出详细日志 |
 
 ## 使用示例


### PR DESCRIPTION
## Summary

- remove the global `--goenv` CLI flag and its help/documentation entries
- remove the portable Go environment setup and process-wide environment mutation
- remove the legacy portable-environment runtime test
- add coverage confirming that the removed flag is rejected

## Motivation

The `--goenv` removal is an independent CLI breaking change and is not required
by the XGo runtime-provider implementation. Keeping it in a separate PR makes
the compatibility impact explicit and keeps the runtime-provider review focused.

## Breaking change

`spx run --goenv=/path/to/goenv` is no longer supported.

Callers that relied on the portable layout must configure the standard Go
environment before invoking SPX, including `GOROOT`, `GOPATH`, `GOCACHE`,
`GOMODCACHE`, and `PATH`. Required SPX runtime assets must be available through
the configured installation/runtime setup.

## Stacking

`feat/xgo-runtime-provider-spx` is rebased on this branch. This PR should merge
before the runtime-provider PR.

## Verification

- `GOWORK=off go test ./cmd/spx/...`