### PR TITLE
ci: add timeouts and retries for apt dependencies

### DIFF
--- a/.github/actions/install-linux-dependencies/action.yml
+++ b/.github/actions/install-linux-dependencies/action.yml
@@ -1,0 +1,87 @@
+name: Install Linux dependencies
+description: Install APT packages with bounded retries and hard timeouts
+
+inputs:
+  packages:
+    description: Whitespace-separated APT package names
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Install APT packages
+      shell: bash
+      env:
+        APT_PACKAGES: ${{ inputs.packages }}
+      run: |
+        set -Eeuo pipefail
+
+        mapfile -t packages < <(
+          printf '%s\n' "$APT_PACKAGES" |
+            tr '[:space:]' '\n' |
+            sed '/^$/d'
+        )
+
+        if ((${#packages[@]} == 0)); then
+          echo "::error::No APT packages were provided"
+          exit 2
+        fi
+
+        retry() {
+          local attempts="$1"
+          local delay_seconds="$2"
+          local description="$3"
+          shift 3
+
+          local attempt
+          local rc=0
+
+          for ((attempt = 1; attempt <= attempts; attempt++)); do
+            echo "[info] ${description}: attempt ${attempt}/${attempts}"
+
+            if "$@"; then
+              return 0
+            else
+              rc=$?
+            fi
+
+            if ((attempt == attempts)); then
+              echo "::error::${description} failed after ${attempts} attempts (exit ${rc})"
+              return "$rc"
+            fi
+
+            echo "::warning::${description} failed with exit ${rc}; retrying in ${delay_seconds} seconds"
+            sleep "$delay_seconds"
+          done
+        }
+
+        apt_acquire_options=(
+          -o Acquire::Retries=3
+          -o Acquire::http::Timeout=30
+          -o Acquire::https::Timeout=30
+        )
+
+        update_package_index() {
+          sudo timeout \
+            --signal=TERM \
+            --kill-after=15s \
+            120s \
+            apt-get "${apt_acquire_options[@]}" update
+        }
+
+        install_packages() {
+          sudo env DEBIAN_FRONTEND=noninteractive \
+            timeout \
+              --signal=TERM \
+              --kill-after=15s \
+              300s \
+              apt-get \
+                "${apt_acquire_options[@]}" \
+                -o DPkg::Lock::Timeout=60 \
+                install \
+                --yes \
+                "${packages[@]}"
+        }
+
+        retry 2 10 "APT package index update" update_package_index
+        retry 2 10 "APT dependency installation" install_packages

--- a/.github/workflows/build_web.yml
+++ b/.github/workflows/build_web.yml
@@ -16,18 +16,19 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install Linux dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install \
-            gcc \
-            libgl1-mesa-dev \
-            libegl1-mesa-dev \
-            libgles2-mesa-dev \
-            libx11-dev \
-            xorg-dev \
-            libasound2-dev \
-            libopenal-dev \
-            binaryen \
+        uses: ./.github/actions/install-linux-dependencies
+        timeout-minutes: 20
+        with:
+          packages: |
+            gcc
+            libgl1-mesa-dev
+            libegl1-mesa-dev
+            libgles2-mesa-dev
+            libx11-dev
+            xorg-dev
+            libasound2-dev
+            libopenal-dev
+            binaryen
             brotli
 
       - name: Set up toolchain and engine assets

--- a/.github/workflows/publish_web_package.yml
+++ b/.github/workflows/publish_web_package.yml
@@ -84,18 +84,19 @@ jobs:
 
       - name: Install Linux dependencies
         if: inputs.release_artifact == ''
-        run: |
-          sudo apt-get update
-          sudo apt-get install \
-            gcc \
-            libgl1-mesa-dev \
-            libegl1-mesa-dev \
-            libgles2-mesa-dev \
-            libx11-dev \
-            xorg-dev \
-            libasound2-dev \
-            libopenal-dev \
-            binaryen \
+        uses: ./.github/actions/install-linux-dependencies
+        timeout-minutes: 20
+        with:
+          packages: |
+            gcc
+            libgl1-mesa-dev
+            libegl1-mesa-dev
+            libgles2-mesa-dev
+            libx11-dev
+            xorg-dev
+            libasound2-dev
+            libopenal-dev
+            binaryen
             brotli
 
       - name: Set up toolchain and engine assets

--- a/.github/workflows/release_linux.yml
+++ b/.github/workflows/release_linux.yml
@@ -37,7 +37,19 @@ jobs:
           path: runtime-assets
 
       - name: Install Linux dependencies
-        run: sudo apt-get update && sudo apt-get install gcc libgl1-mesa-dev libegl1-mesa-dev libgles2-mesa-dev libx11-dev xorg-dev libasound2-dev libopenal-dev zip
+        uses: ./.github/actions/install-linux-dependencies
+        timeout-minutes: 20
+        with:
+          packages: |
+            gcc
+            libgl1-mesa-dev
+            libegl1-mesa-dev
+            libgles2-mesa-dev
+            libx11-dev
+            xorg-dev
+            libasound2-dev
+            libopenal-dev
+            zip
 
       - name: Set up toolchain and engine assets
         uses: ./.github/actions/deps

--- a/.github/workflows/release_runtime_assets.yml
+++ b/.github/workflows/release_runtime_assets.yml
@@ -23,7 +23,19 @@ jobs:
           merge-multiple: true
 
       - name: Install Linux dependencies
-        run: sudo apt-get update && sudo apt-get install gcc libgl1-mesa-dev libegl1-mesa-dev libgles2-mesa-dev libx11-dev xorg-dev libasound2-dev libopenal-dev zip
+        uses: ./.github/actions/install-linux-dependencies
+        timeout-minutes: 20
+        with:
+          packages: |
+            gcc
+            libgl1-mesa-dev
+            libegl1-mesa-dev
+            libgles2-mesa-dev
+            libx11-dev
+            xorg-dev
+            libasound2-dev
+            libopenal-dev
+            zip
 
       - name: Set up toolchain and engine assets
         uses: ./.github/actions/deps

--- a/.github/workflows/release_web.yml
+++ b/.github/workflows/release_web.yml
@@ -55,7 +55,20 @@ jobs:
           path: runtime-assets
 
       - name: Install Linux dependencies
-        run: sudo apt-get update && sudo apt-get install gcc libgl1-mesa-dev libegl1-mesa-dev libgles2-mesa-dev libx11-dev xorg-dev libasound2-dev libopenal-dev binaryen brotli
+        uses: ./.github/actions/install-linux-dependencies
+        timeout-minutes: 20
+        with:
+          packages: |
+            gcc
+            libgl1-mesa-dev
+            libegl1-mesa-dev
+            libgles2-mesa-dev
+            libx11-dev
+            xorg-dev
+            libasound2-dev
+            libopenal-dev
+            binaryen
+            brotli
 
       - name: Set up toolchain and engine assets
         uses: ./.github/actions/deps


### PR DESCRIPTION
## What changed

Make Linux dependency installation more resilient to transient APT mirror and network failures in GitHub Actions.

* Add a reusable `install-linux-dependencies` composite action.
* Add bounded timeouts for `apt-get update` and `apt-get install`.
* Configure APT HTTP/HTTPS timeouts and retries.
* Retry the complete dependency installation when an attempt fails or times out.
* Run package installation non-interactively.
* Add a step-level timeout as a final safeguard.
* Reuse the same installation logic across Web, Linux, runtime asset, and npm publishing workflows.

## Why

Linux jobs could occasionally hang during:

```text
sudo apt-get update
```

For example, a Web bundle job could stop making progress immediately after reading the runner's APT mirror list:

```text
Get:1 file:/etc/apt/apt-mirrors.txt Mirrorlist [144 B]
```

This is an external and transient failure mode involving the GitHub-hosted runner's APT mirror/network path. The previous workflows ran `apt-get` without bounded network timeouts or an outer retry, allowing a single stalled APT operation to block the job for an excessive amount of time.

The new installation action makes this failure bounded and recoverable:

```text
APT request
    │
    ├── success ──────────────> continue build
    │
    └── timeout/failure
             │
             └── retry installation
                      │
                      ├── success ──> continue build
                      └── failure ──> fail explicitly
```

This keeps transient infrastructure failures from indefinitely blocking release workflows while preserving the existing package set and build behavior.

## Scope

This change only affects Linux dependency installation in CI. It does not change SPX, Godot, Web export, packaging, or release behavior.
