### PR TITLE
feat(project): add secure packaging primitives

### DIFF
--- a/internal/projectassets/collect.go
+++ b/internal/projectassets/collect.go
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package projectassets resolves typed resource references in an SPX project.
+package projectassets
+
+import (
+	"fmt"
+	"path"
+	"sort"
+)
+
+const packedIndexFile = "index_pack.json"
+
+// Config identifies a project and its asset indexes.
+type Config struct {
+	ProjectDir string
+	PackDir    string
+	PackIndex  string
+}
+
+// Resolution is the stable set of referenced files outside PackDir.
+type Resolution struct {
+	Files          []string
+	HasSourceIndex bool
+	HasPackedIndex bool
+}
+
+// Resolve validates typed resource references and returns their sorted paths.
+// A packed index overrides source root fields and same-name child entries.
+func Resolve(cfg Config) (Resolution, error) {
+	if err := validateConfig(cfg); err != nil {
+		return Resolution{}, err
+	}
+	root, err := openProjectRoot(cfg.ProjectDir)
+	if err != nil {
+		return Resolution{}, err
+	}
+	defer root.Close()
+
+	if _, ok, err := readPinnedDir(root, cfg.PackDir); err != nil {
+		return Resolution{}, err
+	} else if !ok {
+		return Resolution{}, fmt.Errorf("projectassets: PackDir %q is missing", cfg.PackDir)
+	}
+
+	sourceName := path.Join(cfg.PackDir, cfg.PackIndex)
+	packedName := path.Join(cfg.PackDir, packedIndexFile)
+	var sourceData []byte
+	var hasSource bool
+	if sourceName != packedName {
+		sourceData, hasSource, err = readPinnedFile(root, sourceName)
+		if err != nil {
+			return Resolution{}, err
+		}
+	}
+	packedData, hasPacked, err := readPinnedFile(root, packedName)
+	if err != nil {
+		return Resolution{}, err
+	}
+	if !hasSource && !hasPacked {
+		if sourceName == packedName {
+			return Resolution{}, fmt.Errorf("projectassets: required config %q is missing", packedName)
+		}
+		return Resolution{}, fmt.Errorf("projectassets: PackDir %q contains neither %q nor %q", cfg.PackDir, cfg.PackIndex, packedIndexFile)
+	}
+
+	resolved, err := parseConfig(sourceName, sourceData, packedName, packedData)
+	if err != nil {
+		return Resolution{}, err
+	}
+	collector := resolver{
+		root:       root,
+		packDir:    cfg.PackDir,
+		referenced: make(map[string]struct{}),
+	}
+	rootSource := sourceName
+	if hasPacked {
+		rootSource = packedName
+	}
+	if err := collector.collectProject(rootSource, resolved.project); err != nil {
+		return Resolution{}, err
+	}
+	if err := collector.collectSprites(resolved.sprites); err != nil {
+		return Resolution{}, err
+	}
+	if err := collector.collectSounds(resolved.sounds); err != nil {
+		return Resolution{}, err
+	}
+	if err := collector.collectFonts(resolved.fonts, resolved.hasFonts); err != nil {
+		return Resolution{}, err
+	}
+
+	files := make([]string, 0, len(collector.referenced))
+	for name := range collector.referenced {
+		files = append(files, name)
+	}
+	sort.Strings(files)
+	return Resolution{Files: files, HasSourceIndex: hasSource, HasPackedIndex: hasPacked}, nil
+}
+
+// Collect returns the referenced files. Resolve is preferred when index
+// presence is also needed.
+func Collect(cfg Config) ([]string, error) {
+	resolved, err := Resolve(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return resolved.Files, nil
+}

--- a/internal/projectassets/collect_test.go
+++ b/internal/projectassets/collect_test.go
@@ -1,0 +1,222 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package projectassets
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestCollectTypedReferences(t *testing.T) {
+	projectDir := t.TempDir()
+	writeAssetTestFile(t, projectDir, "root/background.png", "image")
+	writeAssetTestFile(t, projectDir, "root/music.wav", "sound")
+	writeAssetTestFile(t, projectDir, "assets/local.png", "local")
+	writeAssetTestFile(t, projectDir, "assets/sprites/Hero/hero.png", "hero")
+	writeAssetTestFile(t, projectDir, "assets/sounds/Jump/jump.wav", "jump")
+	writeAssetTestFile(t, projectDir, "assets/fonts/Body/body.ttf", "font")
+	writeAssetTestFile(t, projectDir, "assets/index.json", `{
+		"description":"../this-is-not-a-resource",
+		"backdrops":[{"path":"res://root/background.png"}],
+		"bgm":"../root/music.wav",
+		"sprites":{"Packed":{"costumeSet":{"path":"res://root/background.png"}}},
+		"sounds":{"Packed":{"path":"res://root/music.wav"}}
+	}`)
+	writeAssetTestFile(t, projectDir, "assets/sprites/Hero/index.json", `{"costumes":[{"path":"hero.png"}],"description":"../../../../not-a-resource"}`)
+	writeAssetTestFile(t, projectDir, "assets/sounds/Jump/index.json", `{"path":"jump.wav"}`)
+	writeAssetTestFile(t, projectDir, "assets/fonts/Body/index.json", `{"faces":[{"path":"body.ttf"}]}`)
+
+	files, err := Collect(Config{ProjectDir: projectDir, PackDir: "assets", PackIndex: "index.json"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"root/background.png", "root/music.wav"}
+	if !reflect.DeepEqual(files, want) {
+		t.Fatalf("Collect() = %#v, want %#v", files, want)
+	}
+}
+
+func TestResolvePackedOnly(t *testing.T) {
+	projectDir := t.TempDir()
+	for name := range map[string]string{
+		"root/background.png": "image",
+		"root/hero.png":       "hero",
+		"root/jump.wav":       "sound",
+		"root/body.ttf":       "font",
+	} {
+		writeAssetTestFile(t, projectDir, name, name)
+	}
+	writeAssetTestFile(t, projectDir, "assets/index_pack.json", `{
+		"backdrops":[{"path":"res://root/background.png"}],
+		"sprites":{"Hero":{"costumes":[{"path":"res://root/hero.png"}]}},
+		"sounds":{"Jump":{"path":"res://root/jump.wav"}},
+		"fonts":{"Body":{"faces":[{"path":"res://root/body.ttf"}]}}
+	}`)
+
+	resolved, err := Resolve(Config{ProjectDir: projectDir, PackDir: "assets", PackIndex: "index.json"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolved.HasSourceIndex || !resolved.HasPackedIndex {
+		t.Fatalf("index presence = source:%v packed:%v, want false/true", resolved.HasSourceIndex, resolved.HasPackedIndex)
+	}
+	want := []string{"root/background.png", "root/body.ttf", "root/hero.png", "root/jump.wav"}
+	if !reflect.DeepEqual(resolved.Files, want) {
+		t.Fatalf("Resolve().Files = %#v, want %#v", resolved.Files, want)
+	}
+}
+
+func TestResolvePackedOverridesStaleSource(t *testing.T) {
+	projectDir := t.TempDir()
+	for _, name := range []string{
+		"root/packed-bg.png",
+		"root/packed-map.json",
+		"root/packed-music.wav",
+		"root/packed-hero.png",
+		"root/packed-jump.wav",
+		"root/packed-font.ttf",
+	} {
+		writeAssetTestFile(t, projectDir, name, name)
+	}
+	writeAssetTestFile(t, projectDir, "assets/index.json", `{
+		"backdrops":[{"path":"res://stale/bg.png"}],
+		"bgm":"res://stale/music.wav",
+		"tilemapPath":"res://stale/map.json"
+	}`)
+	writeAssetTestFile(t, projectDir, "assets/sprites/Hero/index.json", `{not source json`)
+	writeAssetTestFile(t, projectDir, "assets/sounds/Jump/index.json", `{"path":"res://stale/jump.wav"}`)
+	writeAssetTestFile(t, projectDir, "assets/fonts/Stale/index.json", `{not source json`)
+	writeAssetTestFile(t, projectDir, "assets/index_pack.json", `{
+		"backdrops":[{"path":"res://root/packed-bg.png"}],
+		"bgm":"res://root/packed-music.wav",
+		"tilemapPath":"res://root/packed-map.json",
+		"sprites":{"Hero":{"costumes":[{"path":"res://root/packed-hero.png"}]}},
+		"sounds":{"Jump":{"path":"res://root/packed-jump.wav"}},
+		"fonts":{"Packed":{"faces":[{"path":"res://root/packed-font.ttf"}]}}
+	}`)
+
+	files, err := Collect(Config{ProjectDir: projectDir, PackDir: "assets", PackIndex: "index.json"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{
+		"root/packed-bg.png",
+		"root/packed-font.ttf",
+		"root/packed-hero.png",
+		"root/packed-jump.wav",
+		"root/packed-map.json",
+		"root/packed-music.wav",
+	}
+	if !reflect.DeepEqual(files, want) {
+		t.Fatalf("Collect() = %#v, want %#v", files, want)
+	}
+}
+
+func TestResolveFallsBackToMissingPackedChildren(t *testing.T) {
+	projectDir := t.TempDir()
+	for _, name := range []string{
+		"root/source-bg.png",
+		"root/source-hero.png",
+		"root/packed-hero.png",
+		"root/source-jump.wav",
+		"root/packed-jump.wav",
+		"root/source-font.ttf",
+	} {
+		writeAssetTestFile(t, projectDir, name, name)
+	}
+	writeAssetTestFile(t, projectDir, "assets/index.json", `{
+		"backdrops":[{"path":"res://root/source-bg.png"}]
+	}`)
+	writeAssetTestFile(t, projectDir, "assets/sprites/Hero/index.json", `{"costumes":[{"path":"res://root/source-hero.png"}]}`)
+	writeAssetTestFile(t, projectDir, "assets/sprites/Packed/index.json", `{"costumes":[{"path":"res://stale/hero.png"}]}`)
+	writeAssetTestFile(t, projectDir, "assets/sounds/Jump/index.json", `{"path":"res://root/source-jump.wav"}`)
+	writeAssetTestFile(t, projectDir, "assets/sounds/Packed/index.json", `{"path":"res://stale/jump.wav"}`)
+	writeAssetTestFile(t, projectDir, "assets/fonts/Source/index.json", `{"faces":[{"path":"res://root/source-font.ttf"}]}`)
+	writeAssetTestFile(t, projectDir, "assets/index_pack.json", `{
+		"zorder":["Hero","Packed"],
+		"sprites":{"Packed":{"costumes":[{"path":"res://root/packed-hero.png"}]}},
+		"sounds":{"Packed":{"path":"res://root/packed-jump.wav"}}
+	}`)
+
+	files, err := Collect(Config{ProjectDir: projectDir, PackDir: "assets", PackIndex: "index.json"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{
+		"root/packed-hero.png",
+		"root/packed-jump.wav",
+		"root/source-bg.png",
+		"root/source-font.ttf",
+		"root/source-hero.png",
+		"root/source-jump.wav",
+	}
+	if !reflect.DeepEqual(files, want) {
+		t.Fatalf("Collect() = %#v, want %#v", files, want)
+	}
+}
+
+func TestCollectRejectsUnsafeTypedReferences(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		reference string
+		want      string
+	}{
+		{name: "escape", reference: "../../outside.png", want: "escapes ProjectDir"},
+		{name: "absolute", reference: "/private/host.png", want: "absolute resource path"},
+		{name: "host scheme", reference: "file:///private/host.png", want: "unsupported resource path"},
+		{name: "missing", reference: "res://missing.png", want: "is missing"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			projectDir := t.TempDir()
+			writeAssetTestFile(t, projectDir, "assets/index.json", `{"backdrops":[{"path":"`+test.reference+`"}]}`)
+			_, err := Collect(Config{ProjectDir: projectDir, PackDir: "assets", PackIndex: "index.json"})
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("Collect() error = %v, want containing %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestCollectRejectsSymlinkedReferencedFile(t *testing.T) {
+	projectDir := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "outside.png")
+	if err := os.WriteFile(outside, []byte("outside"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	writeAssetTestFile(t, projectDir, "assets/index.json", `{"backdrops":[{"path":"res://linked.png"}]}`)
+	if err := os.Symlink(outside, filepath.Join(projectDir, "linked.png")); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	_, err := Collect(Config{ProjectDir: projectDir, PackDir: "assets", PackIndex: "index.json"})
+	if err == nil || !strings.Contains(err.Error(), "non-symlink") {
+		t.Fatalf("Collect() error = %v", err)
+	}
+}
+
+func writeAssetTestFile(t *testing.T, root, relative, content string) {
+	t.Helper()
+	name := filepath.Join(root, filepath.FromSlash(relative))
+	if err := os.MkdirAll(filepath.Dir(name), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(name, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/projectassets/config.go
+++ b/internal/projectassets/config.go
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package projectassets
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+)
+
+type resourceConfig struct {
+	Path string `json:"path"`
+}
+
+type projectConfig struct {
+	Backdrops   []*resourceConfig `json:"backdrops"`
+	Bgm         string            `json:"bgm"`
+	TilemapPath string            `json:"tilemapPath"`
+}
+
+type spriteConfig struct {
+	Costumes     []*resourceConfig `json:"costumes"`
+	CostumeSet   *resourceConfig   `json:"costumeSet"`
+	CostumeMPSet *resourceConfig   `json:"costumeMPSet"`
+}
+
+type soundConfig struct {
+	Path string `json:"path"`
+}
+
+type fontFamilyConfig struct {
+	Faces []resourceConfig `json:"faces"`
+}
+
+type packedConfig struct {
+	project  projectConfig
+	sprites  map[string]spriteConfig
+	sounds   map[string]soundConfig
+	fonts    map[string]fontFamilyConfig
+	hasFonts bool
+}
+
+func parseConfig(sourceName string, sourceData []byte, packedName string, packedData []byte) (packedConfig, error) {
+	sourceRoot, err := parseRoot(sourceName, sourceData)
+	if err != nil {
+		return packedConfig{}, err
+	}
+	packedRoot, err := parseRoot(packedName, packedData)
+	if err != nil {
+		return packedConfig{}, err
+	}
+
+	merged := make(map[string]json.RawMessage, len(sourceRoot)+len(packedRoot))
+	for key, value := range sourceRoot {
+		merged[key] = value
+	}
+	for key, value := range packedRoot {
+		merged[key] = value
+	}
+	var config packedConfig
+	if err := decodeProjectConfig(merged, &config.project); err != nil {
+		name := sourceName
+		if len(packedData) != 0 {
+			name = packedName
+		}
+		return packedConfig{}, fmt.Errorf("projectassets: decode merged project config at %q: %w", name, err)
+	}
+	config.sprites, err = decodePackedObjects[spriteConfig](packedName, "sprites", packedRoot["sprites"])
+	if err != nil {
+		return packedConfig{}, err
+	}
+	config.sounds, err = decodePackedObjects[soundConfig](packedName, "sounds", packedRoot["sounds"])
+	if err != nil {
+		return packedConfig{}, err
+	}
+	_, config.hasFonts = packedRoot["fonts"]
+	config.fonts, err = decodePackedObjects[fontFamilyConfig](packedName, "fonts", packedRoot["fonts"])
+	if err != nil {
+		return packedConfig{}, err
+	}
+	return config, nil
+}
+
+func parseRoot(name string, data []byte) (map[string]json.RawMessage, error) {
+	if data == nil {
+		return nil, nil
+	}
+	var root map[string]json.RawMessage
+	if err := json.Unmarshal(data, &root); err != nil {
+		return nil, fmt.Errorf("projectassets: decode %q: %w", name, err)
+	}
+	return root, nil
+}
+
+func decodeProjectConfig(root map[string]json.RawMessage, dest *projectConfig) error {
+	data, err := json.Marshal(root)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(data, dest)
+}
+
+func decodePackedObjects[T any](indexName, section string, raw json.RawMessage) (map[string]T, error) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil, nil
+	}
+	var entries map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &entries); err != nil {
+		return nil, fmt.Errorf("projectassets: decode %q section %q: %w", indexName, section, err)
+	}
+	names := make([]string, 0, len(entries))
+	for name := range entries {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	configs := make(map[string]T, len(entries))
+	for _, name := range names {
+		if err := validateConfigEntryName(section, name); err != nil {
+			return nil, err
+		}
+		var config T
+		if err := json.Unmarshal(entries[name], &config); err != nil {
+			return nil, fmt.Errorf("projectassets: decode %q section %q entry %q: %w", indexName, section, name, err)
+		}
+		configs[name] = config
+	}
+	return configs, nil
+}

--- a/internal/projectassets/paths.go
+++ b/internal/projectassets/paths.go
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package projectassets
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path"
+	"strings"
+)
+
+func validateConfig(cfg Config) error {
+	if cfg.ProjectDir == "" {
+		return errors.New("projectassets: ProjectDir is empty")
+	}
+	if cfg.PackDir == "" || cfg.PackDir == "." || strings.Contains(cfg.PackDir, "\\") || path.IsAbs(cfg.PackDir) || path.Clean(cfg.PackDir) != cfg.PackDir || cfg.PackDir == ".." || strings.HasPrefix(cfg.PackDir, "../") {
+		return fmt.Errorf("projectassets: PackDir must be a clean non-empty relative slash path: %q", cfg.PackDir)
+	}
+	if cfg.PackIndex == "" || cfg.PackIndex == "." || cfg.PackIndex == ".." || strings.ContainsAny(cfg.PackIndex, "/\\\x00") {
+		return fmt.Errorf("projectassets: PackIndex must be a plain file name: %q", cfg.PackIndex)
+	}
+	return nil
+}
+
+func validateConfigEntryName(section, name string) error {
+	if name == "" || name == "." || name == ".." || strings.ContainsAny(name, "/\\\x00") {
+		return fmt.Errorf("projectassets: section %q has unsafe entry name %q", section, name)
+	}
+	return nil
+}
+
+func (r *resolver) addReference(source, base, reference string) error {
+	if reference == "" {
+		return nil
+	}
+	if strings.ContainsAny(reference, "\\\x00") {
+		return fmt.Errorf("projectassets: config %q has unsafe resource path %q", source, reference)
+	}
+
+	var name string
+	switch {
+	case strings.HasPrefix(reference, "res://"):
+		name = strings.TrimPrefix(reference, "res://")
+		if name == "" || path.IsAbs(name) {
+			return fmt.Errorf("projectassets: config %q references absolute resource path %q", source, reference)
+		}
+		if strings.Contains(name, ":") {
+			return fmt.Errorf("projectassets: config %q has unsupported resource path %q", source, reference)
+		}
+	case strings.Contains(reference, ":"):
+		return fmt.Errorf("projectassets: config %q has unsupported resource path %q", source, reference)
+	case path.IsAbs(reference):
+		return fmt.Errorf("projectassets: config %q references absolute resource path %q", source, reference)
+	default:
+		name = path.Join(base, reference)
+	}
+	name = path.Clean(name)
+	if name == "." || name == ".." || strings.HasPrefix(name, "../") || path.IsAbs(name) {
+		return fmt.Errorf("projectassets: config %q resource %q escapes ProjectDir (outside project directory)", source, reference)
+	}
+	if err := pinRegularFile(r.root, name); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("projectassets: config %q resource %q is missing", source, reference)
+		}
+		return fmt.Errorf("projectassets: config %q resource %q: %w", source, reference, err)
+	}
+	if name != r.packDir && !strings.HasPrefix(name, r.packDir+"/") {
+		r.referenced[name] = struct{}{}
+	}
+	return nil
+}

--- a/internal/projectassets/references.go
+++ b/internal/projectassets/references.go
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package projectassets
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path"
+	"sort"
+)
+
+type resolver struct {
+	root       *os.Root
+	packDir    string
+	referenced map[string]struct{}
+}
+
+func (r *resolver) collectProject(source string, config projectConfig) error {
+	for _, backdrop := range config.Backdrops {
+		if backdrop != nil {
+			if err := r.addReference(source, r.packDir, backdrop.Path); err != nil {
+				return err
+			}
+		}
+	}
+	for _, reference := range []string{config.Bgm, config.TilemapPath} {
+		if err := r.addReference(source, r.packDir, reference); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *resolver) collectSprites(packed map[string]spriteConfig) error {
+	if err := forEachSorted(packed, func(name string, config spriteConfig) error {
+		return r.addSpriteReferences(path.Join(r.packDir, packedIndexFile)+"#sprites/"+name, path.Join(r.packDir, "sprites", name), config)
+	}); err != nil {
+		return err
+	}
+	return collectSourceSection(r, "sprites", packed, func(source, base string, data []byte) error {
+		var config spriteConfig
+		if err := json.Unmarshal(data, &config); err != nil {
+			return fmt.Errorf("projectassets: decode %q: %w", source, err)
+		}
+		return r.addSpriteReferences(source, base, config)
+	})
+}
+
+func (r *resolver) addSpriteReferences(source, base string, config spriteConfig) error {
+	for _, costume := range config.Costumes {
+		if costume != nil {
+			if err := r.addReference(source, base, costume.Path); err != nil {
+				return err
+			}
+		}
+	}
+	for _, costume := range []*resourceConfig{config.CostumeSet, config.CostumeMPSet} {
+		if costume != nil {
+			if err := r.addReference(source, base, costume.Path); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (r *resolver) collectSounds(packed map[string]soundConfig) error {
+	if err := forEachSorted(packed, func(name string, config soundConfig) error {
+		return r.addReference(path.Join(r.packDir, packedIndexFile)+"#sounds/"+name, path.Join(r.packDir, "sounds", name), config.Path)
+	}); err != nil {
+		return err
+	}
+	return collectSourceSection(r, "sounds", packed, func(source, base string, data []byte) error {
+		var config soundConfig
+		if err := json.Unmarshal(data, &config); err != nil {
+			return fmt.Errorf("projectassets: decode %q: %w", source, err)
+		}
+		return r.addReference(source, base, config.Path)
+	})
+}
+
+func (r *resolver) collectFonts(packed map[string]fontFamilyConfig, hasPackedCatalog bool) error {
+	if hasPackedCatalog {
+		return forEachSorted(packed, func(name string, config fontFamilyConfig) error {
+			return r.addFontReferences(path.Join(r.packDir, packedIndexFile)+"#fonts/"+name, path.Join(r.packDir, "fonts", name), config)
+		})
+	}
+	return collectSourceSection(r, "fonts", map[string]fontFamilyConfig(nil), func(source, base string, data []byte) error {
+		var config fontFamilyConfig
+		if err := json.Unmarshal(data, &config); err != nil {
+			return fmt.Errorf("projectassets: decode %q: %w", source, err)
+		}
+		return r.addFontReferences(source, base, config)
+	})
+}
+
+func (r *resolver) addFontReferences(source, base string, config fontFamilyConfig) error {
+	for _, face := range config.Faces {
+		if err := r.addReference(source, base, face.Path); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func collectSourceSection[T any](r *resolver, section string, packed map[string]T, collect func(source, base string, data []byte) error) error {
+	directory := path.Join(r.packDir, section)
+	entries, ok, err := readPinnedDir(r.root, directory)
+	if err != nil || !ok {
+		return err
+	}
+	for _, entry := range entries {
+		if entry.Type()&os.ModeSymlink != 0 {
+			return fmt.Errorf("projectassets: config directory %q is a symlink", path.Join(directory, entry.Name()))
+		}
+		if !entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if err := validateConfigEntryName(section, name); err != nil {
+			return err
+		}
+		if _, overridden := packed[name]; overridden {
+			continue
+		}
+		base := path.Join(directory, name)
+		source := path.Join(base, "index.json")
+		data, found, err := readPinnedFile(r.root, source)
+		if err != nil {
+			return err
+		}
+		if found {
+			if err := collect(source, base, data); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func forEachSorted[T any](values map[string]T, visit func(string, T) error) error {
+	names := make([]string, 0, len(values))
+	for name := range values {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		if err := visit(name, values[name]); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/projectassets/snapshot.go
+++ b/internal/projectassets/snapshot.go
@@ -1,0 +1,203 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package projectassets
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"sort"
+	"strings"
+)
+
+const maxConfigBytes = int64(16 << 20)
+
+func openProjectRoot(name string) (*os.Root, error) {
+	before, err := os.Lstat(name)
+	if err != nil {
+		return nil, fmt.Errorf("projectassets: inspect ProjectDir: %w", err)
+	}
+	if before.Mode()&os.ModeSymlink != 0 || !before.IsDir() {
+		return nil, fmt.Errorf("projectassets: ProjectDir %q is not a real directory", name)
+	}
+	root, err := os.OpenRoot(name)
+	if err != nil {
+		return nil, fmt.Errorf("projectassets: open ProjectDir: %w", err)
+	}
+	probe, err := root.Open(".")
+	if err != nil {
+		root.Close()
+		return nil, fmt.Errorf("projectassets: pin ProjectDir: %w", err)
+	}
+	opened, statErr := probe.Stat()
+	closeErr := probe.Close()
+	if statErr != nil || closeErr != nil || !opened.IsDir() || !os.SameFile(before, opened) {
+		root.Close()
+		return nil, fmt.Errorf("projectassets: ProjectDir %q changed while opening", name)
+	}
+	return root, nil
+}
+
+func readPinnedFile(root *os.Root, name string) ([]byte, bool, error) {
+	before, err := inspectPath(root, name, false)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	file, err := root.Open(name)
+	if err != nil {
+		return nil, false, fmt.Errorf("projectassets: open %q: %w", name, err)
+	}
+	opened, statErr := file.Stat()
+	if statErr != nil || !opened.Mode().IsRegular() || !os.SameFile(before[len(before)-1], opened) {
+		file.Close()
+		return nil, false, fmt.Errorf("projectassets: %q changed while opening", name)
+	}
+	data, readErr := io.ReadAll(io.LimitReader(file, maxConfigBytes+1))
+	afterOpened, statErr := file.Stat()
+	closeErr := file.Close()
+	after, inspectErr := inspectPath(root, name, false)
+	if readErr != nil {
+		return nil, false, fmt.Errorf("projectassets: read %q: %w", name, readErr)
+	}
+	if statErr != nil {
+		return nil, false, fmt.Errorf("projectassets: stat %q: %w", name, statErr)
+	}
+	if closeErr != nil {
+		return nil, false, fmt.Errorf("projectassets: close %q: %w", name, closeErr)
+	}
+	if int64(len(data)) > maxConfigBytes {
+		return nil, false, fmt.Errorf("projectassets: %q exceeds %d bytes", name, maxConfigBytes)
+	}
+	if inspectErr != nil || int64(len(data)) != opened.Size() || !samePathSnapshot(before, after) || !sameStableFile(opened, afterOpened) || !os.SameFile(opened, afterOpened) {
+		return nil, false, fmt.Errorf("projectassets: %q changed while reading", name)
+	}
+	return data, true, nil
+}
+
+func readPinnedDir(root *os.Root, name string) ([]os.DirEntry, bool, error) {
+	before, err := inspectPath(root, name, true)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	directory, err := root.Open(name)
+	if err != nil {
+		return nil, false, fmt.Errorf("projectassets: open directory %q: %w", name, err)
+	}
+	opened, statErr := directory.Stat()
+	if statErr != nil || !opened.IsDir() || !os.SameFile(before[len(before)-1], opened) {
+		directory.Close()
+		return nil, false, fmt.Errorf("projectassets: directory %q changed while opening", name)
+	}
+	entries, readErr := directory.ReadDir(-1)
+	afterOpened, statErr := directory.Stat()
+	closeErr := directory.Close()
+	after, inspectErr := inspectPath(root, name, true)
+	if readErr != nil {
+		return nil, false, fmt.Errorf("projectassets: read directory %q: %w", name, readErr)
+	}
+	if statErr != nil {
+		return nil, false, fmt.Errorf("projectassets: stat directory %q: %w", name, statErr)
+	}
+	if closeErr != nil {
+		return nil, false, fmt.Errorf("projectassets: close directory %q: %w", name, closeErr)
+	}
+	if inspectErr != nil || !samePathSnapshot(before, after) || !sameStableFile(opened, afterOpened) || !os.SameFile(opened, afterOpened) {
+		return nil, false, fmt.Errorf("projectassets: directory %q changed while reading", name)
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Name() < entries[j].Name() })
+	return entries, true, nil
+}
+
+func pinRegularFile(root *os.Root, name string) error {
+	before, err := inspectPath(root, name, false)
+	if err != nil {
+		return err
+	}
+	file, err := root.Open(name)
+	if err != nil {
+		return err
+	}
+	opened, statErr := file.Stat()
+	afterOpened, secondStatErr := file.Stat()
+	closeErr := file.Close()
+	after, inspectErr := inspectPath(root, name, false)
+	if statErr != nil {
+		return statErr
+	}
+	if secondStatErr != nil {
+		return secondStatErr
+	}
+	if closeErr != nil {
+		return closeErr
+	}
+	if inspectErr != nil || !opened.Mode().IsRegular() || !os.SameFile(before[len(before)-1], opened) || !os.SameFile(opened, afterOpened) || !sameStableFile(opened, afterOpened) || !samePathSnapshot(before, after) {
+		return fmt.Errorf("projectassets: %q is not a stable regular non-symlink file", name)
+	}
+	return nil
+}
+
+func inspectPath(root *os.Root, name string, finalDirectory bool) ([]os.FileInfo, error) {
+	if name == "" || name == "." || name == ".." || path.IsAbs(name) || path.Clean(name) != name || strings.HasPrefix(name, "../") || strings.ContainsAny(name, "\\\x00") {
+		return nil, fmt.Errorf("projectassets: unsafe project path %q", name)
+	}
+	parts := strings.Split(name, "/")
+	infos := make([]os.FileInfo, 0, len(parts))
+	for i := range parts {
+		candidate := path.Join(parts[:i+1]...)
+		info, err := root.Lstat(candidate)
+		if err != nil {
+			return nil, err
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return nil, fmt.Errorf("projectassets: %q is not a regular non-symlink path (symlink at %q)", name, candidate)
+		}
+		last := i == len(parts)-1
+		if !last || finalDirectory {
+			if !info.IsDir() {
+				return nil, fmt.Errorf("projectassets: %q contains a non-directory component %q", name, candidate)
+			}
+		} else if !info.Mode().IsRegular() {
+			return nil, fmt.Errorf("projectassets: %q is not a regular non-symlink file", name)
+		}
+		infos = append(infos, info)
+	}
+	return infos, nil
+}
+
+func samePathSnapshot(before, after []os.FileInfo) bool {
+	if len(before) != len(after) {
+		return false
+	}
+	for i := range before {
+		if !os.SameFile(before[i], after[i]) || !sameStableFile(before[i], after[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func sameStableFile(before, after os.FileInfo) bool {
+	return before.Mode() == after.Mode() && before.Size() == after.Size() && before.ModTime() == after.ModTime()
+}

--- a/internal/projectbundle/archive.go
+++ b/internal/projectbundle/archive.go
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2021 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package projectbundle
+
+import (
+	"archive/zip"
+	"compress/flate"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+)
+
+var canonicalZipTime = time.Date(1980, time.January, 1, 0, 0, 0, 0, time.UTC)
+
+// String returns the lowercase hexadecimal SHA-256.
+func (d Digest) String() string {
+	return hex.EncodeToString(d[:])
+}
+
+// WriteArchive collects cfg and writes its canonical ZIP to w.
+func WriteArchive(w io.Writer, cfg Config) (Digest, error) {
+	bundle, err := collect(cfg)
+	if err != nil {
+		return Digest{}, err
+	}
+	return bundle.writeZIP(w)
+}
+
+// writeZIP writes the canonical ZIP to w. It does not close w.
+func (b *bundle) writeZIP(w io.Writer) (Digest, error) {
+	if b == nil {
+		return Digest{}, errors.New("projectbundle: nil bundle")
+	}
+	if w == nil {
+		return Digest{}, errors.New("projectbundle: nil writer")
+	}
+
+	hasher := sha256.New()
+	limited := &archiveLimitWriter{writer: w, remaining: b.limits.maxArchiveBytes}
+	writer := zip.NewWriter(io.MultiWriter(limited, hasher))
+	writer.RegisterCompressor(zip.Deflate, func(w io.Writer) (io.WriteCloser, error) {
+		return flate.NewWriter(w, flate.BestCompression)
+	})
+
+	for _, entry := range b.entries {
+		header := &zip.FileHeader{Name: entry.name, Method: zip.Deflate}
+		header.SetModTime(canonicalZipTime)
+		header.SetMode(0o644)
+		output, err := writer.CreateHeader(header)
+		if err != nil {
+			_ = writer.Close()
+			return Digest{}, fmt.Errorf("projectbundle: create ZIP entry %q: %w", entry.name, err)
+		}
+		if _, err := output.Write(entry.data); err != nil {
+			_ = writer.Close()
+			return Digest{}, fmt.Errorf("projectbundle: write ZIP entry %q: %w", entry.name, err)
+		}
+	}
+	if err := writer.Close(); err != nil {
+		return Digest{}, fmt.Errorf("projectbundle: close ZIP: %w", err)
+	}
+
+	var digest Digest
+	copy(digest[:], hasher.Sum(nil))
+	return digest, nil
+}
+
+type archiveLimitWriter struct {
+	writer    io.Writer
+	remaining int64
+}
+
+func (w *archiveLimitWriter) Write(data []byte) (int, error) {
+	if int64(len(data)) > w.remaining {
+		return 0, fmt.Errorf("%w: ZIP exceeds archive byte limit", ErrLimit)
+	}
+	n, err := w.writer.Write(data)
+	w.remaining -= int64(n)
+	if err == nil && n != len(data) {
+		err = io.ErrShortWrite
+	}
+	return n, err
+}

--- a/internal/projectbundle/bundle.go
+++ b/internal/projectbundle/bundle.go
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2021 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package projectbundle
+
+import (
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"sort"
+)
+
+const (
+	defaultMaxEntries            = 10_000
+	defaultMaxFileBytes    int64 = 64 << 20
+	defaultMaxTotalBytes   int64 = 256 << 20
+	defaultMaxArchiveBytes int64 = 512 << 20
+)
+
+var (
+	// ErrInvalidPath reports an absolute, traversing, or non-canonical member path.
+	ErrInvalidPath = errors.New("projectbundle: invalid relative path")
+	// ErrUnsafeFile reports a symlink, non-regular file, or file changed while read.
+	ErrUnsafeFile = errors.New("projectbundle: unsafe file")
+	// ErrCollision reports duplicate, Unicode-canonical, or case-folded entry names.
+	ErrCollision = errors.New("projectbundle: entry name collision")
+	// ErrLimit reports an entry-count or byte-size limit violation.
+	ErrLimit = errors.New("projectbundle: limit exceeded")
+)
+
+// Config defines the complete allowlist and limits for one project archive.
+type Config struct {
+	ProjectDir    string
+	ProjectFiles  []string
+	IncludeConfig bool
+	ConfigBytes   []byte
+	PackDir       string
+	Output        string
+	FinalOutput   string
+	Limits        Limits
+}
+
+// Limits bounds collection memory and ZIP output. Zero selects a default;
+// negative values are invalid.
+type Limits struct {
+	MaxEntries      int
+	MaxFileBytes    int64
+	MaxTotalBytes   int64
+	MaxArchiveBytes int64
+}
+
+// Digest is the SHA-256 of the complete canonical ZIP bytes.
+type Digest [sha256.Size]byte
+
+type collectedEntry struct {
+	name string
+	data []byte
+}
+
+// bundle is an immutable in-memory snapshot of collected source files.
+type bundle struct {
+	entries []collectedEntry
+	limits  resolvedLimits
+}
+
+func collect(cfg Config) (*bundle, error) {
+	limits, err := resolveLimits(cfg.Limits)
+	if err != nil {
+		return nil, err
+	}
+	if cfg.ProjectDir == "" {
+		return nil, fmt.Errorf("%w: ProjectDir is empty", ErrInvalidPath)
+	}
+
+	projectRootObservation, err := observeRoot(cfg.ProjectDir)
+	if err != nil {
+		return nil, fmt.Errorf("projectbundle: observe ProjectDir: %w", err)
+	}
+	projectDir := projectRootObservation.path
+
+	projectFiles := make([]string, len(cfg.ProjectFiles))
+	for i, name := range cfg.ProjectFiles {
+		projectFiles[i], err = validateRelativePath(name, "ProjectFiles")
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	packDir := ""
+	if cfg.PackDir != "" {
+		packDir, err = validateRelativePath(cfg.PackDir, "PackDir")
+		if err != nil {
+			return nil, err
+		}
+	}
+	packRoot := ""
+	if packDir != "" {
+		packRoot = filepath.Join(projectDir, filepath.FromSlash(packDir))
+	}
+	if err := validateOutputs(projectDir, cfg.Output, cfg.FinalOutput, packRoot); err != nil {
+		return nil, err
+	}
+
+	projectRoot, err := openSafeRoot(projectDir, projectRootObservation.info)
+	if err != nil {
+		return nil, fmt.Errorf("projectbundle: open ProjectDir %q: %w", projectDir, err)
+	}
+	defer projectRoot.Close()
+
+	collector := newCollector(limits)
+	for _, name := range projectFiles {
+		if err := collector.addFile(projectRoot, name, name); err != nil {
+			return nil, err
+		}
+	}
+	if cfg.IncludeConfig {
+		if cfg.ConfigBytes != nil {
+			err = collector.addData(".config", cfg.ConfigBytes)
+		} else {
+			err = collector.addFile(projectRoot, ".config", ".config")
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
+	if packDir != "" {
+		root, err := projectRoot.OpenDir(filepath.FromSlash(packDir))
+		if err != nil {
+			return nil, fmt.Errorf("projectbundle: open PackDir %q: %w", packDir, err)
+		}
+		if err := collector.addTree(root, packDir); err != nil {
+			root.Close()
+			return nil, err
+		}
+		if err := root.Close(); err != nil {
+			return nil, fmt.Errorf("projectbundle: close PackDir %q: %w", packDir, err)
+		}
+	}
+	sort.Slice(collector.entries, func(i, j int) bool {
+		return collector.entries[i].name < collector.entries[j].name
+	})
+	return &bundle{entries: collector.entries, limits: limits}, nil
+}

--- a/internal/projectbundle/bundle_test.go
+++ b/internal/projectbundle/bundle_test.go
@@ -1,0 +1,571 @@
+/*
+ * Copyright (c) 2021 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package projectbundle
+
+import (
+	"archive/zip"
+	"bytes"
+	"crypto/sha256"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestArchiveCanonicalAndDeterministic(t *testing.T) {
+	projectDir := t.TempDir()
+	outputDir := t.TempDir()
+
+	writeBundleTestFile(t, filepath.Join(projectDir, "z.go"), "z", 0o700)
+	writeBundleTestFile(t, filepath.Join(projectDir, "main.go"), "main", 0o600)
+	writeBundleTestFile(t, filepath.Join(projectDir, ".config"), "config", 0o600)
+	writeBundleTestFile(t, filepath.Join(projectDir, "assets", "z.txt"), "asset-z", 0o600)
+	writeBundleTestFile(t, filepath.Join(projectDir, "assets", "nested", "a.txt"), "asset-a", 0o700)
+
+	output := filepath.Join(outputDir, "output.zip")
+	finalOutput := filepath.Join(outputDir, "final.zip")
+	writeBundleTestFile(t, output, "keep-output", 0o600)
+	writeBundleTestFile(t, finalOutput, "keep-final", 0o600)
+
+	config := Config{
+		ProjectDir:    projectDir,
+		ProjectFiles:  []string{"z.go", "main.go"},
+		IncludeConfig: true,
+		PackDir:       "assets",
+		Output:        output,
+		FinalOutput:   finalOutput,
+	}
+	bundle, err := collect(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantNames := []string{".config", "assets/nested/a.txt", "assets/z.txt", "main.go", "z.go"}
+	wantSizes := []int64{6, 7, 7, 4, 1}
+	if len(bundle.entries) != len(wantNames) {
+		t.Fatalf("entries = %#v, want %d entries", bundle.entries, len(wantNames))
+	}
+	for i, entry := range bundle.entries {
+		if entry.name != wantNames[i] || int64(len(entry.data)) != wantSizes[i] {
+			t.Errorf("entry %d = (%q, %d), want (%q, %d)", i, entry.name, len(entry.data), wantNames[i], wantSizes[i])
+		}
+	}
+
+	var archive bytes.Buffer
+	digest, err := bundle.writeZIP(&archive)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data := archive.Bytes()
+	if want := Digest(sha256.Sum256(data)); digest != want {
+		t.Fatalf("digest = %s, want %s", digest, want)
+	}
+	if len(digest.String()) != sha256.Size*2 {
+		t.Fatalf("digest string length = %d, want %d", len(digest.String()), sha256.Size*2)
+	}
+
+	reader, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	contents := make(map[string]string, len(reader.File))
+	for i, file := range reader.File {
+		if file.Name != wantNames[i] {
+			t.Fatalf("ZIP entry %d = %q, want %q", i, file.Name, wantNames[i])
+		}
+		if strings.ContainsRune(file.Name, '\\') {
+			t.Fatalf("ZIP entry %q contains a host separator", file.Name)
+		}
+		if file.Method != zip.Deflate {
+			t.Fatalf("ZIP entry %q method = %d, want Deflate", file.Name, file.Method)
+		}
+		if !file.Modified.Equal(canonicalZipTime) {
+			t.Fatalf("ZIP entry %q time = %s, want %s", file.Name, file.Modified, canonicalZipTime)
+		}
+		if got := file.Mode(); got != 0o644 {
+			t.Fatalf("ZIP entry %q mode = %s, want 0644", file.Name, got)
+		}
+		input, err := file.Open()
+		if err != nil {
+			t.Fatal(err)
+		}
+		content, readErr := io.ReadAll(input)
+		closeErr := input.Close()
+		if readErr != nil {
+			t.Fatal(readErr)
+		}
+		if closeErr != nil {
+			t.Fatal(closeErr)
+		}
+		contents[file.Name] = string(content)
+	}
+	if contents["assets/nested/a.txt"] != "asset-a" {
+		t.Fatalf("unexpected ZIP contents: %#v", contents)
+	}
+
+	reordered := config
+	reordered.ProjectFiles = []string{"main.go", "z.go"}
+	secondData, secondDigest, err := archiveBytes(reordered)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(data, secondData) || digest != secondDigest {
+		t.Fatal("archive changed when allowlist order changed")
+	}
+
+	changedTime := time.Date(2037, time.August, 9, 10, 11, 12, 0, time.UTC)
+	if err := os.Chmod(filepath.Join(projectDir, "main.go"), 0o777); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(filepath.Join(projectDir, "main.go"), changedTime, changedTime); err != nil {
+		t.Fatal(err)
+	}
+	thirdData, thirdDigest, err := archiveBytes(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(data, thirdData) || digest != thirdDigest {
+		t.Fatal("archive changed when source metadata changed")
+	}
+
+	var streamed bytes.Buffer
+	streamDigest, err := WriteArchive(&streamed, config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(data, streamed.Bytes()) || digest != streamDigest {
+		t.Fatal("WriteArchive output differs from archive")
+	}
+	assertBundleTestFile(t, output, "keep-output")
+	assertBundleTestFile(t, finalOutput, "keep-final")
+}
+
+func TestCollectUsesImmutableConfigBytes(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		data []byte
+	}{
+		{name: "content", data: []byte(`{"name":"validated"}`)},
+		{name: "empty", data: []byte{}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			projectDir := t.TempDir()
+			writeBundleTestFile(t, filepath.Join(projectDir, ".config"), `{"extasset":"live"}`, 0o600)
+
+			bundle, err := collect(Config{
+				ProjectDir: projectDir, IncludeConfig: true, ConfigBytes: tt.data,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := bundle.entries; len(got) != 1 || got[0].name != ".config" || !bytes.Equal(got[0].data, tt.data) {
+				t.Fatalf("collected entries = %#v, want immutable .config %q", got, tt.data)
+			}
+			if len(tt.data) != 0 {
+				tt.data[0] ^= 0xff
+				if bytes.Equal(bundle.entries[0].data, tt.data) {
+					t.Fatal("bundle retained caller-owned config storage")
+				}
+			}
+		})
+	}
+}
+
+func TestCollectRejectsInvalidRelativePaths(t *testing.T) {
+	projectDir := t.TempDir()
+	writeBundleTestFile(t, filepath.Join(projectDir, "file.txt"), "file", 0o600)
+
+	tests := []struct {
+		name   string
+		config Config
+	}{
+		{name: "project absolute", config: Config{ProjectDir: projectDir, ProjectFiles: []string{filepath.Join(projectDir, "file.txt")}}},
+		{name: "project parent", config: Config{ProjectDir: projectDir, ProjectFiles: []string{"../file.txt"}}},
+		{name: "project unclean", config: Config{ProjectDir: projectDir, ProjectFiles: []string{"dir/../file.txt"}}},
+		{name: "project backslash", config: Config{ProjectDir: projectDir, ProjectFiles: []string{`dir\file.txt`}}},
+		{name: "project windows absolute", config: Config{ProjectDir: projectDir, ProjectFiles: []string{"C:/file.txt"}}},
+		{name: "project windows ADS", config: Config{ProjectDir: projectDir, ProjectFiles: []string{"file.txt:secret"}}},
+		{name: "project DOS device", config: Config{ProjectDir: projectDir, ProjectFiles: []string{"CON.txt"}}},
+		{name: "project trailing dot", config: Config{ProjectDir: projectDir, ProjectFiles: []string{"file.txt."}}},
+		{name: "project trailing space", config: Config{ProjectDir: projectDir, ProjectFiles: []string{"file.txt "}}},
+		{name: "project reserved wildcard", config: Config{ProjectDir: projectDir, ProjectFiles: []string{"file?.txt"}}},
+		{name: "pack parent", config: Config{ProjectDir: projectDir, PackDir: "../pack"}},
+		{name: "pack dot", config: Config{ProjectDir: projectDir, PackDir: "."}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := collect(test.config)
+			if !errors.Is(err, ErrInvalidPath) {
+				t.Fatalf("collect() error = %v, want ErrInvalidPath", err)
+			}
+		})
+	}
+}
+
+func TestValidateRelativePathRejectsPortableAliases(t *testing.T) {
+	rejected := []string{
+		"file:stream",
+		"dir/file.",
+		"dir/file ",
+		"dir/bad<name",
+		`dir/bad"name`,
+		"dir/bad|name",
+		"dir/bad?name",
+		"dir/bad*name",
+		"dir/bad\x1fname",
+		"CON",
+		"con.txt",
+		"PRN.tar.gz",
+		"dir/AUX",
+		"dir/nul.json",
+		"CLOCK$",
+		"CONIN$.txt",
+		"conout$",
+		"COM1",
+		"com9.log",
+		"LPT1",
+		"lpt9.log",
+		"COM\u00b9.txt",
+		"LPT\u00b2",
+	}
+	for _, name := range rejected {
+		t.Run(name, func(t *testing.T) {
+			if _, err := validateRelativePath(name, "test"); !errors.Is(err, ErrInvalidPath) {
+				t.Fatalf("validateRelativePath(%q) error = %v, want ErrInvalidPath", name, err)
+			}
+		})
+	}
+
+	allowed := []string{".config", "console.txt", "com0.txt", "com10.txt", "lpt10.txt", "file name.txt", "caf\u00e9.txt"}
+	for _, name := range allowed {
+		if got, err := validateRelativePath(name, "test"); err != nil || got != name {
+			t.Errorf("validateRelativePath(%q) = %q, %v", name, got, err)
+		}
+	}
+}
+
+func TestCollectRejectsEntryNameCollisions(t *testing.T) {
+	projectDir := t.TempDir()
+	writeBundleTestFile(t, filepath.Join(projectDir, "same.txt"), "same", 0o600)
+	writeBundleTestFile(t, filepath.Join(projectDir, "pack", "same.txt"), "pack", 0o600)
+
+	tests := []struct {
+		name   string
+		config Config
+	}{
+		{
+			name:   "duplicate declarations",
+			config: Config{ProjectDir: projectDir, ProjectFiles: []string{"same.txt", "same.txt"}},
+		},
+		{
+			name:   "project and pack",
+			config: Config{ProjectDir: projectDir, ProjectFiles: []string{"pack/same.txt"}, PackDir: "pack"},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := collect(test.config)
+			if !errors.Is(err, ErrCollision) {
+				t.Fatalf("collect() error = %v, want ErrCollision", err)
+			}
+		})
+	}
+}
+
+func TestCollectorRejectsCanonicalEntryNameCollisions(t *testing.T) {
+	limits, err := resolveLimits(Limits{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, test := range []struct {
+		name   string
+		first  string
+		second string
+	}{
+		{name: "case folded", first: "Shared/File.txt", second: "shared/file.TXT"},
+		{name: "unicode canonical", first: "café.txt", second: "cafe\u0301.txt"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			collector := newCollector(limits)
+			if err := collector.reserveName(test.first); err != nil {
+				t.Fatal(err)
+			}
+			if err := collector.reserveName(test.second); !errors.Is(err, ErrCollision) {
+				t.Fatalf("reserveName(%q) error = %v, want ErrCollision", test.second, err)
+			}
+		})
+	}
+}
+
+func TestCollectRejectsSymlinksAndNonRegularFiles(t *testing.T) {
+	t.Run("project file symlink", func(t *testing.T) {
+		projectDir := t.TempDir()
+		outside := filepath.Join(t.TempDir(), "outside.txt")
+		writeBundleTestFile(t, outside, "outside", 0o600)
+		if err := os.Symlink(outside, filepath.Join(projectDir, "link.txt")); err != nil {
+			t.Skipf("symlinks unavailable: %v", err)
+		}
+		_, err := collect(Config{ProjectDir: projectDir, ProjectFiles: []string{"link.txt"}})
+		if !errors.Is(err, ErrUnsafeFile) {
+			t.Fatalf("collect() error = %v, want ErrUnsafeFile", err)
+		}
+	})
+
+	t.Run("project parent symlink", func(t *testing.T) {
+		projectDir := t.TempDir()
+		outside := t.TempDir()
+		writeBundleTestFile(t, filepath.Join(outside, "outside.txt"), "outside", 0o600)
+		if err := os.Symlink(outside, filepath.Join(projectDir, "linked")); err != nil {
+			t.Skipf("symlinks unavailable: %v", err)
+		}
+		_, err := collect(Config{ProjectDir: projectDir, ProjectFiles: []string{"linked/outside.txt"}})
+		if !errors.Is(err, ErrUnsafeFile) {
+			t.Fatalf("collect() error = %v, want ErrUnsafeFile", err)
+		}
+	})
+
+	t.Run("pack symlink", func(t *testing.T) {
+		projectDir := t.TempDir()
+		writeBundleTestFile(t, filepath.Join(projectDir, "pack", "file.txt"), "file", 0o600)
+		if err := os.Symlink("file.txt", filepath.Join(projectDir, "pack", "link.txt")); err != nil {
+			t.Skipf("symlinks unavailable: %v", err)
+		}
+		_, err := collect(Config{ProjectDir: projectDir, PackDir: "pack"})
+		if !errors.Is(err, ErrUnsafeFile) {
+			t.Fatalf("collect() error = %v, want ErrUnsafeFile", err)
+		}
+	})
+
+	t.Run("PackDir symlink", func(t *testing.T) {
+		projectDir := t.TempDir()
+		realPack := filepath.Join(projectDir, "real-pack")
+		writeBundleTestFile(t, filepath.Join(realPack, "file.txt"), "file", 0o600)
+		if err := os.Symlink(realPack, filepath.Join(projectDir, "linked-pack")); err != nil {
+			t.Skipf("symlinks unavailable: %v", err)
+		}
+		_, err := collect(Config{ProjectDir: projectDir, PackDir: "linked-pack"})
+		if !errors.Is(err, ErrUnsafeFile) {
+			t.Fatalf("collect() error = %v, want ErrUnsafeFile", err)
+		}
+	})
+
+	t.Run("PackDir parent symlink", func(t *testing.T) {
+		projectDir := t.TempDir()
+		realParent := filepath.Join(projectDir, "real-parent")
+		if err := os.MkdirAll(filepath.Join(realParent, "pack"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(realParent, filepath.Join(projectDir, "linked-parent")); err != nil {
+			t.Skipf("symlinks unavailable: %v", err)
+		}
+		_, err := collect(Config{ProjectDir: projectDir, PackDir: "linked-parent/pack"})
+		if !errors.Is(err, ErrUnsafeFile) {
+			t.Fatalf("collect() error = %v, want ErrUnsafeFile", err)
+		}
+	})
+
+	t.Run("listed directory", func(t *testing.T) {
+		projectDir := t.TempDir()
+		if err := os.Mkdir(filepath.Join(projectDir, "directory"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		_, err := collect(Config{ProjectDir: projectDir, ProjectFiles: []string{"directory"}})
+		if !errors.Is(err, ErrUnsafeFile) {
+			t.Fatalf("collect() error = %v, want ErrUnsafeFile", err)
+		}
+	})
+}
+
+func TestCollectCanonicalizesConfiguredRootPaths(t *testing.T) {
+	container := t.TempDir()
+	realRoot := filepath.Join(container, "real")
+	projectDir := filepath.Join(realRoot, "project")
+	writeBundleTestFile(t, filepath.Join(projectDir, "main.go"), "main", 0o600)
+	if err := os.Symlink(realRoot, filepath.Join(container, "alias")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	bundle, err := collect(Config{
+		ProjectDir:   filepath.Join(container, "alias", "project"),
+		ProjectFiles: []string{"main.go"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := bundle.entries; len(got) != 1 {
+		t.Fatalf("entries = %#v, want one entry", got)
+	}
+}
+
+func TestOpenSafeRootRejectsReplacementAfterObservation(t *testing.T) {
+	container := t.TempDir()
+	rootPath := filepath.Join(container, "root")
+	if err := os.Mkdir(rootPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	observation, err := observeRoot(rootPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(rootPath, filepath.Join(container, "original-root")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(rootPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	root, err := openSafeRoot(observation.path, observation.info)
+	if root != nil {
+		_ = root.Close()
+	}
+	if !errors.Is(err, ErrUnsafeFile) {
+		t.Fatalf("openSafeRoot() error = %v, want ErrUnsafeFile", err)
+	}
+}
+
+func TestCollectRejectsOutputsWithinRecursiveRoots(t *testing.T) {
+	projectDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(projectDir, "pack"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join(projectDir, "pack"), filepath.Join(projectDir, "pack-alias")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	base := Config{
+		ProjectDir: projectDir,
+		PackDir:    "pack",
+	}
+	tests := []struct {
+		name        string
+		output      string
+		finalOutput string
+	}{
+		{name: "pack root", output: filepath.Join(projectDir, "pack")},
+		{name: "pack descendant missing", output: filepath.Join(projectDir, "pack", "new", "out.zip")},
+		{name: "pack symlink alias", output: filepath.Join(projectDir, "pack-alias", "out.zip")},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			config := base
+			config.Output = test.output
+			config.FinalOutput = test.finalOutput
+			_, err := collect(config)
+			if !errors.Is(err, ErrInvalidPath) {
+				t.Fatalf("collect() error = %v, want ErrInvalidPath", err)
+			}
+		})
+	}
+
+	allowed := base
+	allowed.Output = filepath.Join(t.TempDir(), "out.zip")
+	if _, err := collect(allowed); err != nil {
+		t.Fatalf("collect() with outside output: %v", err)
+	}
+}
+
+func TestCollectEnforcesLimits(t *testing.T) {
+	projectDir := t.TempDir()
+	writeBundleTestFile(t, filepath.Join(projectDir, "one"), "123", 0o600)
+	writeBundleTestFile(t, filepath.Join(projectDir, "two"), "456", 0o600)
+
+	tests := []struct {
+		name   string
+		limits Limits
+		files  []string
+	}{
+		{name: "entries", limits: Limits{MaxEntries: 1}, files: []string{"one", "two"}},
+		{name: "one file", limits: Limits{MaxFileBytes: 2}, files: []string{"one"}},
+		{name: "total", limits: Limits{MaxTotalBytes: 5}, files: []string{"one", "two"}},
+		{name: "negative", limits: Limits{MaxEntries: -1}, files: []string{"one"}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := collect(Config{ProjectDir: projectDir, ProjectFiles: test.files, Limits: test.limits})
+			if !errors.Is(err, ErrLimit) {
+				t.Fatalf("collect() error = %v, want ErrLimit", err)
+			}
+		})
+	}
+
+	reference, _, err := archiveBytes(Config{ProjectDir: projectDir, ProjectFiles: []string{"one"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	exactBundle, err := collect(Config{
+		ProjectDir:   projectDir,
+		ProjectFiles: []string{"one"},
+		Limits:       Limits{MaxArchiveBytes: int64(len(reference))},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var exactArchive bytes.Buffer
+	_, err = exactBundle.writeZIP(&exactArchive)
+	if err != nil {
+		t.Fatalf("writeZIP() at exact archive limit: %v", err)
+	}
+	exact := exactArchive.Bytes()
+	if !bytes.Equal(exact, reference) {
+		t.Fatal("archive changed when exact archive limit was applied")
+	}
+	overBundle, err := collect(Config{
+		ProjectDir:   projectDir,
+		ProjectFiles: []string{"one"},
+		Limits:       Limits{MaxArchiveBytes: int64(len(reference) - 1)},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var overArchive bytes.Buffer
+	if _, err := overBundle.writeZIP(&overArchive); !errors.Is(err, ErrLimit) {
+		t.Fatalf("writeZIP() error = %v, want ErrLimit", err)
+	}
+}
+
+func writeBundleTestFile(t *testing.T, name, content string, mode os.FileMode) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(name), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(name, []byte(content), mode); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(name, mode); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func archiveBytes(cfg Config) ([]byte, Digest, error) {
+	var output bytes.Buffer
+	digest, err := WriteArchive(&output, cfg)
+	return output.Bytes(), digest, err
+}
+
+func assertBundleTestFile(t *testing.T, name, want string) {
+	t.Helper()
+	data, err := os.ReadFile(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := string(data); got != want {
+		t.Fatalf("file %q = %q, want %q", name, got, want)
+	}
+}

--- a/internal/projectbundle/bundle_unix_test.go
+++ b/internal/projectbundle/bundle_unix_test.go
@@ -1,0 +1,44 @@
+//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+
+/*
+ * Copyright (c) 2021 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package projectbundle
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestCollectRejectsDeviceLikePackEntry(t *testing.T) {
+	projectDir := t.TempDir()
+	packDir := filepath.Join(projectDir, "pack")
+	if err := os.Mkdir(packDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := unix.Mkfifo(filepath.Join(packDir, "pipe"), 0o600); err != nil {
+		t.Skipf("mkfifo unavailable: %v", err)
+	}
+
+	_, err := collect(Config{ProjectDir: projectDir, PackDir: "pack"})
+	if !errors.Is(err, ErrUnsafeFile) {
+		t.Fatalf("collect() error = %v, want ErrUnsafeFile", err)
+	}
+}

--- a/internal/projectbundle/collect.go
+++ b/internal/projectbundle/collect.go
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2021 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package projectbundle
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+type collector struct {
+	limits    resolvedLimits
+	entries   []collectedEntry
+	total     int64
+	exact     map[string]string
+	canonical map[string]string
+	folded    map[string]string
+}
+
+func newCollector(limits resolvedLimits) *collector {
+	return &collector{
+		limits:    limits,
+		exact:     make(map[string]string),
+		canonical: make(map[string]string),
+		folded:    make(map[string]string),
+	}
+}
+
+func (c *collector) addFile(root *safeDir, sourcePath, archiveName string) error {
+	if err := c.reserveEntry(archiveName); err != nil {
+		return err
+	}
+
+	file, err := root.OpenFile(filepath.FromSlash(sourcePath))
+	if err != nil {
+		return fmt.Errorf("projectbundle: open source %q: %w", sourcePath, err)
+	}
+	defer file.Close()
+
+	data, err := readRegularFile(file, sourcePath, c.limits.maxFileBytes, c.limits.maxTotalBytes-c.total)
+	if err != nil {
+		return err
+	}
+	return c.appendEntry(archiveName, data, false)
+}
+
+func (c *collector) addData(archiveName string, data []byte) error {
+	if err := c.reserveEntry(archiveName); err != nil {
+		return err
+	}
+	return c.appendEntry(archiveName, data, true)
+}
+
+func (c *collector) reserveEntry(name string) error {
+	name, err := validateRelativePath(name, "archive entry")
+	if err != nil {
+		return err
+	}
+	if err := c.reserveName(name); err != nil {
+		return err
+	}
+	if len(c.entries) >= c.limits.maxEntries {
+		return fmt.Errorf("%w: more than %d entries", ErrLimit, c.limits.maxEntries)
+	}
+	return nil
+}
+
+func (c *collector) appendEntry(name string, data []byte, clone bool) error {
+	size := int64(len(data))
+	if size > c.limits.maxFileBytes {
+		return fmt.Errorf("%w: source %q exceeds %d bytes", ErrLimit, name, c.limits.maxFileBytes)
+	}
+	if size > c.limits.maxTotalBytes-c.total {
+		return fmt.Errorf("%w: total input exceeds %d bytes", ErrLimit, c.limits.maxTotalBytes)
+	}
+	contents := data
+	if clone {
+		contents = append([]byte(nil), data...)
+		if data != nil && contents == nil {
+			contents = []byte{}
+		}
+	}
+	c.total += size
+	c.entries = append(c.entries, collectedEntry{name: name, data: contents})
+	return nil
+}
+
+func (c *collector) addTree(root *safeDir, prefix string) error {
+	entries, err := root.ReadDir()
+	if err != nil {
+		return fmt.Errorf("projectbundle: read PackDir %q: %w", prefix, err)
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Name() < entries[j].Name() })
+	for _, entry := range entries {
+		name := prefix + "/" + entry.Name()
+		if _, err := validateRelativePath(name, "PackDir entry"); err != nil {
+			return err
+		}
+		if entry.Type()&os.ModeSymlink != 0 {
+			return fmt.Errorf("%w: PackDir entry %q is a symbolic link", ErrUnsafeFile, name)
+		}
+		if entry.IsDir() {
+			child, err := root.OpenDir(entry.Name())
+			if err != nil {
+				return fmt.Errorf("projectbundle: open PackDir directory %q: %w", name, err)
+			}
+			err = c.addTree(child, name)
+			closeErr := child.Close()
+			if err != nil {
+				return err
+			}
+			if closeErr != nil {
+				return fmt.Errorf("projectbundle: close PackDir directory %q: %w", name, closeErr)
+			}
+			continue
+		}
+		if err := c.addFile(root, entry.Name(), name); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/projectbundle/collision.go
+++ b/internal/projectbundle/collision.go
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2021 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package projectbundle
+
+import (
+	"fmt"
+
+	"golang.org/x/text/cases"
+	"golang.org/x/text/unicode/norm"
+)
+
+var unicodeFold = cases.Fold()
+
+func (c *collector) reserveName(name string) error {
+	if previous, ok := c.exact[name]; ok {
+		return fmt.Errorf("%w: duplicate path %q (already declared as %q)", ErrCollision, name, previous)
+	}
+	canonical := norm.NFC.String(name)
+	if previous, ok := c.canonical[canonical]; ok {
+		return fmt.Errorf("%w: Unicode-canonical paths %q and %q", ErrCollision, previous, name)
+	}
+	folded := unicodeFold.String(canonical)
+	if previous, ok := c.folded[folded]; ok {
+		return fmt.Errorf("%w: case-folded paths %q and %q", ErrCollision, previous, name)
+	}
+	c.exact[name] = name
+	c.canonical[canonical] = name
+	c.folded[folded] = name
+	return nil
+}

--- a/internal/projectbundle/doc.go
+++ b/internal/projectbundle/doc.go
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2021 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package projectbundle collects an explicitly allowed set of project files
+// and writes it as a deterministic ZIP archive.
+//
+// Configured roots are resolved to canonical filesystem paths before use, and
+// collection never follows symbolic links below those roots. Project and
+// member paths must be clean relative paths. Every archive entry name is
+// supplied by the caller rather than derived from an absolute host path.
+package projectbundle

--- a/internal/projectbundle/limits.go
+++ b/internal/projectbundle/limits.go
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2021 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package projectbundle
+
+import "fmt"
+
+type resolvedLimits struct {
+	maxEntries      int
+	maxFileBytes    int64
+	maxTotalBytes   int64
+	maxArchiveBytes int64
+}
+
+func resolveLimits(limits Limits) (resolvedLimits, error) {
+	resolved := resolvedLimits{
+		maxEntries:      limits.MaxEntries,
+		maxFileBytes:    limits.MaxFileBytes,
+		maxTotalBytes:   limits.MaxTotalBytes,
+		maxArchiveBytes: limits.MaxArchiveBytes,
+	}
+	if resolved.maxEntries == 0 {
+		resolved.maxEntries = defaultMaxEntries
+	}
+	if resolved.maxFileBytes == 0 {
+		resolved.maxFileBytes = defaultMaxFileBytes
+	}
+	if resolved.maxTotalBytes == 0 {
+		resolved.maxTotalBytes = defaultMaxTotalBytes
+	}
+	if resolved.maxArchiveBytes == 0 {
+		resolved.maxArchiveBytes = defaultMaxArchiveBytes
+	}
+	if resolved.maxEntries < 0 || resolved.maxFileBytes < 0 || resolved.maxTotalBytes < 0 || resolved.maxArchiveBytes < 0 {
+		return resolvedLimits{}, fmt.Errorf("%w: limits must not be negative", ErrLimit)
+	}
+	const maxInt64 = int64(^uint64(0) >> 1)
+	if resolved.maxFileBytes == maxInt64 || resolved.maxTotalBytes == maxInt64 {
+		return resolvedLimits{}, fmt.Errorf("%w: file and total byte limits must be less than MaxInt64", ErrLimit)
+	}
+	return resolved, nil
+}

--- a/internal/projectbundle/open_other.go
+++ b/internal/projectbundle/open_other.go
@@ -1,0 +1,163 @@
+//go:build !aix && !darwin && !dragonfly && !freebsd && !linux && !netbsd && !openbsd && !solaris
+
+/*
+ * Copyright (c) 2021 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package projectbundle
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// safeDir uses os.Root on platforms without openat(2). os.Root provides
+// root-confined opens; explicit Lstat/open/fstat identity checks reject links
+// and replacements observed around an open.
+type safeDir struct {
+	root *os.Root
+}
+
+func openSafeRoot(name string, observed os.FileInfo) (*safeDir, error) {
+	before, err := os.Lstat(name)
+	if err != nil {
+		return nil, err
+	}
+	if before.Mode()&os.ModeSymlink != 0 || !before.IsDir() || observed == nil || !os.SameFile(observed, before) {
+		return nil, fmt.Errorf("%w: root %q is not a real directory", ErrUnsafeFile, name)
+	}
+	root, err := os.OpenRoot(name)
+	if err != nil {
+		return nil, err
+	}
+	probe, err := root.Open(".")
+	if err != nil {
+		root.Close()
+		return nil, err
+	}
+	after, statErr := probe.Stat()
+	closeErr := probe.Close()
+	if statErr != nil {
+		root.Close()
+		return nil, statErr
+	}
+	if closeErr != nil {
+		root.Close()
+		return nil, closeErr
+	}
+	if !after.IsDir() || !os.SameFile(observed, after) || !os.SameFile(before, after) {
+		root.Close()
+		return nil, fmt.Errorf("%w: root %q changed while it was opened", ErrUnsafeFile, name)
+	}
+	return &safeDir{root: root}, nil
+}
+
+func (d *safeDir) OpenFile(name string) (*os.File, error) {
+	before, err := d.validateComponents(name, false)
+	if err != nil {
+		return nil, err
+	}
+	file, err := d.root.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	after, err := file.Stat()
+	if err != nil {
+		file.Close()
+		return nil, err
+	}
+	if !after.Mode().IsRegular() || !os.SameFile(before, after) {
+		file.Close()
+		return nil, fmt.Errorf("%w: file %q changed while it was opened", ErrUnsafeFile, name)
+	}
+	return file, nil
+}
+
+func (d *safeDir) OpenDir(name string) (*safeDir, error) {
+	before, err := d.validateComponents(name, true)
+	if err != nil {
+		return nil, err
+	}
+	root, err := d.root.OpenRoot(name)
+	if err != nil {
+		return nil, err
+	}
+	probe, err := root.Open(".")
+	if err != nil {
+		root.Close()
+		return nil, err
+	}
+	after, statErr := probe.Stat()
+	closeErr := probe.Close()
+	if statErr != nil {
+		root.Close()
+		return nil, statErr
+	}
+	if closeErr != nil {
+		root.Close()
+		return nil, closeErr
+	}
+	if !after.IsDir() || !os.SameFile(before, after) {
+		root.Close()
+		return nil, fmt.Errorf("%w: directory %q changed while it was opened", ErrUnsafeFile, name)
+	}
+	return &safeDir{root: root}, nil
+}
+
+func (d *safeDir) validateComponents(name string, finalDirectory bool) (os.FileInfo, error) {
+	parts := strings.Split(filepath.Clean(name), string(filepath.Separator))
+	for i := range parts {
+		candidate := filepath.Join(parts[:i+1]...)
+		info, err := d.root.Lstat(candidate)
+		if err != nil {
+			return nil, err
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return nil, fmt.Errorf("%w: %q contains a symbolic link", ErrUnsafeFile, name)
+		}
+		last := i == len(parts)-1
+		if !last || finalDirectory {
+			if !info.IsDir() {
+				return nil, fmt.Errorf("%w: %q contains a non-directory component", ErrUnsafeFile, name)
+			}
+		} else if !info.Mode().IsRegular() {
+			return nil, fmt.Errorf("%w: %q is not a regular file", ErrUnsafeFile, name)
+		}
+		if last {
+			return info, nil
+		}
+	}
+	return nil, fmt.Errorf("%w: empty descriptor path", ErrInvalidPath)
+}
+
+func (d *safeDir) ReadDir() ([]fs.DirEntry, error) {
+	file, err := d.root.Open(".")
+	if err != nil {
+		return nil, err
+	}
+	entries, readErr := file.ReadDir(-1)
+	closeErr := file.Close()
+	if readErr != nil {
+		return nil, readErr
+	}
+	return entries, closeErr
+}
+
+func (d *safeDir) Close() error {
+	return d.root.Close()
+}

--- a/internal/projectbundle/open_unix.go
+++ b/internal/projectbundle/open_unix.go
@@ -1,0 +1,151 @@
+//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+
+/*
+ * Copyright (c) 2021 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package projectbundle
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/sys/unix"
+)
+
+type safeDir struct {
+	file *os.File
+}
+
+func openSafeRoot(name string, observed os.FileInfo) (*safeDir, error) {
+	name = filepath.Clean(name)
+	if !filepath.IsAbs(name) {
+		return nil, fmt.Errorf("%w: root %q is not absolute", ErrInvalidPath, name)
+	}
+	flags := unix.O_RDONLY | unix.O_CLOEXEC | unix.O_DIRECTORY | unix.O_NOFOLLOW | unix.O_NONBLOCK
+	fd, err := unix.Open(string(os.PathSeparator), flags, 0)
+	if err != nil {
+		return nil, err
+	}
+	for _, component := range strings.Split(strings.TrimPrefix(name, string(os.PathSeparator)), string(os.PathSeparator)) {
+		if component == "" {
+			continue
+		}
+		nextFD, openErr := unix.Openat(fd, component, flags, 0)
+		_ = unix.Close(fd)
+		if openErr != nil {
+			return nil, fmt.Errorf("%w: no-follow open root %q: %w", ErrUnsafeFile, name, openErr)
+		}
+		fd = nextFD
+	}
+	file := os.NewFile(uintptr(fd), name)
+	if file == nil {
+		_ = unix.Close(fd)
+		return nil, fmt.Errorf("projectbundle: wrap root descriptor %q", name)
+	}
+	info, err := file.Stat()
+	if err != nil {
+		file.Close()
+		return nil, err
+	}
+	if !info.IsDir() || observed == nil || !os.SameFile(observed, info) {
+		file.Close()
+		return nil, fmt.Errorf("%w: root %q changed after it was observed", ErrUnsafeFile, name)
+	}
+	return &safeDir{file: file}, nil
+}
+
+func (d *safeDir) OpenFile(name string) (*os.File, error) {
+	file, err := d.open(name, false)
+	if err != nil {
+		return nil, err
+	}
+	info, err := file.Stat()
+	if err != nil {
+		file.Close()
+		return nil, err
+	}
+	if !info.Mode().IsRegular() {
+		file.Close()
+		return nil, fmt.Errorf("%w: %q has mode %s", ErrUnsafeFile, name, info.Mode())
+	}
+	return file, nil
+}
+
+func (d *safeDir) OpenDir(name string) (*safeDir, error) {
+	file, err := d.open(name, true)
+	if err != nil {
+		return nil, err
+	}
+	return &safeDir{file: file}, nil
+}
+
+func (d *safeDir) open(name string, directory bool) (*os.File, error) {
+	parts := strings.Split(name, string(os.PathSeparator))
+	parentFD := int(d.file.Fd())
+	ownedParent := false
+	defer func() {
+		if ownedParent {
+			_ = unix.Close(parentFD)
+		}
+	}()
+
+	for i, part := range parts {
+		flags := unix.O_RDONLY | unix.O_CLOEXEC | unix.O_NOFOLLOW | unix.O_NONBLOCK
+		last := i == len(parts)-1
+		if !last || directory {
+			flags |= unix.O_DIRECTORY
+		}
+		fd, err := unix.Openat(parentFD, part, flags, 0)
+		if err != nil {
+			return nil, fmt.Errorf("%w: no-follow open %q: %w", ErrUnsafeFile, name, err)
+		}
+		if !last {
+			if ownedParent {
+				_ = unix.Close(parentFD)
+			}
+			parentFD = fd
+			ownedParent = true
+			continue
+		}
+		file := os.NewFile(uintptr(fd), name)
+		if file == nil {
+			_ = unix.Close(fd)
+			return nil, fmt.Errorf("projectbundle: wrap descriptor %q", name)
+		}
+		info, err := file.Stat()
+		if err != nil {
+			file.Close()
+			return nil, err
+		}
+		if directory && !info.IsDir() {
+			file.Close()
+			return nil, fmt.Errorf("%w: %q is not a directory", ErrUnsafeFile, name)
+		}
+		return file, nil
+	}
+	return nil, fmt.Errorf("%w: empty descriptor path", ErrInvalidPath)
+}
+
+func (d *safeDir) ReadDir() ([]fs.DirEntry, error) {
+	return d.file.ReadDir(-1)
+}
+
+func (d *safeDir) Close() error {
+	return d.file.Close()
+}

--- a/internal/projectbundle/read.go
+++ b/internal/projectbundle/read.go
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2021 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package projectbundle
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+func readRegularFile(file *os.File, name string, maxFileBytes, remainingTotalBytes int64) ([]byte, error) {
+	before, err := file.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("projectbundle: fstat source %q: %w", name, err)
+	}
+	if !before.Mode().IsRegular() {
+		return nil, fmt.Errorf("%w: source %q has mode %s", ErrUnsafeFile, name, before.Mode())
+	}
+	if before.Size() < 0 || before.Size() > maxFileBytes {
+		return nil, fmt.Errorf("%w: source %q exceeds %d bytes", ErrLimit, name, maxFileBytes)
+	}
+	if before.Size() > remainingTotalBytes {
+		return nil, fmt.Errorf("%w: source %q exceeds remaining total allowance of %d bytes", ErrLimit, name, remainingTotalBytes)
+	}
+	readLimit := min(maxFileBytes, remainingTotalBytes)
+
+	data, err := io.ReadAll(io.LimitReader(file, readLimit+1))
+	if err != nil {
+		return nil, fmt.Errorf("projectbundle: read source %q: %w", name, err)
+	}
+	if int64(len(data)) > readLimit {
+		return nil, fmt.Errorf("%w: source %q grew beyond its byte allowance", ErrLimit, name)
+	}
+	after, err := file.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("projectbundle: second fstat source %q: %w", name, err)
+	}
+	if !after.Mode().IsRegular() || !os.SameFile(before, after) || before.Mode() != after.Mode() || before.Size() != after.Size() ||
+		!before.ModTime().Equal(after.ModTime()) || int64(len(data)) != after.Size() {
+		return nil, fmt.Errorf("%w: source %q changed while it was read", ErrUnsafeFile, name)
+	}
+	return data, nil
+}

--- a/internal/projectbundle/validate.go
+++ b/internal/projectbundle/validate.go
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) 2021 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package projectbundle
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"unicode/utf8"
+)
+
+func validateRelativePath(name, field string) (string, error) {
+	if name == "" || name == "." || !utf8.ValidString(name) || strings.IndexByte(name, 0) >= 0 {
+		return "", fmt.Errorf("%w: %s %q", ErrInvalidPath, field, name)
+	}
+	if strings.ContainsRune(name, '\\') || path.IsAbs(name) || filepath.IsAbs(name) || looksLikeWindowsAbsolutePath(name) {
+		return "", fmt.Errorf("%w: %s %q must be slash-separated and relative", ErrInvalidPath, field, name)
+	}
+	if path.Clean(name) != name {
+		return "", fmt.Errorf("%w: %s %q is not clean", ErrInvalidPath, field, name)
+	}
+	for _, component := range strings.Split(name, "/") {
+		if component == "" || component == "." || component == ".." {
+			return "", fmt.Errorf("%w: %s %q contains an invalid component", ErrInvalidPath, field, name)
+		}
+		if err := validatePortableComponent(component); err != nil {
+			return "", fmt.Errorf("%w: %s %q: %v", ErrInvalidPath, field, name, err)
+		}
+	}
+	return name, nil
+}
+
+func validatePortableComponent(component string) error {
+	if strings.HasSuffix(component, ".") || strings.HasSuffix(component, " ") {
+		return errors.New("component ends in a dot or space")
+	}
+	if strings.ContainsAny(component, `<>:"|?*`) {
+		return errors.New("component contains a Windows-reserved character")
+	}
+	for _, character := range component {
+		if character < 0x20 {
+			return errors.New("component contains a control character")
+		}
+	}
+
+	base := component
+	if dot := strings.IndexByte(base, '.'); dot >= 0 {
+		base = base[:dot]
+	}
+	base = strings.ToUpper(strings.TrimRight(base, " ."))
+	switch base {
+	case "CON", "PRN", "AUX", "NUL", "CLOCK$", "CONIN$", "CONOUT$":
+		return errors.New("component uses a reserved DOS device name")
+	}
+	if len(base) == 4 && (strings.HasPrefix(base, "COM") || strings.HasPrefix(base, "LPT")) && base[3] >= '1' && base[3] <= '9' {
+		return errors.New("component uses a reserved DOS device name")
+	}
+	for _, prefix := range []string{"COM", "LPT"} {
+		for _, digit := range []string{"¹", "²", "³"} {
+			if base == prefix+digit {
+				return errors.New("component uses a reserved DOS device name")
+			}
+		}
+	}
+	return nil
+}
+
+func looksLikeWindowsAbsolutePath(name string) bool {
+	if strings.HasPrefix(name, "//") || strings.HasPrefix(name, `\\`) {
+		return true
+	}
+	return len(name) >= 3 && ((name[0] >= 'a' && name[0] <= 'z') || (name[0] >= 'A' && name[0] <= 'Z')) && name[1] == ':' && (name[2] == '/' || name[2] == '\\')
+}
+
+func validateOutputs(projectDir, output, finalOutput, packRoot string) error {
+	var roots []string
+	if packRoot != "" {
+		roots = append(roots, packRoot)
+	}
+
+	canonicalRoots := make([]string, len(roots))
+	for i, root := range roots {
+		canonical, err := canonicalFilesystemPath(root)
+		if err != nil {
+			return fmt.Errorf("projectbundle: canonicalize input root %q: %w", root, err)
+		}
+		canonicalRoots[i] = canonical
+	}
+	for _, item := range []struct {
+		field string
+		value string
+	}{
+		{field: "Output", value: output},
+		{field: "FinalOutput", value: finalOutput},
+	} {
+		if item.value == "" {
+			continue
+		}
+		candidate := item.value
+		if !filepath.IsAbs(candidate) {
+			candidate = filepath.Join(projectDir, candidate)
+		}
+		canonical, err := canonicalFilesystemPath(candidate)
+		if err != nil {
+			return fmt.Errorf("projectbundle: canonicalize %s %q: %w", item.field, item.value, err)
+		}
+		for i, root := range canonicalRoots {
+			if isSameOrWithin(canonical, root) {
+				return fmt.Errorf("%w: %s %q is within collected root %q", ErrInvalidPath, item.field, item.value, roots[i])
+			}
+		}
+	}
+	return nil
+}
+
+func canonicalFilesystemPath(name string) (string, error) {
+	absolute, err := filepath.Abs(name)
+	if err != nil {
+		return "", err
+	}
+	absolute = filepath.Clean(absolute)
+	current := absolute
+	var suffix []string
+	for {
+		_, err := os.Lstat(current)
+		if err == nil {
+			resolved, err := filepath.EvalSymlinks(current)
+			if err != nil {
+				return "", err
+			}
+			for i := len(suffix) - 1; i >= 0; i-- {
+				resolved = filepath.Join(resolved, suffix[i])
+			}
+			return filepath.Clean(resolved), nil
+		}
+		if !os.IsNotExist(err) {
+			return "", err
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return "", err
+		}
+		suffix = append(suffix, filepath.Base(current))
+		current = parent
+	}
+}
+
+type observedRoot struct {
+	path string
+	info os.FileInfo
+}
+
+func observeRoot(name string) (observedRoot, error) {
+	absolute, err := filepath.Abs(name)
+	if err != nil {
+		return observedRoot{}, err
+	}
+	absolute = filepath.Clean(absolute)
+	before, err := os.Stat(absolute)
+	if err != nil {
+		return observedRoot{}, err
+	}
+	if !before.IsDir() {
+		return observedRoot{}, fmt.Errorf("%w: root %q is not a directory", ErrUnsafeFile, name)
+	}
+	canonical, err := filepath.EvalSymlinks(absolute)
+	if err != nil {
+		return observedRoot{}, err
+	}
+	canonical, err = filepath.Abs(canonical)
+	if err != nil {
+		return observedRoot{}, err
+	}
+	canonical = filepath.Clean(canonical)
+	after, err := os.Lstat(canonical)
+	if err != nil {
+		return observedRoot{}, err
+	}
+	if after.Mode()&os.ModeSymlink != 0 || !after.IsDir() || !os.SameFile(before, after) {
+		return observedRoot{}, fmt.Errorf("%w: root %q changed while it was canonicalized", ErrUnsafeFile, name)
+	}
+	return observedRoot{path: canonical, info: before}, nil
+}
+
+func isSameOrWithin(name, root string) bool {
+	relative, err := filepath.Rel(root, name)
+	if err != nil {
+		return false
+	}
+	return relative == "." || (relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator)))
+}

--- a/internal/projectpolicy/config.go
+++ b/internal/projectpolicy/config.go
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package projectpolicy contains validation for portable SPX projects.
+package projectpolicy
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const (
+	configName = ".config"
+	// Keep portable policy reads within the bundle's default per-file budget.
+	maxPortableConfigBytes = 64 << 20
+
+	portableConfigAbsentIdentity = "absent"
+	portableConfigSHA256Prefix   = "sha256:"
+)
+
+// PortableConfigSnapshot binds the validated portable configuration to the
+// exact file identity and bytes that were inspected. Its fields are private so
+// callers cannot manufacture a snapshot that bypasses validation.
+type PortableConfigSnapshot struct {
+	ready    bool
+	found    bool
+	data     []byte
+	digest   [sha256.Size]byte
+	fileInfo os.FileInfo
+}
+
+// Present reports whether .config existed when the snapshot was captured.
+func (s PortableConfigSnapshot) Present() bool {
+	return s.ready && s.found
+}
+
+// Bytes returns an immutable copy of the validated .config contents. It
+// returns nil when .config was absent.
+func (s PortableConfigSnapshot) Bytes() []byte {
+	if !s.Present() {
+		return nil
+	}
+	data := make([]byte, len(s.data))
+	copy(data, s.data)
+	return data
+}
+
+// Identity binds both .config presence and its exact bytes. It is suitable for
+// carrying the expected snapshot across a process boundary.
+func (s PortableConfigSnapshot) Identity() (string, error) {
+	if !s.ready {
+		return "", fmt.Errorf("portable project config snapshot is uninitialized")
+	}
+	if !s.found {
+		return portableConfigAbsentIdentity, nil
+	}
+	return portableConfigSHA256Prefix + hex.EncodeToString(s.digest[:]), nil
+}
+
+// ValidatePortableConfig rejects configuration that cannot be captured in a
+// self-contained project snapshot for the driver. A missing .config is valid;
+// when present it must be a stable regular non-symlink file.
+func ValidatePortableConfig(projectDir string) error {
+	_, err := SnapshotPortableConfig(projectDir)
+	return err
+}
+
+// SnapshotPortableConfig validates .config and retains the exact identity and
+// bytes for later use by a portable run or build.
+func SnapshotPortableConfig(projectDir string) (PortableConfigSnapshot, error) {
+	configPath := filepath.Join(projectDir, configName)
+	root, err := os.OpenRoot(projectDir)
+	if err != nil {
+		return PortableConfigSnapshot{}, fmt.Errorf("validate project config %q: open project root: %w", configPath, err)
+	}
+	defer root.Close()
+	data, info, found, err := readStableRegularRootFile(root, configName)
+	if err != nil {
+		return PortableConfigSnapshot{}, fmt.Errorf("validate project config %q: %w", configPath, err)
+	}
+	return makePortableConfigSnapshot(configPath, data, info, found)
+}
+
+// SnapshotPortableConfigRoot reads .config through a pinned directory handle.
+// It is used at process boundaries where path containment would leave a
+// replacement window between validation and read.
+func SnapshotPortableConfigRoot(root *os.Root) (PortableConfigSnapshot, error) {
+	if root == nil {
+		return PortableConfigSnapshot{}, fmt.Errorf("portable project config root is nil")
+	}
+	data, info, found, err := readStableRegularRootFile(root, configName)
+	if err != nil {
+		return PortableConfigSnapshot{}, fmt.Errorf("read portable project config: %w", err)
+	}
+	return makePortableConfigSnapshot(configName, data, info, found)
+}
+
+func makePortableConfigSnapshot(configPath string, data []byte, info os.FileInfo, found bool) (PortableConfigSnapshot, error) {
+	if !found {
+		return PortableConfigSnapshot{ready: true}, nil
+	}
+
+	var config struct {
+		ExtAsset json.RawMessage `json:"extasset"`
+	}
+	if err := json.Unmarshal(data, &config); err != nil {
+		return PortableConfigSnapshot{}, fmt.Errorf("parse project config %q: %w", configPath, err)
+	}
+	if config.ExtAsset != nil {
+		return PortableConfigSnapshot{}, fmt.Errorf("project config %q uses unsupported extasset; move resources inside the project directory", configPath)
+	}
+	return PortableConfigSnapshot{
+		ready: true, found: true, data: data, digest: sha256.Sum256(data), fileInfo: info,
+	}, nil
+}
+
+// Verify confirms that the current .config still has the identity, metadata,
+// and bytes captured by the snapshot. Once this succeeds, callers should use
+// Bytes rather than reopen the user-controlled file.
+func (s PortableConfigSnapshot) Verify(projectDir string) error {
+	if !s.ready {
+		return fmt.Errorf("portable project config snapshot is uninitialized")
+	}
+	configPath := filepath.Join(projectDir, configName)
+	data, info, found, err := readStableRegularFile(configPath)
+	if err != nil {
+		return fmt.Errorf("revalidate project config %q: %w", configPath, err)
+	}
+	if found != s.found {
+		return fmt.Errorf("project config %q changed after validation", configPath)
+	}
+	if !found {
+		return nil
+	}
+	if !os.SameFile(s.fileInfo, info) || !stableMetadata(s.fileInfo, info) ||
+		sha256.Sum256(data) != s.digest || !bytes.Equal(data, s.data) {
+		return fmt.Errorf("project config %q changed after validation", configPath)
+	}
+	return nil
+}

--- a/internal/projectpolicy/config_test.go
+++ b/internal/projectpolicy/config_test.go
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package projectpolicy
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestValidatePortableConfig(t *testing.T) {
+	projectDir := t.TempDir()
+	if err := ValidatePortableConfig(projectDir); err != nil {
+		t.Fatalf("ValidatePortableConfig() without .config: %v", err)
+	}
+	configPath := filepath.Join(projectDir, configName)
+	if err := os.WriteFile(configPath, []byte(`{"name":"demo"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := ValidatePortableConfig(projectDir); err != nil {
+		t.Fatalf("ValidatePortableConfig() with supported fields: %v", err)
+	}
+	for _, key := range []string{"extasset", "ExtAsset", "EXTASSET"} {
+		if err := os.WriteFile(configPath, []byte(`{"`+key+`":"../shared-assets"}`), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := ValidatePortableConfig(projectDir); err == nil || !strings.Contains(err.Error(), "unsupported extasset") {
+			t.Fatalf("ValidatePortableConfig() key %q error = %v, want extasset rejection", key, err)
+		}
+	}
+}
+
+func TestValidatePortableConfigRejectsSymlink(t *testing.T) {
+	projectDir := t.TempDir()
+	target := filepath.Join(t.TempDir(), "config")
+	if err := os.WriteFile(target, []byte(`{}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, filepath.Join(projectDir, configName)); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	if err := ValidatePortableConfig(projectDir); err == nil {
+		t.Fatal("ValidatePortableConfig accepted symlink .config")
+	}
+}
+
+func TestPortableConfigSnapshotRejectsIdentityAndContentDrift(t *testing.T) {
+	projectDir := t.TempDir()
+	configPath := filepath.Join(projectDir, configName)
+	if err := os.WriteFile(configPath, []byte(`{"name":"first"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := SnapshotPortableConfig(projectDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := string(snapshot.Bytes()); got != `{"name":"first"}` {
+		t.Fatalf("snapshot bytes = %q", got)
+	}
+	digest := sha256.Sum256([]byte(`{"name":"first"}`))
+	wantIdentity := portableConfigSHA256Prefix + hex.EncodeToString(digest[:])
+	if identity, err := snapshot.Identity(); err != nil || identity != wantIdentity {
+		t.Fatalf("snapshot identity = %q, %v, want %q", identity, err, wantIdentity)
+	}
+	if err := snapshot.Verify(projectDir); err != nil {
+		t.Fatalf("unchanged snapshot verification: %v", err)
+	}
+
+	if err := os.Remove(configPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(configPath, []byte(`{"name":"first"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := snapshot.Verify(projectDir); err == nil || !strings.Contains(err.Error(), "changed after validation") {
+		t.Fatalf("replacement verification error = %v", err)
+	}
+
+	snapshot, err = SnapshotPortableConfig(projectDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(configPath, []byte(`{"name":"second"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := snapshot.Verify(projectDir); err == nil || !strings.Contains(err.Error(), "changed after validation") {
+		t.Fatalf("content drift verification error = %v", err)
+	}
+}
+
+func TestSnapshotPortableConfigRootUsesPinnedDirectory(t *testing.T) {
+	projectDir := t.TempDir()
+	configPath := filepath.Join(projectDir, configName)
+	data := []byte(`{"name":"pinned"}`)
+	if err := os.WriteFile(configPath, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	root, err := os.OpenRoot(projectDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer root.Close()
+	snapshot, err := SnapshotPortableConfigRoot(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := string(snapshot.Bytes()); got != string(data) {
+		t.Fatalf("pinned snapshot bytes = %q, want %q", got, data)
+	}
+}
+
+func TestAbsentPortableConfigSnapshotRejectsCreation(t *testing.T) {
+	projectDir := t.TempDir()
+	snapshot, err := SnapshotPortableConfig(projectDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if snapshot.Present() || snapshot.Bytes() != nil {
+		t.Fatal("absent config snapshot reported content")
+	}
+	if identity, err := snapshot.Identity(); err != nil || identity != portableConfigAbsentIdentity {
+		t.Fatalf("absent snapshot identity = %q, %v", identity, err)
+	}
+	if err := os.WriteFile(filepath.Join(projectDir, configName), []byte(`{}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := snapshot.Verify(projectDir); err == nil || !strings.Contains(err.Error(), "changed after validation") {
+		t.Fatalf("created config verification error = %v", err)
+	}
+}
+
+func TestPortableConfigSnapshotRejectsOversizeFile(t *testing.T) {
+	projectDir := t.TempDir()
+	configPath := filepath.Join(projectDir, configName)
+	file, err := os.OpenFile(configPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := file.Truncate(maxPortableConfigBytes + 1); err != nil {
+		file.Close()
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := SnapshotPortableConfig(projectDir); err == nil || !strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("SnapshotPortableConfig() oversize error = %v", err)
+	}
+}
+
+func TestPortableConfigSnapshotIdentityRejectsZeroValue(t *testing.T) {
+	if identity, err := (PortableConfigSnapshot{}).Identity(); err == nil || identity != "" {
+		t.Fatalf("zero snapshot identity = %q, %v, want initialization error", identity, err)
+	}
+}

--- a/internal/projectpolicy/stablefile.go
+++ b/internal/projectpolicy/stablefile.go
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package projectpolicy
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+type stableFileAccess struct {
+	lstat func(string) (os.FileInfo, error)
+	open  func(string) (*os.File, error)
+}
+
+func readStableRegularFile(name string) ([]byte, os.FileInfo, bool, error) {
+	return readStableFile(name, stableFileAccess{lstat: os.Lstat, open: os.Open})
+}
+
+func readStableRegularRootFile(root *os.Root, name string) ([]byte, os.FileInfo, bool, error) {
+	return readStableFile(name, stableFileAccess{lstat: root.Lstat, open: root.Open})
+}
+
+func readStableFile(name string, access stableFileAccess) ([]byte, os.FileInfo, bool, error) {
+	before, err := access.lstat(name)
+	if os.IsNotExist(err) {
+		return nil, nil, false, nil
+	}
+	if err != nil {
+		return nil, nil, false, err
+	}
+	if before.Mode()&os.ModeSymlink != 0 || !before.Mode().IsRegular() {
+		return nil, nil, false, fmt.Errorf("must be a regular non-symlink file")
+	}
+	if before.Size() < 0 || before.Size() > maxPortableConfigBytes {
+		return nil, nil, false, fmt.Errorf("exceeds %d bytes", maxPortableConfigBytes)
+	}
+
+	file, err := access.open(name)
+	if err != nil {
+		return nil, nil, false, err
+	}
+	opened, err := file.Stat()
+	if err != nil {
+		file.Close()
+		return nil, nil, false, err
+	}
+	if !opened.Mode().IsRegular() || !os.SameFile(before, opened) {
+		file.Close()
+		return nil, nil, false, fmt.Errorf("changed while opening")
+	}
+	if opened.Size() < 0 || opened.Size() > maxPortableConfigBytes {
+		file.Close()
+		return nil, nil, false, fmt.Errorf("exceeds %d bytes", maxPortableConfigBytes)
+	}
+	data, readErr := io.ReadAll(io.LimitReader(file, maxPortableConfigBytes+1))
+	afterOpened, statErr := file.Stat()
+	closeErr := file.Close()
+	afterPath, lstatErr := access.lstat(name)
+	if readErr != nil {
+		return nil, nil, false, readErr
+	}
+	if statErr != nil {
+		return nil, nil, false, statErr
+	}
+	if closeErr != nil {
+		return nil, nil, false, closeErr
+	}
+	if int64(len(data)) > maxPortableConfigBytes {
+		return nil, nil, false, fmt.Errorf("exceeds %d bytes", maxPortableConfigBytes)
+	}
+	if lstatErr != nil || afterPath.Mode()&os.ModeSymlink != 0 ||
+		!os.SameFile(opened, afterOpened) || !os.SameFile(afterOpened, afterPath) ||
+		int64(len(data)) != opened.Size() || !stableMetadata(opened, afterOpened) ||
+		!stableMetadata(afterOpened, afterPath) {
+		return nil, nil, false, fmt.Errorf("changed while reading")
+	}
+	return data, afterOpened, true, nil
+}
+
+func stableMetadata(before, after os.FileInfo) bool {
+	return before.Mode() == after.Mode() && before.Size() == after.Size() && before.ModTime() == after.ModTime()
+}


### PR DESCRIPTION
## Summary

- resolve typed project assets through stable file snapshots
- validate portable project configuration without following symlinks
- write deterministic, bounded project archives from an explicit allowlist
- reject path aliases, collisions, unsafe files, root replacement, and output recursion

## Validation

- `go test -race -count=1 ./internal/projectassets ./internal/projectbundle ./internal/projectpolicy`
- `go vet ./internal/projectassets ./internal/projectbundle ./internal/projectpolicy`
- `go test -count=1 ./...`
- Windows amd64 package compilation
- `go mod tidy` (no diff)
- `git diff --check`