### PR TITLE
feat(runtimepayload): add canonical launcher payload

### DIFF
--- a/internal/runtimepayload/build.go
+++ b/internal/runtimepayload/build.go
@@ -1,0 +1,212 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package runtimepayload
+
+import (
+	"archive/zip"
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"sort"
+
+	"github.com/goplus/spx/v3/internal/runtimebundle"
+)
+
+// BuildTo writes canonical payload bytes to dst and returns the full payload
+// and manifest SHA-256 values. An error may leave a partial payload in dst.
+func BuildTo(dst io.Writer, cfg BuildConfig, sources []FileSource) (payloadSHA256, manifestSHA256 string, err error) {
+	if dst == nil {
+		return "", "", errors.New("runtimepayload: nil payload writer")
+	}
+	if err := validateIdentity(cfg); err != nil {
+		return "", "", err
+	}
+	if err := validateSourceLimits(cfg, sources); err != nil {
+		return "", "", err
+	}
+	prepared, err := prepareSources(sources, ManifestPath)
+	if err != nil {
+		return "", "", err
+	}
+	entries := make([]runtimebundle.Entry, len(prepared))
+	for i := range prepared {
+		entries[i] = prepared[i].entry
+	}
+	if err := validateComponentClaims(cfg, prepared, entries); err != nil {
+		return "", "", err
+	}
+
+	manifest := Manifest{
+		Schema: SchemaV1, Protocol: ProtocolV1, SPX: cfg.SPX, Target: cfg.Target,
+		Engine: cfg.Engine, Bridge: cfg.Bridge, Project: cfg.Project, Entries: entries,
+	}
+	manifestBytes, err := json.Marshal(manifest)
+	if err != nil {
+		return "", "", fmt.Errorf("runtimepayload: encode manifest: %w", err)
+	}
+	if err := validatePreparedPayloadLimits(entries, int64(len(manifestBytes))); err != nil {
+		return "", "", err
+	}
+	manifestSum := sha256.Sum256(manifestBytes)
+
+	all := make([]preparedSource, 0, len(prepared)+1)
+	all = append(all, prepared...)
+	all = append(all, preparedSource{
+		source: FileSource{
+			Name: ManifestPath, Mode: 0o644,
+			ReaderAt: bytes.NewReader(manifestBytes), Size: int64(len(manifestBytes)),
+		},
+		entry: runtimebundle.Entry{
+			Name: ManifestPath, Mode: 0o644, Size: int64(len(manifestBytes)),
+			SHA256: hex.EncodeToString(manifestSum[:]),
+		},
+	})
+	sort.Slice(all, func(i, j int) bool { return all[i].source.Name < all[j].source.Name })
+
+	payloadHasher := sha256.New()
+	writer := zip.NewWriter(io.MultiWriter(dst, payloadHasher))
+	for _, file := range all {
+		header := &zip.FileHeader{Name: file.source.Name, Method: zip.Store}
+		header.SetMode(file.source.Mode)
+		header.SetModTime(canonicalTime)
+		entry, createErr := writer.CreateHeader(header)
+		if createErr != nil {
+			_ = writer.Close()
+			return "", "", fmt.Errorf("runtimepayload: create entry %q: %w", file.source.Name, createErr)
+		}
+		digest, writeErr := writeSource(entry, file.source)
+		if writeErr != nil {
+			_ = writer.Close()
+			return "", "", fmt.Errorf("runtimepayload: write entry %q: %w", file.source.Name, writeErr)
+		}
+		if digest != file.entry.SHA256 {
+			_ = writer.Close()
+			return "", "", fmt.Errorf("runtimepayload: source %q changed between hash and write", file.source.Name)
+		}
+	}
+	if err := writer.Close(); err != nil {
+		return "", "", fmt.Errorf("runtimepayload: close payload ZIP: %w", err)
+	}
+	return hex.EncodeToString(payloadHasher.Sum(nil)), hex.EncodeToString(manifestSum[:]), nil
+}
+
+func prepareSources(sources []FileSource, reserved string) ([]preparedSource, error) {
+	sources = append([]FileSource(nil), sources...)
+	sort.Slice(sources, func(i, j int) bool { return sources[i].Name < sources[j].Name })
+	prepared := make([]preparedSource, 0, len(sources))
+	seen := make(map[string]struct{}, len(sources))
+	for _, source := range sources {
+		if err := validateEntryName(source.Name); err != nil {
+			return nil, err
+		}
+		if reserved != "" && source.Name == reserved {
+			return nil, fmt.Errorf("runtimepayload: %q is reserved for the top-level manifest", source.Name)
+		}
+		if _, duplicate := seen[source.Name]; duplicate {
+			return nil, fmt.Errorf("runtimepayload: duplicate entry %q", source.Name)
+		}
+		seen[source.Name] = struct{}{}
+		if source.ReaderAt == nil {
+			return nil, fmt.Errorf("runtimepayload: entry %q has a nil ReaderAt", source.Name)
+		}
+		if source.Size < 0 {
+			return nil, fmt.Errorf("runtimepayload: entry %q has negative size %d", source.Name, source.Size)
+		}
+		source.Mode = canonicalFileMode(source.Mode)
+		digest, err := hashSource(source)
+		if err != nil {
+			return nil, fmt.Errorf("runtimepayload: hash entry %q: %w", source.Name, err)
+		}
+		prepared = append(prepared, preparedSource{
+			source: source,
+			entry: runtimebundle.Entry{
+				Name: source.Name, Mode: uint32(source.Mode), Size: source.Size, SHA256: digest,
+			},
+		})
+	}
+	return prepared, nil
+}
+
+func canonicalFileMode(mode fs.FileMode) fs.FileMode {
+	if mode.Perm()&0o111 != 0 {
+		return 0o755
+	}
+	return 0o644
+}
+
+func hashSource(source FileSource) (string, error) {
+	hasher := sha256.New()
+	count, err := io.Copy(hasher, io.NewSectionReader(source.ReaderAt, 0, source.Size))
+	if err != nil {
+		return "", err
+	}
+	if count != source.Size {
+		return "", fmt.Errorf("short read: read %d bytes, want %d: %w", count, source.Size, io.ErrUnexpectedEOF)
+	}
+	return hex.EncodeToString(hasher.Sum(nil)), nil
+}
+
+func writeSource(dst io.Writer, source FileSource) (string, error) {
+	hasher := sha256.New()
+	count, err := io.Copy(io.MultiWriter(dst, hasher), io.NewSectionReader(source.ReaderAt, 0, source.Size))
+	if err != nil {
+		return "", err
+	}
+	if count != source.Size {
+		return "", fmt.Errorf("short read: read %d bytes, want %d: %w", count, source.Size, io.ErrUnexpectedEOF)
+	}
+	return hex.EncodeToString(hasher.Sum(nil)), nil
+}
+
+func validateComponentClaims(cfg BuildConfig, prepared []preparedSource, entries []runtimebundle.Entry) error {
+	engine, err := componentBundleFromEntries(entries, "engine/", runtimebundle.NamespaceEngine)
+	if err != nil {
+		return err
+	}
+	if engine.Digest != cfg.Engine.BundleDigest {
+		return fmt.Errorf("runtimepayload: engine bundle digest does not match payload entries")
+	}
+	bridge, err := componentBundleFromEntries(entries, "bridge/", runtimebundle.NamespaceBridge)
+	if err != nil {
+		return err
+	}
+	if bridge.Digest != cfg.Bridge.BundleDigest {
+		return fmt.Errorf("runtimepayload: bridge bundle digest does not match payload entries")
+	}
+	for _, file := range prepared {
+		if file.source.Name != ProjectZipPath {
+			continue
+		}
+		if file.entry.SHA256 != cfg.Project.ArchiveSHA256 {
+			return fmt.Errorf("runtimepayload: project archive digest does not match payload entry")
+		}
+		project, err := ComponentBundleReaderAt(file.source.ReaderAt, file.source.Size, runtimebundle.NamespaceProject)
+		if err != nil {
+			return fmt.Errorf("runtimepayload: verify project archive: %w", err)
+		}
+		if project.Digest != cfg.Project.BundleDigest {
+			return fmt.Errorf("runtimepayload: project bundle digest does not match payload entry")
+		}
+		return nil
+	}
+	return fmt.Errorf("runtimepayload: missing required entry %q", ProjectZipPath)
+}

