### PR TITLE
feat(xgolauncher): run embedded payloads offline

### DIFF
--- a/x/xgolauncher/command.go
+++ b/x/xgolauncher/command.go
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package xgolauncher
+
+import (
+	"context"
+	"errors"
+)
+
+// RunCommand owns signal cancellation around one launcher command.
+func RunCommand(parent context.Context, run func(context.Context) (ProcessStatus, error)) (ProcessStatus, error) {
+	if parent == nil {
+		parent = context.Background()
+	}
+	if run == nil {
+		return ProcessStatus{}, errors.New("xgolauncher: nil command")
+	}
+	return runCommand(parent, run)
+}

--- a/x/xgolauncher/command_unix.go
+++ b/x/xgolauncher/command_unix.go
@@ -1,0 +1,74 @@
+//go:build !windows
+
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package xgolauncher
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+
+	"github.com/goplus/spx/v3/internal/processsupervisor"
+)
+
+func runCommand(parent context.Context, run func(context.Context) (ProcessStatus, error)) (ProcessStatus, error) {
+	ctx, cancel := context.WithCancelCause(parent)
+	defer cancel(nil)
+	signals := make(chan os.Signal, 8)
+	done := make(chan struct{})
+	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP, syscall.SIGQUIT)
+	var (
+		mu       sync.Mutex
+		received syscall.Signal
+		wait     sync.WaitGroup
+	)
+	wait.Add(1)
+	go func() {
+		defer wait.Done()
+		for {
+			select {
+			case current := <-signals:
+				unixSignal, ok := current.(syscall.Signal)
+				if !ok {
+					continue
+				}
+				mu.Lock()
+				if received == 0 {
+					received = unixSignal
+					cancel(&processsupervisor.SignalCause{Signal: unixSignal})
+				}
+				mu.Unlock()
+			case <-done:
+				return
+			}
+		}
+	}()
+	status, err := run(ctx)
+	signal.Stop(signals)
+	close(done)
+	wait.Wait()
+	mu.Lock()
+	original := received
+	mu.Unlock()
+	if original != 0 {
+		return ProcessStatus{Signal: int(original)}, nil
+	}
+	return status, err
+}

