### PR TITLE
feat(release): add pinned runtime acquisition metadata

### DIFF
--- a/internal/cmd/buildctl/runtimecmd/assets.go
+++ b/internal/cmd/buildctl/runtimecmd/assets.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 
 	"github.com/goplus/spx/v3/internal/cmd/buildctl/shared"
@@ -67,10 +68,46 @@ func ExportPackRuntime(runner shared.ScriptRunner) error {
 	}
 
 	dstZip := filepath.Join(workspace.goBinDir, release.RuntimeAssetZipName)
-	return shared.WriteNamedZip(dstZip, map[string]string{
+	if err := shared.WriteNamedZip(dstZip, map[string]string{
 		"gdspxrt.pck":         workspace.outputPack,
 		"runtime.gdextension": runtimeExtension,
-	})
+	}); err != nil {
+		return err
+	}
+	return writeLocalRuntimeManifestIfComplete(workspace.repoRoot, workspace.goBinDir)
+}
+
+// writeLocalRuntimeManifestIfComplete publishes the explicit source-mode
+// runtime declaration after the Engine and PCK have both been produced. A
+// standalone export-pack may legitimately run before the Engine build, so it
+// leaves no incomplete manifest in that case.
+func writeLocalRuntimeManifestIfComplete(repoRoot, goBinDir string) error {
+	lock := release.DefaultRuntimeLock()
+	spec, err := release.HostRuntimeSpecFor(lock, runtime.GOOS, runtime.GOARCH)
+	if err != nil {
+		return err
+	}
+	enginePath := filepath.Join(goBinDir, spec.RuntimeName)
+	if _, err := os.Lstat(enginePath); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("inspect local runtime Engine: %w", err)
+	}
+	packPath := filepath.Join(goBinDir, spec.PackName)
+	manifest, err := release.NewLocalRuntimeManifest(lock, spec.GOOS, spec.GOARCH, enginePath, packPath)
+	if err != nil {
+		return err
+	}
+	manifestPath, err := release.LocalRuntimeManifestPath(repoRoot, lock, spec.GOOS, spec.GOARCH)
+	if err != nil {
+		return err
+	}
+	if err := release.PublishLocalRuntimeManifest(manifestPath, manifest, enginePath, packPath); err != nil {
+		return err
+	}
+	fmt.Fprintf(os.Stdout, "Local runtime manifest: %s\n", manifestPath)
+	return nil
 }
 
 func exportWebRuntime(cfg runtimeExportWebConfig, runner shared.ScriptRunner) error {

--- a/internal/cmd/buildctl/runtimecmd/cmd_test.go
+++ b/internal/cmd/buildctl/runtimecmd/cmd_test.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -113,6 +114,12 @@ func TestRuntimeExportWebSequence(t *testing.T) {
 func TestRuntimeExportPackSequence(t *testing.T) {
 	runner := newRuntimeFixtureRunner(t)
 	version := mustDefaultRuntimeVersion(t)
+	spec, err := release.HostRuntimeSpecFor(release.DefaultRuntimeLock(), runtime.GOOS, runtime.GOARCH)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gopathBin := filepath.Join(os.Getenv("GOPATH"), "bin")
+	mustWriteFile(t, filepath.Join(gopathBin, spec.RuntimeName), []byte("runtime-engine"))
 
 	if err := ExportPackRuntime(runner); err != nil {
 		t.Fatalf("exportPackRuntime returned error: %v", err)
@@ -120,12 +127,32 @@ func TestRuntimeExportPackSequence(t *testing.T) {
 
 	assertSingleRuntimeWorkspaceCommand(t, runner, "spx", []string{"export"})
 
-	gopathBin := filepath.Join(os.Getenv("GOPATH"), "bin")
 	if !shared.FileExists(filepath.Join(gopathBin, "gdspxrt"+version+".pck")) {
 		t.Fatalf("expected exported pck to exist")
 	}
 	if !shared.FileExists(filepath.Join(gopathBin, release.RuntimeAssetZipName)) {
 		t.Fatalf("expected exported zip to exist")
+	}
+	manifestPath := filepath.Join(runner.repoRoot, ".spx", "runtime", version, spec.GOOS+"-"+spec.GOARCH, "engine-manifest.json")
+	manifestData, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatalf("read local runtime manifest: %v", err)
+	}
+	manifest, err := release.ParseLocalRuntimeManifest(manifestData)
+	if err != nil {
+		t.Fatalf("parse local runtime manifest: %v", err)
+	}
+	if err := manifest.ValidateForLock(release.DefaultRuntimeLock(), spec.GOOS, spec.GOARCH); err != nil {
+		t.Fatal(err)
+	}
+	manifestDir := filepath.Dir(manifestPath)
+	if err := manifest.VerifyFiles(manifestDir); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{manifest.Engine.Name, manifest.Pack.Name} {
+		if !shared.FileExists(filepath.Join(manifestDir, name)) {
+			t.Fatalf("expected published local runtime file %s beside manifest", name)
+		}
 	}
 }
 

--- a/internal/release/host_runtime.go
+++ b/internal/release/host_runtime.go
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2021 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package release
+
+import (
+	"fmt"
+	"slices"
+)
+
+// HostRuntimeSpec describes one host runtime archive and its output names.
+type HostRuntimeSpec struct {
+	GOOS        string
+	GOARCH      string
+	ArchiveName string
+	BinaryName  string
+	RuntimeName string
+	PackName    string
+}
+
+// HostRuntimeSpecFor resolves host runtime names after validating the lock.
+func HostRuntimeSpecFor(lock RuntimeLock, goos, goarch string) (HostRuntimeSpec, error) {
+	if err := lock.Validate(); err != nil {
+		return HostRuntimeSpec{}, err
+	}
+
+	releaseArch, ok := hostReleaseArch(goarch)
+	if !ok {
+		return HostRuntimeSpec{}, fmt.Errorf("release: unsupported host platform %s/%s", goos, goarch)
+	}
+
+	platform, binaryPlatform, ok := hostPlatform(goos)
+	if !ok {
+		return HostRuntimeSpec{}, fmt.Errorf("release: unsupported host platform %s/%s", goos, goarch)
+	}
+
+	archiveName := platform + "-" + releaseArch + ".zip"
+	if !slices.Contains(lock.RequiredAssets, archiveName) {
+		return HostRuntimeSpec{}, fmt.Errorf("release: runtime lock does not require host asset %q", archiveName)
+	}
+
+	binaryName := fmt.Sprintf("godot.%s.template_release.%s", binaryPlatform, releaseArch)
+	runtimeName := RuntimeTag + lock.RuntimeVersion
+	if goos == "windows" {
+		binaryName += ".exe"
+		runtimeName += ".exe"
+	}
+	return HostRuntimeSpec{
+		GOOS:        goos,
+		GOARCH:      goarch,
+		ArchiveName: archiveName,
+		BinaryName:  binaryName,
+		RuntimeName: runtimeName,
+		PackName:    RuntimeTag + lock.RuntimeVersion + ".pck",
+	}, nil
+}
+
+func hostReleaseArch(goarch string) (string, bool) {
+	switch goarch {
+	case "amd64":
+		return "x86_64", true
+	case "arm64":
+		return "arm64", true
+	default:
+		return "", false
+	}
+}
+
+func hostPlatform(goos string) (platform, binaryPlatform string, ok bool) {
+	switch goos {
+	case "linux":
+		return "linux", "linuxbsd", true
+	case "darwin":
+		return "macos", "macos", true
+	case "windows":
+		return "windows", "windows", true
+	default:
+		return "", "", false
+	}
+}

--- a/internal/release/host_runtime_test.go
+++ b/internal/release/host_runtime_test.go
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2021 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package release
+
+import (
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestHostRuntimeSpecFor(t *testing.T) {
+	lock := DefaultRuntimeLock()
+	runtimeName := RuntimeTag + lock.RuntimeVersion
+	for _, test := range []struct {
+		goos        string
+		goarch      string
+		wantArchive string
+		wantBinary  string
+	}{
+		{goos: "linux", goarch: "amd64", wantArchive: "linux-x86_64.zip", wantBinary: "godot.linuxbsd.template_release.x86_64"},
+		{goos: "darwin", goarch: "amd64", wantArchive: "macos-x86_64.zip", wantBinary: "godot.macos.template_release.x86_64"},
+		{goos: "darwin", goarch: "arm64", wantArchive: "macos-arm64.zip", wantBinary: "godot.macos.template_release.arm64"},
+		{goos: "windows", goarch: "amd64", wantArchive: "windows-x86_64.zip", wantBinary: "godot.windows.template_release.x86_64.exe"},
+	} {
+		t.Run(test.goos+"/"+test.goarch, func(t *testing.T) {
+			spec, err := HostRuntimeSpecFor(lock, test.goos, test.goarch)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if spec.GOOS != test.goos || spec.GOARCH != test.goarch {
+				t.Fatalf("host identity = %s/%s, want %s/%s", spec.GOOS, spec.GOARCH, test.goos, test.goarch)
+			}
+			wantRuntime := runtimeName
+			if test.goos == "windows" {
+				wantRuntime += ".exe"
+			}
+			if spec.ArchiveName != test.wantArchive || spec.BinaryName != test.wantBinary || spec.RuntimeName != wantRuntime {
+				t.Fatalf("spec = %#v", spec)
+			}
+			if spec.PackName != runtimeName+".pck" {
+				t.Fatalf("pack name = %q", spec.PackName)
+			}
+		})
+	}
+}
+
+func TestHostRuntimeSpecForSupportsMissingReleaseAssetsWhenLocked(t *testing.T) {
+	lock := DefaultRuntimeLock()
+	lock.RequiredAssets = append(lock.RequiredAssets, "linux-arm64.zip", "windows-arm64.zip")
+	slices.Sort(lock.RequiredAssets)
+
+	for _, test := range []struct {
+		goos        string
+		goarch      string
+		wantArchive string
+		wantBinary  string
+	}{
+		{goos: "linux", goarch: "arm64", wantArchive: "linux-arm64.zip", wantBinary: "godot.linuxbsd.template_release.arm64"},
+		{goos: "windows", goarch: "arm64", wantArchive: "windows-arm64.zip", wantBinary: "godot.windows.template_release.arm64.exe"},
+	} {
+		t.Run(test.goos+"/"+test.goarch, func(t *testing.T) {
+			spec, err := HostRuntimeSpecFor(lock, test.goos, test.goarch)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if spec.ArchiveName != test.wantArchive || spec.BinaryName != test.wantBinary {
+				t.Fatalf("spec = %#v", spec)
+			}
+		})
+	}
+}
+
+func TestHostRuntimeSpecForRejectsMissingAsset(t *testing.T) {
+	lock := DefaultRuntimeLock()
+	if _, err := HostRuntimeSpecFor(lock, "linux", "arm64"); err == nil || !strings.Contains(err.Error(), "linux-arm64.zip") {
+		t.Fatalf("HostRuntimeSpecFor missing-asset error = %v", err)
+	}
+	if _, err := HostRuntimeSpecFor(lock, "windows", "arm64"); err == nil || !strings.Contains(err.Error(), "windows-arm64.zip") {
+		t.Fatalf("HostRuntimeSpecFor missing-asset error = %v", err)
+	}
+}
+
+func TestHostRuntimeSpecForRejectsUnsupportedHost(t *testing.T) {
+	lock := DefaultRuntimeLock()
+	for _, test := range []struct {
+		goos   string
+		goarch string
+	}{
+		{goos: "freebsd", goarch: "amd64"},
+		{goos: "linux", goarch: "386"},
+	} {
+		t.Run(test.goos+"/"+test.goarch, func(t *testing.T) {
+			if _, err := HostRuntimeSpecFor(lock, test.goos, test.goarch); err == nil || !strings.Contains(err.Error(), "unsupported host platform") {
+				t.Fatalf("HostRuntimeSpecFor error = %v", err)
+			}
+		})
+	}
+}
+
+func TestHostRuntimeSpecForValidatesLock(t *testing.T) {
+	lock := DefaultRuntimeLock()
+	lock.RuntimeVersion = "invalid"
+	if _, err := HostRuntimeSpecFor(lock, "linux", "amd64"); err == nil || !strings.Contains(err.Error(), "invalid runtime version") {
+		t.Fatalf("HostRuntimeSpecFor invalid-lock error = %v", err)
+	}
+}

--- a/internal/release/local_runtime_manifest.go
+++ b/internal/release/local_runtime_manifest.go
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package release
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/goplus/spx/v3/internal/strictjson"
+)
+
+const localRuntimeManifestSchema = "spx-local-engine/v1"
+
+// LocalRuntimeFile declares one local Engine/PCK output.
+type LocalRuntimeFile struct {
+	Name   string `json:"name"`
+	Size   int64  `json:"size"`
+	SHA256 string `json:"sha256"`
+}
+
+// LocalRuntimeManifest describes a locally built runtime, not a publication.
+type LocalRuntimeManifest struct {
+	Schema         string           `json:"schema"`
+	Mode           string           `json:"mode"`
+	RuntimeVersion string           `json:"runtime_version"`
+	RuntimeABI     int              `json:"runtime_abi"`
+	LockSHA256     string           `json:"lock_sha256"`
+	GOOS           string           `json:"goos"`
+	GOARCH         string           `json:"goarch"`
+	Engine         LocalRuntimeFile `json:"engine"`
+	Pack           LocalRuntimeFile `json:"pack"`
+}
+
+// ParseLocalRuntimeManifest decodes and validates a local manifest.
+func ParseLocalRuntimeManifest(data []byte) (LocalRuntimeManifest, error) {
+	var manifest LocalRuntimeManifest
+	if err := strictjson.Decode(data, &manifest); err != nil {
+		return LocalRuntimeManifest{}, fmt.Errorf("decode local runtime manifest: %w", err)
+	}
+	if err := manifest.Validate(); err != nil {
+		return LocalRuntimeManifest{}, err
+	}
+	return manifest, nil
+}
+
+// Validate checks the manifest's local structure and file declarations.
+func (m LocalRuntimeManifest) Validate() error {
+	if m.Schema != localRuntimeManifestSchema {
+		return fmt.Errorf("release: local runtime manifest schema = %q, want %q", m.Schema, localRuntimeManifestSchema)
+	}
+	if m.Mode != "local" {
+		return fmt.Errorf("release: local runtime manifest mode = %q, want local", m.Mode)
+	}
+	if !runtimeVersionPattern.MatchString(m.RuntimeVersion) {
+		return fmt.Errorf("release: invalid local runtime version %q", m.RuntimeVersion)
+	}
+	if m.RuntimeABI <= 0 {
+		return fmt.Errorf("release: local runtime ABI must be positive")
+	}
+	if !isLowerHexDigest(m.LockSHA256, sha256.Size*2) {
+		return fmt.Errorf("release: invalid local runtime lock SHA-256 %q", m.LockSHA256)
+	}
+	if m.GOOS == "" || strings.ContainsAny(m.GOOS, `/\\`) || m.GOARCH == "" || strings.ContainsAny(m.GOARCH, `/\\`) {
+		return fmt.Errorf("release: invalid local runtime target %q/%q", m.GOOS, m.GOARCH)
+	}
+	if err := validateLocalRuntimeFile("engine", m.Engine); err != nil {
+		return err
+	}
+	if err := validateLocalRuntimeFile("pack", m.Pack); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateLocalRuntimeFile(label string, file LocalRuntimeFile) error {
+	if file.Name == "" || file.Name == "." || file.Name == ".." || filepath.Base(file.Name) != file.Name || strings.ContainsAny(file.Name, `/\\`) {
+		return fmt.Errorf("release: local runtime %s has invalid name %q", label, file.Name)
+	}
+	if file.Size <= 0 {
+		return fmt.Errorf("release: local runtime %s size must be positive", label)
+	}
+	if !isLowerHexDigest(file.SHA256, sha256.Size*2) {
+		return fmt.Errorf("release: local runtime %s has invalid SHA-256 %q", label, file.SHA256)
+	}
+	return nil
+}
+
+// ValidateForLock verifies the local manifest's runtime and target identity.
+func (m LocalRuntimeManifest) ValidateForLock(lock RuntimeLock, goos, goarch string) error {
+	if err := lock.Validate(); err != nil {
+		return err
+	}
+	if err := m.Validate(); err != nil {
+		return err
+	}
+	lockSHA, err := lock.SHA256()
+	if err != nil {
+		return err
+	}
+	if m.RuntimeVersion != lock.RuntimeVersion || m.RuntimeABI != lock.RuntimeABI {
+		return fmt.Errorf("release: local runtime identity does not match lock")
+	}
+	if m.LockSHA256 != lockSHA {
+		return fmt.Errorf("release: local runtime lock SHA-256 %q does not match %q", m.LockSHA256, lockSHA)
+	}
+	if m.GOOS != goos || m.GOARCH != goarch {
+		return fmt.Errorf("release: local runtime target %s/%s does not match host %s/%s", m.GOOS, m.GOARCH, goos, goarch)
+	}
+	spec, err := HostRuntimeSpecFor(lock, goos, goarch)
+	if err != nil {
+		return err
+	}
+	if m.Engine.Name != localRuntimeObjectName(spec.RuntimeName, m.Engine.SHA256) || m.Pack.Name != localRuntimeObjectName(spec.PackName, m.Pack.SHA256) {
+		return fmt.Errorf("release: local runtime file names do not match locked host runtime")
+	}
+	return nil
+}
+
+func (m LocalRuntimeManifest) json() ([]byte, error) {
+	if err := m.Validate(); err != nil {
+		return nil, err
+	}
+	data, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("encode local runtime manifest: %w", err)
+	}
+	return append(data, '\n'), nil
+}
+
+// LocalRuntimeManifestPath returns the deterministic source-mode manifest
+// location for one locked host runtime.
+func LocalRuntimeManifestPath(repoRoot string, lock RuntimeLock, goos, goarch string) (string, error) {
+	if repoRoot == "" || !filepath.IsAbs(repoRoot) || filepath.Clean(repoRoot) != repoRoot {
+		return "", fmt.Errorf("release: local runtime repository root must be absolute and clean: %q", repoRoot)
+	}
+	spec, err := HostRuntimeSpecFor(lock, goos, goarch)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(repoRoot, ".spx", "runtime", lock.RuntimeVersion, spec.GOOS+"-"+spec.GOARCH, "engine-manifest.json"), nil
+}

--- a/internal/release/local_runtime_manifest_io.go
+++ b/internal/release/local_runtime_manifest_io.go
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package release
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// VerifyFiles verifies the declared local files beneath manifestDir using
+// no-follow/open/re-stat checks and exact size/digest comparisons.
+func (m LocalRuntimeManifest) VerifyFiles(manifestDir string) error {
+	if err := m.Validate(); err != nil {
+		return err
+	}
+	for _, item := range []struct {
+		label string
+		file  LocalRuntimeFile
+	}{
+		{label: "engine", file: m.Engine},
+		{label: "pack", file: m.Pack},
+	} {
+		path := filepath.Join(manifestDir, item.file.Name)
+		if err := verifyLocalRuntimeFile(path, item.file); err != nil {
+			return fmt.Errorf("release: verify local runtime %s: %w", item.label, err)
+		}
+	}
+	return nil
+}
+
+func verifyLocalRuntimeFile(path string, want LocalRuntimeFile) error {
+	got, err := readVerifiedLocalRuntimeFile(path, nil)
+	if err != nil {
+		return err
+	}
+	if got.Size != want.Size {
+		return fmt.Errorf("%s size = %d, want %d", path, got.Size, want.Size)
+	}
+	if got.SHA256 != want.SHA256 {
+		return fmt.Errorf("%s SHA-256 = %s, want %s", path, got.SHA256, want.SHA256)
+	}
+	return nil
+}
+
+func hashLocalRuntimeFile(path string) (LocalRuntimeFile, error) {
+	return readVerifiedLocalRuntimeFile(path, nil)
+}
+
+// readVerifiedLocalRuntimeFile reads a regular non-symlink file after checking
+// that the path still names the file that was opened. The optional sink is
+// created after the source passes its opening checks and receives the bytes
+// before they are hashed.
+func readVerifiedLocalRuntimeFile(path string, newSink func() (io.Writer, error)) (LocalRuntimeFile, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return LocalRuntimeFile{}, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+		return LocalRuntimeFile{}, fmt.Errorf("%s is not a regular non-symlink file", path)
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return LocalRuntimeFile{}, err
+	}
+	opened, err := file.Stat()
+	if err != nil {
+		_ = file.Close()
+		return LocalRuntimeFile{}, err
+	}
+	if !os.SameFile(info, opened) || info.Size() != opened.Size() {
+		_ = file.Close()
+		return LocalRuntimeFile{}, fmt.Errorf("%s changed while opening", path)
+	}
+	hasher := sha256.New()
+	var writer io.Writer = hasher
+	if newSink != nil {
+		sink, err := newSink()
+		if err != nil {
+			_ = file.Close()
+			return LocalRuntimeFile{}, err
+		}
+		writer = io.MultiWriter(sink, writer)
+	}
+	expectedSize := info.Size()
+	size, err := io.CopyN(writer, file, expectedSize)
+	closeErr := file.Close()
+	if err != nil {
+		return LocalRuntimeFile{}, err
+	}
+	if closeErr != nil {
+		return LocalRuntimeFile{}, closeErr
+	}
+	after, err := os.Lstat(path)
+	if err != nil || after.Mode()&os.ModeSymlink != 0 || !after.Mode().IsRegular() || !os.SameFile(opened, after) || after.Size() != expectedSize || size != expectedSize {
+		return LocalRuntimeFile{}, fmt.Errorf("%s changed while reading", path)
+	}
+	return LocalRuntimeFile{Name: filepath.Base(path), Size: size, SHA256: hex.EncodeToString(hasher.Sum(nil))}, nil
+}

--- a/internal/release/local_runtime_manifest_publish.go
+++ b/internal/release/local_runtime_manifest_publish.go
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package release
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func writeLocalRuntimeManifest(path string, manifest LocalRuntimeManifest) error {
+	data, err := manifest.json()
+	if err != nil {
+		return err
+	}
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("create local runtime manifest directory: %w", err)
+	}
+	tmp, err := os.CreateTemp(dir, ".engine-manifest-*")
+	if err != nil {
+		return fmt.Errorf("create local runtime manifest: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer func() { _ = os.Remove(tmpPath) }()
+	if err := tmp.Chmod(0o644); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("chmod local runtime manifest: %w", err)
+	}
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write local runtime manifest: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("sync local runtime manifest: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close local runtime manifest: %w", err)
+	}
+	if err := replaceLocalRuntimeFile(tmpPath, path, 0o644); err != nil {
+		return fmt.Errorf("install local runtime manifest: %w", err)
+	}
+	return nil
+}
+
+// PublishLocalRuntimeManifest copies the verified local Engine and PCK beside
+// path, then writes the manifest last. The manifest's basename references are
+// therefore self-contained and never point back into GOPATH/bin.
+func PublishLocalRuntimeManifest(path string, manifest LocalRuntimeManifest, enginePath, packPath string) error {
+	lock, err := RuntimeLockForVersion(manifest.RuntimeVersion)
+	if err != nil {
+		return err
+	}
+	if err := manifest.ValidateForLock(lock, manifest.GOOS, manifest.GOARCH); err != nil {
+		return err
+	}
+	// Verify both sources before publishing either content-addressed object.
+	// The copy below repeats this check while holding each source open.
+	if err := verifyLocalRuntimeFile(enginePath, manifest.Engine); err != nil {
+		return fmt.Errorf("verify local runtime Engine before publish: %w", err)
+	}
+	if err := verifyLocalRuntimeFile(packPath, manifest.Pack); err != nil {
+		return fmt.Errorf("verify local runtime PCK before publish: %w", err)
+	}
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("create local runtime manifest directory: %w", err)
+	}
+	if err := copyVerifiedLocalRuntimeFile(enginePath, filepath.Join(dir, manifest.Engine.Name), manifest.Engine, 0o755); err != nil {
+		return fmt.Errorf("publish local runtime Engine: %w", err)
+	}
+	if err := copyVerifiedLocalRuntimeFile(packPath, filepath.Join(dir, manifest.Pack.Name), manifest.Pack, 0o644); err != nil {
+		return fmt.Errorf("publish local runtime PCK: %w", err)
+	}
+	if err := writeLocalRuntimeManifest(path, manifest); err != nil {
+		return err
+	}
+	if err := manifest.VerifyFiles(dir); err != nil {
+		return fmt.Errorf("verify published local runtime: %w", err)
+	}
+	return nil
+}
+
+// NewLocalRuntimeManifest constructs a manifest for two already-built files.
+func NewLocalRuntimeManifest(lock RuntimeLock, goos, goarch, enginePath, packPath string) (LocalRuntimeManifest, error) {
+	lockSHA, err := lock.SHA256()
+	if err != nil {
+		return LocalRuntimeManifest{}, err
+	}
+	spec, err := HostRuntimeSpecFor(lock, goos, goarch)
+	if err != nil {
+		return LocalRuntimeManifest{}, err
+	}
+	if filepath.Base(enginePath) != spec.RuntimeName || filepath.Base(packPath) != spec.PackName {
+		return LocalRuntimeManifest{}, fmt.Errorf("release: local runtime source file names do not match locked host runtime")
+	}
+	engine, err := hashLocalRuntimeFile(enginePath)
+	if err != nil {
+		return LocalRuntimeManifest{}, fmt.Errorf("hash local Engine: %w", err)
+	}
+	pack, err := hashLocalRuntimeFile(packPath)
+	if err != nil {
+		return LocalRuntimeManifest{}, fmt.Errorf("hash local runtime PCK: %w", err)
+	}
+	engine.Name = localRuntimeObjectName(spec.RuntimeName, engine.SHA256)
+	pack.Name = localRuntimeObjectName(spec.PackName, pack.SHA256)
+	manifest := LocalRuntimeManifest{
+		Schema: localRuntimeManifestSchema, Mode: "local", RuntimeVersion: lock.RuntimeVersion,
+		RuntimeABI: lock.RuntimeABI, LockSHA256: lockSHA, GOOS: goos, GOARCH: goarch,
+		Engine: engine, Pack: pack,
+	}
+	if err := manifest.ValidateForLock(lock, goos, goarch); err != nil {
+		return LocalRuntimeManifest{}, err
+	}
+	return manifest, nil
+}
+
+func localRuntimeObjectName(name, digest string) string {
+	extension := filepath.Ext(name)
+	base := strings.TrimSuffix(name, extension)
+	return base + "." + digest + extension
+}
+
+func copyVerifiedLocalRuntimeFile(src, dst string, want LocalRuntimeFile, mode os.FileMode) (err error) {
+	var tmp *os.File
+	var tmpPath string
+	defer func() {
+		if tmp != nil {
+			_ = tmp.Close()
+		}
+		if tmpPath != "" {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+	got, err := readVerifiedLocalRuntimeFile(src, func() (io.Writer, error) {
+		var err error
+		tmp, err = os.CreateTemp(filepath.Dir(dst), ".local-runtime-file-*")
+		if err != nil {
+			return nil, err
+		}
+		tmpPath = tmp.Name()
+		return tmp, nil
+	})
+	if err != nil {
+		return err
+	}
+	if got.Size != want.Size {
+		_ = tmp.Close()
+		return fmt.Errorf("%s size = %d, want %d", src, got.Size, want.Size)
+	}
+	if got.SHA256 != want.SHA256 {
+		_ = tmp.Close()
+		return fmt.Errorf("%s SHA-256 = %s, want %s", src, got.SHA256, want.SHA256)
+	}
+	if err := tmp.Chmod(mode); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := replaceLocalRuntimeFile(tmpPath, dst, mode); err != nil {
+		return err
+	}
+	return verifyLocalRuntimeFile(dst, want)
+}
+
+func replaceLocalRuntimeFile(src, dst string, mode os.FileMode) error {
+	if info, err := os.Lstat(dst); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+			return fmt.Errorf("destination %q is not a regular non-symlink file", dst)
+		}
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+	if err := os.Rename(src, dst); err != nil {
+		return err
+	}
+	if runtime.GOOS != "windows" {
+		return os.Chmod(dst, mode)
+	}
+	return nil
+}

--- a/internal/release/local_runtime_manifest_test.go
+++ b/internal/release/local_runtime_manifest_test.go
@@ -1,0 +1,303 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package release
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestLocalRuntimeManifestWriteAndVerify(t *testing.T) {
+	lock := DefaultRuntimeLock()
+	spec, err := HostRuntimeSpecFor(lock, runtime.GOOS, runtime.GOARCH)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := t.TempDir()
+	enginePath := filepath.Join(root, spec.RuntimeName)
+	packPath := filepath.Join(root, spec.PackName)
+	if err := os.WriteFile(enginePath, []byte("engine-v1"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(packPath, []byte("pack-v1"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	manifest, err := NewLocalRuntimeManifest(lock, runtime.GOOS, runtime.GOARCH, enginePath, packPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifestPath, err := LocalRuntimeManifestPath(root, lock, runtime.GOOS, runtime.GOARCH)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := PublishLocalRuntimeManifest(manifestPath, manifest, enginePath, packPath); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := loadLocalRuntimeManifest(manifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := loaded.ValidateForLock(lock, runtime.GOOS, runtime.GOARCH); err != nil {
+		t.Fatal(err)
+	}
+	manifestDir := filepath.Dir(manifestPath)
+	if err := loaded.VerifyFiles(manifestDir); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{loaded.Engine.Name, loaded.Pack.Name} {
+		if _, err := os.Stat(filepath.Join(manifestDir, name)); err != nil {
+			t.Fatalf("published local runtime file %s: %v", name, err)
+		}
+	}
+
+	if err := os.WriteFile(enginePath, []byte("engine-v2"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	updated, err := NewLocalRuntimeManifest(lock, runtime.GOOS, runtime.GOARCH, enginePath, packPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := PublishLocalRuntimeManifest(manifestPath, updated, enginePath, packPath); err != nil {
+		t.Fatal(err)
+	}
+	reloaded, err := loadLocalRuntimeManifest(manifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reloaded.Engine.SHA256 == loaded.Engine.SHA256 {
+		t.Fatal("rewriting local runtime manifest did not replace the old digest")
+	}
+	if reloaded.Engine.Name == loaded.Engine.Name {
+		t.Fatal("rewriting local runtime manifest reused the old content address")
+	}
+	if err := reloaded.VerifyFiles(manifestDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := loaded.VerifyFiles(manifestDir); err != nil {
+		t.Fatalf("previous manifest stopped resolving after atomic update: %v", err)
+	}
+	entries, err := os.ReadDir(filepath.Dir(manifestPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), ".engine-manifest-") {
+			t.Fatalf("temporary manifest file was left behind: %s", entry.Name())
+		}
+	}
+}
+
+func TestNewLocalRuntimeManifestRejectsSymlink(t *testing.T) {
+	lock := DefaultRuntimeLock()
+	spec, err := HostRuntimeSpecFor(lock, runtime.GOOS, runtime.GOARCH)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := t.TempDir()
+	engineTarget := filepath.Join(root, "engine-target")
+	enginePath := filepath.Join(root, spec.RuntimeName)
+	packPath := filepath.Join(root, spec.PackName)
+	if err := os.WriteFile(engineTarget, []byte("engine"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(engineTarget, enginePath); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	if err := os.WriteFile(packPath, []byte("pack"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := NewLocalRuntimeManifest(lock, runtime.GOOS, runtime.GOARCH, enginePath, packPath); err == nil || !strings.Contains(err.Error(), "non-symlink") {
+		t.Fatalf("NewLocalRuntimeManifest error = %v, want symlink rejection", err)
+	}
+}
+
+func TestNewLocalRuntimeManifestRejectsUnlockedNames(t *testing.T) {
+	lock := DefaultRuntimeLock()
+	root := t.TempDir()
+	enginePath := filepath.Join(root, "engine")
+	packPath := filepath.Join(root, "runtime.pck")
+	if err := os.WriteFile(enginePath, []byte("engine"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(packPath, []byte("pack"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := NewLocalRuntimeManifest(lock, runtime.GOOS, runtime.GOARCH, enginePath, packPath); err == nil || !strings.Contains(err.Error(), "file names") {
+		t.Fatalf("NewLocalRuntimeManifest error = %v, want locked-name rejection", err)
+	}
+}
+
+func TestLocalRuntimeManifestPathRequiresAbsoluteCleanRoot(t *testing.T) {
+	lock := DefaultRuntimeLock()
+	for _, root := range []string{"", ".", t.TempDir() + string(filepath.Separator) + ".."} {
+		if _, err := LocalRuntimeManifestPath(root, lock, runtime.GOOS, runtime.GOARCH); err == nil {
+			t.Fatalf("LocalRuntimeManifestPath accepted root %q", root)
+		}
+	}
+}
+
+func TestPublishLocalRuntimeManifestRejectsChangedSource(t *testing.T) {
+	lock := DefaultRuntimeLock()
+	spec, err := HostRuntimeSpecFor(lock, runtime.GOOS, runtime.GOARCH)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := t.TempDir()
+	enginePath := filepath.Join(root, spec.RuntimeName)
+	packPath := filepath.Join(root, spec.PackName)
+	if err := os.WriteFile(enginePath, []byte("engine-v1"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(packPath, []byte("pack-v1"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	manifest, err := NewLocalRuntimeManifest(lock, runtime.GOOS, runtime.GOARCH, enginePath, packPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(enginePath, []byte("engine-v2"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	manifestPath, err := LocalRuntimeManifestPath(root, lock, runtime.GOOS, runtime.GOARCH)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := PublishLocalRuntimeManifest(manifestPath, manifest, enginePath, packPath); err == nil || !strings.Contains(err.Error(), "SHA-256") {
+		t.Fatalf("PublishLocalRuntimeManifest error = %v, want digest mismatch", err)
+	}
+	if _, err := os.Lstat(manifestPath); !os.IsNotExist(err) {
+		t.Fatalf("manifest after failed publish: err=%v", err)
+	}
+}
+
+func TestPublishLocalRuntimeManifestKeepsPreviousGenerationOnPackFailure(t *testing.T) {
+	lock := DefaultRuntimeLock()
+	spec, err := HostRuntimeSpecFor(lock, runtime.GOOS, runtime.GOARCH)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sourceDir := t.TempDir()
+	repoRoot := t.TempDir()
+	enginePath := filepath.Join(sourceDir, spec.RuntimeName)
+	packPath := filepath.Join(sourceDir, spec.PackName)
+	if err := os.WriteFile(enginePath, []byte("engine-v1"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(packPath, []byte("pack-v1"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	previous, err := NewLocalRuntimeManifest(lock, runtime.GOOS, runtime.GOARCH, enginePath, packPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifestPath, err := LocalRuntimeManifestPath(repoRoot, lock, runtime.GOOS, runtime.GOARCH)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := PublishLocalRuntimeManifest(manifestPath, previous, enginePath, packPath); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(enginePath, []byte("engine-v2"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(packPath, []byte("pack-v2"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	next, err := NewLocalRuntimeManifest(lock, runtime.GOOS, runtime.GOARCH, enginePath, packPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(packPath, []byte("changed-after-manifest"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := PublishLocalRuntimeManifest(manifestPath, next, enginePath, packPath); err == nil {
+		t.Fatal("publish with changed PCK unexpectedly succeeded")
+	}
+
+	loaded, err := loadLocalRuntimeManifest(manifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.Engine.SHA256 != previous.Engine.SHA256 || loaded.Pack.SHA256 != previous.Pack.SHA256 {
+		t.Fatalf("failed publish replaced previous manifest: %#v", loaded)
+	}
+	if err := loaded.VerifyFiles(filepath.Dir(manifestPath)); err != nil {
+		t.Fatalf("failed publish damaged previous generation: %v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(filepath.Dir(manifestPath), next.Engine.Name)); !os.IsNotExist(err) {
+		t.Fatalf("failed preflight left next Engine object: %v", err)
+	}
+}
+
+func TestPublishLocalRuntimeManifestRejectsDestinationSymlink(t *testing.T) {
+	lock := DefaultRuntimeLock()
+	spec, err := HostRuntimeSpecFor(lock, runtime.GOOS, runtime.GOARCH)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := t.TempDir()
+	enginePath := filepath.Join(root, spec.RuntimeName)
+	packPath := filepath.Join(root, spec.PackName)
+	if err := os.WriteFile(enginePath, []byte("engine"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(packPath, []byte("pack"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	manifest, err := NewLocalRuntimeManifest(lock, runtime.GOOS, runtime.GOARCH, enginePath, packPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifestPath, err := LocalRuntimeManifestPath(root, lock, runtime.GOOS, runtime.GOARCH)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifestDir := filepath.Dir(manifestPath)
+	if err := os.MkdirAll(manifestDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(root, "outside-engine")
+	if err := os.WriteFile(target, []byte("outside"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	destination := filepath.Join(manifestDir, manifest.Engine.Name)
+	if err := os.Symlink(target, destination); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	if err := PublishLocalRuntimeManifest(manifestPath, manifest, enginePath, packPath); err == nil || !strings.Contains(err.Error(), "non-symlink") {
+		t.Fatalf("PublishLocalRuntimeManifest error = %v, want destination symlink rejection", err)
+	}
+	if got, err := os.ReadFile(target); err != nil || string(got) != "outside" {
+		t.Fatalf("symlink target changed: data=%q err=%v", got, err)
+	}
+	if _, err := os.Lstat(manifestPath); !os.IsNotExist(err) {
+		t.Fatalf("manifest after failed publish: err=%v", err)
+	}
+}
+
+func loadLocalRuntimeManifest(path string) (LocalRuntimeManifest, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return LocalRuntimeManifest{}, err
+	}
+	return ParseLocalRuntimeManifest(data)
+}

--- a/internal/release/runtime_lock.go
+++ b/internal/release/runtime_lock.go
@@ -24,13 +24,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"io/fs"
 	"path"
 	"regexp"
 	"slices"
 	"strings"
 	"unicode"
+
+	"github.com/goplus/spx/v3/internal/strictjson"
 )
 
 const RuntimeLockSchema = 1
@@ -184,16 +185,8 @@ func cloneRuntimeLock(lock RuntimeLock) RuntimeLock {
 // ParseRuntimeLock decodes and validates a runtime lock. Unknown JSON fields
 // are rejected so misspelled release inputs cannot silently change a build.
 func ParseRuntimeLock(data []byte) (RuntimeLock, error) {
-	if err := rejectDuplicateJSONKeys(data); err != nil {
-		return RuntimeLock{}, fmt.Errorf("decode runtime lock: %w", err)
-	}
 	var lock RuntimeLock
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	if err := decoder.Decode(&lock); err != nil {
-		return RuntimeLock{}, fmt.Errorf("decode runtime lock: %w", err)
-	}
-	if err := requireJSONEOF(decoder); err != nil {
+	if err := strictjson.Decode(data, &lock); err != nil {
 		return RuntimeLock{}, fmt.Errorf("decode runtime lock: %w", err)
 	}
 	if err := lock.Validate(); err != nil {
@@ -301,88 +294,6 @@ func (l RuntimeLock) SHA256() (string, error) {
 	}
 	sum := sha256.Sum256(data)
 	return hex.EncodeToString(sum[:]), nil
-}
-
-func requireJSONEOF(decoder *json.Decoder) error {
-	var extra any
-	if err := decoder.Decode(&extra); err == io.EOF {
-		return nil
-	} else if err != nil {
-		return err
-	}
-	return errors.New("multiple JSON values")
-}
-
-// rejectDuplicateJSONKeys walks one JSON value before typed decoding so all
-// consumers reject ambiguous objects consistently. encoding/json otherwise
-// accepts duplicate keys and silently keeps the last value.
-func rejectDuplicateJSONKeys(data []byte) error {
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.UseNumber()
-	if err := consumeUniqueJSONValue(decoder, "$"); err != nil {
-		return err
-	}
-	if err := requireJSONEOF(decoder); err != nil {
-		return err
-	}
-	return nil
-}
-
-func consumeUniqueJSONValue(decoder *json.Decoder, location string) error {
-	token, err := decoder.Token()
-	if err != nil {
-		return err
-	}
-	delim, ok := token.(json.Delim)
-	if !ok {
-		return nil
-	}
-	switch delim {
-	case '{':
-		seen := make(map[string]struct{})
-		for decoder.More() {
-			keyToken, err := decoder.Token()
-			if err != nil {
-				return err
-			}
-			key, ok := keyToken.(string)
-			if !ok {
-				return fmt.Errorf("object key at %s is not a string", location)
-			}
-			if _, exists := seen[key]; exists {
-				return fmt.Errorf("duplicate JSON key %q at %s", key, location)
-			}
-			seen[key] = struct{}{}
-			if err := consumeUniqueJSONValue(decoder, location+"."+key); err != nil {
-				return err
-			}
-		}
-		end, err := decoder.Token()
-		if err != nil {
-			return err
-		}
-		if end != json.Delim('}') {
-			return fmt.Errorf("invalid object terminator at %s", location)
-		}
-	case '[':
-		index := 0
-		for decoder.More() {
-			if err := consumeUniqueJSONValue(decoder, fmt.Sprintf("%s[%d]", location, index)); err != nil {
-				return err
-			}
-			index++
-		}
-		end, err := decoder.Token()
-		if err != nil {
-			return err
-		}
-		if end != json.Delim(']') {
-			return fmt.Errorf("invalid array terminator at %s", location)
-		}
-	default:
-		return fmt.Errorf("invalid JSON delimiter %q at %s", delim, location)
-	}
-	return nil
 }
 
 func validateBaseName(kind, name string) error {

--- a/internal/release/runtime_manifest.go
+++ b/internal/release/runtime_manifest.go
@@ -17,7 +17,6 @@
 package release
 
 import (
-	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -28,6 +27,8 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+
+	"github.com/goplus/spx/v3/internal/strictjson"
 )
 
 const (
@@ -115,16 +116,8 @@ func GenerateRuntimeManifest(lock RuntimeLock, provenance RuntimeProvenance, inp
 // ParseRuntimeManifest decodes and structurally validates a manifest. Use
 // ValidateForLock as well when consuming a release for a known lock.
 func ParseRuntimeManifest(data []byte) (RuntimeManifest, error) {
-	if err := rejectDuplicateJSONKeys(data); err != nil {
-		return RuntimeManifest{}, fmt.Errorf("decode runtime manifest: %w", err)
-	}
 	var manifest RuntimeManifest
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	if err := decoder.Decode(&manifest); err != nil {
-		return RuntimeManifest{}, fmt.Errorf("decode runtime manifest: %w", err)
-	}
-	if err := requireJSONEOF(decoder); err != nil {
+	if err := strictjson.Decode(data, &manifest); err != nil {
 		return RuntimeManifest{}, fmt.Errorf("decode runtime manifest: %w", err)
 	}
 	if err := manifest.Validate(); err != nil {

--- a/internal/release/runtime_manifest_pin.go
+++ b/internal/release/runtime_manifest_pin.go
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package release
+
+import (
+	"crypto/sha256"
+	"embed"
+	"fmt"
+	"io/fs"
+	"path"
+	"strings"
+
+	"github.com/goplus/spx/v3/internal/strictjson"
+)
+
+const runtimeManifestPinSchema = 1
+
+// RuntimeManifestPin pins a release manifest independently of RuntimeLock.
+type RuntimeManifestPin struct {
+	Schema         int    `json:"schema"`
+	RuntimeVersion string `json:"runtime_version"`
+	Name           string `json:"name"`
+	Size           int64  `json:"size"`
+	SHA256         string `json:"sha256"`
+}
+
+var (
+	//go:embed runtime_manifest_pins/*.json
+	embeddedRuntimeManifestPins embed.FS
+	runtimeManifestPins         = mustLoadRuntimeManifestPins(embeddedRuntimeManifestPins)
+)
+
+func parseRuntimeManifestPin(data []byte) (RuntimeManifestPin, error) {
+	var pin RuntimeManifestPin
+	if err := strictjson.Decode(data, &pin); err != nil {
+		return RuntimeManifestPin{}, fmt.Errorf("decode runtime manifest pin: %w", err)
+	}
+	if err := pin.validate(); err != nil {
+		return RuntimeManifestPin{}, err
+	}
+	return pin, nil
+}
+
+func (p RuntimeManifestPin) validate() error {
+	if p.Schema != runtimeManifestPinSchema {
+		return fmt.Errorf("release: runtime manifest pin schema = %d, want %d", p.Schema, runtimeManifestPinSchema)
+	}
+	if !runtimeVersionPattern.MatchString(p.RuntimeVersion) {
+		return fmt.Errorf("release: invalid pinned runtime version %q", p.RuntimeVersion)
+	}
+	if err := validateBaseName("pinned runtime manifest", p.Name); err != nil {
+		return err
+	}
+	if p.Size <= 0 {
+		return fmt.Errorf("release: pinned runtime manifest size must be positive")
+	}
+	if !isLowerHexDigest(p.SHA256, sha256.Size*2) {
+		return fmt.Errorf("release: invalid pinned runtime manifest SHA-256 %q", p.SHA256)
+	}
+	return nil
+}
+
+// ValidateForLock checks a pin against one runtime lock.
+func (p RuntimeManifestPin) ValidateForLock(lock RuntimeLock) error {
+	if err := lock.Validate(); err != nil {
+		return err
+	}
+	if err := p.validate(); err != nil {
+		return err
+	}
+	if p.RuntimeVersion != lock.RuntimeVersion || p.Name != lock.Manifest {
+		return fmt.Errorf("release: runtime manifest pin does not match lock")
+	}
+	return nil
+}
+
+// RuntimeManifestPinForLock returns the pinned manifest identity for lock.
+// Missing pins fail closed.
+func RuntimeManifestPinForLock(lock RuntimeLock) (RuntimeManifestPin, error) {
+	if err := lock.Validate(); err != nil {
+		return RuntimeManifestPin{}, err
+	}
+	pin, ok := runtimeManifestPins[lock.RuntimeVersion]
+	if !ok {
+		return RuntimeManifestPin{}, fmt.Errorf("release: no runtime manifest pin for version %q", lock.RuntimeVersion)
+	}
+	if err := pin.ValidateForLock(lock); err != nil {
+		return RuntimeManifestPin{}, err
+	}
+	return pin, nil
+}
+
+func mustLoadRuntimeManifestPins(fileSystem fs.FS) map[string]RuntimeManifestPin {
+	files, err := fs.Glob(fileSystem, "runtime_manifest_pins/*.json")
+	if err != nil {
+		panic("release: list runtime manifest pins: " + err.Error())
+	}
+	pins := make(map[string]RuntimeManifestPin, len(files))
+	for _, file := range files {
+		data, err := fs.ReadFile(fileSystem, file)
+		if err != nil {
+			panic("release: read runtime manifest pin: " + err.Error())
+		}
+		pin, err := parseRuntimeManifestPin(data)
+		if err != nil {
+			panic("release: invalid runtime manifest pin: " + err.Error())
+		}
+		version := strings.TrimSuffix(path.Base(file), ".json")
+		if pin.RuntimeVersion != version {
+			panic(fmt.Sprintf("release: runtime manifest pin %s declares version %q", file, pin.RuntimeVersion))
+		}
+		if _, exists := pins[version]; exists {
+			panic("release: duplicate runtime manifest pin for " + version)
+		}
+		pins[version] = pin
+	}
+	return pins
+}

--- a/internal/release/runtime_manifest_pin_test.go
+++ b/internal/release/runtime_manifest_pin_test.go
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package release
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRuntimeManifestPinsMatchLocks(t *testing.T) {
+	if len(runtimeManifestPins) == 0 {
+		t.Fatal("no runtime manifest pins")
+	}
+	for version := range runtimeManifestPins {
+		t.Run(version, func(t *testing.T) {
+			lock, err := RuntimeLockForVersion(version)
+			if err != nil {
+				t.Fatal(err)
+			}
+			pin, err := RuntimeManifestPinForLock(lock)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if pin.RuntimeVersion != lock.RuntimeVersion || pin.Name != lock.Manifest || pin.Size <= 0 || len(pin.SHA256) != 64 {
+				t.Fatalf("runtime manifest pin = %#v", pin)
+			}
+		})
+	}
+}
+
+func TestRuntimeManifestPinValidation(t *testing.T) {
+	lock, err := RuntimeLockForVersion("2.4.1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	pin, err := RuntimeManifestPinForLock(lock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, mutate := range []func(*RuntimeManifestPin){
+		func(p *RuntimeManifestPin) { p.Schema++ },
+		func(p *RuntimeManifestPin) { p.RuntimeVersion = "invalid" },
+		func(p *RuntimeManifestPin) { p.Name = "../manifest.json" },
+		func(p *RuntimeManifestPin) { p.Size = 0 },
+		func(p *RuntimeManifestPin) { p.SHA256 = strings.Repeat("A", 64) },
+	} {
+		candidate := pin
+		mutate(&candidate)
+		if err := candidate.validate(); err == nil {
+			t.Fatalf("invalid runtime manifest pin accepted: %#v", candidate)
+		}
+	}
+}
+
+func TestRuntimeManifestPinForLockRejectsUnpinnedRuntime(t *testing.T) {
+	lock := DefaultRuntimeLock()
+	lock.RuntimeVersion = "9.9.9"
+	if _, err := RuntimeManifestPinForLock(lock); err == nil || !strings.Contains(err.Error(), "no runtime manifest pin") {
+		t.Fatalf("RuntimeManifestPinForLock error = %v", err)
+	}
+}
+
+func TestRuntimeManifestPinForLockDoesNotInventCurrentRuntime(t *testing.T) {
+	lock := DefaultRuntimeLock()
+	if lock.RuntimeVersion != "2.4.4" {
+		t.Fatalf("default runtime version = %q, want current unpublished 2.4.4", lock.RuntimeVersion)
+	}
+	if _, ok := runtimeManifestPins[lock.RuntimeVersion]; ok {
+		t.Fatalf("runtime manifest pin unexpectedly exists for unpublished %s", lock.RuntimeVersion)
+	}
+	if _, err := RuntimeManifestPinForLock(lock); err == nil || !strings.Contains(err.Error(), "no runtime manifest pin") {
+		t.Fatalf("RuntimeManifestPinForLock error = %v, want missing-pin failure", err)
+	}
+}

--- a/internal/release/runtime_manifest_pins/2.4.1.json
+++ b/internal/release/runtime_manifest_pins/2.4.1.json
@@ -1,0 +1,7 @@
+{
+  "schema": 1,
+  "runtime_version": "2.4.1",
+  "name": "runtime-manifest.json",
+  "size": 3563,
+  "sha256": "7fe10dfa089b62cffc57ba820deff4de36a5b84ec831803fa07cd5e9336b3be5"
+}

--- a/internal/release/runtime_manifest_pins/2.4.2.json
+++ b/internal/release/runtime_manifest_pins/2.4.2.json
@@ -1,0 +1,7 @@
+{
+  "schema": 1,
+  "runtime_version": "2.4.2",
+  "name": "runtime-manifest.json",
+  "size": 3563,
+  "sha256": "5a2f0621393c42c7ecf83c7fcda3a73fd6aac0149e1c4a375a9b2da602a16bd8"
+}

--- a/internal/release/runtime_manifest_pins/2.4.3.json
+++ b/internal/release/runtime_manifest_pins/2.4.3.json
@@ -1,0 +1,7 @@
+{
+  "schema": 1,
+  "runtime_version": "2.4.3",
+  "name": "runtime-manifest.json",
+  "size": 3563,
+  "sha256": "74252ff398cfeeb571adb3414b988a61a33ea028a7462b2e0e804c589856027d"
+}


### PR DESCRIPTION
## Summary

- resolve host runtime archive and installed output names from the runtime lock
- pin published runtime manifests independently from mutable release metadata
- publish content-addressed local Engine/PCK outputs with an atomic manifest
- make buildctl emit a self-contained local runtime source for launcher builds
- reuse strict JSON decoding for runtime locks and manifests

Runtime 2.4.4 intentionally has no manifest pin until its release manifest is published; published acquisition fails closed meanwhile.

## Validation

- `make buildctl`
- `go test -race -count=1 ./internal/release ./internal/cmd/buildctl/runtimecmd`
- `go vet ./...`
- `go test -count=1 ./...`
- Windows amd64 release/runtimecmd compilation
- `go mod tidy` (no diff)
- `git diff --check`