### PR TITLE
refactor(runtimebundle): split cache locks and gc

### DIFF
--- a/internal/runtimebundle/cache.go
+++ b/internal/runtimebundle/cache.go
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package runtimebundle
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// CacheOptions controls a Cache. Zero Limits selects the verifier defaults. A custom
+// LockProvider or Permissions implementation is useful for tests and for
+// platforms with an explicitly verified integration.
+type CacheOptions struct {
+	Limits       Limits
+	LockProvider LockProvider
+	Permissions  Permissions
+}
+
+// Cache is a content-addressed runtime bundle cache. It creates
+// <root>/<namespace>/<full-sha256> directories and never uses a shortened
+// digest. NewCache uses an OS-backed cross-process provider; callers that
+// explicitly accept process-local coordination must use NewProcessLocalCache.
+type Cache struct {
+	Root         string
+	Limits       Limits
+	LockProvider LockProvider
+	Permissions  Permissions
+}
+
+// NewCache constructs a cache using OS-backed cross-process locks.
+func NewCache(root string) *Cache {
+	return newCache(root, CrossProcessLockProvider{})
+}
+
+// NewProcessLocalCache constructs a cache using the explicitly opt-in,
+// process-local lock and platform permissions. It is suitable for tests and
+// adapters that can prove they never share a cache root across processes.
+func NewProcessLocalCache(root string) *Cache {
+	return newCache(root, ProcessLockProvider{})
+}
+
+func newCache(root string, lockProvider LockProvider) *Cache {
+	return &Cache{
+		Root:         filepath.Clean(root),
+		Limits:       Limits{},
+		LockProvider: lockProvider,
+		Permissions:  defaultPermissions(),
+	}
+}
+
+// NewCacheWithOptions validates options and constructs a cache.
+func NewCacheWithOptions(root string, options CacheOptions) (*Cache, error) {
+	if root == "" {
+		return nil, fmt.Errorf("runtimebundle: cache root is empty")
+	}
+	limits, err := options.Limits.withDefaults()
+	if err != nil {
+		return nil, err
+	}
+	if options.LockProvider == nil {
+		options.LockProvider = CrossProcessLockProvider{}
+	}
+	if options.Permissions == nil {
+		options.Permissions = defaultPermissions()
+	}
+	return &Cache{
+		Root:         filepath.Clean(root),
+		Limits:       limits,
+		LockProvider: options.LockProvider,
+		Permissions:  options.Permissions,
+	}, nil
+}
+
+// DefaultCacheRoot returns the user cache namespace used by runtimebundle
+// when an embedding application does not choose an explicit root.
+func DefaultCacheRoot() string {
+	base, err := os.UserCacheDir()
+	if err != nil || base == "" {
+		base = os.TempDir()
+	}
+	return filepath.Join(base, "spx", "runtimebundle")
+}
+
+// Path returns the on-disk location for a namespace/digest pair. It does not
+// create anything and rejects invalid identities.
+func (c *Cache) Path(namespace Namespace, digest string) (string, error) {
+	if c == nil || c.Root == "" {
+		return "", fmt.Errorf("runtimebundle: nil or empty cache root")
+	}
+	if !filepath.IsAbs(c.Root) || filepath.Clean(c.Root) != c.Root {
+		return "", fmt.Errorf("runtimebundle: cache root must be absolute and clean: %q", c.Root)
+	}
+	if err := validateCacheRoot(c.Root); err != nil {
+		return "", err
+	}
+	if !namespace.valid() {
+		return "", fmt.Errorf("runtimebundle: invalid cache namespace %q", namespace)
+	}
+	if err := validateSHA256(digest); err != nil {
+		return "", fmt.Errorf("runtimebundle: invalid cache digest: %v", err)
+	}
+	return filepath.Join(c.Root, string(namespace), digest), nil
+}

--- a/internal/runtimebundle/cache_admin.go
+++ b/internal/runtimebundle/cache_admin.go
@@ -1,0 +1,256 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package runtimebundle
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Remove removes a cache target only when it is absent or fails complete
+// verification. It refuses to remove a valid target; callers needing quota or
+// age-based deletion must wait for the lease-aware GC implementation.
+func (c *Cache) Remove(namespace Namespace, digest string) error {
+	if c == nil {
+		return fmt.Errorf("runtimebundle: nil cache")
+	}
+	if c.LockProvider == nil {
+		return ErrCrossProcessLockUnsupported
+	}
+	if c.Permissions == nil {
+		c.Permissions = defaultPermissions()
+	}
+	target, err := c.Path(namespace, digest)
+	if err != nil {
+		return err
+	}
+	namespacePath := filepath.Join(c.Root, string(namespace))
+	if err := validateCacheComponent(namespacePath); err != nil {
+		return err
+	}
+	if _, err := os.Stat(namespacePath); os.IsNotExist(err) {
+		return nil
+	} else if err != nil {
+		return err
+	}
+	if err := c.prepareCacheNamespace(namespace); err != nil {
+		return err
+	}
+	lease, err := c.LockProvider.AcquireExclusive(context.Background(), target)
+	if err != nil {
+		return err
+	}
+	if lease == nil {
+		return fmt.Errorf("runtimebundle: lock provider returned a nil exclusive lease")
+	}
+	defer lease.Close()
+	cacheRoot, err := openPinnedRoot(c.Root)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("runtimebundle: pin cache root: %w", err)
+	}
+	defer cacheRoot.Close()
+	namespaceRoot, err := openPinnedChildRoot(cacheRoot, string(namespace))
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("runtimebundle: pin cache namespace: %w", err)
+	}
+	defer namespaceRoot.Close()
+	if err := checkPinnedRootPath(c.Root, cacheRoot); err != nil {
+		return err
+	}
+	if err := checkPinnedChildPath(cacheRoot, string(namespace), namespaceRoot); err != nil {
+		return err
+	}
+	name := filepath.FromSlash(digest)
+	if info, statErr := namespaceRoot.Lstat(name); statErr == nil && info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("%w: refusing to remove symlink cache target %s", ErrUnsafeArchive, target)
+	} else if statErr != nil && !os.IsNotExist(statErr) {
+		return statErr
+	}
+	if ok, verifyErr := c.validCacheHitRoot(namespaceRoot, string(namespace), digest, nil); verifyErr == nil && ok {
+		return fmt.Errorf("runtimebundle: refusing to remove valid cache target %s", target)
+	}
+	// RemoveAll is scoped to the already pinned namespace root. The root and
+	// namespace path checks above are deliberately repeated at this point so a
+	// caller cannot turn this destructive operation into a path-swap escape.
+	if err := checkPinnedRootPath(c.Root, cacheRoot); err != nil {
+		return err
+	}
+	if err := checkPinnedChildPath(cacheRoot, string(namespace), namespaceRoot); err != nil {
+		return err
+	}
+	if err := namespaceRoot.RemoveAll(name); err != nil {
+		return err
+	}
+	if err := checkPinnedRootPath(c.Root, cacheRoot); err != nil {
+		return err
+	}
+	return checkPinnedChildPath(cacheRoot, string(namespace), namespaceRoot)
+}
+
+// CacheStats is reserved for the future quota/age collector. It is provided
+// as a stable shape so callers do not need to inspect cache internals.
+type CacheStats struct {
+	Bytes        int64
+	Entries      int
+	Oldest       time.Time
+	Namespaces   map[Namespace]int
+	CompleteOnly bool
+}
+
+// List returns only complete, digest-addressed cache directories. Every
+// candidate is revalidated with the same marker, manifest, tree and digest
+// checks used by a cache hit; incomplete/corrupt candidates are skipped. It
+// does not recursively repair or delete entries.
+func (c *Cache) List(namespace Namespace) ([]string, error) {
+	if c == nil {
+		return nil, fmt.Errorf("runtimebundle: nil cache")
+	}
+	if c.LockProvider == nil {
+		return nil, ErrCrossProcessLockUnsupported
+	}
+	if c.Permissions == nil {
+		c.Permissions = defaultPermissions()
+	}
+	if err := validateCacheRoot(c.Root); err != nil {
+		return nil, err
+	}
+	if !namespace.valid() {
+		return nil, fmt.Errorf("runtimebundle: invalid cache namespace %q", namespace)
+	}
+	cacheRoot, err := openPinnedRoot(c.Root)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer cacheRoot.Close()
+	if err := verifyPrivateRootPath(cacheRoot, "."); err != nil {
+		return nil, err
+	}
+	namespaceRoot, err := openPinnedChildRoot(cacheRoot, string(namespace))
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer namespaceRoot.Close()
+	if err := verifyPrivateRootPath(namespaceRoot, "."); err != nil {
+		return nil, err
+	}
+	if err := checkPinnedRootPath(c.Root, cacheRoot); err != nil {
+		return nil, err
+	}
+	if err := checkPinnedChildPath(cacheRoot, string(namespace), namespaceRoot); err != nil {
+		return nil, err
+	}
+	dir := filepath.Join(c.Root, string(namespace))
+	items, err := fs.ReadDir(namespaceRoot.FS(), ".")
+	if err != nil {
+		return nil, err
+	}
+	var result []string
+	for _, item := range items {
+		if !item.IsDir() || strings.HasPrefix(item.Name(), ".") {
+			continue
+		}
+		if err := validateSHA256(item.Name()); err != nil {
+			continue
+		}
+		target := filepath.Join(dir, item.Name())
+		lease, err := c.LockProvider.AcquireShared(context.Background(), target)
+		if err != nil {
+			return nil, err
+		}
+		if lease == nil {
+			return nil, fmt.Errorf("runtimebundle: lock provider returned a nil shared lease")
+		}
+		ok, verifyErr := c.validCacheHitRoot(namespaceRoot, string(namespace), item.Name(), nil)
+		closeErr := lease.Close()
+		if closeErr != nil {
+			return nil, closeErr
+		}
+		if verifyErr != nil || !ok {
+			continue
+		}
+		result = append(result, target)
+	}
+	if err := checkPinnedRootPath(c.Root, cacheRoot); err != nil {
+		return nil, err
+	}
+	if err := checkPinnedChildPath(cacheRoot, string(namespace), namespaceRoot); err != nil {
+		return nil, err
+	}
+	sort.Strings(result)
+	return result, nil
+}
+
+// validateCacheRoot rejects relative/unclean roots and an existing root
+// symlink. Ancestors are intentionally not rejected: common system temp/cache
+// paths such as /tmp may themselves be symlinks, while the cache root and its
+// namespace are private objects controlled by this package.
+func validateCacheRoot(root string) error {
+	if root == "" || !filepath.IsAbs(root) || filepath.Clean(root) != root {
+		return fmt.Errorf("runtimebundle: cache root must be absolute and clean: %q", root)
+	}
+	if isFilesystemRoot(root) {
+		return fmt.Errorf("%w: cache root must not be a filesystem root", ErrUnsafeArchive)
+	}
+	if info, err := os.Lstat(root); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+			return fmt.Errorf("%w: cache root is not a real directory: %s", ErrUnsafeArchive, root)
+		}
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+func isFilesystemRoot(path string) bool {
+	clean := filepath.Clean(path)
+	if volume := filepath.VolumeName(clean); volume != "" {
+		return clean == volume+string(filepath.Separator)
+	}
+	return clean == string(filepath.Separator)
+}
+
+func validateCacheComponent(path string) error {
+	info, err := os.Lstat(path)
+	if err == nil {
+		if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+			return fmt.Errorf("%w: cache namespace is not a real directory: %s", ErrUnsafeArchive, path)
+		}
+		return nil
+	}
+	if os.IsNotExist(err) {
+		return nil
+	}
+	return err
+}