--- a/internal/runtimepayload/component.go
+++ b/internal/runtimepayload/component.go
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package runtimepayload
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/goplus/spx/v3/internal/runtimebundle"
+)
+
+// ComponentBundleReaderAt derives a namespace-qualified runtimebundle identity
+// without materializing the archive bytes in memory.
+func ComponentBundleReaderAt(reader io.ReaderAt, size int64, namespace runtimebundle.Namespace) (runtimebundle.Bundle, error) {
+	bundle, err := runtimebundle.VerifyZipReader(reader, size)
+	if err != nil {
+		return runtimebundle.Bundle{}, err
+	}
+	bundle.Namespace = namespace
+	return bundle.WithDigest()
+}
+
+// ComponentBundleSources derives the identity of the canonical component ZIP
+// represented by sources without first constructing that ZIP in memory.
+func ComponentBundleSources(sources []FileSource, namespace runtimebundle.Namespace) (runtimebundle.Bundle, error) {
+	prepared, err := prepareSources(sources, "")
+	if err != nil {
+		return runtimebundle.Bundle{}, err
+	}
+	entries := make([]runtimebundle.Entry, len(prepared))
+	for i := range prepared {
+		entries[i] = prepared[i].entry
+	}
+	return componentBundleFromEntries(entries, "", namespace)
+}
+
+func componentBundleFromEntries(entries []runtimebundle.Entry, prefix string, namespace runtimebundle.Namespace) (runtimebundle.Bundle, error) {
+	component := make([]runtimebundle.Entry, 0, len(entries))
+	for _, entry := range entries {
+		if prefix != "" && !strings.HasPrefix(entry.Name, prefix) {
+			continue
+		}
+		entry.Name = strings.TrimPrefix(entry.Name, prefix)
+		component = append(component, entry)
+	}
+	if len(component) == 0 {
+		return runtimebundle.Bundle{}, fmt.Errorf("runtimepayload: empty %s component", strings.TrimSuffix(prefix, "/"))
+	}
+	bundle := runtimebundle.Bundle{
+		Schema: runtimebundle.SchemaV1, Namespace: namespace, Entries: component,
+	}
+	return bundle.WithDigest()
+}

--- a/internal/runtimepayload/limits.go
+++ b/internal/runtimepayload/limits.go
@@ -1,0 +1,212 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package runtimepayload
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/goplus/spx/v3/internal/runtimebundle"
+)
+
+// validateSourceLimits checks every bound that can be decided from the
+// caller-provided source metadata. It deliberately runs before prepareSources
+// hashes any ReaderAt, so a source that cannot possibly fit in a payload is
+// rejected without touching its body.
+func validateSourceLimits(cfg BuildConfig, sources []FileSource) error {
+	// The manifest is an outer ZIP entry in addition to the caller's sources.
+	if len(sources) >= runtimebundle.MaxEntries {
+		return fmt.Errorf("runtimepayload: %d entries exceeds limit %d: %w", len(sources)+1, runtimebundle.MaxEntries, runtimebundle.ErrArchiveLimit)
+	}
+
+	ordered := append([]FileSource(nil), sources...)
+	sort.Slice(ordered, func(i, j int) bool { return ordered[i].Name < ordered[j].Name })
+	seen := make(map[string]struct{}, len(ordered))
+	entries := make([]runtimebundle.Entry, 0, len(ordered))
+	var total int64
+	placeholder := strings.Repeat("0", sha256.Size*2)
+	for _, source := range ordered {
+		if err := validateEntryName(source.Name); err != nil {
+			return err
+		}
+		if source.Name == ManifestPath {
+			return fmt.Errorf("runtimepayload: %q is reserved for the top-level manifest", source.Name)
+		}
+		if _, duplicate := seen[source.Name]; duplicate {
+			return fmt.Errorf("runtimepayload: duplicate entry %q", source.Name)
+		}
+		seen[source.Name] = struct{}{}
+		if source.ReaderAt == nil {
+			return fmt.Errorf("runtimepayload: entry %q has a nil ReaderAt", source.Name)
+		}
+		if source.Size < 0 {
+			return fmt.Errorf("runtimepayload: entry %q has negative size %d", source.Name, source.Size)
+		}
+		if source.Size > runtimebundle.MaxEntrySize {
+			return fmt.Errorf("runtimepayload: entry %q size %d exceeds limit %d: %w", source.Name, source.Size, runtimebundle.MaxEntrySize, runtimebundle.ErrArchiveLimit)
+		}
+		if source.Size > runtimebundle.MaxTotalSize-total {
+			return fmt.Errorf("runtimepayload: total size exceeds limit %d: %w", runtimebundle.MaxTotalSize, runtimebundle.ErrArchiveLimit)
+		}
+		if len(source.Name) > zipMaxNameBytes {
+			return fmt.Errorf("runtimepayload: entry %q name is too long", source.Name)
+		}
+		total += source.Size
+		entries = append(entries, runtimebundle.Entry{
+			Name: source.Name, Mode: uint32(canonicalFileMode(source.Mode)), Size: source.Size, SHA256: placeholder,
+		})
+	}
+
+	manifest := Manifest{
+		Schema: SchemaV1, Protocol: ProtocolV1, SPX: cfg.SPX, Target: cfg.Target,
+		Engine: cfg.Engine, Bridge: cfg.Bridge, Project: cfg.Project, Entries: entries,
+	}
+	manifestBytes, err := json.Marshal(manifest)
+	if err != nil {
+		return fmt.Errorf("runtimepayload: encode manifest: %w", err)
+	}
+	return validatePreparedPayloadLimits(entries, int64(len(manifestBytes)))
+}
+
+// validatePreparedPayloadLimits validates the complete outer payload after
+// the manifest is encoded. The same check is also used by the source preflight
+// with placeholder digests; SHA-256 values are fixed-width, so that dry-run
+// manifest has the exact same size as the eventual manifest.
+func validatePreparedPayloadLimits(entries []runtimebundle.Entry, manifestSize int64) error {
+	if len(entries) >= runtimebundle.MaxEntries {
+		return fmt.Errorf("runtimepayload: %d entries exceeds limit %d: %w", len(entries)+1, runtimebundle.MaxEntries, runtimebundle.ErrArchiveLimit)
+	}
+	if manifestSize < 0 {
+		return fmt.Errorf("runtimepayload: negative manifest size %d", manifestSize)
+	}
+	if manifestSize > maxPayloadManifestBytes {
+		return fmt.Errorf("runtimepayload: manifest size %d exceeds limit %d: %w", manifestSize, maxPayloadManifestBytes, runtimebundle.ErrArchiveLimit)
+	}
+
+	var total int64
+	for _, entry := range entries {
+		if entry.Size < 0 {
+			return fmt.Errorf("runtimepayload: entry %q has negative size %d", entry.Name, entry.Size)
+		}
+		if entry.Size > runtimebundle.MaxEntrySize {
+			return fmt.Errorf("runtimepayload: entry %q size %d exceeds limit %d: %w", entry.Name, entry.Size, runtimebundle.MaxEntrySize, runtimebundle.ErrArchiveLimit)
+		}
+		if entry.Size > runtimebundle.MaxTotalSize-total {
+			return fmt.Errorf("runtimepayload: total size exceeds limit %d: %w", runtimebundle.MaxTotalSize, runtimebundle.ErrArchiveLimit)
+		}
+		total += entry.Size
+	}
+	if manifestSize > runtimebundle.MaxEntrySize {
+		return fmt.Errorf("runtimepayload: manifest size %d exceeds limit %d: %w", manifestSize, runtimebundle.MaxEntrySize, runtimebundle.ErrArchiveLimit)
+	}
+	if manifestSize > runtimebundle.MaxTotalSize-total {
+		return fmt.Errorf("runtimepayload: total size exceeds limit %d: %w", runtimebundle.MaxTotalSize, runtimebundle.ErrArchiveLimit)
+	}
+
+	archiveEntries := make([]runtimebundle.Entry, 0, len(entries)+1)
+	archiveEntries = append(archiveEntries, entries...)
+	archiveEntries = append(archiveEntries, runtimebundle.Entry{Name: ManifestPath, Size: manifestSize})
+	archiveSize, err := estimatePayloadArchiveSize(archiveEntries)
+	if err != nil {
+		return err
+	}
+	if archiveSize > runtimebundle.MaxArchiveBytes {
+		return fmt.Errorf("runtimepayload: archive size %d exceeds limit %d: %w", archiveSize, runtimebundle.MaxArchiveBytes, runtimebundle.ErrArchiveLimit)
+	}
+	return nil
+}
+
+// estimatePayloadArchiveSize computes the exact size emitted by BuildTo's
+// canonical archive/zip sequence from entry names and declared sizes. No
+// source bytes are read. This also accounts for ZIP64 central-directory
+// records, should the aggregate metadata push an offset over the 32-bit ZIP
+// boundary.
+func estimatePayloadArchiveSize(entries []runtimebundle.Entry) (int64, error) {
+	ordered := append([]runtimebundle.Entry(nil), entries...)
+	sort.Slice(ordered, func(i, j int) bool { return ordered[i].Name < ordered[j].Name })
+	var offset, centralSize int64
+	for _, entry := range ordered {
+		if len(entry.Name) > zipMaxNameBytes {
+			return 0, fmt.Errorf("runtimepayload: entry %q name is too long", entry.Name)
+		}
+		if entry.Size < 0 {
+			return 0, fmt.Errorf("runtimepayload: entry %q has negative size %d", entry.Name, entry.Size)
+		}
+		nameBytes := int64(len(entry.Name))
+		localSize, err := addPayloadSize(zipLocalHeaderBytes+zipModTimeExtraBytes, nameBytes)
+		if err != nil {
+			return 0, fmt.Errorf("runtimepayload: payload archive size overflow: %w", err)
+		}
+		descriptorSize := zipDataDescriptorBytes
+		centralExtraSize := zipModTimeExtraBytes
+		zip64Entry := uint64(entry.Size) >= zip32Max
+		if zip64Entry {
+			descriptorSize = zipDataDescriptor64Bytes
+		}
+		if zip64Entry || uint64(offset) >= zip32Max {
+			centralExtraSize += zip64CentralExtraBytes
+		}
+		centralEntrySize, err := addPayloadSize(zipCentralHeaderBytes+centralExtraSize, nameBytes)
+		if err != nil {
+			return 0, fmt.Errorf("runtimepayload: payload archive size overflow: %w", err)
+		}
+		localSize, err = addPayloadSize(localSize, entry.Size)
+		if err != nil {
+			return 0, fmt.Errorf("runtimepayload: payload archive size overflow: %w", err)
+		}
+		localSize, err = addPayloadSize(localSize, descriptorSize)
+		if err != nil {
+			return 0, fmt.Errorf("runtimepayload: payload archive size overflow: %w", err)
+		}
+		offset, err = addPayloadSize(offset, localSize)
+		if err != nil {
+			return 0, fmt.Errorf("runtimepayload: payload archive size overflow: %w", err)
+		}
+		centralSize, err = addPayloadSize(centralSize, centralEntrySize)
+		if err != nil {
+			return 0, fmt.Errorf("runtimepayload: payload archive size overflow: %w", err)
+		}
+	}
+	zip64 := len(ordered) >= 1<<16 || uint64(centralSize) >= zip32Max || uint64(offset) >= zip32Max
+	archiveSize, err := addPayloadSize(offset, centralSize)
+	if err != nil {
+		return 0, fmt.Errorf("runtimepayload: payload archive size overflow: %w", err)
+	}
+	archiveSize, err = addPayloadSize(archiveSize, zipEndBytes)
+	if err != nil {
+		return 0, fmt.Errorf("runtimepayload: payload archive size overflow: %w", err)
+	}
+	if zip64 {
+		archiveSize, err = addPayloadSize(archiveSize, zip64EndBytes)
+		if err != nil {
+			return 0, fmt.Errorf("runtimepayload: payload archive size overflow: %w", err)
+		}
+	}
+	return archiveSize, nil
+}
+
+func addPayloadSize(first, second int64) (int64, error) {
+	const maxInt64 = int64(^uint64(0) >> 1)
+	if first < 0 || second < 0 || first > maxInt64-second {
+		return 0, errors.New("size exceeds MaxInt64")
+	}
+	return first + second, nil
+}

