### PR TITLE
feat(runtimebundle): add secure asset acquisition

### DIFF
--- a/internal/runtimebundle/acquire.go
+++ b/internal/runtimebundle/acquire.go
@@ -1,0 +1,395 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package runtimebundle
+
+import (
+	"context"
+	cryptorand "crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+var errAcquireSizeLimit = errors.New("runtimebundle: acquired asset exceeds size limit")
+
+// FetchFunc writes one URL response to dst and must honor ctx.
+type FetchFunc func(ctx context.Context, url string, dst io.Writer) error
+
+// FetchSpec pins one downloadable asset.
+type FetchSpec struct {
+	Name    string
+	URL     string
+	Size    int64
+	SHA256  string
+	Offline bool
+	Fetch   FetchFunc
+}
+
+// AcquiredFile is a verified cache file held by a shared use lease.
+type AcquiredFile struct {
+	file      *os.File
+	lease     LockLease
+	closeOnce sync.Once
+	closeErr  error
+}
+
+func (f *AcquiredFile) Read(p []byte) (int, error) {
+	if f == nil || f.file == nil {
+		return 0, os.ErrInvalid
+	}
+	return f.file.Read(p)
+}
+
+func (f *AcquiredFile) ReadAt(p []byte, off int64) (int, error) {
+	if f == nil || f.file == nil {
+		return 0, os.ErrInvalid
+	}
+	return f.file.ReadAt(p, off)
+}
+
+func (f *AcquiredFile) Stat() (os.FileInfo, error) {
+	if f == nil || f.file == nil {
+		return nil, os.ErrInvalid
+	}
+	return f.file.Stat()
+}
+
+// Close is idempotent and safe for concurrent callers.
+func (f *AcquiredFile) Close() error {
+	if f == nil {
+		return nil
+	}
+	f.closeOnce.Do(func() {
+		var fileErr, leaseErr error
+		if f.file != nil {
+			fileErr = f.file.Close()
+		}
+		if f.lease != nil {
+			leaseErr = f.lease.Close()
+		}
+		f.closeErr = errors.Join(fileErr, leaseErr)
+	})
+	return f.closeErr
+}
+
+// AcquireFile downloads or reuses one file, verifies it, and keeps a shared
+// use lease while the returned descriptor is read.
+func AcquireFile(ctx context.Context, root string, spec FetchSpec) (*AcquiredFile, error) {
+	_, err := acquirePath(ctx, root, spec)
+	if err != nil {
+		return nil, err
+	}
+	cacheRoot, err := openOrCreateCacheRoot(root, defaultPermissions())
+	if err != nil {
+		return nil, fmt.Errorf("runtimebundle: pin acquisition root for use: %w", err)
+	}
+	defer cacheRoot.Close()
+	lease, err := acquirePlatformRootFileLock(ctx, root, cacheRoot, spec.Name, lockShared)
+	if err != nil {
+		return nil, fmt.Errorf("runtimebundle: acquire shared lock for asset %q: %w", spec.Name, err)
+	}
+	closeLease := true
+	defer func() {
+		if closeLease {
+			_ = lease.Close()
+		}
+	}()
+	if err := checkPinnedRootPath(root, cacheRoot); err != nil {
+		return nil, err
+	}
+	file, err := openVerifiedAcquireRootFile(cacheRoot, spec.Name, spec.Size, spec.SHA256)
+	if err != nil {
+		return nil, fmt.Errorf("runtimebundle: verify acquired asset %q for use: %w", spec.Name, err)
+	}
+	if err := checkPinnedRootPath(root, cacheRoot); err != nil {
+		_ = file.Close()
+		return nil, err
+	}
+	closeLease = false
+	return &AcquiredFile{file: file, lease: lease}, nil
+}
+
+func acquirePath(ctx context.Context, root string, spec FetchSpec) (string, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := validateAcquireSpec(spec); err != nil {
+		return "", err
+	}
+	if root == "" || !filepath.IsAbs(root) || filepath.Clean(root) != root {
+		return "", fmt.Errorf("runtimebundle: acquisition root must be absolute and clean: %q", root)
+	}
+	cacheRoot, err := openOrCreateCacheRoot(root, defaultPermissions())
+	if err != nil {
+		return "", fmt.Errorf("runtimebundle: pin acquisition root: %w", err)
+	}
+	defer cacheRoot.Close()
+	path := filepath.Join(root, spec.Name)
+	lease, err := acquirePlatformRootFileLock(ctx, root, cacheRoot, spec.Name, lockExclusive)
+	if err != nil {
+		return "", fmt.Errorf("runtimebundle: acquire lock for asset %q: %w", spec.Name, err)
+	}
+	defer lease.Close()
+	if err := checkPinnedRootPath(root, cacheRoot); err != nil {
+		return "", err
+	}
+	if info, err := cacheRoot.Lstat(spec.Name); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+			return "", fmt.Errorf("%w: cached asset %q is not a regular non-symlink file", ErrUnsafeArchive, path)
+		}
+		if err := verifyAcquireRootFile(cacheRoot, spec.Name, spec.Size, spec.SHA256); err == nil {
+			if err := checkPinnedRootPath(root, cacheRoot); err != nil {
+				return "", err
+			}
+			return path, nil
+		} else if spec.Offline {
+			return "", fmt.Errorf("runtimebundle: offline cached asset %q failed verification: %w", path, err)
+		}
+	} else if err != nil && !os.IsNotExist(err) {
+		return "", fmt.Errorf("runtimebundle: inspect cached asset %q: %w", path, err)
+	}
+	if spec.Offline {
+		return "", fmt.Errorf("runtimebundle: offline cache miss for %q (URL: %s)", spec.Name, spec.URL)
+	}
+	if spec.Fetch == nil {
+		return "", fmt.Errorf("runtimebundle: no fetcher for %q", spec.Name)
+	}
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	tmpName, tmp, err := newAcquireRootTemp(cacheRoot)
+	if err != nil {
+		return "", fmt.Errorf("runtimebundle: create temporary asset %q: %w", spec.Name, err)
+	}
+	defer func() {
+		_ = cacheRoot.Remove(tmpName)
+	}()
+	limiter := &acquireLimitWriter{destination: tmp, remaining: spec.Size}
+	if err := spec.Fetch(ctx, spec.URL, limiter); err != nil {
+		_ = tmp.Close()
+		return "", fmt.Errorf("runtimebundle: fetch %q: %w", spec.Name, err)
+	}
+	if limiter.exceeded {
+		_ = tmp.Close()
+		return "", errAcquireSizeLimit
+	}
+	if err := checkPinnedRootPath(root, cacheRoot); err != nil {
+		_ = tmp.Close()
+		return "", err
+	}
+	if err := ctx.Err(); err != nil {
+		_ = tmp.Close()
+		return "", err
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return "", fmt.Errorf("runtimebundle: sync downloaded asset %q: %w", spec.Name, err)
+	}
+	if err := tmp.Close(); err != nil {
+		return "", fmt.Errorf("runtimebundle: close downloaded asset %q: %w", spec.Name, err)
+	}
+	if err := verifyAcquireRootFile(cacheRoot, tmpName, spec.Size, spec.SHA256); err != nil {
+		return "", fmt.Errorf("runtimebundle: verify downloaded asset %q: %w", spec.Name, err)
+	}
+	if err := checkPinnedRootPath(root, cacheRoot); err != nil {
+		return "", err
+	}
+	if err := replaceAcquireRootFile(cacheRoot, tmpName, spec.Name); err != nil {
+		return "", fmt.Errorf("runtimebundle: publish downloaded asset %q: %w", spec.Name, err)
+	}
+	if err := syncRootDir(cacheRoot); err != nil {
+		return "", fmt.Errorf("runtimebundle: sync acquired asset directory %q: %w", spec.Name, err)
+	}
+	if err := verifyAcquireRootFile(cacheRoot, spec.Name, spec.Size, spec.SHA256); err != nil {
+		return "", fmt.Errorf("runtimebundle: verify published asset %q: %w", spec.Name, err)
+	}
+	if err := checkPinnedRootPath(root, cacheRoot); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+func validateAcquireSpec(spec FetchSpec) error {
+	if spec.Name == "" || spec.Name == "." || spec.Name == ".." || filepath.Base(spec.Name) != spec.Name || filepath.IsAbs(spec.Name) {
+		return fmt.Errorf("runtimebundle: invalid acquired asset name %q", spec.Name)
+	}
+	if strings.ContainsAny(spec.Name, `/\\`) {
+		return fmt.Errorf("runtimebundle: acquired asset name must be a basename: %q", spec.Name)
+	}
+	if spec.Size <= 0 {
+		return fmt.Errorf("runtimebundle: asset size must be positive for %q", spec.Name)
+	}
+	if err := validateSHA256(spec.SHA256); err != nil {
+		return fmt.Errorf("runtimebundle: invalid asset SHA-256 for %q: %w", spec.Name, err)
+	}
+	return nil
+}
+
+type acquireLimitWriter struct {
+	destination io.Writer
+	remaining   int64
+	exceeded    bool
+}
+
+func (w *acquireLimitWriter) Write(data []byte) (int, error) {
+	if len(data) == 0 {
+		return 0, nil
+	}
+	if w.remaining <= 0 {
+		w.exceeded = true
+		return 0, errAcquireSizeLimit
+	}
+	writable := data
+	limited := int64(len(data)) > w.remaining
+	if limited {
+		w.exceeded = true
+		writable = data[:w.remaining]
+	}
+	n, err := w.destination.Write(writable)
+	w.remaining -= int64(n)
+	if err != nil {
+		return n, err
+	}
+	if n != len(writable) {
+		return n, io.ErrShortWrite
+	}
+	if limited {
+		return n, errAcquireSizeLimit
+	}
+	return n, nil
+}
+
+func newAcquireRootTemp(root *os.Root) (string, *os.File, error) {
+	var random [12]byte
+	for attempt := 0; attempt < 32; attempt++ {
+		if _, err := cryptorand.Read(random[:]); err != nil {
+			return "", nil, err
+		}
+		name := ".asset-" + hex.EncodeToString(random[:])
+		file, err := root.OpenFile(name, os.O_CREATE|os.O_EXCL|os.O_RDWR, 0o600)
+		if err != nil {
+			if errors.Is(err, os.ErrExist) {
+				continue
+			}
+			return "", nil, err
+		}
+		if runtimeIsUnix() {
+			if err := file.Chmod(0o600); err != nil {
+				_ = file.Close()
+				_ = root.Remove(name)
+				return "", nil, err
+			}
+		}
+		if err := verifyPrivateRootPath(root, name); err != nil {
+			_ = file.Close()
+			_ = root.Remove(name)
+			return "", nil, err
+		}
+		return name, file, nil
+	}
+	return "", nil, fmt.Errorf("runtimebundle: unable to allocate sibling temporary asset")
+}
+
+func verifyAcquireRootFile(root *os.Root, name string, expectedSize int64, expectedDigest string) error {
+	file, err := openVerifiedAcquireRootFile(root, name, expectedSize, expectedDigest)
+	if err != nil {
+		return err
+	}
+	return file.Close()
+}
+
+func openVerifiedAcquireRootFile(root *os.Root, name string, expectedSize int64, expectedDigest string) (file *os.File, err error) {
+	name = filepath.FromSlash(name)
+	before, err := root.Lstat(name)
+	if err != nil {
+		return nil, err
+	}
+	if before.Mode()&os.ModeSymlink != 0 || !before.Mode().IsRegular() {
+		return nil, fmt.Errorf("%w: acquired asset is not a regular non-symlink file", ErrUnsafeArchive)
+	}
+	file, err = root.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err != nil {
+			_ = file.Close()
+		}
+	}()
+	opened, err := file.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if !os.SameFile(before, opened) {
+		return nil, fmt.Errorf("%w: acquired asset changed while opening", ErrUnsafeArchive)
+	}
+	hasher := sha256.New()
+	size, copyErr := io.Copy(hasher, file)
+	if copyErr != nil {
+		return nil, copyErr
+	}
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return nil, err
+	}
+	after, err := root.Lstat(name)
+	if err != nil {
+		return nil, err
+	}
+	if after.Mode()&os.ModeSymlink != 0 || !after.Mode().IsRegular() || !os.SameFile(opened, after) || after.Size() != size {
+		return nil, fmt.Errorf("%w: acquired asset changed while reading", ErrUnsafeArchive)
+	}
+	if err := verifyPrivateRootPath(root, name); err != nil {
+		return nil, err
+	}
+	if expectedSize > 0 && size != expectedSize {
+		return nil, fmt.Errorf("%w: size = %d, want %d", ErrDigestMismatch, size, expectedSize)
+	}
+	if expectedDigest != "" {
+		got := hex.EncodeToString(hasher.Sum(nil))
+		if got != expectedDigest {
+			return nil, fmt.Errorf("%w: SHA-256 = %s, want %s", ErrDigestMismatch, got, expectedDigest)
+		}
+	}
+	return file, nil
+}
+
+func replaceAcquireRootFile(root *os.Root, src, dst string) error {
+	src = filepath.FromSlash(src)
+	dst = filepath.FromSlash(dst)
+	if info, err := root.Lstat(src); err != nil {
+		return err
+	} else if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+		return fmt.Errorf("%w: source is not a regular non-symlink file: %s", ErrUnsafeArchive, src)
+	}
+	if info, err := root.Lstat(dst); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+			return fmt.Errorf("%w: destination is not a regular non-symlink file: %s", ErrUnsafeArchive, dst)
+		}
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+	if err := root.Rename(src, dst); err != nil {
+		return err
+	}
+	return verifyPrivateRootPath(root, dst)
+}