--- a/internal/runtimebundle/cache_integrity.go
+++ b/internal/runtimebundle/cache_integrity.go
@@ -1,0 +1,293 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package runtimebundle
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func openAndVerify(zipPath string, options VerifyOptions) (verifiedArchive, io.Closer, error) {
+	file, err := openSourceZip(zipPath)
+	if err != nil {
+		return verifiedArchive{}, nil, fmt.Errorf("runtimebundle: open ZIP %s: %w", zipPath, err)
+	}
+	info, err := file.Stat()
+	if err != nil {
+		_ = file.Close()
+		return verifiedArchive{}, nil, fmt.Errorf("runtimebundle: stat ZIP %s: %w", zipPath, err)
+	}
+	archive, err := verifyReaderAt(file, info.Size(), options)
+	if err != nil {
+		_ = file.Close()
+		return verifiedArchive{}, nil, err
+	}
+	return archive, file, nil
+}
+
+func writeRootPrivateFile(root *os.Root, name string, data []byte, executable bool) error {
+	file, err := root.OpenFile(filepath.FromSlash(name), os.O_WRONLY|os.O_CREATE|os.O_EXCL, privateFileMode(func() uint32 {
+		if executable {
+			return 0o700
+		}
+		return 0o600
+	}()))
+	if err != nil {
+		return err
+	}
+	closeErr := func() error {
+		if _, err := file.Write(data); err != nil {
+			_ = file.Close()
+			_ = root.Remove(filepath.FromSlash(name))
+			return err
+		}
+		if runtimeIsUnix() {
+			if err := file.Chmod(privateFileMode(func() uint32 {
+				if executable {
+					return 0o700
+				}
+				return 0o600
+			}())); err != nil {
+				_ = file.Close()
+				_ = root.Remove(filepath.FromSlash(name))
+				return err
+			}
+		}
+		if err := file.Sync(); err != nil {
+			_ = file.Close()
+			_ = root.Remove(filepath.FromSlash(name))
+			return err
+		}
+		return file.Close()
+	}()
+	if closeErr != nil {
+		return closeErr
+	}
+	return nil
+}
+
+func writeMetadataRoot(root *os.Root, bundle Bundle) error {
+	manifest, err := bundle.WithDigest()
+	if err != nil {
+		return err
+	}
+	data, err := json.Marshal(manifest)
+	if err != nil {
+		return fmt.Errorf("runtimebundle: encode cache manifest: %w", err)
+	}
+	if err := writeRootPrivateFile(root, cacheManifestName, data, false); err != nil {
+		return fmt.Errorf("runtimebundle: write cache manifest: %w", err)
+	}
+	if err := writeRootPrivateFile(root, completeMarkerName, []byte(manifest.Digest+"\n"), false); err != nil {
+		return fmt.Errorf("runtimebundle: write cache complete marker: %w", err)
+	}
+	return nil
+}
+
+func syncRootDir(root *os.Root) error {
+	if runtime.GOOS == "windows" {
+		return nil
+	}
+	dir, err := root.Open(".")
+	if err != nil {
+		return err
+	}
+	defer dir.Close()
+	return dir.Sync()
+}
+
+func readRootRegularFile(root *os.Root, name string) ([]byte, error) {
+	name = filepath.FromSlash(name)
+	info, err := root.Lstat(name)
+	if err != nil {
+		return nil, err
+	}
+	if !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {
+		return nil, fmt.Errorf("%w: metadata path is not a regular file: %s", ErrUnsafeArchive, name)
+	}
+	if runtimeIsUnix() && info.Mode().Perm() != 0o600 {
+		return nil, fmt.Errorf("%w: metadata path is not private: %s", ErrUnsafeArchive, name)
+	}
+	if err := verifyPrivateRootPath(root, name); err != nil {
+		return nil, err
+	}
+	return root.ReadFile(name)
+}
+
+func (c *Cache) validCacheHitRoot(namespaceRoot *os.Root, namespace, digest string, expected *Bundle) (bool, error) {
+	info, err := namespaceRoot.Lstat(filepath.FromSlash(digest))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return false, fmt.Errorf("%w: cache target is a symlink: %s", ErrUnsafeArchive, digest)
+	}
+	if !info.IsDir() {
+		return false, nil
+	}
+	if runtimeIsUnix() && info.Mode().Perm() != 0o700 {
+		return false, nil
+	}
+	targetRoot, err := openPinnedChildRoot(namespaceRoot, digest)
+	if err != nil {
+		return false, err
+	}
+	defer targetRoot.Close()
+	if err := verifyPrivateRootPath(targetRoot, "."); err != nil {
+		return false, err
+	}
+	manifestData, err := readRootRegularFile(targetRoot, cacheManifestName)
+	if err != nil {
+		return false, nil
+	}
+	manifest, err := ParseManifest(manifestData)
+	if err != nil {
+		return false, nil
+	}
+	if manifest.Namespace != Namespace(namespace) || manifest.Digest != digest {
+		return false, nil
+	}
+	marker, err := readRootRegularFile(targetRoot, completeMarkerName)
+	if err != nil || strings.TrimSpace(string(marker)) != digest {
+		return false, nil
+	}
+	if expected != nil {
+		if err := manifestEntriesEqual(manifest, *expected); err != nil {
+			return false, nil
+		}
+	}
+	if err := verifyMaterializedTreeRoot(targetRoot, manifest); err != nil {
+		return false, nil
+	}
+	if err := checkPinnedChildPath(namespaceRoot, digest, targetRoot); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func verifyMaterializedTreeRoot(root *os.Root, manifest Bundle) error {
+	expected := make(map[string]Entry, len(manifest.Entries))
+	allowedDirs := map[string]struct{}{".": {}}
+	for _, original := range manifest.Entries {
+		entry, _, err := original.normalized()
+		if err != nil {
+			return err
+		}
+		key := strings.TrimSuffix(entry.Name, "/")
+		expected[key] = entry
+		if entry.isDir() {
+			allowedDirs[key] = struct{}{}
+		}
+		parts := strings.Split(key, "/")
+		for i := 1; i < len(parts); i++ {
+			allowedDirs[strings.Join(parts[:i], "/")] = struct{}{}
+		}
+	}
+	seen := make(map[string]struct{}, len(expected))
+	err := fs.WalkDir(root.FS(), ".", func(name string, dirent fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if name == "." {
+			return nil
+		}
+		if name == cacheManifestName || name == completeMarkerName {
+			if dirent.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if dirent.Type()&os.ModeSymlink != 0 {
+			return fmt.Errorf("%w: cache contains symlink %s", ErrUnsafeArchive, name)
+		}
+		key := filepath.ToSlash(name)
+		if dirent.IsDir() {
+			if _, ok := allowedDirs[key]; !ok {
+				return fmt.Errorf("%w: cache contains unexpected directory %s", ErrDigestMismatch, name)
+			}
+			if entry, ok := expected[key]; ok && !entry.isDir() {
+				return fmt.Errorf("%w: cache file/directory collision at %s", ErrDigestMismatch, name)
+			}
+			if runtimeIsUnix() {
+				info, err := root.Lstat(filepath.FromSlash(key))
+				if err != nil {
+					return err
+				}
+				if info.Mode().Perm() != 0o700 {
+					return fmt.Errorf("%w: cache directory %s is not private", ErrDigestMismatch, name)
+				}
+			}
+			if err := verifyPrivateRootPath(root, key); err != nil {
+				return err
+			}
+			if _, explicit := expected[key]; explicit {
+				seen[key] = struct{}{}
+			}
+			return nil
+		}
+		entry, ok := expected[key]
+		if !ok || entry.isDir() {
+			return fmt.Errorf("%w: cache contains unexpected file %s", ErrDigestMismatch, name)
+		}
+		file, err := root.Open(filepath.FromSlash(key))
+		if err != nil {
+			return err
+		}
+		info, statErr := file.Stat()
+		if statErr == nil && (!info.Mode().IsRegular() || info.Size() != entry.Size) {
+			statErr = fmt.Errorf("%w: cache entry %s size/type mismatch", ErrDigestMismatch, name)
+		}
+		if statErr == nil && runtimeIsUnix() && info.Mode().Perm() != privateFileMode(entry.Mode).Perm() {
+			statErr = fmt.Errorf("%w: cache entry %s is not private", ErrDigestMismatch, name)
+		}
+		if statErr == nil {
+			statErr = verifyPrivateRootPath(root, key)
+		}
+		var digest string
+		if statErr == nil {
+			digest, _, statErr = hashReader(file, entry.Size)
+		}
+		closeErr := file.Close()
+		if statErr == nil {
+			statErr = closeErr
+		}
+		if statErr != nil {
+			return statErr
+		}
+		if digest != entry.SHA256 {
+			return fmt.Errorf("%w: cache entry %s digest mismatch", ErrDigestMismatch, name)
+		}
+		seen[key] = struct{}{}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	if len(seen) != len(expected) {
+		return fmt.Errorf("%w: cache is missing entries", ErrDigestMismatch)
+	}
+	return nil
+}

--- a/internal/runtimebundle/cache_materialize.go
+++ b/internal/runtimebundle/cache_materialize.go
@@ -1,0 +1,356 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package runtimebundle
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// materializePath verifies zipPath and atomically materializes it under the
+// namespace-specific content address. The caller must acquire a shared lease
+// before exposing the returned path to a consumer.
+func (c *Cache) materializePath(ctx context.Context, namespace Namespace, zipPath string, expected *Bundle) (string, error) {
+	if c == nil {
+		return "", fmt.Errorf("runtimebundle: nil cache")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	limits, err := c.Limits.withDefaults()
+	if err != nil {
+		return "", err
+	}
+	if !namespace.valid() {
+		return "", fmt.Errorf("runtimebundle: invalid cache namespace %q", namespace)
+	}
+	if c.LockProvider == nil {
+		return "", ErrCrossProcessLockUnsupported
+	}
+	if c.Permissions == nil {
+		c.Permissions = defaultPermissions()
+	}
+	expected, err = normalizeExpectedBundle(namespace, expected, limits)
+	if err != nil {
+		return "", err
+	}
+
+	var digest string
+	if expected != nil {
+		digest = expected.Digest
+	}
+	// A nil expected has no address until the archive has been read. It is
+	// therefore intentionally verified before lock acquisition; callers that
+	// already possess a manifest get the cheap cache-hit path first.
+	if digest == "" {
+		bundle, verifyErr := VerifyZip(zipPath, VerifyOptions{Limits: limits})
+		if verifyErr != nil {
+			return "", verifyErr
+		}
+		bundle.Namespace = namespace
+		bundle, err = bundle.WithDigest()
+		if err != nil {
+			return "", err
+		}
+		digest = bundle.Digest
+		expected = &bundle
+	}
+
+	target, err := c.Path(namespace, digest)
+	if err != nil {
+		return "", err
+	}
+	if err := c.prepareCacheNamespace(namespace); err != nil {
+		return "", err
+	}
+	lease, err := c.LockProvider.AcquireExclusive(ctx, target)
+	if err != nil {
+		return "", err
+	}
+	if lease == nil {
+		return "", fmt.Errorf("runtimebundle: lock provider returned a nil exclusive lease")
+	}
+	defer lease.Close()
+
+	cacheRoot, err := openOrCreateCacheRoot(c.Root, c.Permissions)
+	if err != nil {
+		return "", fmt.Errorf("runtimebundle: pin cache root: %w", err)
+	}
+	defer cacheRoot.Close()
+	if err := ensureRootDir(cacheRoot, filepath.FromSlash(string(namespace))); err != nil {
+		return "", fmt.Errorf("runtimebundle: prepare cache namespace: %w", err)
+	}
+	namespaceRoot, err := openPinnedChildRoot(cacheRoot, string(namespace))
+	if err != nil {
+		return "", fmt.Errorf("runtimebundle: pin cache namespace: %w", err)
+	}
+	defer namespaceRoot.Close()
+	if err := checkPinnedRootPath(c.Root, cacheRoot); err != nil {
+		return "", err
+	}
+	if err := checkPinnedChildPath(cacheRoot, string(namespace), namespaceRoot); err != nil {
+		return "", err
+	}
+
+	if ok, hitErr := c.validCacheHitRoot(namespaceRoot, string(namespace), digest, expected); hitErr != nil {
+		return "", hitErr
+	} else if ok {
+		if err := checkPinnedRootPath(c.Root, cacheRoot); err != nil {
+			return "", err
+		}
+		if err := checkPinnedChildPath(cacheRoot, string(namespace), namespaceRoot); err != nil {
+			return "", err
+		}
+		return target, nil
+	}
+
+	// A corrupt/incomplete target is never reused. It is removed through the
+	// pinned namespace root, never by resolving the namespace path again.
+	if info, statErr := namespaceRoot.Lstat(filepath.FromSlash(digest)); statErr == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return "", fmt.Errorf("%w: refusing to remove symlink cache target %s", ErrUnsafeArchive, target)
+		}
+		if err := namespaceRoot.RemoveAll(filepath.FromSlash(digest)); err != nil {
+			return "", fmt.Errorf("runtimebundle: remove corrupt cache %s: %w", target, err)
+		}
+	} else if !os.IsNotExist(statErr) {
+		return "", statErr
+	}
+
+	tempName, err := newRootTemp(namespaceRoot)
+	if err != nil {
+		return "", fmt.Errorf("runtimebundle: create sibling temp directory: %w", err)
+	}
+	published := false
+	defer func() {
+		if !published {
+			_ = namespaceRoot.RemoveAll(filepath.FromSlash(tempName))
+		}
+	}()
+	tempRoot, err := openPinnedChildRoot(namespaceRoot, tempName)
+	if err != nil {
+		return "", fmt.Errorf("runtimebundle: pin sibling temp directory: %w", err)
+	}
+	tempOpen := true
+	defer func() {
+		if tempOpen {
+			_ = tempRoot.Close()
+		}
+	}()
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+
+	// Re-open and verify the source after the cache lock is held. This keeps
+	// the source/hash/extraction transaction coherent if a caller replaces a
+	// downloaded ZIP between the initial identity check and publication.
+	source, closeSource, err := openAndVerify(zipPath, VerifyOptions{Limits: limits, Expected: expected})
+	if err != nil {
+		return "", err
+	}
+	defer closeSource.Close()
+	if source.bundle.Namespace != namespace {
+		source.bundle.Namespace = namespace
+		source.bundle, err = source.bundle.WithDigest()
+		if err != nil {
+			return "", err
+		}
+	}
+	if source.bundle.Digest != digest {
+		return "", fmt.Errorf("%w: source %s, cache target %s", ErrDigestMismatch, source.bundle.Digest, digest)
+	}
+	if err := extractVerifiedRoot(source, tempRoot); err != nil {
+		return "", fmt.Errorf("runtimebundle: materialize %s: %w", zipPath, err)
+	}
+	if err := writeMetadataRoot(tempRoot, source.bundle); err != nil {
+		return "", err
+	}
+	if err := syncRootDir(tempRoot); err != nil {
+		return "", err
+	}
+	if err := checkPinnedRootPath(c.Root, cacheRoot); err != nil {
+		return "", err
+	}
+	if err := checkPinnedChildPath(cacheRoot, string(namespace), namespaceRoot); err != nil {
+		return "", err
+	}
+	if err := checkPinnedChildPath(namespaceRoot, tempName, tempRoot); err != nil {
+		return "", err
+	}
+	if err := tempRoot.Close(); err != nil {
+		return "", err
+	}
+	tempOpen = false
+	if err := namespaceRoot.Rename(filepath.FromSlash(tempName), filepath.FromSlash(digest)); err != nil {
+		// Revalidate a competing publisher's winner; never accept an
+		// unverified target merely because rename lost.
+		if ok, hitErr := c.validCacheHitRoot(namespaceRoot, string(namespace), digest, expected); hitErr == nil && ok {
+			return target, nil
+		}
+		return "", fmt.Errorf("runtimebundle: atomically publish cache %s: %w", target, err)
+	}
+	published = true
+	if err := syncRootDir(namespaceRoot); err != nil {
+		return "", err
+	}
+	if err := checkPinnedRootPath(c.Root, cacheRoot); err != nil {
+		return "", err
+	}
+	if err := checkPinnedChildPath(cacheRoot, string(namespace), namespaceRoot); err != nil {
+		return "", err
+	}
+	return target, nil
+}
+
+// Materialize verifies and publishes a bundle, then returns while holding a
+// shared use lease for the materialized target. The caller must Close the
+// returned value after its final read or execution.
+func (c *Cache) Materialize(ctx context.Context, namespace Namespace, zipPath string, expected *Bundle) (*Materialized, error) {
+	if c == nil {
+		return nil, fmt.Errorf("runtimebundle: nil cache")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	limits, err := c.Limits.withDefaults()
+	if err != nil {
+		return nil, err
+	}
+	if expected == nil {
+		bundle, err := VerifyZip(zipPath, VerifyOptions{Limits: limits})
+		if err != nil {
+			return nil, err
+		}
+		expected = &bundle
+	}
+	expected, err = normalizeExpectedBundle(namespace, expected, limits)
+	if err != nil {
+		return nil, err
+	}
+	if hit, ok, err := c.tryMaterializedHit(ctx, namespace, expected.Digest, expected); err != nil {
+		return nil, err
+	} else if ok {
+		return hit, nil
+	}
+	target, err := c.materializePath(ctx, namespace, zipPath, expected)
+	if err != nil {
+		return nil, err
+	}
+	// Publication releases its exclusive lease before a shared use lease is
+	// acquired. Revalidate under the shared lease so the returned path is never
+	// exposed through an unprotected lock-transition window.
+	hit, ok, err := c.tryMaterializedHit(ctx, namespace, expected.Digest, expected)
+	if err != nil {
+		return nil, err
+	}
+	if !ok || hit.Path != target {
+		return nil, fmt.Errorf("runtimebundle: published cache target failed shared-lease revalidation: %s", target)
+	}
+	return hit, nil
+}
+
+func normalizeExpectedBundle(namespace Namespace, expected *Bundle, limits Limits) (*Bundle, error) {
+	if expected == nil {
+		return nil, nil
+	}
+	want := *expected
+	originalNamespace := want.Namespace
+	originalDigest := want.Digest
+	if originalNamespace != "" && originalNamespace != namespace {
+		return nil, fmt.Errorf("runtimebundle: expected namespace %q does not match %q", want.Namespace, namespace)
+	}
+	if originalNamespace == "" && originalDigest != "" {
+		// An empty namespace identifies the archive manifest itself. Verify that
+		// identity before deriving the namespace-specific cache identity.
+		namespaceLess := want
+		namespaceLess.Digest = ""
+		identity, err := namespaceLess.IdentityDigest()
+		if err != nil {
+			return nil, err
+		}
+		if identity != originalDigest {
+			return nil, fmt.Errorf("%w: namespace-empty expected digest %s, identity %s", ErrDigestMismatch, originalDigest, identity)
+		}
+	}
+	want.Namespace = namespace
+	want.Digest = ""
+	if err := want.ValidateWithLimits(limits); err != nil {
+		return nil, err
+	}
+	digest, err := want.IdentityDigest()
+	if err != nil {
+		return nil, err
+	}
+	if originalNamespace != "" && originalDigest != "" && originalDigest != digest {
+		return nil, fmt.Errorf("%w: expected manifest digest %s, identity %s", ErrDigestMismatch, originalDigest, digest)
+	}
+	want.Digest = digest
+	return &want, nil
+}
+
+func (c *Cache) tryMaterializedHit(ctx context.Context, namespace Namespace, digest string, expected *Bundle) (*Materialized, bool, error) {
+	if c.LockProvider == nil {
+		return nil, false, ErrCrossProcessLockUnsupported
+	}
+	target, err := c.Path(namespace, digest)
+	if err != nil {
+		return nil, false, err
+	}
+	if err := c.prepareCacheNamespace(namespace); err != nil {
+		return nil, false, err
+	}
+	lease, err := c.LockProvider.AcquireShared(ctx, target)
+	if err != nil {
+		return nil, false, err
+	}
+	if lease == nil {
+		return nil, false, fmt.Errorf("runtimebundle: lock provider returned a nil shared lease")
+	}
+	closeLease := true
+	defer func() {
+		if closeLease {
+			_ = lease.Close()
+		}
+	}()
+	cacheRoot, err := openOrCreateCacheRoot(c.Root, c.Permissions)
+	if err != nil {
+		return nil, false, fmt.Errorf("runtimebundle: pin cache root: %w", err)
+	}
+	defer cacheRoot.Close()
+	namespaceRoot, err := openPinnedChildRoot(cacheRoot, string(namespace))
+	if err != nil {
+		return nil, false, fmt.Errorf("runtimebundle: pin cache namespace: %w", err)
+	}
+	defer namespaceRoot.Close()
+	if err := checkPinnedRootPath(c.Root, cacheRoot); err != nil {
+		return nil, false, err
+	}
+	if err := checkPinnedChildPath(cacheRoot, string(namespace), namespaceRoot); err != nil {
+		return nil, false, err
+	}
+	ok, err := c.validCacheHitRoot(namespaceRoot, string(namespace), digest, expected)
+	if err != nil || !ok {
+		return nil, false, err
+	}
+	closeLease = false
+	return &Materialized{Path: target, lease: lease}, true, nil
+}

--- a/internal/runtimebundle/cache_roots.go
+++ b/internal/runtimebundle/cache_roots.go
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package runtimebundle
+
+import (
+	cryptorand "crypto/rand"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+// prepareCacheNamespace creates the lock-file parent through the same pinned
+// root path used by publication. It runs before lock acquisition because the
+// sidecar lives beside the target, not inside it.
+func (c *Cache) prepareCacheNamespace(namespace Namespace) error {
+	if c.Permissions == nil {
+		c.Permissions = defaultPermissions()
+	}
+	cacheRoot, err := openOrCreateCacheRoot(c.Root, c.Permissions)
+	if err != nil {
+		return fmt.Errorf("runtimebundle: pin cache root for lock: %w", err)
+	}
+	defer cacheRoot.Close()
+	if runtimeIsWindows() {
+		if err := c.Permissions.EnsureDir(filepath.Join(c.Root, string(namespace))); err != nil {
+			return fmt.Errorf("runtimebundle: protect cache namespace: %w", err)
+		}
+	}
+	if err := ensureRootDir(cacheRoot, filepath.FromSlash(string(namespace))); err != nil {
+		return fmt.Errorf("runtimebundle: prepare cache namespace for lock: %w", err)
+	}
+	namespaceRoot, err := openPinnedChildRoot(cacheRoot, string(namespace))
+	if err != nil {
+		return fmt.Errorf("runtimebundle: pin cache namespace for lock: %w", err)
+	}
+	defer namespaceRoot.Close()
+	if err := checkPinnedRootPath(c.Root, cacheRoot); err != nil {
+		return err
+	}
+	return checkPinnedChildPath(cacheRoot, string(namespace), namespaceRoot)
+}
+
+// openOrCreateCacheRoot creates missing cache-root components beneath the
+// nearest pinned existing ancestor. This avoids MkdirAll/Chmod path traversal
+// races on POSIX. Windows uses the creation-time DACL primitive in
+// permissions_windows.go.
+func openOrCreateCacheRoot(path string, permissions Permissions) (*os.Root, error) {
+	if runtime.GOOS == "windows" {
+		if err := permissions.EnsureDir(path); err != nil {
+			return nil, err
+		}
+		return openPinnedRoot(path)
+	}
+	if info, err := os.Lstat(path); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+			return nil, fmt.Errorf("%w: cache root is not a real directory: %s", ErrUnsafeArchive, path)
+		}
+		root, err := openPinnedRoot(path)
+		if err != nil {
+			return nil, err
+		}
+		if err := root.Chmod(".", 0o700); err != nil {
+			_ = root.Close()
+			return nil, err
+		}
+		return root, nil
+	} else if !os.IsNotExist(err) {
+		return nil, err
+	}
+	currentPath := path
+	missing := make([]string, 0, 4)
+	for {
+		info, err := os.Lstat(currentPath)
+		if err == nil {
+			if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+				return nil, fmt.Errorf("%w: cache ancestor is not a real directory: %s", ErrUnsafeArchive, currentPath)
+			}
+			break
+		}
+		if !os.IsNotExist(err) {
+			return nil, err
+		}
+		parentPath := filepath.Dir(currentPath)
+		base := filepath.Base(currentPath)
+		if parentPath == currentPath || base == "" || base == "." || base == string(filepath.Separator) {
+			return nil, fmt.Errorf("%w: cache root has no existing directory ancestor", ErrUnsafeArchive)
+		}
+		missing = append(missing, base)
+		currentPath = parentPath
+	}
+	root, err := openPinnedRoot(currentPath)
+	if err != nil {
+		return nil, fmt.Errorf("%w: pin existing cache ancestor: %v", ErrUnsafeArchive, err)
+	}
+	for index := len(missing) - 1; index >= 0; index-- {
+		name := missing[index]
+		if err := root.Mkdir(name, 0o700); err != nil && !errors.Is(err, os.ErrExist) {
+			_ = root.Close()
+			return nil, err
+		}
+		child, err := openPinnedChildRoot(root, name)
+		if err != nil {
+			_ = root.Close()
+			return nil, err
+		}
+		if err := child.Chmod(".", 0o700); err != nil {
+			_ = child.Close()
+			_ = root.Close()
+			return nil, err
+		}
+		currentPath = filepath.Join(currentPath, name)
+		if err := checkPinnedRootPath(currentPath, child); err != nil {
+			_ = child.Close()
+			_ = root.Close()
+			return nil, err
+		}
+		if err := root.Close(); err != nil {
+			_ = child.Close()
+			return nil, err
+		}
+		root = child
+	}
+	return root, nil
+}
+
+func openPinnedChildRoot(parent *os.Root, name string) (*os.Root, error) {
+	name = filepath.FromSlash(name)
+	before, err := parent.Lstat(name)
+	if err != nil {
+		return nil, err
+	}
+	if before.Mode()&os.ModeSymlink != 0 || !before.IsDir() {
+		return nil, fmt.Errorf("%w: cache component is not a real directory: %s", ErrUnsafeArchive, name)
+	}
+	child, err := parent.OpenRoot(name)
+	if err != nil {
+		return nil, err
+	}
+	after, err := child.Stat(".")
+	if err != nil || !os.SameFile(before, after) {
+		_ = child.Close()
+		if err != nil {
+			return nil, err
+		}
+		return nil, fmt.Errorf("%w: cache component changed while opening: %s", ErrUnsafeArchive, name)
+	}
+	if err := checkPinnedChildPath(parent, name, child); err != nil {
+		_ = child.Close()
+		return nil, err
+	}
+	return child, nil
+}
+
+// checkPinnedChildPath verifies that a child root still occupies the same
+// pathname beneath its pinned parent. This is the post-open half of the
+// identity check; without it a concurrent rename could publish into an old
+// directory while the caller observes a replacement at the namespace path.
+func checkPinnedChildPath(parent *os.Root, name string, child *os.Root) error {
+	info, err := parent.Lstat(name)
+	if err != nil {
+		return fmt.Errorf("%w: cache component pathname changed: %v", ErrUnsafeArchive, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		return fmt.Errorf("%w: cache component pathname is not a real directory: %s", ErrUnsafeArchive, name)
+	}
+	pinned, err := child.Stat(".")
+	if err != nil {
+		return fmt.Errorf("%w: stat pinned cache component: %v", ErrUnsafeArchive, err)
+	}
+	if !os.SameFile(info, pinned) {
+		return fmt.Errorf("%w: cache component pathname was replaced: %s", ErrUnsafeArchive, name)
+	}
+	return nil
+}
+
+func newRootTemp(root *os.Root) (string, error) {
+	var random [12]byte
+	for attempt := 0; attempt < 32; attempt++ {
+		if _, err := cryptorand.Read(random[:]); err != nil {
+			return "", err
+		}
+		name := ".runtimebundle-" + fmt.Sprintf("%x", random[:])
+		if err := mkdirPrivateRootChild(root, name); err != nil {
+			if errors.Is(err, os.ErrExist) {
+				continue
+			}
+			return "", err
+		}
+		return name, nil
+	}
+	return "", fmt.Errorf("runtimebundle: unable to allocate sibling temp directory")
+}

--- a/internal/runtimebundle/cache_test.go
+++ b/internal/runtimebundle/cache_test.go
@@ -1,0 +1,678 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package runtimebundle
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestCacheMaterializeRepairsSameSizeTamper(t *testing.T) {
+	zipPath := writeTestZip(t, testZipEntry{name: "runtime", mode: 0o755, data: "trusted"})
+	bundle, err := VerifyZip(zipPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bundle.Namespace = NamespaceEngine
+	bundle, err = bundle.WithDigest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cache := NewProcessLocalCache(t.TempDir())
+	ctx := context.Background()
+	dir, err := materializeTestPath(cache, ctx, NamespaceEngine, zipPath, &bundle)
+	if err != nil {
+		t.Fatalf("first materialize: %v", err)
+	}
+	if filepath.Base(filepath.Dir(dir)) != string(NamespaceEngine) || filepath.Base(dir) != bundle.Digest {
+		t.Fatalf("cache path = %s, want namespace/full digest", dir)
+	}
+	if info, err := os.Stat(filepath.Join(dir, "runtime")); err != nil || info.Mode().Perm() != 0o700 {
+		t.Fatalf("runtime permissions = %v, err=%v; want 0700", info.Mode().Perm(), err)
+	}
+	if marker, err := os.ReadFile(filepath.Join(dir, completeMarkerName)); err != nil || strings.TrimSpace(string(marker)) != bundle.Digest {
+		t.Fatalf("complete marker = %q, err=%v", marker, err)
+	}
+
+	if err := os.WriteFile(filepath.Join(dir, "runtime"), []byte("tampered"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	repaired, err := materializeTestPath(cache, ctx, NamespaceEngine, zipPath, &bundle)
+	if err != nil {
+		t.Fatalf("repair materialize: %v", err)
+	}
+	if repaired != dir {
+		t.Fatalf("repaired path = %s, want %s", repaired, dir)
+	}
+	content, err := os.ReadFile(filepath.Join(dir, "runtime"))
+	if err != nil || string(content) != "trusted" {
+		t.Fatalf("repaired content = %q, err=%v", content, err)
+	}
+}
+
+func TestCacheNestedFileCacheHitDoesNotRequireExplicitParentEntry(t *testing.T) {
+	zipPath := writeTestZip(t, testZipEntry{name: "bin/run", mode: 0o755, data: "trusted"})
+	bundle, err := VerifyZip(zipPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cache := NewProcessLocalCache(t.TempDir())
+	first, err := materializeTestPath(cache, context.Background(), NamespaceEngine, zipPath, &bundle)
+	if err != nil {
+		t.Fatalf("first materialize: %v", err)
+	}
+	second, err := materializeTestPath(cache, context.Background(), NamespaceEngine, zipPath, &bundle)
+	if err != nil {
+		t.Fatalf("cache hit: %v", err)
+	}
+	if first != second {
+		t.Fatalf("cache hit path = %s, want %s", second, first)
+	}
+}
+
+func TestCacheRemovePinsNamespaceAndRefusesValidTarget(t *testing.T) {
+	zipPath := writeTestZip(t, testZipEntry{name: "runtime", data: "trusted"})
+	bundle, err := VerifyZip(zipPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cache := NewProcessLocalCache(t.TempDir())
+	dir, err := materializeTestPath(cache, context.Background(), NamespaceEngine, zipPath, &bundle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cache.Remove(NamespaceEngine, filepath.Base(dir)); err == nil {
+		t.Fatal("Remove deleted a valid cache target")
+	}
+	if _, err := os.Stat(dir); err != nil {
+		t.Fatalf("valid target disappeared after Remove: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "runtime"), []byte("tampered"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := cache.Remove(NamespaceEngine, filepath.Base(dir)); err != nil {
+		t.Fatalf("Remove corrupted target: %v", err)
+	}
+	if _, err := os.Lstat(dir); !os.IsNotExist(err) {
+		t.Fatalf("corrupted target remains, stat error = %v", err)
+	}
+}
+
+func TestCacheConcurrentMaterializePublishesOneCompleteTarget(t *testing.T) {
+	zipPath := writeTestZip(t, testZipEntry{name: "engine", data: "engine bytes"})
+	bundle, err := VerifyZip(zipPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bundle.Namespace = NamespaceEngine
+	bundle, err = bundle.WithDigest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cache := NewProcessLocalCache(t.TempDir())
+	const workers = 16
+	paths := make([]string, workers)
+	errs := make([]error, workers)
+	var group sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		group.Add(1)
+		go func(i int) {
+			defer group.Done()
+			paths[i], errs[i] = materializeTestPath(cache, context.Background(), NamespaceEngine, zipPath, &bundle)
+		}(i)
+	}
+	group.Wait()
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("worker %d: %v", i, err)
+		}
+		if paths[i] != paths[0] {
+			t.Fatalf("worker %d path %s, want %s", i, paths[i], paths[0])
+		}
+	}
+	items, err := cache.List(NamespaceEngine)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(items) != 1 || items[0] != paths[0] {
+		t.Fatalf("cache entries = %#v, want one published target", items)
+	}
+	if err := os.Mkdir(filepath.Join(filepath.Dir(paths[0]), strings.Repeat("f", sha256.Size*2)), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	items, err = cache.List(NamespaceEngine)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(items) != 1 || items[0] != paths[0] {
+		t.Fatalf("List included incomplete named directory: %#v", items)
+	}
+}
+
+func TestCacheRejectsRootAndTargetSymlinks(t *testing.T) {
+	zipPath := writeTestZip(t, testZipEntry{name: "x", data: "x"})
+	bundle, err := VerifyZip(zipPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bundle.Namespace = NamespaceEngine
+	bundle, err = bundle.WithDigest()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rootReal := t.TempDir()
+	rootLink := filepath.Join(t.TempDir(), "cache-link")
+	if err := os.Symlink(rootReal, rootLink); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	if _, err := materializeTestPath(NewProcessLocalCache(rootLink), context.Background(), NamespaceEngine, zipPath, &bundle); !errors.Is(err, ErrUnsafeArchive) {
+		t.Fatalf("root symlink error = %v, want ErrUnsafeArchive", err)
+	}
+
+	root := t.TempDir()
+	namespace := filepath.Join(root, string(NamespaceEngine))
+	if err := os.MkdirAll(namespace, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(namespace, bundle.Digest)
+	outside := t.TempDir()
+	if err := os.Symlink(outside, target); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	if _, err := materializeTestPath(NewProcessLocalCache(root), context.Background(), NamespaceEngine, zipPath, &bundle); !errors.Is(err, ErrUnsafeArchive) {
+		t.Fatalf("target symlink error = %v, want ErrUnsafeArchive", err)
+	}
+	if _, err := os.Stat(outside); err != nil {
+		t.Fatalf("outside target was affected: %v", err)
+	}
+
+	namespaceRoot := t.TempDir()
+	namespaceOutside := t.TempDir()
+	if err := os.Symlink(namespaceOutside, filepath.Join(namespaceRoot, string(NamespaceEngine))); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	namespaceCache := NewProcessLocalCache(namespaceRoot)
+	if _, err := materializeTestPath(namespaceCache, context.Background(), NamespaceEngine, zipPath, &bundle); !errors.Is(err, ErrUnsafeArchive) {
+		t.Fatalf("namespace symlink error = %v, want ErrUnsafeArchive", err)
+	}
+	if _, err := namespaceCache.List(NamespaceEngine); !errors.Is(err, ErrUnsafeArchive) {
+		t.Fatalf("List namespace symlink error = %v, want ErrUnsafeArchive", err)
+	}
+}
+
+func TestPinnedChildRootRejectsPathReplacement(t *testing.T) {
+	parentPath := filepath.Join(t.TempDir(), "parent")
+	childPath := filepath.Join(parentPath, "child")
+	if err := os.MkdirAll(childPath, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	parent, err := openPinnedRoot(parentPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer parent.Close()
+	child, err := openPinnedChildRoot(parent, "child")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer child.Close()
+	if err := os.Rename(childPath, childPath+".old"); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(childPath, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := checkPinnedChildPath(parent, "child", child); !errors.Is(err, ErrUnsafeArchive) {
+		t.Fatalf("replaced child check = %v, want ErrUnsafeArchive", err)
+	}
+}
+
+func TestCrossProcessAndGCBoundariesFailClosed(t *testing.T) {
+	if _, err := (UnsupportedCrossProcessLockProvider{}).AcquireExclusive(context.Background(), "cache-key"); !errors.Is(err, ErrCrossProcessLockUnsupported) {
+		t.Fatalf("cross-process lock error = %v, want ErrCrossProcessLockUnsupported", err)
+	}
+	if err := NewProcessLocalCache(t.TempDir()).Collect(context.Background(), GCOptions{}); !errors.Is(err, ErrGCUnsupported) {
+		t.Fatalf("GC error = %v, want ErrGCUnsupported", err)
+	}
+}
+
+func TestNewCacheUsesCrossProcessLockAndNilProviderFailsClosed(t *testing.T) {
+	zipPath := writeTestZip(t, testZipEntry{name: "x", data: "x"})
+	materialized, err := NewCache(t.TempDir()).Materialize(context.Background(), NamespaceEngine, zipPath, nil)
+	if err != nil {
+		t.Fatalf("default cache materialize = %v", err)
+	}
+	if err := materialized.Close(); err != nil {
+		t.Fatal(err)
+	}
+	cache := NewProcessLocalCache(t.TempDir())
+	cache.LockProvider = nil
+	if _, err := cache.Materialize(context.Background(), NamespaceEngine, zipPath, nil); !errors.Is(err, ErrCrossProcessLockUnsupported) {
+		t.Fatalf("nil provider error = %v, want ErrCrossProcessLockUnsupported", err)
+	}
+}
+
+func TestRuntimeBundleProcessHelper(t *testing.T) {
+	if os.Getenv("RUNTIMEBUNDLE_HELPER") == "" {
+		return
+	}
+	ready := os.Getenv("RUNTIMEBUNDLE_HELPER_READY")
+	start := os.Getenv("RUNTIMEBUNDLE_HELPER_START")
+	if ready != "" {
+		if err := os.WriteFile(ready, []byte("ready"), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if start != "" {
+		waitTestFile(t, start, 10*time.Second)
+	}
+	switch os.Getenv("RUNTIMEBUNDLE_HELPER") {
+	case "materialize":
+		materialized, err := NewCache(os.Getenv("RUNTIMEBUNDLE_HELPER_ROOT")).Materialize(
+			context.Background(), NamespaceEngine, os.Getenv("RUNTIMEBUNDLE_HELPER_ZIP"), nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(os.Getenv("RUNTIMEBUNDLE_HELPER_RESULT"), []byte(materialized.Path), 0600); err != nil {
+			_ = materialized.Close()
+			t.Fatal(err)
+		}
+		if err := materialized.Close(); err != nil {
+			t.Fatal(err)
+		}
+	case "lock":
+		provider := CrossProcessLockProvider{}
+		var lease LockLease
+		var err error
+		if os.Getenv("RUNTIMEBUNDLE_HELPER_LOCK_MODE") == "shared" {
+			lease, err = provider.AcquireShared(context.Background(), os.Getenv("RUNTIMEBUNDLE_HELPER_KEY"))
+		} else {
+			lease, err = provider.AcquireExclusive(context.Background(), os.Getenv("RUNTIMEBUNDLE_HELPER_KEY"))
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(os.Getenv("RUNTIMEBUNDLE_HELPER_ACQUIRED"), []byte("acquired"), 0600); err != nil {
+			_ = lease.Close()
+			t.Fatal(err)
+		}
+		waitTestFile(t, os.Getenv("RUNTIMEBUNDLE_HELPER_RELEASE"), 10*time.Minute)
+		if err := lease.Close(); err != nil {
+			t.Fatal(err)
+		}
+	default:
+		t.Fatalf("unknown helper mode %q", os.Getenv("RUNTIMEBUNDLE_HELPER"))
+	}
+}
+
+func TestCrossProcessFirstMaterialize(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("subprocess cache test requires the POSIX test runner")
+	}
+	zipPath := writeTestZip(t, testZipEntry{name: "engine", data: "engine bytes"})
+	root := t.TempDir()
+	start := filepath.Join(root, "start")
+	cmds := make([]*exec.Cmd, 2)
+	results := make([]string, 2)
+	for i := range cmds {
+		ready := filepath.Join(root, "ready-"+strconv.Itoa(i))
+		results[i] = filepath.Join(root, "result-"+strconv.Itoa(i))
+		cmds[i] = runtimeBundleHelperCommand(t, map[string]string{
+			"RUNTIMEBUNDLE_HELPER":        "materialize",
+			"RUNTIMEBUNDLE_HELPER_ROOT":   root,
+			"RUNTIMEBUNDLE_HELPER_ZIP":    zipPath,
+			"RUNTIMEBUNDLE_HELPER_READY":  ready,
+			"RUNTIMEBUNDLE_HELPER_START":  start,
+			"RUNTIMEBUNDLE_HELPER_RESULT": results[i],
+		})
+		if err := cmds[i].Start(); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() {
+			if cmds[i].Process != nil {
+				_ = cmds[i].Process.Kill()
+			}
+		})
+	}
+	for i := range cmds {
+		waitTestFile(t, filepath.Join(root, "ready-"+strconv.Itoa(i)), 10*time.Second)
+	}
+	if err := os.WriteFile(start, []byte("go"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	for i, cmd := range cmds {
+		if err := cmd.Wait(); err != nil {
+			t.Fatalf("materialize helper %d: %v", i, err)
+		}
+	}
+	bundle, err := VerifyZip(zipPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bundle.Namespace = NamespaceEngine
+	bundle, err = bundle.WithDigest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(root, string(NamespaceEngine), bundle.Digest)
+	for i, result := range results {
+		got, err := os.ReadFile(result)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(got) != want {
+			t.Fatalf("helper %d path = %q, want %q", i, got, want)
+		}
+	}
+	if _, err := os.Stat(want + ".lock"); err != nil {
+		t.Fatalf("sidecar lock = %v", err)
+	}
+	items, err := NewCache(root).List(NamespaceEngine)
+	if err != nil || len(items) != 1 || items[0] != want {
+		t.Fatalf("cache list = %#v, %v", items, err)
+	}
+}
+
+func TestMaterializeLeaseBlocksRepair(t *testing.T) {
+	zipPath := writeTestZip(t, testZipEntry{name: "runtime", mode: 0o755, data: "trusted"})
+	bundle, err := VerifyZip(zipPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bundle.Namespace = NamespaceEngine
+	bundle, err = bundle.WithDigest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cache := NewCache(t.TempDir())
+	first, err := cache.Materialize(context.Background(), NamespaceEngine, zipPath, &bundle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(first.Path, "runtime"), []byte("tampered"), 0o600); err != nil {
+		_ = first.Close()
+		t.Fatal(err)
+	}
+	repaired := make(chan error, 1)
+	go func() {
+		materialized, err := cache.Materialize(context.Background(), NamespaceEngine, zipPath, &bundle)
+		if err == nil {
+			err = materialized.Close()
+		}
+		repaired <- err
+	}()
+	select {
+	case err := <-repaired:
+		_ = first.Close()
+		t.Fatalf("repair completed while shared lease was held: %v", err)
+	case <-time.After(150 * time.Millisecond):
+	}
+	if err := first.Close(); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case err := <-repaired:
+		if err != nil {
+			t.Fatalf("repair after lease close: %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("repair did not finish after shared lease close")
+	}
+	content, err := os.ReadFile(filepath.Join(first.Path, "runtime"))
+	if err != nil || string(content) != "trusted" {
+		t.Fatalf("repaired content = %q, %v", content, err)
+	}
+}
+
+func TestMaterializeValidHitSharesUseLease(t *testing.T) {
+	zipPath := writeTestZip(t, testZipEntry{name: "runtime", mode: 0o755, data: "trusted"})
+	bundle, err := VerifyZip(zipPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bundle.Namespace = NamespaceEngine
+	bundle, err = bundle.WithDigest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cache := NewCache(t.TempDir())
+	first, err := cache.Materialize(context.Background(), NamespaceEngine, zipPath, &bundle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer first.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	second, err := cache.Materialize(ctx, NamespaceEngine, zipPath, &bundle)
+	if err != nil {
+		t.Fatalf("valid cache hit waited for an existing shared use lease: %v", err)
+	}
+	defer second.Close()
+	if second.Path != first.Path {
+		t.Fatalf("shared cache hit path = %q, want %q", second.Path, first.Path)
+	}
+}
+
+func TestMaterializeLeaseBlocksRemove(t *testing.T) {
+	zipPath := writeTestZip(t, testZipEntry{name: "runtime", data: "trusted"})
+	bundle, err := VerifyZip(zipPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bundle.Namespace = NamespaceEngine
+	bundle, err = bundle.WithDigest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cache := NewCache(t.TempDir())
+	materialized, err := cache.Materialize(context.Background(), NamespaceEngine, zipPath, &bundle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(materialized.Path, "runtime"), []byte("tampered"), 0o600); err != nil {
+		_ = materialized.Close()
+		t.Fatal(err)
+	}
+	removed := make(chan error, 1)
+	go func() { removed <- cache.Remove(NamespaceEngine, bundle.Digest) }()
+	select {
+	case err := <-removed:
+		_ = materialized.Close()
+		t.Fatalf("remove completed while shared lease was held: %v", err)
+	case <-time.After(150 * time.Millisecond):
+	}
+	if err := materialized.Close(); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case err := <-removed:
+		if err != nil {
+			t.Fatalf("remove after lease close: %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("remove did not finish after shared lease close")
+	}
+	if _, err := os.Lstat(filepath.Join(filepath.Dir(materialized.Path), bundle.Digest)); !os.IsNotExist(err) {
+		t.Fatalf("removed target stat = %v", err)
+	}
+}
+
+func TestCrossProcessLockContextCancellation(t *testing.T) {
+	provider := CrossProcessLockProvider{}
+	key := filepath.Join(t.TempDir(), "namespace", strings.Repeat("a", sha256.Size*2))
+	first, err := provider.AcquireExclusive(context.Background(), key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer first.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	if _, err := provider.AcquireShared(ctx, key); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("cancelled shared lock = %v, want context deadline", err)
+	}
+}
+
+func TestCrossProcessSharedLocksCanOverlap(t *testing.T) {
+	provider := CrossProcessLockProvider{}
+	key := filepath.Join(t.TempDir(), "namespace", strings.Repeat("c", sha256.Size*2))
+	first, err := provider.AcquireShared(context.Background(), key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := provider.AcquireShared(context.Background(), key)
+	if err != nil {
+		_ = first.Close()
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	if _, err := provider.AcquireExclusive(ctx, key); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("exclusive lock with readers = %v, want context deadline", err)
+	}
+	if err := second.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := first.Close(); err != nil {
+		t.Fatal(err)
+	}
+	lease, err := provider.AcquireExclusive(context.Background(), key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := lease.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestMaterializedCloseIsGoroutineSafe(t *testing.T) {
+	zipPath := writeTestZip(t, testZipEntry{name: "runtime", data: "trusted"})
+	cache := NewCache(t.TempDir())
+	materialized, err := cache.Materialize(context.Background(), NamespaceEngine, zipPath, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const closers = 16
+	var group sync.WaitGroup
+	errs := make(chan error, closers)
+	group.Add(closers)
+	for i := 0; i < closers; i++ {
+		go func() {
+			defer group.Done()
+			errs <- materialized.Close()
+		}()
+	}
+	group.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	lease, err := cache.LockProvider.AcquireExclusive(context.Background(), materialized.Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := lease.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCrossProcessLockKillReleases(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows process termination is covered by the cross-compile ACL test")
+	}
+	root := t.TempDir()
+	key := filepath.Join(root, "namespace", strings.Repeat("b", sha256.Size*2))
+	acquired := filepath.Join(root, "acquired")
+	release := filepath.Join(root, "release")
+	cmd := runtimeBundleHelperCommand(t, map[string]string{
+		"RUNTIMEBUNDLE_HELPER":           "lock",
+		"RUNTIMEBUNDLE_HELPER_KEY":       key,
+		"RUNTIMEBUNDLE_HELPER_LOCK_MODE": "shared",
+		"RUNTIMEBUNDLE_HELPER_ACQUIRED":  acquired,
+		"RUNTIMEBUNDLE_HELPER_RELEASE":   release,
+	})
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+		}
+	})
+	waitTestFile(t, acquired, 10*time.Second)
+	if err := cmd.Process.Kill(); err != nil {
+		t.Fatal(err)
+	}
+	_ = cmd.Wait()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	lease, err := (CrossProcessLockProvider{}).AcquireExclusive(ctx, key)
+	if err != nil {
+		t.Fatalf("exclusive lock after killed holder: %v", err)
+	}
+	if err := lease.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func runtimeBundleHelperCommand(t *testing.T, values map[string]string) *exec.Cmd {
+	t.Helper()
+	cmd := exec.Command(os.Args[0], "-test.run=^TestRuntimeBundleProcessHelper$", "-test.v")
+	env := append([]string(nil), os.Environ()...)
+	for key, value := range values {
+		env = append(env, key+"="+value)
+	}
+	cmd.Env = env
+	return cmd
+}
+
+func waitTestFile(t *testing.T, path string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(path); err == nil {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", path)
+}
+
+func materializeTestPath(cache *Cache, ctx context.Context, namespace Namespace, zipPath string, expected *Bundle) (string, error) {
+	materialized, err := cache.Materialize(ctx, namespace, zipPath, expected)
+	if err != nil {
+		return "", err
+	}
+	path := materialized.Path
+	if err := materialized.Close(); err != nil {
+		return "", err
+	}
+	return path, nil
+}

--- a/internal/runtimebundle/gc.go
+++ b/internal/runtimebundle/gc.go
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package runtimebundle
+
+import (
+	"context"
+	"errors"
+)
+
+// ErrGCUnsupported reports that cache collection has not been implemented.
+var ErrGCUnsupported = errors.New("runtimebundle: garbage collection is unsupported")
+
+// GCOptions describes the quota/age policy reserved for the cross-process
+// collector. Cache.Remove already uses the OS-backed shared/exclusive lock;
+// quota/age selection remains future work.
+type GCOptions struct {
+	MaxBytes int64
+	MaxAge   int64 // seconds; kept scalar so callers need not import time here
+}
+
+// GarbageCollector is the future quota/lease-aware cache collector seam.
+type GarbageCollector interface {
+	Collect(context.Context, GCOptions) error
+}
+
+// Collect returns ErrGCUnsupported until quota/age selection is implemented.
+// This explicit failure is preferable to a collector that can race a running
+// provider.
+func (c *Cache) Collect(ctx context.Context, options GCOptions) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return ErrGCUnsupported
+}

--- a/internal/runtimebundle/lock.go
+++ b/internal/runtimebundle/lock.go
@@ -1,0 +1,426 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package runtimebundle
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"time"
+)
+
+// ErrCrossProcessLockUnsupported reports that the current platform cannot
+// provide the cache's required cross-process lease semantics.
+var ErrCrossProcessLockUnsupported = errors.New("runtimebundle: cross-process locks are unsupported")
+
+// LockProvider coordinates publication/repair (exclusive) and use (shared)
+// leases for one cache target. Implementations must keep the lease alive until
+// Close; an OS-backed implementation therefore also survives a crashed
+// process by letting the kernel close the underlying handle.
+type LockProvider interface {
+	AcquireExclusive(context.Context, string) (LockLease, error)
+	AcquireShared(context.Context, string) (LockLease, error)
+}
+
+// LockLease is an idempotent, goroutine-safe lock release handle.
+type LockLease interface {
+	Close() error
+}
+
+// CrossProcessLockProvider uses a sidecar lock file next to (not inside) the
+// target. The platform implementation uses flock on POSIX and LockFileEx on
+// Windows.
+type CrossProcessLockProvider struct{}
+
+func (CrossProcessLockProvider) AcquireExclusive(ctx context.Context, key string) (LockLease, error) {
+	return acquirePlatformFileLock(ctx, key, lockExclusive)
+}
+
+func (CrossProcessLockProvider) AcquireShared(ctx context.Context, key string) (LockLease, error) {
+	return acquirePlatformFileLock(ctx, key, lockShared)
+}
+
+// UnsupportedCrossProcessLockProvider is retained as an explicit fail-closed
+// test seam. It is not used by NewCache.
+type UnsupportedCrossProcessLockProvider struct{}
+
+func (UnsupportedCrossProcessLockProvider) AcquireExclusive(context.Context, string) (LockLease, error) {
+	return nil, ErrCrossProcessLockUnsupported
+}
+
+func (UnsupportedCrossProcessLockProvider) AcquireShared(context.Context, string) (LockLease, error) {
+	return nil, ErrCrossProcessLockUnsupported
+}
+
+// ProcessLockProvider is an explicitly opt-in process-local implementation.
+// It is useful for tests which deliberately do not share a cache root across
+// processes; production callers should use NewCache.
+type ProcessLockProvider struct{}
+
+type processGate struct {
+	mu      sync.Mutex
+	readers int
+	writer  bool
+}
+
+var processLocks sync.Map // map[string]*processGate
+
+func (ProcessLockProvider) AcquireExclusive(ctx context.Context, key string) (LockLease, error) {
+	return acquireProcessLock(ctx, key, lockExclusive)
+}
+
+func (ProcessLockProvider) AcquireShared(ctx context.Context, key string) (LockLease, error) {
+	return acquireProcessLock(ctx, key, lockShared)
+}
+
+func acquireProcessLock(ctx context.Context, key string, mode lockMode) (LockLease, error) {
+	if key == "" {
+		return nil, fmt.Errorf("runtimebundle: empty cache lock key")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	value, _ := processLocks.LoadOrStore(key, &processGate{})
+	gate := value.(*processGate)
+	for {
+		if gate.tryAcquire(mode) {
+			return &processLease{gate: gate, mode: mode}, nil
+		}
+		if err := waitForLock(ctx); err != nil {
+			return nil, err
+		}
+	}
+}
+
+func (g *processGate) tryAcquire(mode lockMode) bool {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if mode == lockExclusive {
+		if g.writer || g.readers != 0 {
+			return false
+		}
+		g.writer = true
+		return true
+	}
+	if g.writer {
+		return false
+	}
+	g.readers++
+	return true
+}
+
+func (g *processGate) release(mode lockMode) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if mode == lockExclusive {
+		g.writer = false
+		return
+	}
+	if g.readers > 0 {
+		g.readers--
+	}
+}
+
+type processLease struct {
+	gate *processGate
+	mode lockMode
+	once sync.Once
+}
+
+func (l *processLease) Close() error {
+	if l == nil {
+		return nil
+	}
+	l.once.Do(func() { l.gate.release(l.mode) })
+	return nil
+}
+
+type lockMode uint8
+
+const (
+	lockShared lockMode = iota
+	lockExclusive
+)
+
+type fileLease struct {
+	file platformLockFile
+	once sync.Once
+	err  error
+}
+
+func (l *fileLease) Close() error {
+	if l == nil {
+		return nil
+	}
+	l.once.Do(func() {
+		unlockErr := l.file.unlock()
+		closeErr := l.file.close()
+		l.err = errors.Join(unlockErr, closeErr)
+	})
+	return l.err
+}
+
+func acquirePlatformFileLock(ctx context.Context, key string, mode lockMode) (LockLease, error) {
+	if key == "" {
+		return nil, fmt.Errorf("runtimebundle: empty cache lock key")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	file, err := openPlatformLockFile(lockSidecarPath(key))
+	if err != nil {
+		return nil, err
+	}
+	return acquireOpenedPlatformFileLock(ctx, file, mode)
+}
+
+func acquirePlatformRootFileLock(ctx context.Context, rootPath string, root *os.Root, key string, mode lockMode) (LockLease, error) {
+	if key == "" || filepath.Base(key) != key || strings.ContainsAny(key, `/\\`) {
+		return nil, fmt.Errorf("runtimebundle: invalid rooted cache lock key %q", key)
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	file, err := openPlatformRootLockFile(rootPath, root, lockSidecarPath(key), false)
+	if err != nil {
+		return nil, err
+	}
+	return acquireOpenedPlatformFileLock(ctx, file, mode)
+}
+
+func acquireOpenedPlatformFileLock(ctx context.Context, file platformLockFile, mode lockMode) (LockLease, error) {
+	for {
+		acquired, tryErr := file.tryLock(mode)
+		if tryErr != nil {
+			_ = file.close()
+			return nil, tryErr
+		}
+		if acquired {
+			if err := file.validate(); err != nil {
+				_ = file.unlock()
+				_ = file.close()
+				return nil, err
+			}
+			return &fileLease{file: file}, nil
+		}
+		if err := waitForLock(ctx); err != nil {
+			_ = file.close()
+			return nil, err
+		}
+	}
+}
+
+func lockSidecarPath(key string) string { return key + ".lock" }
+
+func openPlatformLockFile(path string) (platformLockFile, error) {
+	parentPath := filepath.Dir(path)
+	root, err := openOrCreateLockParent(parentPath)
+	if err != nil {
+		return nil, err
+	}
+	file, err := openPlatformRootLockFile(parentPath, root, filepath.Base(path), true)
+	if err != nil {
+		_ = root.Close()
+		return nil, err
+	}
+	return file, nil
+}
+
+type rootedPlatformLockFile struct {
+	file     rawPlatformLockFile
+	rootPath string
+	root     *os.Root
+	name     string
+	ownsRoot bool
+}
+
+func openPlatformRootLockFile(rootPath string, root *os.Root, name string, ownsRoot bool) (platformLockFile, error) {
+	if root == nil {
+		return nil, fmt.Errorf("runtimebundle: nil pinned lock root")
+	}
+	if name == "" || name == "." || name == ".." || filepath.Base(name) != name || strings.ContainsAny(name, `/\\`) {
+		return nil, fmt.Errorf("runtimebundle: invalid lock sidecar name %q", name)
+	}
+	var before os.FileInfo
+	if info, err := root.Lstat(name); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+			return nil, fmt.Errorf("%w: lock sidecar is not a regular non-symlink file: %s", ErrUnsafeArchive, name)
+		}
+		before = info
+	} else if !os.IsNotExist(err) {
+		return nil, err
+	}
+	raw, err := openPlatformLockFileImpl(root, name)
+	if err != nil {
+		return nil, fmt.Errorf("runtimebundle: open lock sidecar %s: %w", name, err)
+	}
+	closeRaw := true
+	defer func() {
+		if closeRaw {
+			_ = raw.close()
+		}
+	}()
+	opened, err := raw.stat()
+	if err != nil {
+		return nil, fmt.Errorf("runtimebundle: stat opened lock sidecar %s: %w", name, err)
+	}
+	if !opened.Mode().IsRegular() {
+		return nil, fmt.Errorf("%w: opened lock sidecar is not regular: %s", ErrUnsafeArchive, name)
+	}
+	if before != nil && !os.SameFile(before, opened) {
+		return nil, fmt.Errorf("%w: lock sidecar changed while opening: %s", ErrUnsafeArchive, name)
+	}
+	file := &rootedPlatformLockFile{file: raw, rootPath: rootPath, root: root, name: name, ownsRoot: ownsRoot}
+	if err := file.validateIdentity(); err != nil {
+		return nil, err
+	}
+	if err := raw.protect(); err != nil {
+		return nil, fmt.Errorf("runtimebundle: protect lock sidecar %s: %w", name, err)
+	}
+	if err := file.validate(); err != nil {
+		return nil, err
+	}
+	closeRaw = false
+	return file, nil
+}
+
+func (f *rootedPlatformLockFile) tryLock(mode lockMode) (bool, error) {
+	return f.file.tryLock(mode)
+}
+
+func (f *rootedPlatformLockFile) unlock() error { return f.file.unlock() }
+
+func (f *rootedPlatformLockFile) close() error {
+	fileErr := f.file.close()
+	if !f.ownsRoot {
+		return fileErr
+	}
+	return errors.Join(fileErr, f.root.Close())
+}
+
+func (f *rootedPlatformLockFile) validate() error {
+	if err := f.validateIdentity(); err != nil {
+		return err
+	}
+	pathInfo, err := f.root.Lstat(f.name)
+	if err != nil {
+		return fmt.Errorf("%w: lock sidecar pathname changed: %v", ErrUnsafeArchive, err)
+	}
+	if runtimeIsUnix() && pathInfo.Mode().Perm() != 0o600 {
+		return fmt.Errorf("%w: lock sidecar is not private: %s", ErrUnsafeArchive, f.name)
+	}
+	return verifyPrivateRootPath(f.root, f.name)
+}
+
+func (f *rootedPlatformLockFile) validateIdentity() error {
+	if err := checkPinnedRootPath(f.rootPath, f.root); err != nil {
+		return err
+	}
+	pathInfo, err := f.root.Lstat(f.name)
+	if err != nil {
+		return fmt.Errorf("%w: lock sidecar pathname changed: %v", ErrUnsafeArchive, err)
+	}
+	if pathInfo.Mode()&os.ModeSymlink != 0 || !pathInfo.Mode().IsRegular() {
+		return fmt.Errorf("%w: lock sidecar is not a regular non-symlink file: %s", ErrUnsafeArchive, f.name)
+	}
+	opened, err := f.file.stat()
+	if err != nil {
+		return err
+	}
+	if !opened.Mode().IsRegular() || !os.SameFile(pathInfo, opened) {
+		return fmt.Errorf("%w: lock sidecar pathname was replaced: %s", ErrUnsafeArchive, f.name)
+	}
+	return nil
+}
+
+func openOrCreateLockParent(parent string) (*os.Root, error) {
+	if parent == "" || parent == "." {
+		return nil, fmt.Errorf("runtimebundle: invalid lock parent")
+	}
+	if info, err := os.Lstat(parent); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+			return nil, fmt.Errorf("%w: lock parent is not a real directory: %s", ErrUnsafeArchive, parent)
+		}
+		if err := validateLockParentSecurity(parent); err != nil {
+			return nil, err
+		}
+		root, err := openPinnedRoot(parent)
+		if err != nil {
+			return nil, err
+		}
+		if err := validateLockParentSecurity(parent); err != nil {
+			_ = root.Close()
+			return nil, err
+		}
+		return root, nil
+	} else if !os.IsNotExist(err) {
+		return nil, err
+	}
+	// Cache materialization normally prepares this directory. Direct provider
+	// users may securely create missing private components from the nearest
+	// pinned existing ancestor.
+	root, err := openOrCreateCacheRoot(parent, defaultPermissions())
+	if err != nil {
+		return nil, err
+	}
+	if err := validateLockParentSecurity(parent); err != nil {
+		_ = root.Close()
+		return nil, err
+	}
+	return root, nil
+}
+
+func waitForLock(ctx context.Context) error {
+	timer := time.NewTimer(10 * time.Millisecond)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func runtimeIsWindows() bool { return runtime.GOOS == "windows" }
+
+// platformLockFile is implemented in lock_posix.go, lock_windows.go, or the
+// explicit unsupported fallback for platforms without an OS lock primitive.
+type rawPlatformLockFile interface {
+	tryLock(lockMode) (bool, error)
+	unlock() error
+	close() error
+	stat() (os.FileInfo, error)
+	protect() error
+}
+
+type platformLockFile interface {
+	tryLock(lockMode) (bool, error)
+	unlock() error
+	close() error
+	validate() error
+}

--- a/internal/runtimebundle/lock_other.go
+++ b/internal/runtimebundle/lock_other.go
@@ -1,0 +1,27 @@
+//go:build !darwin && !dragonfly && !freebsd && !linux && !netbsd && !openbsd && !solaris && !windows
+
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package runtimebundle
+
+import "os"
+
+func openPlatformLockFileImpl(*os.Root, string) (rawPlatformLockFile, error) {
+	return nil, ErrCrossProcessLockUnsupported
+}
+
+func validateLockParentSecurity(string) error { return ErrCrossProcessLockUnsupported }

--- a/internal/runtimebundle/lock_posix.go
+++ b/internal/runtimebundle/lock_posix.go
@@ -1,0 +1,96 @@
+//go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package runtimebundle
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/unix"
+)
+
+type posixLockFile struct{ file *os.File }
+
+func openPlatformLockFileImpl(root *os.Root, name string) (rawPlatformLockFile, error) {
+	for attempt := 0; attempt < 16; attempt++ {
+		file, err := root.OpenFile(name, os.O_CREATE|os.O_EXCL|os.O_RDWR, 0o600)
+		if err == nil {
+			return &posixLockFile{file: file}, nil
+		}
+		if !errors.Is(err, os.ErrExist) {
+			return nil, err
+		}
+		directory, err := root.Open(".")
+		if err != nil {
+			return nil, err
+		}
+		fd, openErr := unix.Openat(int(directory.Fd()), name, unix.O_RDWR|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+		closeErr := directory.Close()
+		if openErr != nil {
+			if errors.Is(openErr, os.ErrNotExist) {
+				continue
+			}
+			if errors.Is(openErr, unix.ELOOP) {
+				return nil, fmt.Errorf("%w: lock sidecar is a symlink: %s", ErrUnsafeArchive, name)
+			}
+			return nil, openErr
+		}
+		if closeErr != nil {
+			_ = unix.Close(fd)
+			return nil, closeErr
+		}
+		file = os.NewFile(uintptr(fd), filepath.Join(root.Name(), name))
+		if file == nil {
+			_ = unix.Close(fd)
+			return nil, os.ErrInvalid
+		}
+		return &posixLockFile{file: file}, nil
+	}
+	return nil, fmt.Errorf("runtimebundle: lock sidecar changed repeatedly while opening: %s", name)
+}
+
+func (f *posixLockFile) tryLock(mode lockMode) (bool, error) {
+	flags := unix.LOCK_NB
+	if mode == lockExclusive {
+		flags |= unix.LOCK_EX
+	} else {
+		flags |= unix.LOCK_SH
+	}
+	if err := unix.Flock(int(f.file.Fd()), flags); err != nil {
+		if errors.Is(err, unix.EAGAIN) || errors.Is(err, unix.EWOULDBLOCK) || errors.Is(err, unix.EINTR) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+func (f *posixLockFile) unlock() error {
+	return unix.Flock(int(f.file.Fd()), unix.LOCK_UN)
+}
+
+func (f *posixLockFile) close() error { return f.file.Close() }
+
+func (f *posixLockFile) stat() (os.FileInfo, error) { return f.file.Stat() }
+
+func (f *posixLockFile) protect() error { return f.file.Chmod(0o600) }
+
+func validateLockParentSecurity(string) error { return nil }

--- a/internal/runtimebundle/lock_posix_test.go
+++ b/internal/runtimebundle/lock_posix_test.go
@@ -1,0 +1,53 @@
+//go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package runtimebundle
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestOpenPlatformLockFileImplRejectsSymlink(t *testing.T) {
+	rootPath := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "outside.lock")
+	if err := os.WriteFile(outside, []byte("outside"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	const name = "runtime.bin.lock"
+	if err := os.Symlink(outside, filepath.Join(rootPath, name)); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	root, err := openPinnedRoot(rootPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer root.Close()
+	file, err := openPlatformLockFileImpl(root, name)
+	if file != nil {
+		_ = file.close()
+	}
+	if !errors.Is(err, ErrUnsafeArchive) {
+		t.Fatalf("open no-follow lock symlink error = %v, want ErrUnsafeArchive", err)
+	}
+	if data, err := os.ReadFile(outside); err != nil || string(data) != "outside" {
+		t.Fatalf("outside lock = %q, err=%v; want unchanged", data, err)
+	}
+}

--- a/internal/runtimebundle/lock_windows.go
+++ b/internal/runtimebundle/lock_windows.go
@@ -1,0 +1,90 @@
+//go:build windows
+
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package runtimebundle
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+const (
+	lockFileFailImmediately = 0x00000001
+	lockFileExclusiveLock   = 0x00000002
+)
+
+type windowsLockFile struct {
+	file       *os.File
+	overlapped windows.Overlapped
+	locked     bool
+}
+
+func openPlatformLockFileImpl(root *os.Root, name string) (rawPlatformLockFile, error) {
+	for attempt := 0; attempt < 16; attempt++ {
+		file, err := root.OpenFile(name, os.O_CREATE|os.O_EXCL|os.O_RDWR, 0o600)
+		if err == nil {
+			return &windowsLockFile{file: file}, nil
+		}
+		if !errors.Is(err, os.ErrExist) {
+			return nil, err
+		}
+		file, err = root.OpenFile(name, os.O_RDWR, 0)
+		if err == nil {
+			return &windowsLockFile{file: file}, nil
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			return nil, err
+		}
+	}
+	return nil, fmt.Errorf("runtimebundle: lock sidecar changed repeatedly while opening: %s", name)
+}
+
+func (f *windowsLockFile) tryLock(mode lockMode) (bool, error) {
+	flags := uint32(lockFileFailImmediately)
+	if mode == lockExclusive {
+		flags |= lockFileExclusiveLock
+	}
+	err := windows.LockFileEx(windows.Handle(f.file.Fd()), flags, 0, 1, 0, &f.overlapped)
+	if err != nil {
+		if errors.Is(err, windows.ERROR_LOCK_VIOLATION) || errors.Is(err, windows.ERROR_IO_PENDING) {
+			return false, nil
+		}
+		return false, err
+	}
+	f.locked = true
+	return true, nil
+}
+
+func (f *windowsLockFile) unlock() error {
+	if !f.locked {
+		return nil
+	}
+	f.locked = false
+	return windows.UnlockFileEx(windows.Handle(f.file.Fd()), 0, 1, 0, &f.overlapped)
+}
+
+func (f *windowsLockFile) close() error { return f.file.Close() }
+
+func (f *windowsLockFile) stat() (os.FileInfo, error) { return f.file.Stat() }
+
+func (f *windowsLockFile) protect() error { return nil }
+
+func validateLockParentSecurity(path string) error { return verifyPrivateDACL(path) }

--- a/internal/runtimebundle/materialized.go
+++ b/internal/runtimebundle/materialized.go
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package runtimebundle
+
+import "sync"
+
+// Materialized is a verified cache path together with its shared use lease.
+// The lease must remain open for as long as the caller may read or execute
+// files below Path; Close is safe to call more than once and from concurrent
+// goroutines.
+type Materialized struct {
+	Path string
+
+	lease     LockLease
+	closeOnce sync.Once
+	closeErr  error
+}
+
+// Close releases the shared use lease. A zero Materialized is a no-op.
+func (m *Materialized) Close() error {
+	if m == nil {
+		return nil
+	}
+	m.closeOnce.Do(func() {
+		if m.lease != nil {
+			m.closeErr = m.lease.Close()
+			m.lease = nil
+		}
+	})
+	return m.closeErr
+}

--- a/internal/runtimebundle/permissions_windows_test.go
+++ b/internal/runtimebundle/permissions_windows_test.go
@@ -19,9 +19,11 @@
 package runtimebundle
 
 import (
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"golang.org/x/sys/windows"
@@ -51,6 +53,20 @@ func TestWindowsPrivateDACLIsAppliedAtCreation(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	key := filepath.Join(child, strings.Repeat("d", 64))
+	lease, err := (CrossProcessLockProvider{}).AcquireExclusive(context.Background(), key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := lease.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := verifyPrivateDACL(key + ".lock"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(key + ".lock"); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestVerifyPrivateSecurityDescriptorUsesBinarySIDs(t *testing.T) {


### PR DESCRIPTION
## Summary

- add the content-addressed runtime bundle cache on top of the merged verification layer
- split cache materialization, roots, integrity, administration, locks, leases, and GC boundaries by responsibility
- remove redundant compatibility aliases and duplicate digest/default-limit implementations
- preserve pinned-root, cross-process lock, cache repair, concurrent lease, and Windows private-DACL checks

This PR intentionally excludes runtime download/acquisition, payload, launcher, and XGo driver code.

## Verification

- go test -race ./internal/runtimebundle
- go vet ./internal/runtimebundle
- GOOS=windows GOARCH=amd64 go test -c ./internal/runtimebundle
- go mod tidy -diff
- go test ./...
- git diff --check