### PR TITLE
feat(ispxnative): load pinned portable project config

### DIFF
--- a/cmd/ispxnative/main.go
+++ b/cmd/ispxnative/main.go
@@ -57,14 +57,22 @@ func run(env []string) (int, error) {
 	if err := validateAssetIndex(roots.AssetDir); err != nil {
 		return 1, err
 	}
-	if err := ispx.ConfigureLegacyFilesystemRoots(roots.ProjectDir, roots.AssetDir); err != nil {
+	configOverlay, err := loadPortableConfigOverlay(env, roots)
+	if err != nil {
+		return 1, err
+	}
+	configureRoots := ispx.ConfigureLegacyFilesystemRoots
+	if configOverlay != nil {
+		configureRoots = ispx.ConfigureFilesystemRoots
+	}
+	if err := configureRoots(roots.ProjectDir, roots.AssetDir); err != nil {
 		return 1, fmt.Errorf("configure filesystem roots: %w", err)
 	}
 	if err := ispx.Init(nil); err != nil {
 		return 1, fmt.Errorf("initialize interpreter: %w", err)
 	}
 
-	if err := buildPinnedProject(roots.ProjectDir, ispx.BuildFS); err != nil {
+	if err := buildPinnedProject(roots.ProjectDir, configOverlay, ispx.BuildFS); err != nil {
 		return 1, fmt.Errorf("build project: %w", err)
 	}
 
@@ -75,13 +83,17 @@ func run(env []string) (int, error) {
 	return exitCode, nil
 }
 
-// buildPinnedProject retains its root because BuildFS may load resources later.
-func buildPinnedProject(projectDir string, build func(fs.FS) error) error {
+// buildPinnedProject keeps the root open for deferred resource loads.
+func buildPinnedProject(projectDir string, configOverlay *portableConfigOverlay, build func(fs.FS) error) error {
 	projectRoot, err := openPinnedProjectRoot(projectDir)
 	if err != nil {
 		return err
 	}
-	if err := build(projectRoot.FS()); err != nil {
+	projectFS := fs.FS(projectRoot.FS())
+	if configOverlay != nil {
+		projectFS = newPortableConfigFS(projectFS, configOverlay)
+	}
+	if err := build(projectFS); err != nil {
 		projectRoot.Close()
 		return err
 	}

--- a/cmd/ispxnative/main_test.go
+++ b/cmd/ispxnative/main_test.go
@@ -95,7 +95,7 @@ func TestBuildPinnedProjectKeepsFilesystemAliveForDeferredResourceLoads(t *testi
 	}
 
 	var runtimeFS fs.FS
-	if err := buildPinnedProject(projectDir, func(fsys fs.FS) error {
+	if err := buildPinnedProject(projectDir, nil, func(fsys fs.FS) error {
 		runtimeFS = fsys
 		return nil
 	}); err != nil {
@@ -116,7 +116,7 @@ func TestBuildPinnedProjectClosesFilesystemOnBuildFailure(t *testing.T) {
 
 	wantErr := errors.New("build failed")
 	var failedFS fs.FS
-	err := buildPinnedProject(projectDir, func(fsys fs.FS) error {
+	err := buildPinnedProject(projectDir, nil, func(fsys fs.FS) error {
 		failedFS = fsys
 		return wantErr
 	})

--- a/cmd/ispxnative/portable_config.go
+++ b/cmd/ispxnative/portable_config.go
@@ -1,0 +1,61 @@
+//go:build !js || !wasm
+
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/goplus/spx/v3/internal/interpruntime"
+	"github.com/goplus/spx/v3/internal/projectpolicy"
+)
+
+type portableConfigOverlay struct {
+	present bool
+	data    []byte
+}
+
+func loadPortableConfigOverlay(env []string, roots interpruntime.Roots) (*portableConfigOverlay, error) {
+	configDir, expectedIdentity, found, err := interpruntime.PortableConfigFromEnv(env)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, nil
+	}
+	if err := validatePortableConfigDir(roots.SessionDir, configDir); err != nil {
+		return nil, err
+	}
+	configRoot, err := openPortableConfigRoot(roots.SessionDir, configDir)
+	if err != nil {
+		return nil, err
+	}
+	defer configRoot.Close()
+	snapshot, err := projectpolicy.SnapshotPortableConfigRoot(configRoot)
+	if err != nil {
+		return nil, fmt.Errorf("ispxnative: load portable config snapshot: %w", err)
+	}
+	identity, err := snapshot.Identity()
+	if err != nil {
+		return nil, fmt.Errorf("ispxnative: identify portable config snapshot: %w", err)
+	}
+	if identity != expectedIdentity {
+		return nil, fmt.Errorf("ispxnative: portable config identity mismatch")
+	}
+	return &portableConfigOverlay{present: snapshot.Present(), data: snapshot.Bytes()}, nil
+}

--- a/cmd/ispxnative/portable_config_fs.go
+++ b/cmd/ispxnative/portable_config_fs.go
@@ -1,0 +1,167 @@
+//go:build !js || !wasm
+
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"bytes"
+	"io"
+	"io/fs"
+	"runtime"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+// portableConfigFS replaces the project .config with the validated snapshot.
+// When the snapshot is absent, it hides a project .config instead.
+type portableConfigFS struct {
+	base    fs.FS
+	present bool
+	data    []byte
+}
+
+func newPortableConfigFS(base fs.FS, overlay *portableConfigOverlay) *portableConfigFS {
+	return &portableConfigFS{base: base, present: overlay.present, data: overlay.data}
+}
+
+func (f *portableConfigFS) Open(name string) (fs.File, error) {
+	if isPortableConfigPath(name) {
+		if !isPortableConfigName(name) || !f.present {
+			return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrNotExist}
+		}
+		return newPortableConfigFile(f.data), nil
+	}
+	file, err := f.base.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	if name == "." {
+		directory, _ := file.(fs.ReadDirFile)
+		return &portableConfigRoot{File: file, directory: directory, overlay: f}, nil
+	}
+	return file, nil
+}
+
+func (f *portableConfigFS) ReadDir(name string) ([]fs.DirEntry, error) {
+	if isPortableConfigPath(name) {
+		return nil, &fs.PathError{Op: "readdir", Path: name, Err: fs.ErrNotExist}
+	}
+	entries, err := fs.ReadDir(f.base, name)
+	if err != nil {
+		return nil, err
+	}
+	if name == "." {
+		entries = f.overlayRootEntries(entries)
+	}
+	return entries, nil
+}
+
+func (f *portableConfigFS) overlayRootEntries(entries []fs.DirEntry) []fs.DirEntry {
+	result := make([]fs.DirEntry, 0, len(entries)+1)
+	for _, entry := range entries {
+		if isPortableConfigName(entry.Name()) {
+			continue
+		}
+		result = append(result, entry)
+	}
+	if f.present {
+		result = append(result, fs.FileInfoToDirEntry(portableConfigInfo{size: int64(len(f.data))}))
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].Name() < result[j].Name() })
+	return result
+}
+
+func isPortableConfigPath(name string) bool {
+	first, _, _ := strings.Cut(name, "/")
+	return isPortableConfigName(first)
+}
+
+func isPortableConfigName(name string) bool {
+	return name == ".config" || (runtime.GOOS == "windows" && strings.EqualFold(name, ".config"))
+}
+
+type portableConfigRoot struct {
+	fs.File
+	directory fs.ReadDirFile
+	overlay   *portableConfigFS
+	once      sync.Once
+	mu        sync.Mutex
+	entries   []fs.DirEntry
+	err       error
+	offset    int
+}
+
+func (f *portableConfigRoot) ReadDir(n int) ([]fs.DirEntry, error) {
+	f.once.Do(func() {
+		if f.directory == nil {
+			f.err = &fs.PathError{Op: "readdir", Path: ".", Err: fs.ErrInvalid}
+		} else {
+			entries, err := f.directory.ReadDir(-1)
+			if err != nil {
+				f.err = err
+			} else {
+				f.entries = f.overlay.overlayRootEntries(entries)
+			}
+		}
+	})
+	if f.err != nil {
+		return nil, f.err
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if n <= 0 {
+		entries := f.entries[f.offset:]
+		f.offset = len(f.entries)
+		return entries, nil
+	}
+	if f.offset >= len(f.entries) {
+		return nil, io.EOF
+	}
+	end := min(f.offset+n, len(f.entries))
+	entries := f.entries[f.offset:end]
+	f.offset = end
+	if len(entries) < n {
+		return entries, io.EOF
+	}
+	return entries, nil
+}
+
+type portableConfigFile struct {
+	*bytes.Reader
+	info portableConfigInfo
+}
+
+func newPortableConfigFile(data []byte) *portableConfigFile {
+	return &portableConfigFile{Reader: bytes.NewReader(data), info: portableConfigInfo{size: int64(len(data))}}
+}
+
+func (f *portableConfigFile) Close() error               { return nil }
+func (f *portableConfigFile) Stat() (fs.FileInfo, error) { return f.info, nil }
+
+type portableConfigInfo struct {
+	size int64
+}
+
+func (portableConfigInfo) Name() string       { return ".config" }
+func (i portableConfigInfo) Size() int64      { return i.size }
+func (portableConfigInfo) Mode() fs.FileMode  { return 0o444 }
+func (portableConfigInfo) ModTime() time.Time { return time.Time{} }
+func (portableConfigInfo) IsDir() bool        { return false }
+func (portableConfigInfo) Sys() any           { return nil }

--- a/cmd/ispxnative/portable_config_root.go
+++ b/cmd/ispxnative/portable_config_root.go
@@ -1,0 +1,108 @@
+//go:build !js || !wasm
+
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func validatePortableConfigDir(sessionDir, configDir string) error {
+	if configDir == "" {
+		return fmt.Errorf("ispxnative: portable config directory is empty")
+	}
+	if !filepath.IsAbs(configDir) {
+		return fmt.Errorf("ispxnative: portable config directory %q is not absolute", configDir)
+	}
+	if clean := filepath.Clean(configDir); clean != configDir {
+		return fmt.Errorf("ispxnative: portable config directory %q is not clean (want %q)", configDir, clean)
+	}
+	info, err := os.Lstat(configDir)
+	if err != nil {
+		return fmt.Errorf("ispxnative: inspect portable config directory %q: %w", configDir, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		return fmt.Errorf("ispxnative: portable config directory %q must be a real directory", configDir)
+	}
+	canonicalSession, err := filepath.EvalSymlinks(sessionDir)
+	if err != nil {
+		return fmt.Errorf("ispxnative: canonicalize session directory %q: %w", sessionDir, err)
+	}
+	canonicalConfig, err := filepath.EvalSymlinks(configDir)
+	if err != nil {
+		return fmt.Errorf("ispxnative: canonicalize portable config directory %q: %w", configDir, err)
+	}
+	rel, err := filepath.Rel(canonicalSession, canonicalConfig)
+	if err != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("ispxnative: portable config directory %q must be below session directory %q", configDir, sessionDir)
+	}
+	return nil
+}
+
+func openPortableConfigRoot(sessionDir, configDir string) (*os.Root, error) {
+	rel, err := filepath.Rel(sessionDir, configDir)
+	if err != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
+		return nil, fmt.Errorf("ispxnative: portable config directory %q is outside session directory %q", configDir, sessionDir)
+	}
+	sessionBefore, err := os.Lstat(sessionDir)
+	if err != nil {
+		return nil, fmt.Errorf("ispxnative: inspect session directory: %w", err)
+	}
+	if sessionBefore.Mode()&os.ModeSymlink != 0 || !sessionBefore.IsDir() {
+		return nil, fmt.Errorf("ispxnative: session directory %q must be a real directory", sessionDir)
+	}
+	sessionRoot, err := os.OpenRoot(sessionDir)
+	if err != nil {
+		return nil, fmt.Errorf("ispxnative: open session directory: %w", err)
+	}
+	opened, statErr := sessionRoot.Stat(".")
+	sessionAfter, pathErr := os.Lstat(sessionDir)
+	if statErr != nil || pathErr != nil || opened == nil || !opened.IsDir() || !os.SameFile(sessionBefore, opened) || !os.SameFile(opened, sessionAfter) {
+		_ = sessionRoot.Close()
+		return nil, fmt.Errorf("ispxnative: session directory changed while opening")
+	}
+	before, err := sessionRoot.Lstat(rel)
+	if err != nil {
+		_ = sessionRoot.Close()
+		return nil, fmt.Errorf("ispxnative: inspect portable config directory: %w", err)
+	}
+	if before.Mode()&os.ModeSymlink != 0 || !before.IsDir() {
+		_ = sessionRoot.Close()
+		return nil, fmt.Errorf("ispxnative: portable config directory %q must be a real directory", configDir)
+	}
+	configRoot, err := sessionRoot.OpenRoot(rel)
+	if err != nil {
+		_ = sessionRoot.Close()
+		return nil, fmt.Errorf("ispxnative: open portable config directory: %w", err)
+	}
+	openedConfig, statErr := configRoot.Stat(".")
+	pathAfter, pathErr := sessionRoot.Lstat(rel)
+	if statErr != nil || pathErr != nil || openedConfig == nil || !os.SameFile(before, openedConfig) || !os.SameFile(openedConfig, pathAfter) {
+		_ = configRoot.Close()
+		_ = sessionRoot.Close()
+		return nil, fmt.Errorf("ispxnative: portable config directory changed while opening")
+	}
+	if err := sessionRoot.Close(); err != nil {
+		_ = configRoot.Close()
+		return nil, fmt.Errorf("ispxnative: close session directory: %w", err)
+	}
+	return configRoot, nil
+}

--- a/cmd/ispxnative/portable_config_test.go
+++ b/cmd/ispxnative/portable_config_test.go
@@ -1,0 +1,258 @@
+//go:build !js || !wasm
+
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/goplus/spx/v3/internal/interpruntime"
+	"github.com/goplus/spx/v3/internal/projectpolicy"
+)
+
+func TestPortableConfigFSUsesCapturedBytes(t *testing.T) {
+	projectDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(projectDir, ".config"), []byte(`{"extasset":"live"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(projectDir, "main.spx"), []byte("onStart => {}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	want := []byte(`{"name":"captured"}`)
+	overlayFS := newPortableConfigFS(os.DirFS(projectDir), &portableConfigOverlay{present: true, data: want})
+
+	got, err := fs.ReadFile(overlayFS, ".config")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(want) {
+		t.Fatalf(".config = %q, want %q", got, want)
+	}
+	assertSinglePortableConfigEntry(t, mustReadDir(t, overlayFS))
+
+	root, err := overlayFS.Open(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer root.Close()
+	directory, ok := root.(fs.ReadDirFile)
+	if !ok {
+		t.Fatal("Open root does not implement fs.ReadDirFile")
+	}
+	entries, err := directory.ReadDir(-1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertSinglePortableConfigEntry(t, entries)
+}
+
+func TestPortableConfigFSHidesAbsentConfig(t *testing.T) {
+	projectDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(projectDir, ".config"), []byte(`{"name":"late"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	overlayFS := newPortableConfigFS(os.DirFS(projectDir), &portableConfigOverlay{})
+	if _, err := fs.ReadFile(overlayFS, ".config"); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("ReadFile(.config) error = %v, want not exist", err)
+	}
+	if _, err := overlayFS.Open(".config/child"); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("Open(.config/child) error = %v, want not exist", err)
+	}
+	for _, entry := range mustReadDir(t, overlayFS) {
+		if isPortableConfigName(entry.Name()) {
+			t.Fatalf("root listing exposed %q", entry.Name())
+		}
+	}
+}
+
+func TestLoadPortableConfigOverlayValidatesSessionContainment(t *testing.T) {
+	sessionDir := t.TempDir()
+	configDir := filepath.Join(sessionDir, "portable-config")
+	if err := os.Mkdir(configDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	want := []byte(`{"name":"captured"}`)
+	if err := os.WriteFile(filepath.Join(configDir, ".config"), want, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	roots := interpruntime.Roots{SessionDir: sessionDir}
+	env := portableConfigTestEnv(t, configDir)
+	overlay, err := loadPortableConfigOverlay(env, roots)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if overlay == nil || !overlay.present || string(overlay.data) != string(want) {
+		t.Fatalf("loaded overlay = %#v, want captured content", overlay)
+	}
+	legacy, err := loadPortableConfigOverlay(nil, roots)
+	if err != nil || legacy != nil {
+		t.Fatalf("legacy overlay = %#v, %v, want nil", legacy, err)
+	}
+
+	outside := t.TempDir()
+	_, err = loadPortableConfigOverlay([]string{
+		interpruntime.PortableConfigDirEnv + "=" + outside,
+		env[1],
+	}, roots)
+	if err == nil || !strings.Contains(err.Error(), "below session") {
+		t.Fatalf("outside overlay error = %v, want containment rejection", err)
+	}
+}
+
+func TestOpenPortableConfigRootPinsSessionTree(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("directory replacement semantics differ on Windows")
+	}
+	sessionDir := t.TempDir()
+	configDir := filepath.Join(sessionDir, "portable-config")
+	if err := os.Mkdir(configDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, ".config"), []byte(`{"name":"inside"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	root, err := openPortableConfigRoot(sessionDir, configDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer root.Close()
+	outside := t.TempDir()
+	if err := os.WriteFile(filepath.Join(outside, ".config"), []byte(`{"name":"outside"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(configDir, filepath.Join(sessionDir, "portable-config-old")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, configDir); err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := projectpolicy.SnapshotPortableConfigRoot(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := string(snapshot.Bytes()); got != `{"name":"inside"}` {
+		t.Fatalf("pinned config = %q, want inside snapshot", got)
+	}
+}
+
+func TestLoadPortableConfigOverlayRejectsMaterializedDrift(t *testing.T) {
+	sessionDir := t.TempDir()
+	configDir := filepath.Join(sessionDir, "portable-config")
+	if err := os.Mkdir(configDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	configPath := filepath.Join(configDir, ".config")
+	if err := os.WriteFile(configPath, []byte(`{"name":"validated"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	env := portableConfigTestEnv(t, configDir)
+	if err := os.Remove(configPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(configPath, []byte(`{"name":"different-but-valid"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := loadPortableConfigOverlay(env, interpruntime.Roots{SessionDir: sessionDir})
+	if err == nil || !strings.Contains(err.Error(), "identity mismatch") {
+		t.Fatalf("loadPortableConfigOverlay() drift error = %v", err)
+	}
+}
+
+func TestLoadPortableConfigOverlayBindsAbsentState(t *testing.T) {
+	sessionDir := t.TempDir()
+	configDir := filepath.Join(sessionDir, "portable-config")
+	if err := os.Mkdir(configDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	env := portableConfigTestEnv(t, configDir)
+	if err := os.WriteFile(filepath.Join(configDir, ".config"), []byte(`{"name":"late"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := loadPortableConfigOverlay(env, interpruntime.Roots{SessionDir: sessionDir})
+	if err == nil || !strings.Contains(err.Error(), "identity mismatch") {
+		t.Fatalf("loadPortableConfigOverlay() absent drift error = %v", err)
+	}
+}
+
+func TestLoadPortableConfigOverlayRejectsIncompleteEnvironment(t *testing.T) {
+	sessionDir := t.TempDir()
+	configDir := filepath.Join(sessionDir, "portable-config")
+	if err := os.Mkdir(configDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	for _, env := range [][]string{
+		{interpruntime.PortableConfigDirEnv + "=" + configDir},
+		{interpruntime.PortableConfigIdentityEnv + "=absent"},
+	} {
+		if _, err := loadPortableConfigOverlay(env, interpruntime.Roots{SessionDir: sessionDir}); err == nil || !strings.Contains(err.Error(), "incomplete") {
+			t.Fatalf("loadPortableConfigOverlay(%v) error = %v", env, err)
+		}
+	}
+}
+
+func portableConfigTestEnv(t *testing.T, configDir string) []string {
+	t.Helper()
+	snapshot, err := projectpolicy.SnapshotPortableConfig(configDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	identity, err := snapshot.Identity()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return []string{
+		interpruntime.PortableConfigDirEnv + "=" + configDir,
+		interpruntime.PortableConfigIdentityEnv + "=" + identity,
+	}
+}
+
+func mustReadDir(t *testing.T, fsys fs.FS) []fs.DirEntry {
+	t.Helper()
+	entries, err := fs.ReadDir(fsys, ".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return entries
+}
+
+func assertSinglePortableConfigEntry(t *testing.T, entries []fs.DirEntry) {
+	t.Helper()
+	count := 0
+	for _, entry := range entries {
+		if isPortableConfigName(entry.Name()) {
+			count++
+			info, err := entry.Info()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if info.IsDir() {
+				t.Fatal("synthetic .config is a directory")
+			}
+		}
+	}
+	if count != 1 {
+		t.Fatalf("portable config entry count = %d, want 1", count)
+	}
+}

--- a/internal/interpruntime/roots.go
+++ b/internal/interpruntime/roots.go
@@ -27,9 +27,11 @@ import (
 )
 
 const (
-	ProjectDirEnv = "SPX_PROJECT_DIR"
-	AssetDirEnv   = "SPX_ASSET_DIR"
-	SessionDirEnv = "SPX_SESSION_DIR"
+	ProjectDirEnv             = "SPX_PROJECT_DIR"
+	AssetDirEnv               = "SPX_ASSET_DIR"
+	SessionDirEnv             = "SPX_SESSION_DIR"
+	PortableConfigDirEnv      = "SPX_PORTABLE_CONFIG_DIR"
+	PortableConfigIdentityEnv = "SPX_PORTABLE_CONFIG_IDENTITY"
 )
 
 // Roots identifies the independent source, asset, and Engine session roots.
@@ -152,8 +154,7 @@ func RootsFromEnv(env []string) (Roots, error) {
 	return r, nil
 }
 
-// Environment returns base with all ambient root variables removed and one
-// validated value for each root appended.
+// Environment replaces ambient runtime paths with validated roots.
 func (r Roots) Environment(base []string) ([]string, error) {
 	if err := r.Validate(); err != nil {
 		return nil, err
@@ -175,9 +176,39 @@ func (r Roots) Environment(base []string) ([]string, error) {
 	), nil
 }
 
+// PortableConfigFromEnv returns the optional driver-owned config directory and
+// its presence/content identity. Both variables must be present together.
+func PortableConfigFromEnv(env []string) (directory, identity string, found bool, err error) {
+	values := make(map[string]string, 2)
+	for _, entry := range env {
+		key, candidate, ok := strings.Cut(entry, "=")
+		if !ok {
+			continue
+		}
+		canonical, ok := rootEnvKey(key)
+		if !ok || (canonical != PortableConfigDirEnv && canonical != PortableConfigIdentityEnv) {
+			continue
+		}
+		if _, duplicate := values[canonical]; duplicate {
+			return "", "", false, fmt.Errorf("interpruntime: duplicate environment variable %s", canonical)
+		}
+		values[canonical] = candidate
+	}
+	directory, dirFound := values[PortableConfigDirEnv]
+	identity, identityFound := values[PortableConfigIdentityEnv]
+	if dirFound != identityFound {
+		return "", "", false, fmt.Errorf("interpruntime: portable config environment is incomplete")
+	}
+	return directory, identity, dirFound, nil
+}
+
 func rootEnvKey(key string) (string, bool) {
-	for _, canonical := range []string{ProjectDirEnv, AssetDirEnv, SessionDirEnv} {
-		if key == canonical || (runtime.GOOS == "windows" && strings.EqualFold(key, canonical)) {
+	return rootEnvKeyForGOOS(key, runtime.GOOS)
+}
+
+func rootEnvKeyForGOOS(key, goos string) (string, bool) {
+	for _, canonical := range []string{ProjectDirEnv, AssetDirEnv, SessionDirEnv, PortableConfigDirEnv, PortableConfigIdentityEnv} {
+		if key == canonical || (goos == "windows" && strings.EqualFold(key, canonical)) {
 			return canonical, true
 		}
 	}

--- a/internal/interpruntime/roots_test.go
+++ b/internal/interpruntime/roots_test.go
@@ -89,6 +89,8 @@ func TestEnvironmentReplacesAmbientRoots(t *testing.T) {
 		ProjectDirEnv + "=/attacker/project",
 		AssetDirEnv + "=/attacker/assets",
 		SessionDirEnv + "=/attacker/session",
+		PortableConfigDirEnv + "=/attacker/config",
+		PortableConfigIdentityEnv + "=sha256:attacker",
 		"UNCHANGED=value",
 	}
 	got, err := roots.Environment(base)
@@ -104,6 +106,40 @@ func TestEnvironmentReplacesAmbientRoots(t *testing.T) {
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("Environment() = %#v, want %#v", got, want)
+	}
+}
+
+func TestPortableConfigFromEnv(t *testing.T) {
+	if directory, identity, found, err := PortableConfigFromEnv([]string{"KEEP=value"}); err != nil || found || directory != "" || identity != "" {
+		t.Fatalf("PortableConfigFromEnv() = %q, %q, %v, %v, want absent", directory, identity, found, err)
+	}
+	directory, identity, found, err := PortableConfigFromEnv([]string{
+		PortableConfigDirEnv + "=/trusted",
+		PortableConfigIdentityEnv + "=sha256:0123456789abcdef",
+	})
+	if err != nil || !found || directory != "/trusted" || identity != "sha256:0123456789abcdef" {
+		t.Fatalf("PortableConfigFromEnv() = %q, %q, %v, %v", directory, identity, found, err)
+	}
+	for _, env := range [][]string{
+		{PortableConfigDirEnv + "=/first", PortableConfigDirEnv + "=/second", PortableConfigIdentityEnv + "=absent"},
+		{PortableConfigDirEnv + "=/trusted"},
+	} {
+		_, _, _, err := PortableConfigFromEnv(env)
+		if err == nil {
+			t.Fatalf("PortableConfigFromEnv(%v) accepted invalid environment", env)
+		}
+	}
+}
+
+func TestPortableConfigEnvironmentKeysAreCaseInsensitiveOnWindows(t *testing.T) {
+	for _, key := range []string{PortableConfigDirEnv, PortableConfigIdentityEnv} {
+		lower := strings.ToLower(key)
+		if canonical, ok := rootEnvKeyForGOOS(lower, "windows"); !ok || canonical != key {
+			t.Fatalf("rootEnvKeyForGOOS(%q, windows) = %q, %v", lower, canonical, ok)
+		}
+		if _, ok := rootEnvKeyForGOOS(lower, "linux"); ok {
+			t.Fatalf("rootEnvKeyForGOOS(%q, linux) accepted case variant", lower)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- carry an optional, identity-bound portable project config through interpreted runtime roots
- load the config from a pinned session directory and reject path or content drift
- overlay the captured config without changing legacy run behavior when absent

## Validation

- `go test -race ./cmd/ispxnative ./internal/interpruntime`
- `go test ./...`
- `go vet ./...`
- `go test -tags pure_engine ./cmd/ispxnative ./internal/interpruntime`
- Windows amd64 `pure_engine` compile
- `go mod tidy -diff`
- `git diff --check`