--- a/internal/runtimepayload/payload_test.go
+++ b/internal/runtimepayload/payload_test.go
@@ -1,0 +1,674 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package runtimepayload
+
+import (
+	"archive/zip"
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"io"
+	"io/fs"
+	"os"
+	"runtime"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/goplus/spx/v3/internal/runtimebundle"
+)
+
+type testFile struct {
+	Name string
+	Mode fs.FileMode
+	Data []byte
+}
+
+type testPayload struct {
+	BuildConfig
+	Files []testFile
+}
+
+func buildPayload(config testPayload) ([]byte, string, string, error) {
+	cfg, sources := fileSources(config)
+	var output bytes.Buffer
+	payloadDigest, manifestDigest, err := BuildTo(&output, cfg, sources)
+	if err != nil {
+		return nil, "", "", err
+	}
+	return output.Bytes(), payloadDigest, manifestDigest, nil
+}
+
+func componentBundleBytes(data []byte, namespace runtimebundle.Namespace) (runtimebundle.Bundle, error) {
+	return ComponentBundleReaderAt(bytes.NewReader(data), int64(len(data)), namespace)
+}
+
+func verifiedComponentZIP(verified *Verified, prefix string) ([]byte, error) {
+	var output bytes.Buffer
+	err := verified.WriteComponentZIP(prefix, &output)
+	return output.Bytes(), err
+}
+
+func verifiedProjectZIP(t *testing.T, verified *Verified) []byte {
+	t.Helper()
+	var output bytes.Buffer
+	if err := verified.WriteProjectZIP(&output); err != nil {
+		t.Fatal(err)
+	}
+	return output.Bytes()
+}
+
+func canonicalComponentZIP(files []testFile) ([]byte, error) {
+	files = append([]testFile(nil), files...)
+	sort.Slice(files, func(i, j int) bool { return files[i].Name < files[j].Name })
+	var output bytes.Buffer
+	writer := zip.NewWriter(&output)
+	for _, file := range files {
+		header := &zip.FileHeader{Name: file.Name, Method: zip.Store}
+		header.SetMode(canonicalFileMode(file.Mode))
+		header.SetModTime(canonicalTime)
+		entry, err := writer.CreateHeader(header)
+		if err != nil {
+			_ = writer.Close()
+			return nil, err
+		}
+		if _, err := entry.Write(file.Data); err != nil {
+			_ = writer.Close()
+			return nil, err
+		}
+	}
+	if err := writer.Close(); err != nil {
+		return nil, err
+	}
+	return output.Bytes(), nil
+}
+
+func TestBuildToMatchesBuildBytes(t *testing.T) {
+	config := testBuildConfig(t)
+	want, wantPayloadDigest, wantManifestDigest, err := buildPayload(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	streamConfig, sources := fileSources(config)
+	var output bytes.Buffer
+	gotPayloadDigest, gotManifestDigest, err := BuildTo(&output, streamConfig, sources)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(output.Bytes(), want) {
+		t.Fatal("BuildTo bytes differ from Build")
+	}
+	if gotPayloadDigest != wantPayloadDigest || gotManifestDigest != wantManifestDigest {
+		t.Fatalf("BuildTo digests = %q/%q, want %q/%q", gotPayloadDigest, gotManifestDigest, wantPayloadDigest, wantManifestDigest)
+	}
+}
+
+func TestBuildToRejectsShortReadWriteFailureAndSourceChange(t *testing.T) {
+	t.Run("short read", func(t *testing.T) {
+		config, sources := fileSources(testBuildConfig(t))
+		sources[0].Size++
+		if _, _, err := BuildTo(io.Discard, config, sources); err == nil || !strings.Contains(err.Error(), "short read") {
+			t.Fatalf("BuildTo error = %v, want short read", err)
+		}
+	})
+
+	t.Run("write failure", func(t *testing.T) {
+		config, sources := fileSources(testBuildConfig(t))
+		writer := &failingWriter{remaining: 64}
+		if _, _, err := BuildTo(writer, config, sources); !errors.Is(err, errWriteFailure) {
+			t.Fatalf("BuildTo error = %v, want %v", err, errWriteFailure)
+		}
+	})
+
+	t.Run("source change", func(t *testing.T) {
+		base := testBuildConfig(t)
+		config, sources := fileSources(base)
+		for i := range sources {
+			if sources[i].Name == "engine/engine" {
+				first := append([]byte(nil), configFileData(t, base, sources[i].Name)...)
+				second := bytes.Repeat([]byte{'x'}, len(first))
+				sources[i].ReaderAt = &changingReaderAt{first: first, second: second}
+				break
+			}
+		}
+		if _, _, err := BuildTo(io.Discard, config, sources); err == nil || !strings.Contains(err.Error(), "changed between hash and write") {
+			t.Fatalf("BuildTo error = %v, want source-change rejection", err)
+		}
+	})
+}
+
+func TestBuildToRejectsOuterLimitsBeforeReadingSources(t *testing.T) {
+	t.Run("entry count", func(t *testing.T) {
+		config, sources := fileSources(testBuildConfig(t))
+		guard := &countingReaderAt{reader: bytes.NewReader([]byte("must not read"))}
+		sources = make([]FileSource, runtimebundle.MaxEntries)
+		sources[0] = FileSource{Name: "entry", ReaderAt: guard, Size: 0}
+		if _, _, err := BuildTo(io.Discard, config, sources); !errors.Is(err, runtimebundle.ErrArchiveLimit) {
+			t.Fatalf("BuildTo error = %v, want runtimebundle.ErrArchiveLimit", err)
+		}
+		if reads, _ := guard.counts(); reads != 0 {
+			t.Fatalf("oversized entry-count source bytes read = %d, want 0", reads)
+		}
+	})
+
+	t.Run("entry size", func(t *testing.T) {
+		config, sources := fileSources(testBuildConfig(t))
+		guard := &countingReaderAt{reader: bytes.NewReader([]byte("must not read"))}
+		sources[0].ReaderAt = guard
+		sources[0].Size = runtimebundle.MaxEntrySize + 1
+		if _, _, err := BuildTo(io.Discard, config, sources); !errors.Is(err, runtimebundle.ErrArchiveLimit) {
+			t.Fatalf("BuildTo error = %v, want runtimebundle.ErrArchiveLimit", err)
+		}
+		if reads, _ := guard.counts(); reads != 0 {
+			t.Fatalf("oversized entry source bytes read = %d, want 0", reads)
+		}
+	})
+
+	t.Run("total size", func(t *testing.T) {
+		config, sources := fileSources(testBuildConfig(t))
+		for i := 0; i < 3; i++ {
+			sources = append(sources, FileSource{Name: "extra-" + string(rune('a'+i))})
+		}
+		guards := make([]*countingReaderAt, len(sources))
+		for i := range sources {
+			guards[i] = &countingReaderAt{reader: bytes.NewReader(nil)}
+			sources[i].ReaderAt = guards[i]
+			sources[i].Size = runtimebundle.MaxEntrySize
+		}
+		if _, _, err := BuildTo(io.Discard, config, sources); !errors.Is(err, runtimebundle.ErrArchiveLimit) {
+			t.Fatalf("BuildTo error = %v, want runtimebundle.ErrArchiveLimit", err)
+		}
+		for i, guard := range guards {
+			if reads, _ := guard.counts(); reads != 0 {
+				t.Fatalf("total-limit source %d bytes read = %d, want 0", i, reads)
+			}
+		}
+	})
+}
+
+func TestVerifyReaderAtRejectsOversizedArchiveBeforeReading(t *testing.T) {
+	reader := &countingReaderAt{reader: bytes.NewReader([]byte("must not read"))}
+	_, err := VerifyReaderAt(reader, runtimebundle.MaxArchiveBytes+1, strings.Repeat("0", sha256.Size*2), strings.Repeat("0", sha256.Size*2), runtime.GOOS, runtime.GOARCH)
+	if !errors.Is(err, runtimebundle.ErrArchiveLimit) {
+		t.Fatalf("VerifyReaderAt error = %v, want runtimebundle.ErrArchiveLimit", err)
+	}
+	if reads, _ := reader.counts(); reads != 0 {
+		t.Fatalf("oversized payload bytes read = %d, want 0", reads)
+	}
+}
+
+func TestEstimatePayloadArchiveSizeMatchesBuild(t *testing.T) {
+	payload, _, _, err := buildPayload(testBuildConfig(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	reader, err := zip.NewReader(bytes.NewReader(payload), int64(len(payload)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	entries := make([]runtimebundle.Entry, 0, len(reader.File))
+	for _, file := range reader.File {
+		entries = append(entries, runtimebundle.Entry{Name: file.Name, Size: int64(file.UncompressedSize64)})
+	}
+	estimated, err := estimatePayloadArchiveSize(entries)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if estimated != int64(len(payload)) {
+		t.Fatalf("estimated payload size = %d, want %d", estimated, len(payload))
+	}
+}
+
+func TestBuildToAndVerifyReaderAtStreamLargeEntry(t *testing.T) {
+	config, sources := fileSources(testBuildConfig(t))
+	const largeSize = int64(16 << 20)
+	large := &patternReaderAt{size: largeSize}
+	for i := range sources {
+		if sources[i].Name == "engine/engine" {
+			sources[i].ReaderAt = large
+			sources[i].Size = largeSize
+			break
+		}
+	}
+	engineBundle, err := ComponentBundleSources(componentSources(sources, "engine/"), runtimebundle.NamespaceEngine)
+	if err != nil {
+		t.Fatal(err)
+	}
+	config.Engine.BundleDigest = engineBundle.Digest
+	large.resetCounts()
+
+	payloadFile, err := os.CreateTemp(t.TempDir(), "payload-*.spxpkg")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer payloadFile.Close()
+	payloadDigest, manifestDigest, err := BuildTo(payloadFile, config, sources)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reads, maxRead := large.counts()
+	if reads != 2*largeSize {
+		t.Fatalf("large source bytes read = %d, want %d (two passes)", reads, 2*largeSize)
+	}
+	if maxRead > 1<<20 {
+		t.Fatalf("largest source read = %d, want bounded streaming reads", maxRead)
+	}
+	if err := payloadFile.Sync(); err != nil {
+		t.Fatal(err)
+	}
+	info, err := payloadFile.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+	payloadReader := &countingReaderAt{reader: payloadFile}
+	verified, err := VerifyReaderAt(payloadReader, info.Size(), payloadDigest, manifestDigest, runtime.GOOS, runtime.GOARCH)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, payloadMaxRead := payloadReader.counts()
+	if payloadMaxRead > 1<<20 {
+		t.Fatalf("largest payload ReaderAt request = %d, want bounded streaming reads", payloadMaxRead)
+	}
+	if err := verified.WriteComponentZIP("engine/", io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	if err := verified.WriteProjectZIP(io.Discard); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestBuildVerifyCanonicalPayload(t *testing.T) {
+	config := testBuildConfig(t)
+	first, firstPayloadDigest, firstManifestDigest, err := buildPayload(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, secondPayloadDigest, secondManifestDigest, err := buildPayload(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(first, second) || firstPayloadDigest != secondPayloadDigest || firstManifestDigest != secondManifestDigest {
+		t.Fatal("Build is not deterministic")
+	}
+
+	verified, err := Verify(first, firstPayloadDigest, firstManifestDigest, runtime.GOOS, runtime.GOARCH)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if verified.Manifest.Protocol != ProtocolV1 || verified.Manifest.Schema != SchemaV1 {
+		t.Fatalf("manifest identity = %q/%q", verified.Manifest.Schema, verified.Manifest.Protocol)
+	}
+	if len(verified.Manifest.Entries) != 6 {
+		t.Fatalf("manifest entries = %d, want 6", len(verified.Manifest.Entries))
+	}
+	for _, entry := range verified.Manifest.Entries {
+		if entry.Name == ManifestPath {
+			t.Fatal("manifest entry table contains itself")
+		}
+	}
+	project := verifiedProjectZIP(t, verified)
+	project[0] ^= 0xff
+	if bytes.Equal(project, verifiedProjectZIP(t, verified)) {
+		t.Fatal("ProjectZIP returned mutable internal storage")
+	}
+	engineZIP, err := verifiedComponentZIP(verified, "engine/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	engine, err := componentBundleBytes(engineZIP, runtimebundle.NamespaceEngine)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if engine.Digest != verified.Manifest.Engine.BundleDigest {
+		t.Fatalf("engine digest = %s, want %s", engine.Digest, verified.Manifest.Engine.BundleDigest)
+	}
+}
+
+func TestVerifyRejectsDigestTargetAndManifestTampering(t *testing.T) {
+	payload, payloadDigest, manifestDigest, err := buildPayload(testBuildConfig(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("payload digest", func(t *testing.T) {
+		changed := append([]byte(nil), payload...)
+		changed[len(changed)/2] ^= 1
+		if _, err := Verify(changed, payloadDigest, manifestDigest, runtime.GOOS, runtime.GOARCH); err == nil || !strings.Contains(err.Error(), "payload SHA-256 mismatch") {
+			t.Fatalf("Verify error = %v", err)
+		}
+	})
+	t.Run("manifest digest", func(t *testing.T) {
+		if _, err := Verify(payload, payloadDigest, strings.Repeat("0", sha256.Size*2), runtime.GOOS, runtime.GOARCH); err == nil || !strings.Contains(err.Error(), "manifest SHA-256 mismatch") {
+			t.Fatalf("Verify error = %v", err)
+		}
+	})
+	t.Run("target", func(t *testing.T) {
+		if _, err := Verify(payload, payloadDigest, manifestDigest, "not-"+runtime.GOOS, runtime.GOARCH); err == nil || !strings.Contains(err.Error(), "does not match host") {
+			t.Fatalf("Verify error = %v", err)
+		}
+	})
+	t.Run("entry table", func(t *testing.T) {
+		changed, changedPayloadDigest, changedManifestDigest := rewritePayloadManifest(t, payload, func(manifest *Manifest) {
+			manifest.Entries[0].SHA256 = strings.Repeat("0", sha256.Size*2)
+		})
+		if _, err := Verify(changed, changedPayloadDigest, changedManifestDigest, runtime.GOOS, runtime.GOARCH); err == nil || !strings.Contains(err.Error(), "entry table") {
+			t.Fatalf("Verify error = %v", err)
+		}
+	})
+	t.Run("component identity", func(t *testing.T) {
+		changed, changedPayloadDigest, changedManifestDigest := rewritePayloadManifest(t, payload, func(manifest *Manifest) {
+			manifest.Engine.BundleDigest = strings.Repeat("0", sha256.Size*2)
+		})
+		if _, err := Verify(changed, changedPayloadDigest, changedManifestDigest, runtime.GOOS, runtime.GOARCH); err == nil || !strings.Contains(err.Error(), "engine bundle digest mismatch") {
+			t.Fatalf("Verify error = %v", err)
+		}
+	})
+}
+
+func TestBuildRejectsInvalidLayoutInputs(t *testing.T) {
+	base := testBuildConfig(t)
+	for _, test := range []struct {
+		name   string
+		mutate func(*testPayload)
+	}{
+		{name: "manifest reserved", mutate: func(config *testPayload) {
+			config.Files[0].Name = ManifestPath
+		}},
+		{name: "duplicate", mutate: func(config *testPayload) {
+			config.Files[1].Name = config.Files[0].Name
+		}},
+		{name: "traversal", mutate: func(config *testPayload) {
+			config.Files[0].Name = "../engine"
+		}},
+		{name: "bad digest", mutate: func(config *testPayload) {
+			config.Engine.BundleDigest = "not-a-digest"
+		}},
+		{name: "bad pack", mutate: func(config *testPayload) {
+			config.Project.PackDirectory = "../assets"
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			config := base
+			config.Files = append([]testFile(nil), base.Files...)
+			test.mutate(&config)
+			if _, _, _, err := buildPayload(config); err == nil {
+				t.Fatal("Build accepted invalid input")
+			}
+		})
+	}
+}
+
+var errWriteFailure = errors.New("test writer failure")
+
+type failingWriter struct {
+	remaining int
+}
+
+func (w *failingWriter) Write(data []byte) (int, error) {
+	if w.remaining <= 0 {
+		return 0, errWriteFailure
+	}
+	if len(data) > w.remaining {
+		written := w.remaining
+		w.remaining = 0
+		return written, errWriteFailure
+	}
+	w.remaining -= len(data)
+	return len(data), nil
+}
+
+type changingReaderAt struct {
+	mu        sync.Mutex
+	first     []byte
+	second    []byte
+	completed bool
+	changed   bool
+}
+
+func (r *changingReaderAt) ReadAt(data []byte, offset int64) (int, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if offset == 0 && r.completed {
+		r.changed = true
+	}
+	source := r.first
+	if r.changed {
+		source = r.second
+	}
+	if offset >= int64(len(source)) {
+		return 0, io.EOF
+	}
+	count := copy(data, source[offset:])
+	if offset+int64(count) == int64(len(source)) {
+		r.completed = true
+	}
+	if count != len(data) {
+		return count, io.EOF
+	}
+	return count, nil
+}
+
+type patternReaderAt struct {
+	mu      sync.Mutex
+	size    int64
+	read    int64
+	maxRead int
+}
+
+func (r *patternReaderAt) ReadAt(data []byte, offset int64) (int, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(data) > r.maxRead {
+		r.maxRead = len(data)
+	}
+	if offset >= r.size {
+		return 0, io.EOF
+	}
+	count := len(data)
+	if remaining := r.size - offset; int64(count) > remaining {
+		count = int(remaining)
+	}
+	for i := 0; i < count; i++ {
+		data[i] = byte((offset + int64(i)) % 251)
+	}
+	r.read += int64(count)
+	if count != len(data) {
+		return count, io.EOF
+	}
+	return count, nil
+}
+
+func (r *patternReaderAt) resetCounts() {
+	r.mu.Lock()
+	r.read = 0
+	r.maxRead = 0
+	r.mu.Unlock()
+}
+
+func (r *patternReaderAt) counts() (int64, int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.read, r.maxRead
+}
+
+type countingReaderAt struct {
+	mu      sync.Mutex
+	reader  io.ReaderAt
+	read    int64
+	maxRead int
+}
+
+func (r *countingReaderAt) ReadAt(data []byte, offset int64) (int, error) {
+	count, err := r.reader.ReadAt(data, offset)
+	r.mu.Lock()
+	r.read += int64(count)
+	if len(data) > r.maxRead {
+		r.maxRead = len(data)
+	}
+	r.mu.Unlock()
+	return count, err
+}
+
+func (r *countingReaderAt) counts() (int64, int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.read, r.maxRead
+}
+
+func fileSources(config testPayload) (BuildConfig, []FileSource) {
+	sources := make([]FileSource, len(config.Files))
+	for i, file := range config.Files {
+		sources[i] = FileSource{
+			Name: file.Name, Mode: file.Mode,
+			ReaderAt: bytes.NewReader(file.Data), Size: int64(len(file.Data)),
+		}
+	}
+	return config.BuildConfig, sources
+}
+
+func componentSources(sources []FileSource, prefix string) []FileSource {
+	var component []FileSource
+	for _, source := range sources {
+		if strings.HasPrefix(source.Name, prefix) {
+			source.Name = strings.TrimPrefix(source.Name, prefix)
+			component = append(component, source)
+		}
+	}
+	return component
+}
+
+func configFileData(t *testing.T, config testPayload, name string) []byte {
+	t.Helper()
+	for _, file := range config.Files {
+		if file.Name == name {
+			return file.Data
+		}
+	}
+	t.Fatalf("missing test config file %q", name)
+	return nil
+}
+
+func testBuildConfig(t *testing.T) testPayload {
+	t.Helper()
+	engineFiles := []testFile{
+		{Name: "runtime-manifest.json", Mode: 0o644, Data: []byte(`{"schema":"test-engine/v1"}`)},
+		{Name: "engine", Mode: 0o755, Data: []byte("engine")},
+		{Name: "engine.pck", Mode: 0o644, Data: []byte("pack")},
+	}
+	bridgeFiles := []testFile{
+		{Name: "bridge-manifest.json", Mode: 0o644, Data: []byte(`{"schema":"test-bridge/v1"}`)},
+		{Name: "bridge.so", Mode: 0o755, Data: []byte("bridge")},
+	}
+	projectZIP, err := canonicalComponentZIP([]testFile{
+		{Name: "main.spx", Mode: 0o644, Data: []byte("onStart => {}")},
+		{Name: "assets/index.json", Mode: 0o644, Data: []byte(`{"zorder":[]}`)},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	engineZIP, err := canonicalComponentZIP(engineFiles)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bridgeZIP, err := canonicalComponentZIP(bridgeFiles)
+	if err != nil {
+		t.Fatal(err)
+	}
+	engine, err := componentBundleBytes(engineZIP, runtimebundle.NamespaceEngine)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bridge, err := componentBundleBytes(bridgeZIP, runtimebundle.NamespaceBridge)
+	if err != nil {
+		t.Fatal(err)
+	}
+	project, err := componentBundleBytes(projectZIP, runtimebundle.NamespaceProject)
+	if err != nil {
+		t.Fatal(err)
+	}
+	projectSum := sha256.Sum256(projectZIP)
+	interfaceSum := sha256.Sum256([]byte("interface"))
+	return testPayload{
+		BuildConfig: BuildConfig{
+			SPX:    SourceIdentity{SelectedPath: "github.com/goplus/spx/v3", EffectivePath: "github.com/goplus/spx/v3", SourceMode: true},
+			Target: Target{GOOS: runtime.GOOS, GOARCH: runtime.GOARCH},
+			Engine: Engine{
+				RuntimeVersion: "test", RuntimeABI: 1, EngineInterfaceDigest: hex.EncodeToString(interfaceSum[:]),
+				Executable: "engine", Pack: "engine.pck", BundleDigest: engine.Digest,
+			},
+			Bridge: Bridge{File: "bridge.so", BundleDigest: bridge.Digest},
+			Project: Project{
+				PackDirectory: "assets", BundleDigest: project.Digest, ArchiveSHA256: hex.EncodeToString(projectSum[:]),
+			},
+		},
+		Files: []testFile{
+			{Name: "engine/runtime-manifest.json", Mode: 0o644, Data: engineFiles[0].Data},
+			{Name: "engine/engine", Mode: 0o755, Data: engineFiles[1].Data},
+			{Name: "engine/engine.pck", Mode: 0o644, Data: engineFiles[2].Data},
+			{Name: "bridge/bridge-manifest.json", Mode: 0o644, Data: bridgeFiles[0].Data},
+			{Name: "bridge/bridge.so", Mode: 0o755, Data: bridgeFiles[1].Data},
+			{Name: ProjectZipPath, Mode: 0o644, Data: projectZIP},
+		},
+	}
+}
+
+func rewritePayloadManifest(t *testing.T, payload []byte, mutate func(*Manifest)) ([]byte, string, string) {
+	t.Helper()
+	reader, err := zip.NewReader(bytes.NewReader(payload), int64(len(payload)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var files []testFile
+	var manifest Manifest
+	for _, file := range reader.File {
+		input, err := file.Open()
+		if err != nil {
+			t.Fatal(err)
+		}
+		data, readErr := io.ReadAll(input)
+		closeErr := input.Close()
+		if readErr != nil {
+			t.Fatal(readErr)
+		}
+		if closeErr != nil {
+			t.Fatal(closeErr)
+		}
+		if file.Name == ManifestPath {
+			if err := json.Unmarshal(data, &manifest); err != nil {
+				t.Fatal(err)
+			}
+			continue
+		}
+		files = append(files, testFile{Name: file.Name, Mode: file.Mode(), Data: data})
+	}
+	mutate(&manifest)
+	manifestData, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	files = append(files, testFile{Name: ManifestPath, Mode: 0o644, Data: manifestData})
+	archive, err := canonicalComponentZIP(files)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payloadSum := sha256.Sum256(archive)
+	manifestSum := sha256.Sum256(manifestData)
+	return archive, hex.EncodeToString(payloadSum[:]), hex.EncodeToString(manifestSum[:])
+}

--- a/internal/runtimepayload/types.go
+++ b/internal/runtimepayload/types.go
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package runtimepayload implements the canonical, self-contained payload
+// embedded in an XGo SPX launcher. It is internal because the driver argv,
+// payload layout, and cache manifests are implementation details of SPX.
+package runtimepayload
+
+import (
+	"io"
+	"io/fs"
+	"time"
+
+	"github.com/goplus/spx/v3/internal/runtimebundle"
+)
+
+const (
+	SchemaV1       = "spx-runtime-payload/v1"
+	ProtocolV1     = "xgo-driver-v1"
+	ManifestPath   = "META-INF/spx-runtime-v1.json"
+	ProjectZipPath = "project/project.zip"
+)
+
+var canonicalTime = time.Date(1980, time.January, 1, 0, 0, 0, 0, time.UTC)
+
+// SourceIdentity records the logical and physical SPX identity selected by
+// the application graph. Source mode intentionally records replacement/main
+// provenance instead of pretending that a local build is a published release.
+type SourceIdentity struct {
+	SelectedPath     string `json:"selected_path"`
+	SelectedVersion  string `json:"selected_version"`
+	EffectivePath    string `json:"effective_path"`
+	EffectiveVersion string `json:"effective_version"`
+	Main             bool   `json:"main"`
+	SourceMode       bool   `json:"source_mode"`
+}
+
+// Target identifies the host executable represented by the payload.
+type Target struct {
+	GOOS   string `json:"goos"`
+	GOARCH string `json:"goarch"`
+}
+
+// Engine describes the verified engine component and its cache identity.
+type Engine struct {
+	RuntimeVersion        string `json:"runtime_version"`
+	RuntimeABI            int    `json:"runtime_abi"`
+	EngineInterfaceDigest string `json:"engine_interface_digest"`
+	Executable            string `json:"executable"`
+	Pack                  string `json:"pack"`
+	BundleDigest          string `json:"bundle_digest"`
+}
+
+// Bridge describes the verified interpreter bridge component.
+type Bridge struct {
+	File         string `json:"file"`
+	BundleDigest string `json:"bundle_digest"`
+}
+
+// Project describes the project materialized for launcher execution.
+type Project struct {
+	PackDirectory string `json:"pack_directory"`
+	BundleDigest  string `json:"bundle_digest"`
+	ArchiveSHA256 string `json:"archive_sha256"`
+}
+
+// Manifest is the only top-level payload manifest. Entries contains every ZIP
+// entry except ManifestPath, avoiding a self-referential digest.
+type Manifest struct {
+	Schema   string                `json:"schema"`
+	Protocol string                `json:"protocol"`
+	SPX      SourceIdentity        `json:"spx"`
+	Target   Target                `json:"target"`
+	Engine   Engine                `json:"engine"`
+	Bridge   Bridge                `json:"bridge"`
+	Project  Project               `json:"project"`
+	Entries  []runtimebundle.Entry `json:"entries"`
+}
+
+// FileSource is one repeatable, fixed-size payload entry. ReaderAt must remain
+// readable and stable for the duration of BuildTo. BuildTo reads every source
+// twice and rejects short reads or content changes between the two passes.
+type FileSource struct {
+	Name     string
+	Mode     fs.FileMode
+	ReaderAt io.ReaderAt
+	Size     int64
+}
+
+// BuildConfig supplies the identities that cannot be inferred from entry
+// bytes. Component bundle digests must be namespace-qualified identities from
+// runtimebundle.Bundle.WithDigest.
+type BuildConfig struct {
+	SPX     SourceIdentity
+	Target  Target
+	Engine  Engine
+	Bridge  Bridge
+	Project Project
+}
+
+type preparedSource struct {
+	source FileSource
+	entry  runtimebundle.Entry
+}

--- a/internal/runtimepayload/validate.go
+++ b/internal/runtimepayload/validate.go
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package runtimepayload
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"path"
+	"strings"
+)
+
+func validateIdentity(cfg BuildConfig) error {
+	required := []struct {
+		name  string
+		value string
+	}{
+		{"selected SPX path", cfg.SPX.SelectedPath},
+		{"effective SPX path", cfg.SPX.EffectivePath},
+		{"target GOOS", cfg.Target.GOOS},
+		{"target GOARCH", cfg.Target.GOARCH},
+		{"runtime version", cfg.Engine.RuntimeVersion},
+		{"engine interface digest", cfg.Engine.EngineInterfaceDigest},
+		{"engine executable", cfg.Engine.Executable},
+		{"engine pack", cfg.Engine.Pack},
+		{"engine bundle digest", cfg.Engine.BundleDigest},
+		{"bridge file", cfg.Bridge.File},
+		{"bridge bundle digest", cfg.Bridge.BundleDigest},
+		{"project pack directory", cfg.Project.PackDirectory},
+		{"project bundle digest", cfg.Project.BundleDigest},
+		{"project archive digest", cfg.Project.ArchiveSHA256},
+	}
+	for _, field := range required {
+		if field.value == "" {
+			return fmt.Errorf("runtimepayload: %s is empty", field.name)
+		}
+	}
+	if cfg.Engine.RuntimeABI <= 0 {
+		return fmt.Errorf("runtimepayload: runtime ABI must be positive")
+	}
+	digests := []struct {
+		name  string
+		value string
+	}{
+		{"engine interface digest", cfg.Engine.EngineInterfaceDigest},
+		{"engine bundle digest", cfg.Engine.BundleDigest},
+		{"bridge bundle digest", cfg.Bridge.BundleDigest},
+		{"project bundle digest", cfg.Project.BundleDigest},
+		{"project archive digest", cfg.Project.ArchiveSHA256},
+	}
+	for _, field := range digests {
+		if err := validateDigest(field.value); err != nil {
+			return fmt.Errorf("runtimepayload: invalid %s: %w", field.name, err)
+		}
+	}
+	for _, name := range []string{cfg.Engine.Executable, cfg.Engine.Pack, cfg.Bridge.File} {
+		if path.Base(name) != name || name == "." || strings.ContainsAny(name, `\\:`) {
+			return fmt.Errorf("runtimepayload: unsafe component basename %q", name)
+		}
+	}
+	if cfg.Project.PackDirectory == "." || path.Clean(cfg.Project.PackDirectory) != cfg.Project.PackDirectory || strings.HasPrefix(cfg.Project.PackDirectory, "../") || path.IsAbs(cfg.Project.PackDirectory) {
+		return fmt.Errorf("runtimepayload: invalid project pack directory %q", cfg.Project.PackDirectory)
+	}
+	return nil
+}
+
+func validateEntryName(name string) error {
+	if name == "" || path.Clean(name) != name || path.IsAbs(name) || strings.ContainsRune(name, '\\') {
+		return fmt.Errorf("runtimepayload: invalid entry path %q", name)
+	}
+	for _, component := range strings.Split(name, "/") {
+		if component == "" || component == "." || component == ".." {
+			return fmt.Errorf("runtimepayload: invalid entry path %q", name)
+		}
+	}
+	return nil
+}
+
+func validateDigest(value string) error {
+	if len(value) != sha256.Size*2 || value != strings.ToLower(value) {
+		return errors.New("digest must be 64 lower-case hexadecimal characters")
+	}
+	if _, err := hex.DecodeString(value); err != nil {
+		return errors.New("digest must be 64 lower-case hexadecimal characters")
+	}
+	return nil
+}

--- a/internal/runtimepayload/verify.go
+++ b/internal/runtimepayload/verify.go
@@ -1,0 +1,386 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package runtimepayload
+
+import (
+	"archive/zip"
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"io/fs"
+	"sort"
+	"strings"
+
+	"github.com/goplus/spx/v3/internal/runtimebundle"
+	"github.com/goplus/spx/v3/internal/strictjson"
+)
+
+// Verified is an immutable payload whose complete archive, top-level manifest,
+// entry table, component identities, and target have been checked.
+type Verified struct {
+	Manifest Manifest
+	source   io.ReaderAt
+	files    map[string]*zip.File
+	entries  []runtimebundle.Entry
+}
+
+// Verify is the in-memory convenience wrapper around VerifyReaderAt.
+func Verify(payload []byte, payloadSHA256, manifestSHA256, goos, goarch string) (*Verified, error) {
+	reader := bytes.NewReader(payload)
+	return VerifyReaderAt(reader, int64(len(payload)), payloadSHA256, manifestSHA256, goos, goarch)
+}
+
+const maxPayloadManifestBytes = 1 << 20
+
+// The payload is a ZIP written with archive/zip's canonical Store headers.
+// Keep these format sizes local to the preflight calculation below: the
+// runtimebundle limits are the policy source of truth, while these constants
+// describe the bytes BuildTo is about to emit.
+const (
+	zipLocalHeaderBytes      int64  = 30
+	zipCentralHeaderBytes    int64  = 46
+	zipDataDescriptorBytes   int64  = 16
+	zipDataDescriptor64Bytes int64  = 24
+	zipEndBytes              int64  = 22
+	zip64EndBytes            int64  = 56 + 20
+	zipModTimeExtraBytes     int64  = 9
+	zip64CentralExtraBytes   int64  = 28
+	zipMaxNameBytes                 = 1<<16 - 1
+	zip32Max                 uint64 = 1<<32 - 1
+)
+
+// VerifyReaderAt authenticates and indexes a payload without retaining copies
+// of its large entries. source must remain readable and unchanged while the
+// returned Verified value is used.
+func VerifyReaderAt(source io.ReaderAt, size int64, payloadSHA256, manifestSHA256, goos, goarch string) (*Verified, error) {
+	if source == nil {
+		return nil, fmt.Errorf("runtimepayload: nil payload reader")
+	}
+	if size < 0 {
+		return nil, fmt.Errorf("runtimepayload: negative payload size %d", size)
+	}
+	if size > runtimebundle.MaxArchiveBytes {
+		return nil, fmt.Errorf("runtimepayload: archive size %d exceeds limit %d: %w", size, runtimebundle.MaxArchiveBytes, runtimebundle.ErrArchiveLimit)
+	}
+	if err := compareReaderAtDigest(source, size, payloadSHA256, "payload"); err != nil {
+		return nil, err
+	}
+	bundle, err := runtimebundle.VerifyZipReader(source, size)
+	if err != nil {
+		return nil, fmt.Errorf("runtimepayload: verify payload ZIP: %w", err)
+	}
+	reader, err := zip.NewReader(source, size)
+	if err != nil {
+		return nil, fmt.Errorf("runtimepayload: open verified payload ZIP: %w", err)
+	}
+	files := make(map[string]*zip.File, len(reader.File))
+	for _, file := range reader.File {
+		files[file.Name] = file
+	}
+	manifestFile, ok := files[ManifestPath]
+	if !ok {
+		return nil, fmt.Errorf("runtimepayload: missing %s", ManifestPath)
+	}
+	manifestBytes, err := readSmallZipEntry(manifestFile, maxPayloadManifestBytes)
+	if err != nil {
+		return nil, fmt.Errorf("runtimepayload: read manifest: %w", err)
+	}
+	if err := compareDigest(manifestBytes, manifestSHA256, "manifest"); err != nil {
+		return nil, err
+	}
+	manifest, err := parseManifest(manifestBytes)
+	if err != nil {
+		return nil, err
+	}
+	if manifest.Target.GOOS != goos || manifest.Target.GOARCH != goarch {
+		return nil, fmt.Errorf("runtimepayload: payload target %s/%s does not match host %s/%s", manifest.Target.GOOS, manifest.Target.GOARCH, goos, goarch)
+	}
+	actualEntries := make([]runtimebundle.Entry, 0, len(bundle.Entries)-1)
+	for _, entry := range bundle.Entries {
+		if entry.Name != ManifestPath {
+			actualEntries = append(actualEntries, entry)
+		}
+	}
+	if !entriesEqual(manifest.Entries, actualEntries) {
+		return nil, fmt.Errorf("runtimepayload: payload entry table does not match archive")
+	}
+	verified := &Verified{
+		Manifest: manifest,
+		source:   source,
+		files:    files,
+		entries:  append([]runtimebundle.Entry(nil), actualEntries...),
+	}
+	if err := verified.validateComponents(); err != nil {
+		return nil, err
+	}
+	// Re-read the complete source after all structural checks. This catches a
+	// mutable ReaderAt changing between the initial payload hash and indexing.
+	if err := compareReaderAtDigest(source, size, payloadSHA256, "payload"); err != nil {
+		return nil, fmt.Errorf("runtimepayload: payload source changed during verification: %w", err)
+	}
+	return verified, nil
+}
+
+func readSmallZipEntry(file *zip.File, limit int64) ([]byte, error) {
+	if file.UncompressedSize64 > uint64(limit) {
+		return nil, fmt.Errorf("entry %q size %d exceeds limit %d", file.Name, file.UncompressedSize64, limit)
+	}
+	input, err := file.Open()
+	if err != nil {
+		return nil, err
+	}
+	data, readErr := io.ReadAll(io.LimitReader(input, limit+1))
+	closeErr := input.Close()
+	if readErr != nil {
+		return nil, readErr
+	}
+	if closeErr != nil {
+		return nil, closeErr
+	}
+	if int64(len(data)) > limit {
+		return nil, fmt.Errorf("entry %q exceeds limit %d", file.Name, limit)
+	}
+	if uint64(len(data)) != file.UncompressedSize64 {
+		return nil, fmt.Errorf("entry %q short read: got %d, want %d", file.Name, len(data), file.UncompressedSize64)
+	}
+	return data, nil
+}
+
+func parseManifest(data []byte) (Manifest, error) {
+	var manifest Manifest
+	if err := strictjson.Decode(data, &manifest); err != nil {
+		return Manifest{}, fmt.Errorf("runtimepayload: decode manifest: %w", err)
+	}
+	if manifest.Schema != SchemaV1 || manifest.Protocol != ProtocolV1 {
+		return Manifest{}, fmt.Errorf("runtimepayload: unsupported manifest schema/protocol %q/%q", manifest.Schema, manifest.Protocol)
+	}
+	cfg := BuildConfig{SPX: manifest.SPX, Target: manifest.Target, Engine: manifest.Engine, Bridge: manifest.Bridge, Project: manifest.Project}
+	if err := validateIdentity(cfg); err != nil {
+		return Manifest{}, err
+	}
+	return manifest, nil
+}
+
+func (v *Verified) validateComponents() error {
+	required := []string{
+		"engine/runtime-manifest.json",
+		"engine/" + v.Manifest.Engine.Executable,
+		"engine/" + v.Manifest.Engine.Pack,
+		"bridge/bridge-manifest.json",
+		"bridge/" + v.Manifest.Bridge.File,
+		ProjectZipPath,
+	}
+	if len(v.files) != len(required)+1 {
+		return fmt.Errorf("runtimepayload: payload has %d component entries, want %d", len(v.files)-1, len(required))
+	}
+	for _, name := range required {
+		if _, ok := v.files[name]; !ok {
+			return fmt.Errorf("runtimepayload: missing required entry %q", name)
+		}
+	}
+	projectEntry, ok := findEntry(v.entries, ProjectZipPath)
+	if !ok {
+		return fmt.Errorf("runtimepayload: missing required entry %q", ProjectZipPath)
+	}
+	if projectEntry.SHA256 != v.Manifest.Project.ArchiveSHA256 {
+		return fmt.Errorf("runtimepayload: project archive SHA-256 mismatch")
+	}
+	projectFile := v.files[ProjectZipPath]
+	projectReader, projectSize, err := v.storedEntryReaderAt(projectFile)
+	if err != nil {
+		return err
+	}
+	project, err := ComponentBundleReaderAt(projectReader, projectSize, runtimebundle.NamespaceProject)
+	if err != nil {
+		return fmt.Errorf("runtimepayload: verify project archive: %w", err)
+	}
+	if project.Digest != v.Manifest.Project.BundleDigest {
+		return fmt.Errorf("runtimepayload: project bundle digest mismatch")
+	}
+	for _, component := range []struct {
+		prefix    string
+		namespace runtimebundle.Namespace
+		digest    string
+	}{
+		{prefix: "engine/", namespace: runtimebundle.NamespaceEngine, digest: v.Manifest.Engine.BundleDigest},
+		{prefix: "bridge/", namespace: runtimebundle.NamespaceBridge, digest: v.Manifest.Bridge.BundleDigest},
+	} {
+		bundle, err := componentBundleFromEntries(v.entries, component.prefix, component.namespace)
+		if err != nil {
+			return fmt.Errorf("runtimepayload: verify %s component: %w", strings.TrimSuffix(component.prefix, "/"), err)
+		}
+		if bundle.Digest != component.digest {
+			return fmt.Errorf("runtimepayload: %s bundle digest mismatch", strings.TrimSuffix(component.prefix, "/"))
+		}
+	}
+	return nil
+}
+
+func (v *Verified) storedEntryReaderAt(file *zip.File) (io.ReaderAt, int64, error) {
+	if v == nil || file == nil {
+		return nil, 0, fmt.Errorf("runtimepayload: nil stored payload entry")
+	}
+	if file.Method != zip.Store || file.CompressedSize64 != file.UncompressedSize64 {
+		return nil, 0, fmt.Errorf("runtimepayload: project archive entry must use canonical ZIP store mode")
+	}
+	offset, err := file.DataOffset()
+	if err != nil {
+		return nil, 0, fmt.Errorf("runtimepayload: locate project archive: %w", err)
+	}
+	size := int64(file.UncompressedSize64)
+	return io.NewSectionReader(v.source, offset, size), size, nil
+}
+
+// WriteComponentZIP writes a deterministic archive containing entries below
+// prefix with the prefix removed. Only engine/ and bridge/ are accepted.
+func (v *Verified) WriteComponentZIP(prefix string, dst io.Writer) error {
+	if v == nil || (prefix != "engine/" && prefix != "bridge/") {
+		return fmt.Errorf("runtimepayload: invalid component prefix %q", prefix)
+	}
+	if dst == nil {
+		return fmt.Errorf("runtimepayload: nil component writer")
+	}
+	var entries []runtimebundle.Entry
+	for _, entry := range v.entries {
+		if strings.HasPrefix(entry.Name, prefix) {
+			entry.Name = strings.TrimPrefix(entry.Name, prefix)
+			entries = append(entries, entry)
+		}
+	}
+	if len(entries) == 0 {
+		return fmt.Errorf("runtimepayload: empty component %q", prefix)
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Name < entries[j].Name })
+	writer := zip.NewWriter(dst)
+	for _, entry := range entries {
+		sourceName := prefix + entry.Name
+		file := v.files[sourceName]
+		if file == nil {
+			_ = writer.Close()
+			return fmt.Errorf("runtimepayload: missing component entry %q", sourceName)
+		}
+		header := &zip.FileHeader{Name: entry.Name, Method: zip.Store}
+		header.SetMode(canonicalFileMode(fs.FileMode(entry.Mode)))
+		header.SetModTime(canonicalTime)
+		output, err := writer.CreateHeader(header)
+		if err != nil {
+			_ = writer.Close()
+			return fmt.Errorf("runtimepayload: create component entry %q: %w", entry.Name, err)
+		}
+		if err := copyVerifiedZipEntry(output, file, runtimebundle.Entry{
+			Name: sourceName, Mode: entry.Mode, Size: entry.Size, SHA256: entry.SHA256,
+		}); err != nil {
+			_ = writer.Close()
+			return err
+		}
+	}
+	if err := writer.Close(); err != nil {
+		return fmt.Errorf("runtimepayload: close component ZIP: %w", err)
+	}
+	return nil
+}
+
+// WriteProjectZIP streams the embedded canonical project archive to dst.
+func (v *Verified) WriteProjectZIP(dst io.Writer) error {
+	if v == nil {
+		return fmt.Errorf("runtimepayload: nil verified payload")
+	}
+	if dst == nil {
+		return fmt.Errorf("runtimepayload: nil project writer")
+	}
+	file := v.files[ProjectZipPath]
+	entry, ok := findEntry(v.entries, ProjectZipPath)
+	if file == nil || !ok {
+		return fmt.Errorf("runtimepayload: missing required entry %q", ProjectZipPath)
+	}
+	return copyVerifiedZipEntry(dst, file, entry)
+}
+
+func copyVerifiedZipEntry(dst io.Writer, file *zip.File, expected runtimebundle.Entry) error {
+	input, err := file.Open()
+	if err != nil {
+		return fmt.Errorf("runtimepayload: open entry %q: %w", file.Name, err)
+	}
+	hasher := sha256.New()
+	count, copyErr := io.Copy(io.MultiWriter(dst, hasher), input)
+	closeErr := input.Close()
+	if copyErr != nil {
+		return fmt.Errorf("runtimepayload: copy entry %q: %w", file.Name, copyErr)
+	}
+	if closeErr != nil {
+		return fmt.Errorf("runtimepayload: close entry %q: %w", file.Name, closeErr)
+	}
+	if count != expected.Size {
+		return fmt.Errorf("runtimepayload: entry %q size changed: got %d, want %d", file.Name, count, expected.Size)
+	}
+	if digest := hex.EncodeToString(hasher.Sum(nil)); digest != expected.SHA256 {
+		return fmt.Errorf("runtimepayload: entry %q digest changed", file.Name)
+	}
+	return nil
+}
+
+func findEntry(entries []runtimebundle.Entry, name string) (runtimebundle.Entry, bool) {
+	for _, entry := range entries {
+		if entry.Name == name {
+			return entry, true
+		}
+	}
+	return runtimebundle.Entry{}, false
+}
+
+func compareDigest(data []byte, expected, name string) error {
+	if err := validateDigest(expected); err != nil {
+		return fmt.Errorf("runtimepayload: invalid expected %s SHA-256: %w", name, err)
+	}
+	sum := sha256.Sum256(data)
+	if hex.EncodeToString(sum[:]) != expected {
+		return fmt.Errorf("runtimepayload: %s SHA-256 mismatch", name)
+	}
+	return nil
+}
+
+func compareReaderAtDigest(reader io.ReaderAt, size int64, expected, name string) error {
+	if err := validateDigest(expected); err != nil {
+		return fmt.Errorf("runtimepayload: invalid expected %s SHA-256: %w", name, err)
+	}
+	digest, err := hashSource(FileSource{ReaderAt: reader, Size: size})
+	if err != nil {
+		return fmt.Errorf("runtimepayload: hash %s: %w", name, err)
+	}
+	if digest != expected {
+		return fmt.Errorf("runtimepayload: %s SHA-256 mismatch", name)
+	}
+	return nil
+}
+
+func entriesEqual(first, second []runtimebundle.Entry) bool {
+	if len(first) != len(second) {
+		return false
+	}
+	left := append([]runtimebundle.Entry(nil), first...)
+	right := append([]runtimebundle.Entry(nil), second...)
+	sort.Slice(left, func(i, j int) bool { return left[i].Name < left[j].Name })
+	sort.Slice(right, func(i, j int) bool { return right[i].Name < right[j].Name })
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## Summary

- build and verify deterministic launcher payloads with bounded streaming I/O
- authenticate the manifest, entry table, component identities, target, and full archive
- split validation, limits, build, component, and verification responsibilities
- keep only streaming APIs used by production callers

## Validation

- `go test -race -count=1 ./internal/runtimepayload`
- `go vet ./...`
- `go test -count=1 ./...`
- `GOOS=windows GOARCH=amd64 go test -c ./internal/runtimepayload`
- `go mod tidy` (no diff)
- `git diff --check`