--- a/internal/runtimebundle/acquire_test.go
+++ b/internal/runtimebundle/acquire_test.go
@@ -1,0 +1,665 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package runtimebundle
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestAcquireRejectsDownloadedSizeAndDigestMismatchWithoutPublishing(t *testing.T) {
+	const payload = "verified payload"
+	tests := []struct {
+		name           string
+		expectedSize   int64
+		expectedSHA256 string
+	}{
+		{
+			name:           "size",
+			expectedSize:   int64(len(payload) + 1),
+			expectedSHA256: testDigest(payload),
+		},
+		{
+			name:           "digest",
+			expectedSize:   int64(len(payload)),
+			expectedSHA256: testDigest("different payload"),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := t.TempDir()
+			var fetches atomic.Int32
+			_, err := acquirePath(context.Background(), root, FetchSpec{
+				Name:   "runtime.bin",
+				URL:    "https://example.invalid/runtime.bin",
+				Size:   test.expectedSize,
+				SHA256: test.expectedSHA256,
+				Fetch: func(_ context.Context, _ string, dst io.Writer) error {
+					fetches.Add(1)
+					_, err := io.WriteString(dst, payload)
+					return err
+				},
+			})
+			if err == nil {
+				t.Fatal("Acquire accepted an asset with mismatched verification data")
+			}
+			if !errors.Is(err, ErrDigestMismatch) {
+				t.Fatalf("verification error = %v, want ErrDigestMismatch", err)
+			}
+			if fetches.Load() != 1 {
+				t.Fatalf("fetch count = %d, want 1", fetches.Load())
+			}
+			entries, err := os.ReadDir(root)
+			if err != nil {
+				t.Fatal(err)
+			}
+			names := acquireTestEntryNames(entries)
+			if len(names) != 0 {
+				t.Fatalf("cache contents after rejected download = %v, want empty", names)
+			}
+		})
+	}
+}
+
+func TestAcquireRejectsResponseOverPinnedSizeWithoutPublishing(t *testing.T) {
+	root := t.TempDir()
+	_, err := acquirePath(context.Background(), root, FetchSpec{
+		Name:   "runtime-manifest.json",
+		URL:    "https://example.invalid/runtime-manifest.json",
+		Size:   8,
+		SHA256: testDigest("12345678"),
+		Fetch: func(_ context.Context, _ string, dst io.Writer) error {
+			_, _ = io.WriteString(dst, "response larger than limit")
+			return nil
+		},
+	})
+	if !errors.Is(err, errAcquireSizeLimit) {
+		t.Fatalf("Acquire over size limit error = %v", err)
+	}
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if names := acquireTestEntryNames(entries); len(names) != 0 {
+		t.Fatalf("cache contents after oversized response = %v, want empty", names)
+	}
+}
+
+func TestAcquireOfflineHitDoesNotFetch(t *testing.T) {
+	const (
+		name    = "runtime.bin"
+		payload = "cached payload"
+	)
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, name), []byte(payload), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var fetches atomic.Int32
+	path, err := acquirePath(context.Background(), root, FetchSpec{
+		Name:    name,
+		URL:     "https://example.invalid/runtime.bin",
+		Size:    int64(len(payload)),
+		SHA256:  testDigest(payload),
+		Offline: true,
+		Fetch: func(_ context.Context, _ string, _ io.Writer) error {
+			fetches.Add(1)
+			return errors.New("offline cache hit must not fetch")
+		},
+	})
+	if err != nil {
+		t.Fatalf("offline cache hit: %v", err)
+	}
+	if path != filepath.Join(root, name) {
+		t.Fatalf("path = %q, want %q", path, filepath.Join(root, name))
+	}
+	if fetches.Load() != 0 {
+		t.Fatalf("fetch count = %d, want 0", fetches.Load())
+	}
+}
+
+func TestAcquireOfflineMissDoesNotFetch(t *testing.T) {
+	root := t.TempDir()
+	var fetches atomic.Int32
+	_, err := acquirePath(context.Background(), root, FetchSpec{
+		Name:    "runtime.bin",
+		URL:     "https://example.invalid/runtime.bin",
+		Size:    1,
+		SHA256:  testDigest("x"),
+		Offline: true,
+		Fetch: func(_ context.Context, _ string, _ io.Writer) error {
+			fetches.Add(1)
+			return nil
+		},
+	})
+	if err == nil {
+		t.Fatal("offline cache miss unexpectedly succeeded")
+	}
+	if fetches.Load() != 0 {
+		t.Fatalf("fetch count = %d, want 0", fetches.Load())
+	}
+	if got := err.Error(); !strings.Contains(got, "offline cache miss") || !strings.Contains(got, "URL:") {
+		t.Fatalf("offline cache miss error = %q, want an actionable English error", got)
+	}
+}
+
+func TestAcquireCreatesNestedPrivateRoot(t *testing.T) {
+	const payload = "nested cache payload"
+	base := t.TempDir()
+	spxRoot := filepath.Join(base, "spx")
+	bundleRoot := filepath.Join(spxRoot, "runtimebundle")
+	root := filepath.Join(bundleRoot, "release-assets")
+	path, err := acquirePath(context.Background(), root, FetchSpec{
+		Name:   "runtime.bin",
+		URL:    "https://example.invalid/runtime.bin",
+		Size:   int64(len(payload)),
+		SHA256: testDigest(payload),
+		Fetch: func(_ context.Context, _ string, dst io.Writer) error {
+			_, err := io.WriteString(dst, payload)
+			return err
+		},
+	})
+	if err != nil {
+		t.Fatalf("Acquire with nested clean cache: %v", err)
+	}
+	if path != filepath.Join(root, "runtime.bin") {
+		t.Fatalf("path = %q, want %q", path, filepath.Join(root, "runtime.bin"))
+	}
+	if data, err := os.ReadFile(path); err != nil || string(data) != payload {
+		t.Fatalf("nested cache asset = %q, err=%v; want %q", data, err, payload)
+	}
+	if runtime.GOOS != "windows" {
+		for _, current := range []string{spxRoot, bundleRoot, root} {
+			info, err := os.Stat(current)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if info.Mode().Perm() != 0o700 {
+				t.Fatalf("nested cache directory %s mode = %o, want 700", current, info.Mode().Perm())
+			}
+		}
+	}
+}
+
+func TestAcquireOfflineInvalidCacheDoesNotFetch(t *testing.T) {
+	const name = "runtime.bin"
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, name), []byte("tampered"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var fetches atomic.Int32
+	_, err := acquirePath(context.Background(), root, FetchSpec{
+		Name:    name,
+		URL:     "https://example.invalid/runtime.bin",
+		Size:    int64(len("trusted")),
+		SHA256:  testDigest("trusted"),
+		Offline: true,
+		Fetch: func(_ context.Context, _ string, _ io.Writer) error {
+			fetches.Add(1)
+			return nil
+		},
+	})
+	if err == nil {
+		t.Fatal("offline invalid cache unexpectedly succeeded")
+	}
+	if fetches.Load() != 0 {
+		t.Fatalf("fetch count = %d, want 0", fetches.Load())
+	}
+	if _, statErr := os.Stat(filepath.Join(root, name)); statErr != nil {
+		t.Fatalf("invalid cache disappeared, stat error = %v", statErr)
+	}
+}
+
+func TestAcquireRetriesAfterFetcherFailure(t *testing.T) {
+	const (
+		name    = "runtime.bin"
+		payload = "retry payload"
+	)
+	root := t.TempDir()
+	var fetches atomic.Int32
+	fetch := func(_ context.Context, _ string, dst io.Writer) error {
+		if fetches.Add(1) == 1 {
+			return errors.New("temporary fetch failure")
+		}
+		_, err := io.WriteString(dst, payload)
+		return err
+	}
+	spec := FetchSpec{
+		Name:   name,
+		URL:    "https://example.invalid/runtime.bin",
+		Size:   int64(len(payload)),
+		SHA256: testDigest(payload),
+		Fetch:  fetch,
+	}
+	if _, err := acquirePath(context.Background(), root, spec); err == nil {
+		t.Fatal("first fetch unexpectedly succeeded")
+	}
+	if entries, err := os.ReadDir(root); err != nil {
+		t.Fatal(err)
+	} else if names := acquireTestEntryNames(entries); len(names) != 0 {
+		t.Fatalf("cache contents after failed fetch = %v, want empty", names)
+	}
+	path, err := acquirePath(context.Background(), root, spec)
+	if err != nil {
+		t.Fatalf("retry fetch: %v", err)
+	}
+	if got, err := os.ReadFile(path); err != nil || string(got) != payload {
+		t.Fatalf("retried asset = %q, err=%v; want %q", got, err, payload)
+	}
+	if fetches.Load() != 2 {
+		t.Fatalf("fetch count = %d, want 2", fetches.Load())
+	}
+}
+
+func TestAcquireRejectsCachedSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("creating symlinks requires privileges on Windows")
+	}
+	root := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "outside.bin")
+	if err := os.WriteFile(outside, []byte("outside"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(root, "runtime.bin")); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	var fetches atomic.Int32
+	_, err := acquirePath(context.Background(), root, FetchSpec{
+		Name:   "runtime.bin",
+		URL:    "https://example.invalid/runtime.bin",
+		Size:   1,
+		SHA256: testDigest("x"),
+		Fetch: func(_ context.Context, _ string, _ io.Writer) error {
+			fetches.Add(1)
+			return nil
+		},
+	})
+	if !errors.Is(err, ErrUnsafeArchive) {
+		t.Fatalf("Acquire cached symlink error = %v, want ErrUnsafeArchive", err)
+	}
+	if fetches.Load() != 0 {
+		t.Fatalf("fetch count = %d, want 0", fetches.Load())
+	}
+	got, err := os.ReadFile(outside)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "outside" {
+		t.Fatalf("symlink target changed to %q", got)
+	}
+}
+
+func TestAcquireRejectsLockSymlinkWithoutTouchingTarget(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("creating symlinks requires privileges on Windows")
+	}
+	root := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "outside.lock")
+	if err := os.WriteFile(outside, []byte("outside lock"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.Stat(outside)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(root, "runtime.bin.lock")); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	var fetches atomic.Int32
+	_, err = acquirePath(context.Background(), root, FetchSpec{
+		Name:   "runtime.bin",
+		URL:    "https://example.invalid/runtime.bin",
+		Size:   1,
+		SHA256: testDigest("x"),
+		Fetch: func(_ context.Context, _ string, _ io.Writer) error {
+			fetches.Add(1)
+			return nil
+		},
+	})
+	if !errors.Is(err, ErrUnsafeArchive) {
+		t.Fatalf("Acquire lock symlink error = %v, want ErrUnsafeArchive", err)
+	}
+	if fetches.Load() != 0 {
+		t.Fatalf("fetch count = %d, want 0", fetches.Load())
+	}
+	data, err := os.ReadFile(outside)
+	if err != nil {
+		t.Fatal(err)
+	}
+	after, err := os.Stat(outside)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "outside lock" || after.Mode().Perm() != before.Mode().Perm() {
+		t.Fatalf("outside lock changed: contents=%q mode=%o, want contents=%q mode=%o", data, after.Mode().Perm(), "outside lock", before.Mode().Perm())
+	}
+}
+
+func TestAcquireFailsClosedWhenRootIsReplacedDuringFetch(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("renaming an open directory is not supported on Windows")
+	}
+	parent := t.TempDir()
+	root := filepath.Join(parent, "cache")
+	if err := os.Mkdir(root, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	originalRoot := filepath.Join(parent, "cache-original")
+	replacement := t.TempDir()
+	_, err := acquirePath(context.Background(), root, FetchSpec{
+		Name:   "runtime.bin",
+		URL:    "https://example.invalid/runtime.bin",
+		Size:   int64(len("trusted payload")),
+		SHA256: testDigest("trusted payload"),
+		Fetch: func(_ context.Context, _ string, dst io.Writer) error {
+			if err := os.Rename(root, originalRoot); err != nil {
+				return err
+			}
+			if err := os.Symlink(replacement, root); err != nil {
+				return err
+			}
+			_, err := io.WriteString(dst, "trusted payload")
+			return err
+		},
+	})
+	if !errors.Is(err, ErrUnsafeArchive) {
+		t.Fatalf("Acquire replaced root error = %v, want ErrUnsafeArchive", err)
+	}
+	if _, err := os.Lstat(filepath.Join(replacement, "runtime.bin")); !os.IsNotExist(err) {
+		t.Fatalf("replacement root asset stat = %v, want not exist", err)
+	}
+	entries, err := os.ReadDir(originalRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if names := acquireTestEntryNames(entries); len(names) != 0 {
+		t.Fatalf("original root contents after replacement = %v, want no acquired assets", names)
+	}
+}
+
+func TestAcquireFailsClosedWhenRootParentIsReplacedDuringFetch(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("renaming an open directory is not supported on Windows")
+	}
+	top := t.TempDir()
+	parent := filepath.Join(top, "cache-parent")
+	root := filepath.Join(parent, "assets")
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	originalParent := filepath.Join(top, "cache-parent-original")
+	_, err := acquirePath(context.Background(), root, FetchSpec{
+		Name:   "runtime.bin",
+		URL:    "https://example.invalid/runtime.bin",
+		Size:   int64(len("trusted payload")),
+		SHA256: testDigest("trusted payload"),
+		Fetch: func(_ context.Context, _ string, dst io.Writer) error {
+			if err := os.Rename(parent, originalParent); err != nil {
+				return err
+			}
+			if err := os.MkdirAll(root, 0o700); err != nil {
+				return err
+			}
+			_, err := io.WriteString(dst, "trusted payload")
+			return err
+		},
+	})
+	if !errors.Is(err, ErrUnsafeArchive) {
+		t.Fatalf("Acquire replaced parent error = %v, want ErrUnsafeArchive", err)
+	}
+	if _, err := os.Lstat(filepath.Join(root, "runtime.bin")); !os.IsNotExist(err) {
+		t.Fatalf("replacement parent asset stat = %v, want not exist", err)
+	}
+	entries, err := os.ReadDir(filepath.Join(originalParent, "assets"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if names := acquireTestEntryNames(entries); len(names) != 0 {
+		t.Fatalf("original root contents after parent replacement = %v, want no acquired assets", names)
+	}
+}
+
+func TestAcquireConcurrentFetchesPublishCompleteAsset(t *testing.T) {
+	const (
+		workers = 16
+		name    = "runtime.bin"
+		payload = "complete concurrent payload"
+	)
+	root := t.TempDir()
+	var fetches atomic.Int32
+	fetch := func(_ context.Context, _ string, dst io.Writer) error {
+		fetches.Add(1)
+		time.Sleep(time.Millisecond)
+		_, err := io.WriteString(dst, payload)
+		return err
+	}
+	spec := FetchSpec{
+		Name:   name,
+		URL:    "https://example.invalid/runtime.bin",
+		Size:   int64(len(payload)),
+		SHA256: testDigest(payload),
+		Fetch:  fetch,
+	}
+	paths := make([]string, workers)
+	errs := make([]error, workers)
+	var group sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		group.Add(1)
+		go func(i int) {
+			defer group.Done()
+			paths[i], errs[i] = acquirePath(context.Background(), root, spec)
+		}(i)
+	}
+	group.Wait()
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("worker %d: %v", i, err)
+		}
+		if paths[i] != filepath.Join(root, name) {
+			t.Fatalf("worker %d path = %q, want %q", i, paths[i], filepath.Join(root, name))
+		}
+	}
+	if fetches.Load() != 1 {
+		t.Fatalf("concurrent acquisition fetch count = %d, want 1", fetches.Load())
+	}
+	got, err := os.ReadFile(filepath.Join(root, name))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != payload {
+		t.Fatalf("published concurrent asset = %q, want %q", got, payload)
+	}
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	names := acquireTestEntryNames(entries)
+	if len(names) != 1 || names[0] != name {
+		t.Fatalf("cache contents after concurrent acquisition = %v, want only %q", names, name)
+	}
+}
+
+func TestAcquireFileHoldsSharedLeaseUntilClose(t *testing.T) {
+	const (
+		name     = "runtime.bin"
+		original = "verified generation one"
+		next     = "verified generation two"
+	)
+	root := t.TempDir()
+	acquired, err := AcquireFile(context.Background(), root, FetchSpec{
+		Name:   name,
+		URL:    "https://example.invalid/runtime.bin",
+		Size:   int64(len(original)),
+		SHA256: testDigest(original),
+		Fetch: func(_ context.Context, _ string, dst io.Writer) error {
+			_, err := io.WriteString(dst, original)
+			return err
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := io.ReadAll(acquired)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != original {
+		t.Fatalf("acquired file = %q, want %q", data, original)
+	}
+
+	started := make(chan struct{})
+	fetched := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		close(started)
+		_, err := acquirePath(context.Background(), root, FetchSpec{
+			Name:   name,
+			URL:    "https://example.invalid/runtime-v2.bin",
+			Size:   int64(len(next)),
+			SHA256: testDigest(next),
+			Fetch: func(_ context.Context, _ string, dst io.Writer) error {
+				close(fetched)
+				_, err := io.WriteString(dst, next)
+				return err
+			},
+		})
+		done <- err
+	}()
+	<-started
+	select {
+	case <-fetched:
+		t.Fatal("exclusive replacement started while AcquireFile held its shared lease")
+	case <-time.After(100 * time.Millisecond):
+	}
+	if err := acquired.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := acquired.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("exclusive replacement remained blocked after AcquireFile.Close")
+	}
+	if got, err := os.ReadFile(filepath.Join(root, name)); err != nil || string(got) != next {
+		t.Fatalf("replacement = %q, err=%v; want %q", got, err, next)
+	}
+}
+
+func TestAcquireFileReadsPinnedInodeAfterRootReplacement(t *testing.T) {
+	const (
+		name    = "runtime.bin"
+		payload = "verified pinned payload"
+	)
+	parent := t.TempDir()
+	root := filepath.Join(parent, "cache")
+	acquired, err := AcquireFile(context.Background(), root, FetchSpec{
+		Name:   name,
+		URL:    "https://example.invalid/runtime.bin",
+		Size:   int64(len(payload)),
+		SHA256: testDigest(payload),
+		Fetch: func(_ context.Context, _ string, dst io.Writer) error {
+			_, err := io.WriteString(dst, payload)
+			return err
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer acquired.Close()
+
+	moved := filepath.Join(parent, "moved-cache")
+	if err := os.Rename(root, moved); err != nil {
+		t.Skipf("cannot replace an open cache root on this platform: %v", err)
+	}
+	if err := os.Mkdir(root, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, name), []byte("replacement payload"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	data, err := io.ReadAll(acquired)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != payload {
+		t.Fatalf("acquired descriptor followed replacement root: got %q, want %q", data, payload)
+	}
+}
+
+func TestAcquireFileAllowsConcurrentReadAndClose(t *testing.T) {
+	payload := strings.Repeat("verified payload", 1024)
+	acquired, err := AcquireFile(context.Background(), t.TempDir(), FetchSpec{
+		Name:   "runtime.bin",
+		URL:    "https://example.invalid/runtime.bin",
+		Size:   int64(len(payload)),
+		SHA256: testDigest(payload),
+		Fetch: func(_ context.Context, _ string, dst io.Writer) error {
+			_, err := io.WriteString(dst, payload)
+			return err
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	start := make(chan struct{})
+	var readers sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		readers.Add(1)
+		go func() {
+			defer readers.Done()
+			<-start
+			buffer := make([]byte, 256)
+			for offset := int64(0); offset < int64(len(payload)); offset += int64(len(buffer)) {
+				if _, err := acquired.ReadAt(buffer, offset); err != nil {
+					return
+				}
+			}
+		}()
+	}
+	close(start)
+	if err := acquired.Close(); err != nil {
+		t.Fatal(err)
+	}
+	readers.Wait()
+	if err := acquired.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+}
+
+func acquireTestEntryNames(entries []os.DirEntry) []string {
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if strings.HasSuffix(entry.Name(), ".lock") {
+			continue
+		}
+		names = append(names, entry.Name())
+	}
+	return names
+}

--- a/internal/runtimebundle/permissions_windows_test.go
+++ b/internal/runtimebundle/permissions_windows_test.go
@@ -21,6 +21,7 @@ package runtimebundle
 import (
 	"context"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -65,6 +66,30 @@ func TestWindowsPrivateDACLIsAppliedAtCreation(t *testing.T) {
 		t.Fatal(err)
 	}
 	if _, err := os.Stat(key + ".lock"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAcquireCreatesProtectedWindowsCache(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "acquire-cache")
+	path, err := acquirePath(context.Background(), root, FetchSpec{
+		Name: "manifest.json", URL: "https://example.invalid/manifest.json",
+		Size: 2, SHA256: testDigest("{}"),
+		Fetch: func(_ context.Context, _ string, dst io.Writer) error {
+			_, err := io.WriteString(dst, "{}")
+			return err
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := verifyProtectedPrivateDACL(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := verifyPrivateDACL(path); err != nil {
+		t.Fatal(err)
+	}
+	if err := verifyPrivateDACL(path + ".lock"); err != nil {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
## Summary

- acquire digest-pinned runtime assets into the private cache
- publish downloads atomically under cross-process leases
- return verified descriptors that retain a shared use lease
- fail closed on size, digest, symlink, root replacement, and permission violations

## Validation

- `go test -race ./internal/runtimebundle`
- `go vet ./...`
- `go test ./...`
- `GOOS=windows GOARCH=amd64 go test -c ./internal/runtimebundle`
- `go mod tidy` (no diff)
- `git diff --check`