--- a/x/xgolauncher/command_unix_test.go
+++ b/x/xgolauncher/command_unix_test.go
@@ -1,0 +1,139 @@
+//go:build !windows
+
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package xgolauncher
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/goplus/spx/v3/internal/processsupervisor"
+)
+
+func TestRunCommandCancelsCleanupBeforeReturningSignal(t *testing.T) {
+	cleaned := false
+	status, err := RunCommand(context.Background(), func(ctx context.Context) (ProcessStatus, error) {
+		defer func() { cleaned = true }()
+		if err := syscall.Kill(os.Getpid(), syscall.SIGTERM); err != nil {
+			return ProcessStatus{}, err
+		}
+		select {
+		case <-ctx.Done():
+			return ProcessStatus{}, ctx.Err()
+		case <-time.After(5 * time.Second):
+			return ProcessStatus{}, context.DeadlineExceeded
+		}
+	})
+	if err != nil || status.Signal != int(syscall.SIGTERM) {
+		t.Fatalf("RunCommand() = (%+v, %v), want SIGTERM", status, err)
+	}
+	if !cleaned {
+		t.Fatal("RunCommand returned before deferred cleanup")
+	}
+}
+
+func TestRunCommandIsSoleSignalOwnerForSupervisor(t *testing.T) {
+	if os.Getenv("SPX_LAUNCHER_SIGNAL_HELPER") == "1" {
+		runSignalRecordingHelper()
+		return
+	}
+	root := t.TempDir()
+	started := filepath.Join(root, "started")
+	recorded := filepath.Join(root, "signals")
+	type commandResult struct {
+		status ProcessStatus
+		err    error
+	}
+	result := make(chan commandResult, 1)
+	go func() {
+		status, err := RunCommand(context.Background(), func(ctx context.Context) (ProcessStatus, error) {
+			command := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestRunCommandIsSoleSignalOwnerForSupervisor$")
+			command.Env = append(os.Environ(),
+				"SPX_LAUNCHER_SIGNAL_HELPER=1",
+				"SPX_LAUNCHER_SIGNAL_STARTED="+started,
+				"SPX_LAUNCHER_SIGNAL_RECORDED="+recorded,
+			)
+			status, err := processsupervisor.Run(ctx, command)
+			return ProcessStatus{Code: status.Code, Signal: status.Signal}, err
+		})
+		result <- commandResult{status: status, err: err}
+	}()
+	waitForLauncherMarker(t, started)
+	if err := syscall.Kill(os.Getpid(), syscall.SIGINT); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case got := <-result:
+		if got.err != nil || got.status != (ProcessStatus{Signal: int(syscall.SIGINT)}) {
+			t.Fatalf("RunCommand supervisor result = (%+v, %v), want SIGINT", got.status, got.err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("RunCommand did not finish after SIGINT")
+	}
+	data, err := os.ReadFile(recorded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := strings.Fields(string(data)), []string{syscall.SIGINT.String()}; len(got) != 1 || got[0] != want[0] {
+		t.Fatalf("child signals = %q, want exactly %q", got, want)
+	}
+}
+
+func runSignalRecordingHelper() {
+	signals := make(chan os.Signal, 8)
+	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
+	defer signal.Stop(signals)
+	if err := os.WriteFile(os.Getenv("SPX_LAUNCHER_SIGNAL_STARTED"), []byte("started"), 0o600); err != nil {
+		os.Exit(70)
+	}
+	received := []string{(<-signals).String()}
+	timer := time.NewTimer(100 * time.Millisecond)
+	defer timer.Stop()
+	for {
+		select {
+		case current := <-signals:
+			received = append(received, current.String())
+		case <-timer.C:
+			if err := os.WriteFile(os.Getenv("SPX_LAUNCHER_SIGNAL_RECORDED"), []byte(strings.Join(received, "\n")+"\n"), 0o600); err != nil {
+				os.Exit(71)
+			}
+			return
+		}
+	}
+}
+
+func waitForLauncherMarker(t *testing.T, name string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if _, err := os.Stat(name); err == nil {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("launcher helper did not create %q", name)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}

--- a/x/xgolauncher/command_windows.go
+++ b/x/xgolauncher/command_windows.go
@@ -1,0 +1,56 @@
+//go:build windows
+
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package xgolauncher
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"sync"
+)
+
+func runCommand(parent context.Context, run func(context.Context) (ProcessStatus, error)) (ProcessStatus, error) {
+	ctx, cancel := context.WithCancel(parent)
+	defer cancel()
+	signals := make(chan os.Signal, 1)
+	signal.Notify(signals, os.Interrupt)
+	interrupted := make(chan struct{}, 1)
+	done := make(chan struct{})
+	var wait sync.WaitGroup
+	wait.Add(1)
+	go func() {
+		defer wait.Done()
+		select {
+		case <-signals:
+			interrupted <- struct{}{}
+			cancel()
+		case <-done:
+		}
+	}()
+	status, err := run(ctx)
+	signal.Stop(signals)
+	close(done)
+	wait.Wait()
+	select {
+	case <-interrupted:
+		return ProcessStatus{Code: 130}, nil
+	default:
+		return status, err
+	}
+}

--- a/x/xgolauncher/launcher.go
+++ b/x/xgolauncher/launcher.go
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package xgolauncher verifies and runs a self-contained SPX payload offline.
+package xgolauncher
+
+import (
+	"context"
+	"io"
+)
+
+// ProcessStatus preserves a process exit code or host signal.
+type ProcessStatus struct {
+	Code   int
+	Signal int
+}
+
+// Success reports whether the process exited normally with status zero.
+func (s ProcessStatus) Success() bool { return s.Signal == 0 && s.Code == 0 }
+
+// Config describes one embedded launcher invocation.
+type Config struct {
+	// Payload must remain unchanged while Run is active.
+	Payload        []byte
+	PayloadSHA256  string
+	ManifestSHA256 string
+	Args           []string
+	Stdin          io.Reader
+	Stdout         io.Writer
+	Stderr         io.Writer
+}
+
+// Run verifies, materializes, and executes an embedded payload.
+func Run(cfg Config) (ProcessStatus, error) {
+	return RunContext(context.Background(), cfg)
+}
+
+// RunContext is Run with caller-controlled cancellation.
+func RunContext(ctx context.Context, cfg Config) (ProcessStatus, error) {
+	return run(ctx, cfg, "")
+}

--- a/x/xgolauncher/launcher_unix_test.go
+++ b/x/xgolauncher/launcher_unix_test.go
@@ -1,0 +1,240 @@
+//go:build !windows
+
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package xgolauncher
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/goplus/spx/v3/internal/runtimebundle"
+	"github.com/goplus/spx/v3/internal/runtimepayload"
+)
+
+func TestRunEmbeddedPayloadAndRepairCache(t *testing.T) {
+	script := `#!/bin/sh
+printf 'ARGV='
+for arg in "$@"; do printf '<%s>' "$arg"; done
+printf '\n'
+actual_cwd=$(pwd -P)
+printf 'ROOTS=<%s><%s><%s><%s>\n' "$SPX_PROJECT_DIR" "$SPX_ASSET_DIR" "$SPX_SESSION_DIR" "$actual_cwd"
+[ -f "$SPX_PROJECT_DIR/main.spx" ] || { printf 'missing project\n' >&2; exit 91; }
+[ -f "$SPX_ASSET_DIR/index.json" ] || { printf 'missing asset index\n' >&2; exit 92; }
+[ "$actual_cwd" -ef "$SPX_SESSION_DIR" ] || { printf 'wrong cwd\n' >&2; exit 93; }
+printf 'FAKE_ENGINE_OK\n'
+exit 42
+`
+	payload, payloadDigest, manifestDigest, manifest := launcherTestPayload(t, script)
+	cacheRoot := filepath.Join(t.TempDir(), "cache")
+	var stdout, stderr bytes.Buffer
+	cfg := Config{
+		Payload: payload, PayloadSHA256: payloadDigest, ManifestSHA256: manifestDigest,
+		Args: []string{"xgo-driver-v1", "", "a b", "--"}, Stdout: &stdout, Stderr: &stderr,
+	}
+	status, err := run(context.Background(), cfg, cacheRoot)
+	if err != nil {
+		t.Fatalf("run error = %v, stdout = %q, stderr = %q", err, stdout.String(), stderr.String())
+	}
+	if status != (ProcessStatus{Code: 42}) {
+		t.Fatalf("status = %+v, stdout = %q, stderr = %q", status, stdout.String(), stderr.String())
+	}
+	if got := stdout.String(); !strings.Contains(got, "ARGV=<xgo-driver-v1><><a b><-->") || !strings.Contains(got, "FAKE_ENGINE_OK") {
+		t.Fatalf("stdout = %q", got)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+
+	enginePath := filepath.Join(cacheRoot, string(runtimebundle.NamespaceEngine), manifest.Engine.BundleDigest, manifest.Engine.Executable)
+	if err := os.WriteFile(enginePath, []byte("tampered"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	stdout.Reset()
+	cfg.Args = nil
+	status, err = run(context.Background(), cfg, cacheRoot)
+	if err != nil {
+		t.Fatalf("cache repair error = %v, stdout = %q, stderr = %q", err, stdout.String(), stderr.String())
+	}
+	if status.Code != 42 || status.Signal != 0 || !strings.Contains(stdout.String(), "FAKE_ENGINE_OK") {
+		t.Fatalf("cache repair status = %+v, stdout = %q, stderr = %q", status, stdout.String(), stderr.String())
+	}
+}
+
+func TestRunPreservesEngineSignal(t *testing.T) {
+	payload, payloadDigest, manifestDigest, _ := launcherTestPayload(t, "#!/bin/sh\nkill -TERM $$\n")
+	status, err := run(context.Background(), Config{
+		Payload: payload, PayloadSHA256: payloadDigest, ManifestSHA256: manifestDigest, Stderr: &bytes.Buffer{},
+	}, filepath.Join(t.TempDir(), "cache"))
+	if err != nil {
+		t.Fatalf("run error = %v", err)
+	}
+	if status.Code != 0 || status.Signal != int(syscall.SIGTERM) {
+		t.Fatalf("status = %+v, want signal %d", status, syscall.SIGTERM)
+	}
+}
+
+func TestRunRejectsReservedEnginePath(t *testing.T) {
+	payload, payloadDigest, manifestDigest, _ := launcherTestPayload(t, "#!/bin/sh\nexit 0\n")
+	var stderr bytes.Buffer
+	status, err := run(context.Background(), Config{
+		Payload: payload, PayloadSHA256: payloadDigest, ManifestSHA256: manifestDigest,
+		Args: []string{"--path=/host"}, Stderr: &stderr,
+	}, filepath.Join(t.TempDir(), "cache"))
+	if err == nil || !strings.Contains(err.Error(), "--path is reserved") {
+		t.Fatalf("error = %v, want reserved path error", err)
+	}
+	if status != (ProcessStatus{}) || stderr.Len() != 0 {
+		t.Fatalf("status = %+v, stderr = %q", status, stderr.String())
+	}
+}
+
+func TestExitReproducesSignal(t *testing.T) {
+	if os.Getenv("SPX_LAUNCHER_EXIT_HELPER") == "1" {
+		Exit(ProcessStatus{Signal: int(syscall.SIGTERM)})
+		return
+	}
+	command := exec.Command(os.Args[0], "-test.run=^TestExitReproducesSignal$")
+	command.Env = append(os.Environ(), "SPX_LAUNCHER_EXIT_HELPER=1")
+	err := command.Run()
+	exitError, ok := err.(*exec.ExitError)
+	if !ok {
+		t.Fatalf("helper error = %v, want ExitError", err)
+	}
+	wait, ok := exitError.ProcessState.Sys().(syscall.WaitStatus)
+	if !ok || !wait.Signaled() || wait.Signal() != syscall.SIGTERM {
+		t.Fatalf("helper wait status = %v, want SIGTERM", exitError.ProcessState.Sys())
+	}
+}
+
+func launcherTestPayload(t *testing.T, engineScript string) ([]byte, string, string, runtimepayload.Manifest) {
+	t.Helper()
+	engineFiles := []launcherTestFile{
+		{Name: "runtime-manifest.json", Mode: 0o644, Data: []byte(`{"schema":"test-engine/v1"}`)},
+		{Name: "engine", Mode: 0o755, Data: []byte(engineScript)},
+		{Name: "engine.pck", Mode: 0o644, Data: []byte("pack")},
+	}
+	bridgeFiles := []launcherTestFile{
+		{Name: "bridge-manifest.json", Mode: 0o644, Data: []byte(`{"schema":"test-bridge/v1"}`)},
+		{Name: "bridge.so", Mode: 0o755, Data: []byte("bridge")},
+	}
+	projectFiles := []launcherTestFile{
+		{Name: "main.spx", Mode: 0o644, Data: []byte("onStart => {}")},
+		{Name: "assets/index.json", Mode: 0o644, Data: []byte(`{"zorder":[]}`)},
+	}
+	engineZIP := launcherTestZIP(t, engineFiles)
+	bridgeZIP := launcherTestZIP(t, bridgeFiles)
+	projectZIP := launcherTestZIP(t, projectFiles)
+	engine := launcherTestBundle(t, engineZIP, runtimebundle.NamespaceEngine)
+	bridge := launcherTestBundle(t, bridgeZIP, runtimebundle.NamespaceBridge)
+	project := launcherTestBundle(t, projectZIP, runtimebundle.NamespaceProject)
+	projectSum := sha256.Sum256(projectZIP)
+	interfaceSum := sha256.Sum256([]byte("interface"))
+	config := runtimepayload.BuildConfig{
+		SPX:    runtimepayload.SourceIdentity{SelectedPath: "github.com/goplus/spx/v3", EffectivePath: "github.com/goplus/spx/v3", SourceMode: true},
+		Target: runtimepayload.Target{GOOS: runtime.GOOS, GOARCH: runtime.GOARCH},
+		Engine: runtimepayload.Engine{
+			RuntimeVersion: "test", RuntimeABI: 1, EngineInterfaceDigest: hex.EncodeToString(interfaceSum[:]),
+			Executable: "engine", Pack: "engine.pck", BundleDigest: engine.Digest,
+		},
+		Bridge: runtimepayload.Bridge{File: "bridge.so", BundleDigest: bridge.Digest},
+		Project: runtimepayload.Project{
+			PackDirectory: "assets", BundleDigest: project.Digest, ArchiveSHA256: hex.EncodeToString(projectSum[:]),
+		},
+	}
+	sources := launcherTestSources(
+		launcherTestFile{Name: "engine/runtime-manifest.json", Mode: 0o644, Data: engineFiles[0].Data},
+		launcherTestFile{Name: "engine/engine", Mode: 0o755, Data: engineFiles[1].Data},
+		launcherTestFile{Name: "engine/engine.pck", Mode: 0o644, Data: engineFiles[2].Data},
+		launcherTestFile{Name: "bridge/bridge-manifest.json", Mode: 0o644, Data: bridgeFiles[0].Data},
+		launcherTestFile{Name: "bridge/bridge.so", Mode: 0o755, Data: bridgeFiles[1].Data},
+		launcherTestFile{Name: runtimepayload.ProjectZipPath, Mode: 0o644, Data: projectZIP},
+	)
+	var payload bytes.Buffer
+	payloadDigest, manifestDigest, err := runtimepayload.BuildTo(&payload, config, sources)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payloadBytes := append([]byte(nil), payload.Bytes()...)
+	verified, err := runtimepayload.Verify(payloadBytes, payloadDigest, manifestDigest, runtime.GOOS, runtime.GOARCH)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return payloadBytes, payloadDigest, manifestDigest, verified.Manifest
+}
+
+type launcherTestFile struct {
+	Name string
+	Mode os.FileMode
+	Data []byte
+}
+
+func launcherTestSources(files ...launcherTestFile) []runtimepayload.FileSource {
+	sources := make([]runtimepayload.FileSource, len(files))
+	for i, file := range files {
+		sources[i] = runtimepayload.FileSource{
+			Name: file.Name, Mode: file.Mode, ReaderAt: bytes.NewReader(file.Data), Size: int64(len(file.Data)),
+		}
+	}
+	return sources
+}
+
+func launcherTestZIP(t *testing.T, files []launcherTestFile) []byte {
+	t.Helper()
+	files = append([]launcherTestFile(nil), files...)
+	sort.Slice(files, func(i, j int) bool { return files[i].Name < files[j].Name })
+	var data bytes.Buffer
+	writer := zip.NewWriter(&data)
+	canonicalTime := time.Date(1980, time.January, 1, 0, 0, 0, 0, time.UTC)
+	for _, file := range files {
+		header := &zip.FileHeader{Name: file.Name, Method: zip.Store}
+		header.SetMode(file.Mode)
+		header.SetModTime(canonicalTime)
+		entry, err := writer.CreateHeader(header)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := entry.Write(file.Data); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return data.Bytes()
+}
+
+func launcherTestBundle(t *testing.T, data []byte, namespace runtimebundle.Namespace) runtimebundle.Bundle {
+	t.Helper()
+	bundle, err := runtimepayload.ComponentBundleReaderAt(bytes.NewReader(data), int64(len(data)), namespace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return bundle
+}

--- a/x/xgolauncher/materialize.go
+++ b/x/xgolauncher/materialize.go
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package xgolauncher
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/goplus/spx/v3/internal/runtimebundle"
+	"github.com/goplus/spx/v3/internal/runtimepayload"
+)
+
+func materializeComponent(ctx context.Context, cache *runtimebundle.Cache, workDir string, namespace runtimebundle.Namespace, expectedDigest string, write func(io.Writer) error) (*runtimebundle.Materialized, error) {
+	if ctx == nil {
+		return nil, fmt.Errorf("xgolauncher: nil materialization context")
+	}
+	if write == nil {
+		return nil, fmt.Errorf("xgolauncher: nil component writer")
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	zipPath := filepath.Join(workDir, string(namespace)+".zip")
+	file, err := os.OpenFile(zipPath, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	closeFile := true
+	defer func() {
+		if closeFile {
+			_ = file.Close()
+		}
+	}()
+	if err := write(contextWriter{ctx: ctx, dst: file}); err != nil {
+		return nil, err
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if err := file.Sync(); err != nil {
+		return nil, err
+	}
+	info, err := file.Stat()
+	if err != nil {
+		return nil, err
+	}
+	bundle, err := runtimepayload.ComponentBundleReaderAt(file, info.Size(), namespace)
+	if err != nil {
+		return nil, err
+	}
+	if bundle.Digest != expectedDigest {
+		return nil, fmt.Errorf("embedded %s identity changed after payload verification", namespace)
+	}
+	if err := file.Close(); err != nil {
+		return nil, err
+	}
+	closeFile = false
+	return cache.Materialize(ctx, namespace, zipPath, &bundle)
+}
+
+type contextWriter struct {
+	ctx context.Context
+	dst io.Writer
+}
+
+func (w contextWriter) Write(p []byte) (int, error) {
+	if err := w.ctx.Err(); err != nil {
+		return 0, err
+	}
+	return w.dst.Write(p)
+}

--- a/x/xgolauncher/run.go
+++ b/x/xgolauncher/run.go
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package xgolauncher
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"github.com/goplus/spx/v3/internal/interpruntime"
+	"github.com/goplus/spx/v3/internal/processsupervisor"
+	"github.com/goplus/spx/v3/internal/runtimebundle"
+	"github.com/goplus/spx/v3/internal/runtimepayload"
+)
+
+func run(ctx context.Context, cfg Config, cacheRoot string) (ProcessStatus, error) {
+	if ctx == nil {
+		return ProcessStatus{}, errors.New("xgolauncher: nil context")
+	}
+	if err := ctx.Err(); err != nil {
+		return ProcessStatus{}, err
+	}
+	verified, err := runtimepayload.Verify(cfg.Payload, cfg.PayloadSHA256, cfg.ManifestSHA256, runtime.GOOS, runtime.GOARCH)
+	if err != nil {
+		return ProcessStatus{}, err
+	}
+	if err := ctx.Err(); err != nil {
+		return ProcessStatus{}, err
+	}
+	if cacheRoot == "" {
+		cacheRoot = runtimebundle.DefaultCacheRoot()
+	}
+	cache := runtimebundle.NewCache(cacheRoot)
+	if _, err := cache.Path(runtimebundle.NamespaceEngine, verified.Manifest.Engine.BundleDigest); err != nil {
+		return ProcessStatus{}, fmt.Errorf("xgolauncher: validate cache root: %w", err)
+	}
+
+	workDir, err := os.MkdirTemp("", "spx-launcher-")
+	if err != nil {
+		return ProcessStatus{}, fmt.Errorf("xgolauncher: create launcher work directory: %w", err)
+	}
+	defer os.RemoveAll(workDir)
+
+	engine, err := materializeComponent(ctx, cache, workDir, runtimebundle.NamespaceEngine, verified.Manifest.Engine.BundleDigest, func(dst io.Writer) error {
+		return verified.WriteComponentZIP("engine/", dst)
+	})
+	if err != nil {
+		return ProcessStatus{}, fmt.Errorf("xgolauncher: materialize Engine: %w", err)
+	}
+	defer engine.Close()
+	bridge, err := materializeComponent(ctx, cache, workDir, runtimebundle.NamespaceBridge, verified.Manifest.Bridge.BundleDigest, func(dst io.Writer) error {
+		return verified.WriteComponentZIP("bridge/", dst)
+	})
+	if err != nil {
+		return ProcessStatus{}, fmt.Errorf("xgolauncher: materialize bridge: %w", err)
+	}
+	defer bridge.Close()
+	project, err := materializeComponent(ctx, cache, workDir, runtimebundle.NamespaceProject, verified.Manifest.Project.BundleDigest, func(dst io.Writer) error {
+		return verified.WriteProjectZIP(dst)
+	})
+	if err != nil {
+		return ProcessStatus{}, fmt.Errorf("xgolauncher: materialize project: %w", err)
+	}
+	defer project.Close()
+
+	if err := ctx.Err(); err != nil {
+		return ProcessStatus{}, err
+	}
+	sessionDir, err := os.MkdirTemp("", "spx-session-")
+	if err != nil {
+		return ProcessStatus{}, fmt.Errorf("xgolauncher: create Engine session: %w", err)
+	}
+	defer os.RemoveAll(sessionDir)
+	if err := ctx.Err(); err != nil {
+		return ProcessStatus{}, err
+	}
+	roots := interpruntime.Roots{
+		ProjectDir: project.Path,
+		AssetDir:   filepath.Join(project.Path, filepath.FromSlash(verified.Manifest.Project.PackDirectory)),
+		SessionDir: sessionDir,
+	}
+	bridgePath := filepath.Join(bridge.Path, verified.Manifest.Bridge.File)
+	if err := interpruntime.PrepareSession(interpruntime.SessionConfig{Roots: roots, BridgePath: bridgePath}); err != nil {
+		return ProcessStatus{}, fmt.Errorf("xgolauncher: prepare Engine session: %w", err)
+	}
+	command, err := interpruntime.PrepareCommand(ctx, interpruntime.CommandConfig{
+		Roots: roots, Executable: filepath.Join(engine.Path, verified.Manifest.Engine.Executable),
+		Args: cfg.Args, Env: os.Environ(), Stdin: cfg.Stdin, Stdout: cfg.Stdout, Stderr: cfg.Stderr,
+		PathPolicy: interpruntime.RejectPath,
+	})
+	if err != nil {
+		return ProcessStatus{}, fmt.Errorf("xgolauncher: prepare Engine command: %w", err)
+	}
+	status, err := processsupervisor.Run(ctx, command)
+	if err != nil {
+		return ProcessStatus{}, fmt.Errorf("xgolauncher: run Engine: %w", err)
+	}
+	return ProcessStatus{Code: status.Code, Signal: status.Signal}, nil
+}

--- a/x/xgolauncher/status_unix.go
+++ b/x/xgolauncher/status_unix.go
@@ -1,0 +1,40 @@
+//go:build !windows
+
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package xgolauncher
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+)
+
+// Exit preserves signal termination at the launcher boundary.
+func Exit(status ProcessStatus) {
+	if status.Signal != 0 {
+		sig := syscall.Signal(status.Signal)
+		signal.Reset(sig)
+		if err := syscall.Kill(os.Getpid(), sig); err == nil {
+			// Let the restored disposition terminate before fallback.
+			time.Sleep(time.Second)
+		}
+		os.Exit(128 + status.Signal)
+	}
+	os.Exit(status.Code)
+}

--- a/x/xgolauncher/status_windows.go
+++ b/x/xgolauncher/status_windows.go
@@ -1,0 +1,29 @@
+//go:build windows
+
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package xgolauncher
+
+import "os"
+
+// Exit terminates a Windows launcher with a conventional signal fallback.
+func Exit(status ProcessStatus) {
+	if status.Signal != 0 {
+		os.Exit(128 + status.Signal)
+	}
+	os.Exit(status.Code)
+}


### PR DESCRIPTION
## Summary

- verify and materialize canonical embedded runtime payloads without downloads
- run each launcher in isolated project, asset, and session roots
- preserve process exits and signals across Unix and Windows

## Validation

- `go test -race ./x/xgolauncher`
- `go test ./...`
- `go vet ./...`
- Windows amd64 test compile
- `go mod tidy -diff`
- `git diff --check`