### PR TITLE
feat(spx): add driver-independent buildlauncher

### DIFF
--- a/cmd/spx/internal/command/args.go
+++ b/cmd/spx/internal/command/args.go
@@ -44,6 +44,7 @@ type ExtraArgs struct {
 	Mode            *string
 	Movie           *bool
 	Verbose         *bool
+	Output          *string
 }
 
 func (e *ExtraArgs) String() []string {
@@ -83,7 +84,7 @@ func (cmd *CmdTool) CheckCmd(ext ...string) bool {
 	cmds := []string{
 		"help", "version", "editor",
 		"init", "clear", "clearbuild",
-		"build", "buildtinygo", "rune", "export",
+		"build", "buildtinygo", "rune", "export", "buildlauncher",
 		"runweb", "buildweb", "exportweb", "stopweb", "runwebworker",
 		"runm", "exportbot", "exportapk", "exportios",
 		"run", "runnative", "exporttemplateweb", "exportminigame", "exportminiprogram", "exportwebworker",
@@ -135,6 +136,7 @@ Available commands:
 
     Development & Building:
     - build           # Build the dynamic library
+    - buildlauncher   # Build a launcher without Godot or an XGo driver
     - buildtinygo     # Build static library using TinyGo for ESP32
     - run             # Run the current project in interpreted mode
     - runnative       # Run the current project with the native PC runtime
@@ -170,6 +172,7 @@ Examples:
     #CMDNAME build --servermode           # Build in server mode
     #CMDNAME runweb --debugweb            # Run web server with debug service
     #CMDNAME buildtinygo                  # Build TinyGo static library for ESP32
+    #CMDNAME buildlauncher --path ./game # Build ./game/.builds/game
     #CMDNAME exportminigame -build=fast   # Export minigame without compression (faster)
     #CMDNAME runnative -tags=pure_engine  # Run in pure engine mode
     #CMDNAME export --fullscreen          # Export with fullscreen mode
@@ -203,6 +206,7 @@ func (cmd *CmdTool) initializeFlags() *bool {
 	cmd.Args.Mode = f.String("mode", "none", "mode: none, worker, minigame")
 	cmd.Args.Movie = f.Bool("movie", false, "record movie mode")
 	cmd.Args.Verbose = f.Bool("v", false, "print verbose information")
+	cmd.Args.Output = f.String("o", "", "launcher output path (buildlauncher)")
 	return help
 }
 

--- a/cmd/spx/internal/command/buildlauncher.go
+++ b/cmd/spx/internal/command/buildlauncher.go
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package command
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"github.com/goplus/spx/v3/internal/launchpack"
+	"github.com/goplus/spx/v3/internal/projectpolicy"
+)
+
+const spxModulePath = "github.com/goplus/spx/v3"
+
+type launcherBuilder func(context.Context, launchpack.Config) (launchpack.Result, error)
+
+func (cmd *CmdTool) runBuildLauncher() error {
+	// A launcher is a host executable; target, runtime, and multiplayer flags
+	// have no meaning for this packaging-only command.
+	if err := validateBuildLauncherArgs(cmd.Args); err != nil {
+		return err
+	}
+	if flag.NArg() != 0 {
+		return fmt.Errorf("buildlauncher: unexpected positional arguments: %q", flag.Args())
+	}
+	projectPath := valueOrDefault(cmd.Args.Path, ".")
+	projectDir, err := canonicalDirectory(projectPath)
+	if err != nil {
+		return fmt.Errorf("buildlauncher: project path: %w", err)
+	}
+	goCommand, err := resolveGoCommand()
+	if err != nil {
+		return fmt.Errorf("buildlauncher: Go command: %w", err)
+	}
+	project, source, err := resolveLauncherInputs(context.Background(), projectDir, goCommand)
+	if err != nil {
+		return err
+	}
+	protected := launcherOutputProtection{
+		Files: append([]string{project.file, project.metadataFile, filepath.Join(project.dir, ".config")}, project.sourceFiles...),
+	}
+	protected.Files = append(protected.Files, source.protectedFiles...)
+	if source.root != "" {
+		protected.Roots = append(protected.Roots, filepath.Join(source.root, "cmd", "ispxnative"))
+	}
+	final, err := resolveLauncherOutput(launcherOutputInputs{
+		ProjectDir: project.dir, ProjectExt: project.extension,
+		PackDir: project.packDir, Protection: protected,
+	}, valueOf(cmd.Args.Output))
+	if err != nil {
+		return err
+	}
+	stage, cleanup, err := stageLauncherOutput(final)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	snapshot, err := projectpolicy.SnapshotPortableConfig(project.dir)
+	if err != nil {
+		return fmt.Errorf("buildlauncher: portable config: %w", err)
+	}
+	config := launchpack.Config{
+		ProjectDir: project.dir, ProjectFile: project.file, ProjectExt: project.extension,
+		PackDir: project.packDir, PackIndex: project.packIndex, PortableConfig: snapshot,
+		RuntimeSourceRoot: source.root, RuntimeIdentity: launchpack.RuntimeIdentity{GOOS: runtime.GOOS, GOARCH: runtime.GOARCH},
+		Source: launchpack.SourceIdentity{
+			SelectedPath: spxModulePath, SelectedVersion: source.selectedVersion,
+			EffectivePath: source.effectivePath, EffectiveVersion: source.effectiveVersion,
+			Main: source.main, SourceMode: source.sourceMode,
+		},
+		GoCommand: source.goCommand, WorkDir: source.workDir, GoWork: source.goWork,
+		GraphFlags: source.graphFlags, BuildFlags: buildLauncherBuildFlags(cmd.Args), Output: stage,
+		BridgePackage: spxModulePath + "/cmd/ispxnative", VerifyGraph: source.verifyGraph,
+		IO: launchpack.IO{Stdin: os.Stdin, Stdout: os.Stdout, Stderr: os.Stderr, Env: source.env},
+	}
+	builder := cmd.launcherBuilder
+	if builder == nil {
+		builder = launchpack.BuildLauncher
+	}
+	if _, err := builder(context.Background(), config); err != nil {
+		return fmt.Errorf("buildlauncher: %w", err)
+	}
+	if err := commitLauncherOutput(stage, final, protected); err != nil {
+		return err
+	}
+	logInfof("Built launcher: %s", final)
+	return nil
+}
+
+func validateBuildLauncherArgs(args ExtraArgs) error {
+	for _, unsupported := range []struct {
+		name  string
+		value string
+	}{
+		{name: "serveraddr", value: valueOf(args.ServerAddr)},
+		{name: "controller", value: valueOf(args.ControllerName)},
+		{name: "arch", value: valueOf(args.Arch)},
+		{name: "tags", value: valueOf(args.Tags)},
+	} {
+		if unsupported.value != "" {
+			return fmt.Errorf("buildlauncher: -%s is not supported for the host-only launcher (got %q)", unsupported.name, unsupported.value)
+		}
+	}
+
+	for _, unsupported := range []struct {
+		name  string
+		value bool
+	}{
+		{name: "servermode", value: boolValue(args.ServerMode)},
+		{name: "headless", value: boolValue(args.HeadlessMode)},
+		{name: "onlys", value: boolValue(args.OnlyServer)},
+		{name: "onlyc", value: boolValue(args.OnlyClient)},
+		{name: "nomap", value: boolValue(args.NoMap)},
+		{name: "install", value: boolValue(args.Install)},
+		{name: "debugweb", value: boolValue(args.DebugWebService)},
+		{name: "fullscreen", value: boolValue(args.FullScreen)},
+		{name: "movie", value: boolValue(args.Movie)},
+	} {
+		if unsupported.value {
+			return fmt.Errorf("buildlauncher: -%s is not supported for the host-only launcher (got true)", unsupported.name)
+		}
+	}
+
+	if target := valueOrDefault(args.Target, "esp32"); target != "esp32" {
+		return fmt.Errorf("buildlauncher: -target is not supported for the host-only launcher (got %q)", target)
+	}
+	if build := valueOrDefault(args.Build, "normal"); build != "normal" {
+		return fmt.Errorf("buildlauncher: -build is not supported for the host-only launcher (got %q)", build)
+	}
+	if mode := valueOrDefault(args.Mode, "none"); mode != "none" {
+		return fmt.Errorf("buildlauncher: -mode is not supported for the host-only launcher (got %q)", mode)
+	}
+	return nil
+}
+
+func buildLauncherBuildFlags(args ExtraArgs) []string {
+	if boolValue(args.Verbose) {
+		return []string{"-v=true"}
+	}
+	return nil
+}
+
+func boolValue(value *bool) bool {
+	return value != nil && *value
+}
+
+func valueOf(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}
+
+func valueOrDefault(value *string, fallback string) string {
+	if value == nil || *value == "" {
+		return fallback
+	}
+	return *value
+}

--- a/cmd/spx/internal/command/buildlauncher_graph.go
+++ b/cmd/spx/internal/command/buildlauncher_graph.go
@@ -1,0 +1,291 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package command
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+type launcherSource struct {
+	main             bool
+	sourceMode       bool
+	root             string
+	effectivePath    string
+	selectedVersion  string
+	effectiveVersion string
+	goCommand        string
+	workDir          string
+	goWork           string
+	graphFlags       []string
+	env              []string
+	protectedFiles   []string
+	verifyGraph      func(context.Context) error
+}
+
+type listedModule struct {
+	Path     string
+	Version  string
+	Main     bool
+	Dir      string
+	GoMod    string
+	Sum      string
+	GoModSum string
+	Replace  *listedModule
+}
+
+func resolveLauncherInputs(ctx context.Context, projectDir, goCommand string) (launcherProject, launcherSource, error) {
+	env := append([]string(nil), os.Environ()...)
+	goMod, err := queryGoEnv(ctx, goCommand, projectDir, env, "GOMOD")
+	if err != nil {
+		return launcherProject{}, launcherSource{}, fmt.Errorf("buildlauncher: resolve Go module file: %w", err)
+	}
+	if goMod == "" || goMod == os.DevNull {
+		return launcherProject{}, launcherSource{}, fmt.Errorf("buildlauncher: project path is outside a Go module")
+	}
+	goMod, err = canonicalFile(goMod)
+	if err != nil {
+		return launcherProject{}, launcherSource{}, fmt.Errorf("buildlauncher: Go module file: %w", err)
+	}
+	moduleRoot := filepath.Dir(goMod)
+	if !launcherPathWithin(moduleRoot, projectDir) {
+		return launcherProject{}, launcherSource{}, fmt.Errorf("buildlauncher: project path %q is outside the active Go module %q", projectDir, moduleRoot)
+	}
+	project, err := loadLauncherProject(moduleRoot, projectDir)
+	if err != nil {
+		return launcherProject{}, launcherSource{}, err
+	}
+	goWork, err := queryGoEnv(ctx, goCommand, projectDir, env, "GOWORK")
+	if err != nil {
+		return launcherProject{}, launcherSource{}, fmt.Errorf("buildlauncher: resolve Go workspace: %w", err)
+	}
+	if goWork == "" {
+		goWork = "off"
+	} else if goWork != "off" {
+		goWork, err = canonicalFile(goWork)
+		if err != nil {
+			return launcherProject{}, launcherSource{}, fmt.Errorf("buildlauncher: Go workspace file: %w", err)
+		}
+	}
+	flags, err := graphFlagsFromEnvironment(projectDir, env)
+	if err != nil {
+		return launcherProject{}, launcherSource{}, err
+	}
+	graphEnv := launcherGraphEnvironment(env, goWork)
+	spx, verifier, err := resolveLauncherGraph(ctx, launcherGraphQuery{
+		goCommand: goCommand, workDir: projectDir, goWork: goWork,
+		graphFlags: flags, env: graphEnv, files: []string{goMod, project.metadataFile},
+	})
+	if err != nil {
+		return launcherProject{}, launcherSource{}, fmt.Errorf("buildlauncher: resolve module graph: %w", err)
+	}
+	root, selectedVersion, effectiveVersion, sourceMode, err := resolveSPXSource(spx)
+	if err != nil {
+		return launcherProject{}, launcherSource{}, err
+	}
+	effectivePath := spxModulePath
+	if spx.Replace != nil && spx.Replace.Path != "" {
+		effectivePath = spx.Replace.Path
+	}
+	return project, launcherSource{
+		main: spx.Main, sourceMode: sourceMode, root: root, effectivePath: effectivePath,
+		selectedVersion: selectedVersion, effectiveVersion: effectiveVersion,
+		goCommand: goCommand, workDir: projectDir, goWork: goWork, graphFlags: flags,
+		env: graphEnv, protectedFiles: launcherGraphProtectedFiles(verifier.files(), flags),
+		verifyGraph: verifier.verify,
+	}, nil
+}
+
+func queryGoEnv(ctx context.Context, goCommand, workDir string, env []string, name string) (string, error) {
+	var stderr strings.Builder
+	command := exec.CommandContext(ctx, goCommand, "env", name)
+	command.Dir = workDir
+	command.Env = env
+	command.Stderr = &stderr
+	output, err := command.Output()
+	if err != nil {
+		if message := strings.TrimSpace(stderr.String()); message != "" {
+			return "", fmt.Errorf("%w: %s", err, message)
+		}
+		return "", err
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+func resolveSPXSource(module listedModule) (root, selectedVersion, effectiveVersion string, sourceMode bool, err error) {
+	if module.Path != spxModulePath {
+		return "", "", "", false, fmt.Errorf("buildlauncher: Go graph selected %q for SPX, want %q", module.Path, spxModulePath)
+	}
+	sourceMode = module.Main || module.Replace != nil && module.Replace.Version == ""
+	effective := module
+	if module.Replace != nil {
+		effective = *module.Replace
+	}
+	if effective.Dir == "" {
+		if sourceMode {
+			return "", "", "", false, fmt.Errorf("buildlauncher: local SPX module has no source directory")
+		}
+		return "", module.Version, effective.Version, false, nil
+	}
+	root, err = canonicalDirectory(effective.Dir)
+	if err != nil {
+		return "", "", "", false, fmt.Errorf("buildlauncher: SPX module root: %w", err)
+	}
+	bridge := filepath.Join(root, "cmd", "ispxnative", "main.go")
+	info, statErr := os.Lstat(bridge)
+	if statErr != nil || info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+		if statErr != nil {
+			return "", "", "", false, fmt.Errorf("buildlauncher: SPX module %q has no cmd/ispxnative package: %w", root, statErr)
+		}
+		return "", "", "", false, fmt.Errorf("buildlauncher: SPX module %q has no regular cmd/ispxnative package", root)
+	}
+	return root, module.Version, effective.Version, sourceMode, nil
+}
+
+func resolveGoCommand() (string, error) {
+	path, err := exec.LookPath("go")
+	if err != nil {
+		return "", err
+	}
+	return canonicalFile(path)
+}
+
+func graphFlagsFromEnv(workDir string) ([]string, error) {
+	return graphFlagsFromEnvironment(workDir, os.Environ())
+}
+
+func graphFlagsFromEnvironment(workDir string, env []string) ([]string, error) {
+	value := launcherEnvValue(env, "GOFLAGS")
+	if strings.TrimSpace(value) == "" {
+		return nil, nil
+	}
+	fields, err := splitGOFLAGS(value)
+	if err != nil {
+		return nil, fmt.Errorf("buildlauncher: parse GOFLAGS: %w", err)
+	}
+	flags := make([]string, 0, len(fields))
+	for _, flag := range fields {
+		path, modfile := launcherModfilePath(flag)
+		if modfile {
+			if !filepath.IsAbs(path) {
+				path = filepath.Join(workDir, path)
+			}
+			canonical, err := canonicalFile(filepath.Clean(path))
+			if err != nil {
+				return nil, fmt.Errorf("buildlauncher: GOFLAGS modfile: %w", err)
+			}
+			flag = "-modfile=" + canonical
+		}
+		flags = append(flags, flag)
+	}
+	return flags, nil
+}
+
+// splitGOFLAGS mirrors Go's cmd/internal/quoted parser.
+func splitGOFLAGS(value string) ([]string, error) {
+	var fields []string
+	for len(value) > 0 {
+		for len(value) > 0 && isGOFLAGSFieldSpace(value[0]) {
+			value = value[1:]
+		}
+		if value == "" {
+			break
+		}
+		if value[0] == '\'' || value[0] == '"' {
+			quote := value[0]
+			value = value[1:]
+			end := strings.IndexByte(value, quote)
+			if end < 0 {
+				return nil, fmt.Errorf("unterminated %c string", quote)
+			}
+			fields = append(fields, value[:end])
+			value = value[end+1:]
+			continue
+		}
+		end := 0
+		for end < len(value) && !isGOFLAGSFieldSpace(value[end]) {
+			end++
+		}
+		fields = append(fields, value[:end])
+		value = value[end:]
+	}
+	return fields, nil
+}
+
+func isGOFLAGSFieldSpace(value byte) bool {
+	return value == ' ' || value == '\t' || value == '\n' || value == '\r'
+}
+
+func canonicalDirectory(path string) (string, error) {
+	if path == "" {
+		return "", fmt.Errorf("path is empty")
+	}
+	absolute, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	absolute = filepath.Clean(absolute)
+	info, err := os.Stat(absolute)
+	if err != nil {
+		return "", err
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("%q is not a regular directory", absolute)
+	}
+	resolved, err := filepath.EvalSymlinks(absolute)
+	if err != nil {
+		return "", fmt.Errorf("%q is not a canonical directory: %w", absolute, err)
+	}
+	resolved, err = filepath.Abs(resolved)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Clean(resolved), nil
+}
+
+func canonicalFile(path string) (string, error) {
+	absolute, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	absolute = filepath.Clean(absolute)
+	info, err := os.Stat(absolute)
+	if err != nil {
+		return "", err
+	}
+	if !info.Mode().IsRegular() {
+		return "", fmt.Errorf("%q is not a regular file", absolute)
+	}
+	resolved, err := filepath.EvalSymlinks(absolute)
+	if err != nil {
+		return "", fmt.Errorf("%q is not a canonical file: %w", absolute, err)
+	}
+	resolved, err = filepath.Abs(resolved)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Clean(resolved), nil
+}
+
+func launcherPathWithin(root, target string) bool {
+	rel, err := filepath.Rel(root, target)
+	return err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) && !filepath.IsAbs(rel)
+}

--- a/cmd/spx/internal/command/buildlauncher_graph_files.go
+++ b/cmd/spx/internal/command/buildlauncher_graph_files.go
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package command
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+func launcherModfilePath(flag string) (string, bool) {
+	if path, ok := strings.CutPrefix(flag, "-modfile="); ok {
+		return path, true
+	}
+	return strings.CutPrefix(flag, "--modfile=")
+}
+
+func launcherGraphProtectedFiles(files, flags []string) []string {
+	protected := append([]string(nil), files...)
+	for _, path := range files {
+		switch filepath.Base(path) {
+		case "go.mod":
+			protected = append(protected, filepath.Join(filepath.Dir(path), "go.sum"))
+		case "go.work":
+			protected = append(protected, filepath.Join(filepath.Dir(path), "go.work.sum"))
+		}
+	}
+	for _, flag := range flags {
+		if path, ok := launcherModfilePath(flag); ok && strings.HasSuffix(path, ".mod") {
+			protected = append(protected, strings.TrimSuffix(path, ".mod")+".sum")
+		}
+	}
+	return protected
+}

--- a/cmd/spx/internal/command/buildlauncher_graph_snapshot.go
+++ b/cmd/spx/internal/command/buildlauncher_graph_snapshot.go
@@ -1,0 +1,279 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package command
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"sort"
+	"strings"
+)
+
+type launcherGraphQuery struct {
+	goCommand  string
+	workDir    string
+	goWork     string
+	graphFlags []string
+	env        []string
+	files      []string
+}
+
+type launcherModuleIdentity struct {
+	Path, Version, Sum, GoModSum                             string
+	ReplacePath, ReplaceVersion, ReplaceSum, ReplaceGoModSum string
+	LocalDir                                                 string
+	Main                                                     bool
+}
+
+type launcherFileIdentity struct {
+	path   string
+	sha256 string
+}
+
+type launcherGraphIdentity struct {
+	module    launcherModuleIdentity
+	selection string
+	files     []launcherFileIdentity
+}
+
+type launcherGraphVerifier struct {
+	query    launcherGraphQuery
+	expected launcherGraphIdentity
+}
+
+func resolveLauncherGraph(ctx context.Context, query launcherGraphQuery) (listedModule, launcherGraphVerifier, error) {
+	query.graphFlags = append([]string(nil), query.graphFlags...)
+	query.env = append([]string(nil), query.env...)
+	query.files = append([]string(nil), query.files...)
+	identity, module, err := snapshotLauncherGraph(ctx, query)
+	if err != nil {
+		return listedModule{}, launcherGraphVerifier{}, err
+	}
+	return module, launcherGraphVerifier{query: query, expected: identity}, nil
+}
+
+func (v launcherGraphVerifier) verify(ctx context.Context) error {
+	current, _, err := snapshotLauncherGraph(ctx, v.query)
+	if err != nil {
+		return err
+	}
+	if current.module != v.expected.module || current.selection != v.expected.selection {
+		return fmt.Errorf("module selection changed")
+	}
+	if !reflect.DeepEqual(current.files, v.expected.files) {
+		return fmt.Errorf("module input changed")
+	}
+	return nil
+}
+
+func (v launcherGraphVerifier) files() []string {
+	files := make([]string, len(v.expected.files))
+	for i, file := range v.expected.files {
+		files[i] = file.path
+	}
+	return files
+}
+
+func snapshotLauncherGraph(ctx context.Context, query launcherGraphQuery) (launcherGraphIdentity, listedModule, error) {
+	module, err := queryListedModule(ctx, query)
+	if err != nil {
+		return launcherGraphIdentity{}, listedModule{}, err
+	}
+	files := append([]string(nil), query.files...)
+	if query.goWork != "" && query.goWork != "off" {
+		files = append(files, query.goWork)
+	}
+	for _, flag := range query.graphFlags {
+		if path, ok := launcherModfilePath(flag); ok {
+			files = append(files, path)
+		}
+	}
+	vendorGraph := false
+	if vendorFile, required := launcherVendorModulesFile(query); vendorFile != "" {
+		if _, err := os.Stat(vendorFile); err == nil {
+			files = append(files, vendorFile)
+			vendorGraph = true
+		} else if required || !os.IsNotExist(err) {
+			return launcherGraphIdentity{}, listedModule{}, fmt.Errorf("vendor graph: %w", err)
+		}
+	}
+	moduleIdentity, localGoMod, err := normalizeLauncherModule(module)
+	if err != nil {
+		return launcherGraphIdentity{}, listedModule{}, err
+	}
+	if localGoMod != "" {
+		files = append(files, localGoMod)
+	}
+	selection := ""
+	if !vendorGraph {
+		selection, err = queryModuleSelection(ctx, query)
+		if err != nil {
+			return launcherGraphIdentity{}, listedModule{}, err
+		}
+	}
+	fileIdentity, err := snapshotLauncherFiles(files)
+	if err != nil {
+		return launcherGraphIdentity{}, listedModule{}, err
+	}
+	return launcherGraphIdentity{module: moduleIdentity, selection: selection, files: fileIdentity}, module, nil
+}
+
+func launcherVendorModulesFile(query launcherGraphQuery) (string, bool) {
+	mode := ""
+	for _, flag := range query.graphFlags {
+		if strings.HasPrefix(flag, "-mod=") {
+			mode = strings.TrimPrefix(flag, "-mod=")
+		}
+	}
+	if mode != "vendor" && mode != "" {
+		return "", false
+	}
+	root := ""
+	if query.goWork != "" && query.goWork != "off" {
+		root = filepath.Dir(query.goWork)
+	} else if len(query.files) > 0 {
+		root = filepath.Dir(query.files[0])
+	}
+	if root == "" {
+		return "", mode == "vendor"
+	}
+	return filepath.Join(root, "vendor", "modules.txt"), mode == "vendor"
+}
+
+func queryModuleSelection(ctx context.Context, query launcherGraphQuery) (string, error) {
+	const format = `{{.Path}}\t{{.Version}}\t{{.Main}}{{with .Replace}}\t{{.Path}}\t{{.Version}}{{end}}`
+	args := append([]string{"list", "-m"}, query.graphFlags...)
+	args = append(args, "-f="+format, "all")
+	var stderr bytes.Buffer
+	command := exec.CommandContext(ctx, query.goCommand, args...)
+	command.Dir, command.Env, command.Stderr = query.workDir, query.env, &stderr
+	output, err := command.Output()
+	if err != nil {
+		if message := strings.TrimSpace(stderr.String()); message != "" {
+			return "", fmt.Errorf("go list module graph: %w: %s", err, message)
+		}
+		return "", fmt.Errorf("go list module graph: %w", err)
+	}
+	digest := sha256.Sum256(output)
+	return hex.EncodeToString(digest[:]), nil
+}
+
+func queryListedModule(ctx context.Context, query launcherGraphQuery) (listedModule, error) {
+	args := append([]string{"list", "-m", "-json"}, query.graphFlags...)
+	args = append(args, spxModulePath)
+	var stderr bytes.Buffer
+	command := exec.CommandContext(ctx, query.goCommand, args...)
+	command.Dir, command.Env, command.Stderr = query.workDir, query.env, &stderr
+	output, err := command.Output()
+	if err != nil {
+		if message := strings.TrimSpace(stderr.String()); message != "" {
+			return listedModule{}, fmt.Errorf("go list module: %w: %s", err, message)
+		}
+		return listedModule{}, fmt.Errorf("go list module: %w", err)
+	}
+	var module listedModule
+	if err := json.Unmarshal(output, &module); err != nil {
+		return listedModule{}, fmt.Errorf("decode go list module: %w", err)
+	}
+	if module.Path != spxModulePath {
+		return listedModule{}, fmt.Errorf("go list returned module %q, want %q", module.Path, spxModulePath)
+	}
+	return module, nil
+}
+
+func normalizeLauncherModule(module listedModule) (launcherModuleIdentity, string, error) {
+	identity := launcherModuleIdentity{
+		Path: module.Path, Version: module.Version, Sum: module.Sum,
+		GoModSum: module.GoModSum, Main: module.Main,
+	}
+	effective := module
+	if module.Replace != nil {
+		effective = *module.Replace
+		identity.ReplacePath = effective.Path
+		identity.ReplaceVersion = effective.Version
+		identity.ReplaceSum = effective.Sum
+		identity.ReplaceGoModSum = effective.GoModSum
+	}
+	if !module.Main && (module.Replace == nil || effective.Version != "") {
+		return identity, "", nil
+	}
+	dir, err := canonicalDirectory(effective.Dir)
+	if err != nil {
+		return launcherModuleIdentity{}, "", fmt.Errorf("local module %q: %w", module.Path, err)
+	}
+	identity.LocalDir = dir
+	if effective.GoMod == "" {
+		return launcherModuleIdentity{}, "", fmt.Errorf("local module %q has no go.mod", module.Path)
+	}
+	return identity, effective.GoMod, nil
+}
+
+func snapshotLauncherFiles(paths []string) ([]launcherFileIdentity, error) {
+	byPath := make(map[string]string, len(paths))
+	for _, path := range paths {
+		if path == "" {
+			continue
+		}
+		canonical, err := canonicalFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("graph input %q: %w", path, err)
+		}
+		data, err := os.ReadFile(canonical)
+		if err != nil {
+			return nil, fmt.Errorf("read graph input %q: %w", canonical, err)
+		}
+		digest := sha256.Sum256(data)
+		byPath[canonical] = hex.EncodeToString(digest[:])
+	}
+	files := make([]launcherFileIdentity, 0, len(byPath))
+	for path, digest := range byPath {
+		files = append(files, launcherFileIdentity{path: path, sha256: digest})
+	}
+	sort.Slice(files, func(i, j int) bool { return files[i].path < files[j].path })
+	return files, nil
+}
+
+func launcherGraphEnvironment(base []string, goWork string) []string {
+	env := make([]string, 0, len(base)+5)
+	for _, entry := range base {
+		key, _, ok := strings.Cut(entry, "=")
+		if ok && (key == "GOFLAGS" || key == "GOWORK" || key == "GOOS" || key == "GOARCH" || key == "CGO_ENABLED") {
+			continue
+		}
+		env = append(env, entry)
+	}
+	return append(env, "GOFLAGS=", "GOWORK="+goWork, "GOOS="+runtime.GOOS, "GOARCH="+runtime.GOARCH)
+}
+
+func launcherEnvValue(env []string, name string) string {
+	for i := len(env) - 1; i >= 0; i-- {
+		key, value, ok := strings.Cut(env[i], "=")
+		if ok && key == name {
+			return value
+		}
+	}
+	return ""
+}

--- a/cmd/spx/internal/command/buildlauncher_graph_test.go
+++ b/cmd/spx/internal/command/buildlauncher_graph_test.go
@@ -1,0 +1,235 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package command
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestResolveSPXSourceModes(t *testing.T) {
+	root := t.TempDir()
+	writeLauncherTestFile(t, filepath.Join(root, "cmd", "ispxnative", "main.go"), "package main\n")
+	wantRoot, err := canonicalDirectory(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, test := range []struct {
+		name   string
+		module listedModule
+		mode   bool
+	}{
+		{
+			name: "module cache",
+			module: listedModule{
+				Path: spxModulePath, Version: "v3.1.0", Dir: root,
+			},
+		},
+		{
+			name: "local replacement",
+			module: listedModule{
+				Path: spxModulePath, Version: "v3.1.0", Dir: root,
+				Replace: &listedModule{Path: root, Dir: root},
+			},
+			mode: true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			gotRoot, selected, _, mode, err := resolveSPXSource(test.module)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if gotRoot != wantRoot || selected != "v3.1.0" || mode != test.mode {
+				t.Fatalf("source = root %q, selected %q, mode %v", gotRoot, selected, mode)
+			}
+		})
+	}
+}
+
+func TestResolveSPXSourceWithoutModuleDirectory(t *testing.T) {
+	root, selected, effective, sourceMode, err := resolveSPXSource(listedModule{
+		Path: spxModulePath, Version: "v3.1.0",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if root != "" || selected != "v3.1.0" || effective != "v3.1.0" || sourceMode {
+		t.Fatalf("source = root %q, selected %q, effective %q, mode %v", root, selected, effective, sourceMode)
+	}
+}
+
+func TestGraphFlagsFromEnvQuotedModfile(t *testing.T) {
+	workDir := t.TempDir()
+	modDir := filepath.Join(workDir, "module with spaces")
+	modfile := filepath.Join(modDir, "go.mod")
+	writeLauncherTestFile(t, modfile, "module example.com/game\n\ngo 1.25.0\n")
+	canonical, err := canonicalFile(modfile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, prefix := range []string{"-modfile=", "--modfile="} {
+		t.Run(prefix, func(t *testing.T) {
+			t.Setenv("GOFLAGS", "-mod=mod '"+prefix+modfile+"' -trimpath")
+			flags, err := graphFlagsFromEnv(workDir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			want := []string{"-mod=mod", "-modfile=" + canonical, "-trimpath"}
+			if !reflect.DeepEqual(flags, want) {
+				t.Fatalf("graphFlagsFromEnv = %#v, want %#v", flags, want)
+			}
+		})
+	}
+}
+
+func TestGraphFlagsFromEnvRejectsUnterminatedQuote(t *testing.T) {
+	t.Setenv("GOFLAGS", "'-modfile=broken")
+	_, err := graphFlagsFromEnv(t.TempDir())
+	if err == nil || !strings.Contains(err.Error(), "parse GOFLAGS") {
+		t.Fatalf("graphFlagsFromEnv error = %v, want GOFLAGS parse error", err)
+	}
+}
+
+func TestLauncherGraphProtectedFilesIncludesSums(t *testing.T) {
+	root := t.TempDir()
+	goMod := filepath.Join(root, "go.mod")
+	goWork := filepath.Join(root, "go.work")
+	modfile := filepath.Join(root, "alternate.mod")
+	files := launcherGraphProtectedFiles(
+		[]string{goMod, goWork, filepath.Join(root, "gox.mod")},
+		[]string{"-modfile=" + modfile},
+	)
+	got := make(map[string]bool, len(files))
+	for _, file := range files {
+		got[file] = true
+	}
+	for _, want := range []string{
+		filepath.Join(root, "go.sum"),
+		filepath.Join(root, "go.work.sum"),
+		filepath.Join(root, "alternate.sum"),
+	} {
+		if !got[want] {
+			t.Errorf("protected files omit %q: %#v", want, files)
+		}
+	}
+	if got[filepath.Join(root, "gox.sum")] {
+		t.Fatalf("protected files include unrelated gox.sum: %#v", files)
+	}
+}
+
+func TestSplitGOFLAGSMatchesGoQuotedFields(t *testing.T) {
+	got, err := splitGOFLAGS(`-trimpath ' -modfile=module with spaces ' "-buildvcs=false"`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"-trimpath", " -modfile=module with spaces ", "-buildvcs=false"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("splitGOFLAGS = %#v, want %#v", got, want)
+	}
+	if _, err := splitGOFLAGS(`'-trimpath`); err == nil {
+		t.Fatal("splitGOFLAGS accepted an unterminated quote")
+	}
+}
+
+func TestLauncherGraphVerifier(t *testing.T) {
+	root := t.TempDir()
+	goMod := filepath.Join(root, "go.mod")
+	metadata := filepath.Join(root, "gox.mod")
+	dependency := filepath.Join(t.TempDir(), "dependency")
+	writeLauncherTestFile(t, filepath.Join(dependency, "go.mod"), "module example.com/dependency\n\ngo 1.25.0\n")
+	moduleText := func(version string) string {
+		return "module example.com/game\n\ngo 1.25.0\n\nrequire (\n\tgithub.com/goplus/spx/v3 v3.0.0\n\texample.com/dependency " + version + "\n)\nreplace github.com/goplus/spx/v3 => " + filepath.ToSlash(findSPXRoot(t)) + "\nreplace example.com/dependency => " + filepath.ToSlash(dependency) + "\n"
+	}
+	writeLauncherTestFile(t, goMod, moduleText("v1.0.0"))
+	writeLauncherTestFile(t, metadata, "xgo 1.8.0\n")
+	goCommand, err := resolveGoCommand()
+	if err != nil {
+		t.Fatal(err)
+	}
+	env := launcherGraphEnvironment(os.Environ(), "off")
+	_, verifier, err := resolveLauncherGraph(context.Background(), launcherGraphQuery{
+		goCommand: goCommand, workDir: root, goWork: "off", env: env,
+		graphFlags: []string{"-mod=mod"}, files: []string{goMod, metadata},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := verifier.verify(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	writeLauncherTestFile(t, filepath.Join(root, "go.sum"), "")
+	if err := verifier.verify(context.Background()); err != nil {
+		t.Fatalf("go.sum changed graph identity: %v", err)
+	}
+	writeLauncherTestFile(t, goMod, moduleText("v1.1.0"))
+	if err := verifier.verify(context.Background()); err == nil || !strings.Contains(err.Error(), "module selection changed") {
+		t.Fatalf("module selection change error = %v", err)
+	}
+	writeLauncherTestFile(t, goMod, moduleText("v1.0.0"))
+	writeLauncherTestFile(t, metadata, "xgo 1.9.0\n")
+	if err := verifier.verify(context.Background()); err == nil || !strings.Contains(err.Error(), "module input changed") {
+		t.Fatalf("metadata change error = %v", err)
+	}
+}
+
+func TestLauncherGraphVerifierVendorMetadata(t *testing.T) {
+	root := t.TempDir()
+	spxRoot := filepath.Join(root, "spx")
+	moduleRoot := filepath.Join(root, "game")
+	writeLauncherTestFile(t, filepath.Join(spxRoot, "go.mod"), "module "+spxModulePath+"\n\ngo 1.25.0\n")
+	writeLauncherTestFile(t, filepath.Join(spxRoot, "cmd", "ispxnative", "main.go"), "package ispxnative\n")
+	goMod := filepath.Join(moduleRoot, "go.mod")
+	writeLauncherTestFile(t, goMod, "module example.com/game\n\ngo 1.25.0\n\nrequire "+spxModulePath+" v3.0.0\nreplace "+spxModulePath+" => "+filepath.ToSlash(spxRoot)+"\n")
+	writeLauncherTestFile(t, filepath.Join(moduleRoot, "main.go"), "package main\nimport _ \""+spxModulePath+"/cmd/ispxnative\"\nfunc main() {}\n")
+	goCommand, err := resolveGoCommand()
+	if err != nil {
+		t.Fatal(err)
+	}
+	command := exec.Command(goCommand, "mod", "vendor")
+	command.Dir, command.Env = moduleRoot, launcherGraphEnvironment(os.Environ(), "off")
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("go mod vendor: %v\n%s", err, output)
+	}
+	_, verifier, err := resolveLauncherGraph(context.Background(), launcherGraphQuery{
+		goCommand: goCommand, workDir: moduleRoot, goWork: "off",
+		graphFlags: []string{"-mod=vendor"}, env: command.Env, files: []string{goMod},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	vendorFile := filepath.Join(moduleRoot, "vendor", "modules.txt")
+	file, err := os.OpenFile(vendorFile, os.O_APPEND|os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := file.WriteString("# changed\n"); err != nil {
+		file.Close()
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := verifier.verify(context.Background()); err == nil || !strings.Contains(err.Error(), "module input changed") {
+		t.Fatalf("vendor metadata change error = %v", err)
+	}
+}

--- a/cmd/spx/internal/command/buildlauncher_metadata.go
+++ b/cmd/spx/internal/command/buildlauncher_metadata.go
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package command
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/goplus/mod/modfile"
+)
+
+type launcherProject struct {
+	dir          string
+	file         string
+	metadataFile string
+	sourceFiles  []string
+	extension    string
+	packDir      string
+	packIndex    string
+}
+
+func loadLauncherProject(moduleRoot, projectDir string) (launcherProject, error) {
+	metadataPath, data, err := readLauncherMetadata(moduleRoot)
+	if err != nil {
+		return launcherProject{}, err
+	}
+	metadata, err := modfile.Parse(metadataPath, data, nil)
+	if err != nil {
+		return launcherProject{}, fmt.Errorf("buildlauncher: parse project metadata %q: %w", metadataPath, err)
+	}
+	var project *modfile.Project
+	for _, candidate := range metadata.Projects {
+		if candidate.Ext != ".spx" {
+			continue
+		}
+		if project != nil {
+			return launcherProject{}, fmt.Errorf("buildlauncher: project metadata declares multiple .spx projects")
+		}
+		project = candidate
+	}
+	if project == nil {
+		return launcherProject{}, fmt.Errorf("buildlauncher: project metadata %q has no .spx project", metadataPath)
+	}
+	if project.Pack == nil || project.Pack.Directory == "" || project.Pack.IndexFile == "" {
+		return launcherProject{}, fmt.Errorf("buildlauncher: project metadata %q must declare 'pack assets index.json'", metadataPath)
+	}
+	sourceFiles, err := listLauncherProjectFiles(projectDir, project.Ext)
+	if err != nil {
+		return launcherProject{}, err
+	}
+	projectFile, err := findLauncherProjectFile(projectDir, project, sourceFiles)
+	if err != nil {
+		return launcherProject{}, err
+	}
+	return launcherProject{
+		dir: projectDir, file: projectFile, metadataFile: metadataPath,
+		sourceFiles: sourceFiles, extension: project.Ext,
+		packDir: project.Pack.Directory, packIndex: project.Pack.IndexFile,
+	}, nil
+}
+
+func readLauncherMetadata(moduleRoot string) (string, []byte, error) {
+	var found string
+	for _, name := range []string{"gox.mod", "gop.mod"} {
+		path := filepath.Join(moduleRoot, name)
+		if info, err := os.Lstat(path); err == nil {
+			if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+				return "", nil, fmt.Errorf("buildlauncher: project metadata %q is not a regular non-symlink file", path)
+			}
+			if found != "" {
+				return "", nil, fmt.Errorf("buildlauncher: module has both %q and %q", filepath.Base(found), name)
+			}
+			found = path
+		} else if !os.IsNotExist(err) {
+			return "", nil, fmt.Errorf("buildlauncher: inspect project metadata %q: %w", path, err)
+		}
+	}
+	if found == "" {
+		return "", nil, fmt.Errorf("buildlauncher: no gox.mod or gop.mod in active module %q", moduleRoot)
+	}
+	data, err := os.ReadFile(found)
+	if err != nil {
+		return "", nil, fmt.Errorf("buildlauncher: read project metadata %q: %w", found, err)
+	}
+	return found, data, nil
+}
+
+func listLauncherProjectFiles(projectDir, extension string) ([]string, error) {
+	entries, err := os.ReadDir(projectDir)
+	if err != nil {
+		return nil, fmt.Errorf("buildlauncher: read project directory: %w", err)
+	}
+	var files []string
+	for _, entry := range entries {
+		if filepath.Ext(entry.Name()) != extension {
+			continue
+		}
+		if entry.Type()&os.ModeSymlink != 0 || !entry.Type().IsRegular() {
+			return nil, fmt.Errorf("buildlauncher: project source %q is not a regular non-symlink file", entry.Name())
+		}
+		files = append(files, filepath.Join(projectDir, entry.Name()))
+	}
+	return files, nil
+}
+
+func findLauncherProjectFile(projectDir string, project *modfile.Project, sourceFiles []string) (string, error) {
+	if project.FullExt != "" && !strings.ContainsAny(project.FullExt, "*") {
+		path := filepath.Join(projectDir, filepath.FromSlash(project.FullExt))
+		if isRegularFile(path) {
+			return path, nil
+		}
+	}
+	mainName := "main" + project.Ext
+	if isRegularFile(filepath.Join(projectDir, mainName)) && project.IsProj(project.Ext, mainName) {
+		return filepath.Join(projectDir, mainName), nil
+	}
+	var matches []string
+	for _, file := range sourceFiles {
+		name := filepath.Base(file)
+		if !project.IsProj(project.Ext, name) {
+			continue
+		}
+		matches = append(matches, file)
+	}
+	if len(matches) == 1 {
+		return matches[0], nil
+	}
+	if len(matches) == 0 {
+		return "", fmt.Errorf("buildlauncher: no project file matching %q in %q", project.Ext, projectDir)
+	}
+	return "", fmt.Errorf("buildlauncher: multiple project files match metadata in %q; name main%s explicitly", projectDir, project.Ext)
+}
+
+func isRegularFile(path string) bool {
+	info, err := os.Lstat(path)
+	return err == nil && info.Mode()&os.ModeSymlink == 0 && info.Mode().IsRegular()
+}

--- a/cmd/spx/internal/command/buildlauncher_output.go
+++ b/cmd/spx/internal/command/buildlauncher_output.go
@@ -1,0 +1,257 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package command
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+type launcherOutputInputs struct {
+	ProjectDir string
+	ProjectExt string
+	PackDir    string
+	Protection launcherOutputProtection
+}
+
+type launcherOutputProtection struct {
+	Files []string
+	Roots []string
+}
+
+func resolveLauncherOutput(inputs launcherOutputInputs, requested string) (string, error) {
+	projectDir, err := canonicalDirectory(inputs.ProjectDir)
+	if err != nil {
+		return "", fmt.Errorf("buildlauncher: resolve project directory: %w", err)
+	}
+	if requested == "" {
+		name := filepath.Base(projectDir)
+		if name == "" || name == "." || name == string(filepath.Separator) {
+			name = "spx-launcher"
+		}
+		requested = filepath.Join(projectDir, ".builds", name+executableSuffix(runtime.GOOS))
+	} else if !filepath.IsAbs(requested) {
+		requested, err = filepath.Abs(requested)
+		if err != nil {
+			return "", fmt.Errorf("buildlauncher: resolve output: %w", err)
+		}
+	}
+	requested = filepath.Clean(requested)
+	requested, err = canonicalizeLauncherOutputAlias(requested)
+	if err != nil {
+		return "", err
+	}
+
+	packRoot := filepath.Join(projectDir, filepath.FromSlash(inputs.PackDir))
+	insidePack, err := launcherPathWithinFilesystem(packRoot, requested)
+	if err != nil {
+		return "", fmt.Errorf("buildlauncher: compare output with pack directory: %w", err)
+	}
+	if launcherPathsEqual(projectDir, requested) || insidePack {
+		return "", fmt.Errorf("buildlauncher: output must not be the project directory or inside the pack directory: %q", requested)
+	}
+	insideProject, err := launcherPathWithinFilesystem(projectDir, requested)
+	if err != nil {
+		return "", fmt.Errorf("buildlauncher: compare output with project directory: %w", err)
+	}
+	if insideProject && inputs.ProjectExt != "" && filepath.Ext(requested) == inputs.ProjectExt {
+		return "", fmt.Errorf("buildlauncher: output must not use project source extension %q", inputs.ProjectExt)
+	}
+	if err := validateLauncherOutputProtection(requested, inputs.Protection); err != nil {
+		return "", err
+	}
+	if err := validateLauncherOutputParent(filepath.Dir(requested), true); err != nil {
+		return "", err
+	}
+	if err := validateLauncherOutputTarget(requested); err != nil {
+		return "", err
+	}
+	return requested, nil
+}
+
+func validateLauncherOutputProtection(output string, protection launcherOutputProtection) error {
+	if input, ok := protectedLauncherInput(output, protection.Files); ok {
+		return fmt.Errorf("buildlauncher: output must not overwrite build input %q", input)
+	}
+	for _, root := range protection.Roots {
+		if root == "" {
+			continue
+		}
+		inside, err := launcherPathWithinFilesystem(root, output)
+		if err != nil {
+			return fmt.Errorf("buildlauncher: compare output with build input directory: %w", err)
+		}
+		if inside {
+			return fmt.Errorf("buildlauncher: output must not overwrite build input under %q", root)
+		}
+	}
+	return nil
+}
+
+func protectedLauncherInput(output string, paths []string) (string, bool) {
+	for _, path := range paths {
+		if path == "" {
+			continue
+		}
+		absolute, err := filepath.Abs(path)
+		if err != nil {
+			continue
+		}
+		absolute = filepath.Clean(absolute)
+		if canonical, canonicalErr := canonicalizeLauncherOutputAlias(absolute); canonicalErr == nil {
+			absolute = canonical
+		}
+		if launcherPathsEqual(output, absolute) {
+			return absolute, true
+		}
+	}
+	return "", false
+}
+
+func launcherPathsEqual(left, right string) bool {
+	if outputPathsEqual(left, right) {
+		return true
+	}
+	leftInfo, leftErr := os.Stat(left)
+	rightInfo, rightErr := os.Stat(right)
+	return leftErr == nil && rightErr == nil && os.SameFile(leftInfo, rightInfo)
+}
+
+func launcherPathWithinFilesystem(root, target string) (bool, error) {
+	if launcherPathWithin(root, target) {
+		return true, nil
+	}
+	rootInfo, err := os.Stat(root)
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	for current := target; ; current = filepath.Dir(current) {
+		if info, statErr := os.Stat(current); statErr == nil {
+			if os.SameFile(rootInfo, info) {
+				return true, nil
+			}
+		} else if !os.IsNotExist(statErr) {
+			return false, statErr
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return false, nil
+		}
+	}
+}
+
+func validateLauncherOutputTarget(path string) error {
+	info, err := os.Lstat(path)
+	if err == nil {
+		if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+			return fmt.Errorf("buildlauncher: output is not a regular file: %q", path)
+		}
+		if reparse, reparseErr := launcherOutputPathIsReparse(path); reparseErr != nil {
+			return fmt.Errorf("buildlauncher: inspect output %q: %w", path, reparseErr)
+		} else if reparse {
+			return fmt.Errorf("buildlauncher: output is a reparse point: %q", path)
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("buildlauncher: inspect output %q: %w", path, err)
+	}
+	return nil
+}
+
+// canonicalizeLauncherOutputAlias permits only macOS system aliases.
+func canonicalizeLauncherOutputAlias(path string) (string, error) {
+	parent := filepath.Dir(path)
+	existing := parent
+	for {
+		resolved, err := filepath.EvalSymlinks(existing)
+		if err == nil {
+			resolved = filepath.Clean(resolved)
+			if outputPathsEqual(existing, resolved) {
+				return path, nil
+			}
+			if !launcherOutputAliasAllowed(existing, resolved) {
+				return "", fmt.Errorf("buildlauncher: output parent contains a symlink: %q", existing)
+			}
+			relative, relErr := filepath.Rel(existing, parent)
+			if relErr != nil {
+				return "", fmt.Errorf("buildlauncher: resolve output parent %q: %w", parent, relErr)
+			}
+			return filepath.Join(resolved, relative, filepath.Base(path)), nil
+		}
+		if !os.IsNotExist(err) {
+			return "", fmt.Errorf("buildlauncher: resolve output parent %q: %w", existing, err)
+		}
+		ancestor := filepath.Dir(existing)
+		if ancestor == existing {
+			return path, nil
+		}
+		existing = ancestor
+	}
+}
+
+// validateLauncherOutputParent rejects symlink and reparse components.
+func validateLauncherOutputParent(path string, allowMissing bool) error {
+	if path == "" {
+		return fmt.Errorf("buildlauncher: output parent is empty")
+	}
+	absolute, err := filepath.Abs(path)
+	if err != nil {
+		return fmt.Errorf("buildlauncher: resolve output parent: %w", err)
+	}
+	absolute = filepath.Clean(absolute)
+	if err := validateLauncherExistingPath(absolute, allowMissing); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateLauncherExistingPath(path string, allowMissing bool) error {
+	info, err := os.Lstat(path)
+	if err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("buildlauncher: output parent contains a symlink: %q", path)
+		}
+		if !info.IsDir() {
+			return fmt.Errorf("buildlauncher: output parent is not a directory: %q", path)
+		}
+		if reparse, reparseErr := launcherOutputPathIsReparse(path); reparseErr != nil {
+			return fmt.Errorf("buildlauncher: inspect output parent %q: %w", path, reparseErr)
+		} else if reparse {
+			return fmt.Errorf("buildlauncher: output parent contains a reparse point: %q", path)
+		}
+		parent := filepath.Dir(path)
+		if parent == path {
+			return nil
+		}
+		return validateLauncherExistingPath(parent, false)
+	}
+	if !os.IsNotExist(err) {
+		return fmt.Errorf("buildlauncher: inspect output parent %q: %w", path, err)
+	}
+	if !allowMissing {
+		return fmt.Errorf("buildlauncher: output parent does not exist: %q", path)
+	}
+	parent := filepath.Dir(path)
+	if parent == path {
+		return nil
+	}
+	return validateLauncherExistingPath(parent, true)
+}

--- a/cmd/spx/internal/command/buildlauncher_output_other.go
+++ b/cmd/spx/internal/command/buildlauncher_output_other.go
@@ -1,0 +1,59 @@
+//go:build !windows
+
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package command
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+func outputPathsEqual(left, right string) bool {
+	return left == right
+}
+
+func launcherOutputPathIsReparse(path string) (bool, error) {
+	return false, nil
+}
+
+func launcherOutputAliasAllowed(existing, resolved string) bool {
+	if runtime.GOOS != "darwin" {
+		return false
+	}
+	for _, alias := range []string{"/var", "/tmp"} {
+		canonical := filepath.Join("/private", filepath.Base(alias))
+		existingRelative, existingErr := filepath.Rel(alias, existing)
+		resolvedRelative, resolvedErr := filepath.Rel(canonical, resolved)
+		if existingErr == nil && resolvedErr == nil &&
+			launcherPathWithin(alias, existing) && launcherPathWithin(canonical, resolved) &&
+			existingRelative == resolvedRelative {
+			return true
+		}
+	}
+	return false
+}
+
+func launcherStageIsExecutable(info os.FileInfo) bool {
+	return info.Mode().Perm()&0o111 != 0 && info.Size() > 0
+}
+
+// The stage and destination share a filesystem, so rename is atomic.
+func commitLauncherOutputPlatform(stage, final string) error {
+	return os.Rename(stage, final)
+}

--- a/cmd/spx/internal/command/buildlauncher_output_stage.go
+++ b/cmd/spx/internal/command/buildlauncher_output_stage.go
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package command
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func stageLauncherOutput(final string) (string, func(), error) {
+	final, err := canonicalizeLauncherOutputAlias(filepath.Clean(final))
+	if err != nil {
+		return "", nil, err
+	}
+	parent := filepath.Dir(final)
+	if err := validateLauncherOutputParent(parent, true); err != nil {
+		return "", nil, err
+	}
+	if err := os.MkdirAll(parent, 0o755); err != nil {
+		return "", nil, fmt.Errorf("buildlauncher: create output directory: %w", err)
+	}
+	if err := validateLauncherOutputParent(parent, false); err != nil {
+		return "", nil, err
+	}
+	if err := validateLauncherOutputTarget(final); err != nil {
+		return "", nil, err
+	}
+	stageDir, err := os.MkdirTemp(parent, "."+filepath.Base(final)+".spx-launchpack-*")
+	if err != nil {
+		return "", nil, fmt.Errorf("buildlauncher: create staging directory: %w", err)
+	}
+	cleanup := func() { _ = os.RemoveAll(stageDir) }
+	if err := os.Chmod(stageDir, 0o700); err != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("buildlauncher: secure staging directory: %w", err)
+	}
+	if err := validateLauncherOutputParent(stageDir, false); err != nil {
+		cleanup()
+		return "", nil, err
+	}
+	return filepath.Join(stageDir, "."+filepath.Base(final)+".spx-launchpack-stage"), cleanup, nil
+}
+
+func commitLauncherOutput(stage, final string, protection launcherOutputProtection) error {
+	stage = filepath.Clean(stage)
+	final, err := canonicalizeLauncherOutputAlias(filepath.Clean(final))
+	if err != nil {
+		return err
+	}
+	if err := validateLauncherStage(stage); err != nil {
+		return err
+	}
+	if err := validateLauncherOutputParent(filepath.Dir(final), false); err != nil {
+		return err
+	}
+	if err := validateLauncherOutputProtection(final, protection); err != nil {
+		return err
+	}
+	if err := validateLauncherOutputTarget(final); err != nil {
+		return err
+	}
+	if err := commitLauncherOutputPlatform(stage, final); err != nil {
+		return fmt.Errorf("buildlauncher: install output: %w", err)
+	}
+	if err := removeLauncherStageDir(stage, final); err != nil {
+		return fmt.Errorf("buildlauncher: clean staging directory: %w", err)
+	}
+	return nil
+}
+
+func validateLauncherStage(stage string) error {
+	if err := validateLauncherOutputParent(filepath.Dir(stage), false); err != nil {
+		return err
+	}
+	info, err := os.Lstat(stage)
+	if err != nil {
+		return fmt.Errorf("buildlauncher: inspect staged output %q: %w", stage, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+		return fmt.Errorf("buildlauncher: staged output is not a regular file: %q", stage)
+	}
+	if !launcherStageIsExecutable(info) {
+		return fmt.Errorf("buildlauncher: staged output is not executable: %q", stage)
+	}
+	return nil
+}
+
+func removeLauncherStageDir(stage, final string) error {
+	dir := filepath.Dir(stage)
+	if !outputPathsEqual(filepath.Dir(dir), filepath.Dir(final)) ||
+		!strings.HasPrefix(filepath.Base(dir), "."+filepath.Base(final)+".spx-launchpack-") {
+		return nil
+	}
+	info, err := os.Lstat(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() || info.Mode().Perm() != 0o700 {
+		return fmt.Errorf("staging directory is not private: %q", dir)
+	}
+	return os.RemoveAll(dir)
+}

--- a/cmd/spx/internal/command/buildlauncher_output_test.go
+++ b/cmd/spx/internal/command/buildlauncher_output_test.go
@@ -1,0 +1,262 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package command
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestResolveLauncherOutputProtectsBuildInputs(t *testing.T) {
+	moduleRoot := t.TempDir()
+	projectDir := filepath.Join(moduleRoot, "project")
+	if err := os.Mkdir(projectDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	bridgeDir := filepath.Join(moduleRoot, "cmd", "ispxnative")
+	if err := os.MkdirAll(bridgeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	projectFile := filepath.Join(projectDir, "main.spx")
+	heroFile := filepath.Join(projectDir, "Hero.spx")
+	for _, path := range []string{
+		projectFile, heroFile,
+		filepath.Join(projectDir, ".config"),
+		filepath.Join(moduleRoot, "gox.mod"),
+		filepath.Join(moduleRoot, "gop.mod"),
+		filepath.Join(bridgeDir, "main.go"),
+	} {
+		if err := os.WriteFile(path, []byte("input"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	inputs := launcherOutputInputs{
+		ProjectDir: projectDir, ProjectExt: ".spx", PackDir: "assets",
+		Protection: launcherOutputProtection{
+			Files: []string{
+				projectFile, heroFile,
+				filepath.Join(projectDir, ".config"),
+				filepath.Join(moduleRoot, "gox.mod"),
+				filepath.Join(moduleRoot, "gop.mod"),
+			},
+			Roots: []string{bridgeDir},
+		},
+	}
+	for _, path := range []string{
+		projectFile, heroFile,
+		filepath.Join(projectDir, "Future.spx"),
+		filepath.Join(projectDir, ".config"),
+		filepath.Join(moduleRoot, "gox.mod"),
+		filepath.Join(moduleRoot, "gop.mod"),
+		filepath.Join(bridgeDir, "main.go"),
+		filepath.Join(projectDir, "assets", "launcher"),
+	} {
+		if _, err := resolveLauncherOutput(inputs, path); err == nil {
+			t.Errorf("resolveLauncherOutput accepted build input %q", path)
+		}
+	}
+
+	defaultOutput, err := resolveLauncherOutput(inputs, "")
+	if err != nil {
+		t.Fatalf("default output: %v", err)
+	}
+	canonicalProjectDir, err := filepath.EvalSymlinks(projectDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(defaultOutput, filepath.Join(canonicalProjectDir, ".builds")) {
+		t.Fatalf("default output = %q", defaultOutput)
+	}
+}
+
+func TestResolveLauncherOutputRejectsSymlinkParentAndTarget(t *testing.T) {
+	root := t.TempDir()
+	realParent := filepath.Join(root, "real")
+	if err := os.Mkdir(realParent, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	linkParent := filepath.Join(root, "alias")
+	if err := os.Symlink(realParent, linkParent); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	inputs := launcherOutputInputs{ProjectDir: root, PackDir: "assets"}
+	if _, err := resolveLauncherOutput(inputs, filepath.Join(linkParent, "launcher")); err == nil || !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("symlink parent error = %v", err)
+	}
+
+	target := filepath.Join(root, "target")
+	if err := os.WriteFile(target, []byte("old"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	outputLink := filepath.Join(root, "launcher")
+	if err := os.Symlink(target, outputLink); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	if _, err := resolveLauncherOutput(inputs, outputLink); err == nil || !strings.Contains(err.Error(), "regular file") {
+		t.Fatalf("symlink output error = %v", err)
+	}
+}
+
+func TestResolveLauncherOutputRejectsCaseAlias(t *testing.T) {
+	root := t.TempDir()
+	project := filepath.Join(root, "main.spx")
+	if err := os.WriteFile(project, []byte("source"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	alias := filepath.Join(root, "MAIN.SPX")
+	if _, err := os.Stat(alias); err != nil {
+		t.Skip("filesystem is case-sensitive")
+	}
+	_, err := resolveLauncherOutput(launcherOutputInputs{
+		ProjectDir: root, PackDir: "assets",
+		Protection: launcherOutputProtection{Files: []string{project}},
+	}, alias)
+	if err == nil || !strings.Contains(err.Error(), "build input") {
+		t.Fatalf("case-alias output error = %v", err)
+	}
+}
+
+func TestStageLauncherOutputUsesPrivateDirectory(t *testing.T) {
+	parent := t.TempDir()
+	final := filepath.Join(parent, "nested", "launcher")
+	stage, cleanup, err := stageLauncherOutput(final)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+	stageDir := filepath.Dir(stage)
+	info, err := os.Stat(stageDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !info.IsDir() || info.Mode().Perm() != 0o700 {
+		t.Fatalf("staging directory mode = %v", info.Mode())
+	}
+	finalParent := filepath.Dir(final)
+	if resolved, resolveErr := filepath.EvalSymlinks(finalParent); resolveErr == nil {
+		finalParent = filepath.Clean(resolved)
+	}
+	if filepath.Dir(stageDir) != finalParent {
+		t.Fatalf("staging directory %q is not under output parent %q", stageDir, finalParent)
+	}
+	if _, err := os.Lstat(stage); !os.IsNotExist(err) {
+		t.Fatalf("stage path exists before compiler creates it: err=%v", err)
+	}
+}
+
+func TestCommitLauncherOutputRequiresExecutableStageAndCleansDirectory(t *testing.T) {
+	parent := t.TempDir()
+	final := filepath.Join(parent, "launcher")
+	stage, cleanup, err := stageLauncherOutput(final)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(stage, nil, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := commitLauncherOutput(stage, final, launcherOutputProtection{}); err == nil || !strings.Contains(err.Error(), "not executable") {
+		t.Fatalf("empty stage error = %v", err)
+	}
+	cleanup()
+
+	stage, cleanup, err = stageLauncherOutput(final)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(stage, []byte("new"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	stageDir := filepath.Dir(stage)
+	if err := commitLauncherOutput(stage, final, launcherOutputProtection{}); err != nil {
+		t.Fatal(err)
+	}
+	cleanup()
+	if _, err := os.Stat(stageDir); !os.IsNotExist(err) {
+		t.Fatalf("staging directory remains after commit: %v", err)
+	}
+	if got, err := os.ReadFile(final); err != nil || string(got) != "new" {
+		t.Fatalf("committed output = %q, err = %v", got, err)
+	}
+}
+
+func TestCommitLauncherOutputRejectsStagedSymlink(t *testing.T) {
+	parent := t.TempDir()
+	final := filepath.Join(parent, "launcher")
+	stage, cleanup, err := stageLauncherOutput(final)
+	if err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(parent, "other")
+	if err := os.WriteFile(target, []byte("target"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, stage); err != nil {
+		cleanup()
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	defer cleanup()
+	if err := commitLauncherOutput(stage, final, launcherOutputProtection{}); err == nil || !strings.Contains(err.Error(), "regular file") {
+		t.Fatalf("staged symlink error = %v", err)
+	}
+}
+
+func TestCommitLauncherOutputRechecksProtectedInputs(t *testing.T) {
+	parent := t.TempDir()
+	final := filepath.Join(parent, "main.spx")
+	if err := os.WriteFile(final, []byte("source"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	stage, cleanup, err := stageLauncherOutput(filepath.Join(parent, "launcher"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+	if err := os.WriteFile(stage, []byte("launcher"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	protection := launcherOutputProtection{Files: []string{final}}
+	if err := commitLauncherOutput(stage, final, protection); err == nil || !strings.Contains(err.Error(), "build input") {
+		t.Fatalf("protected commit error = %v", err)
+	}
+	if data, err := os.ReadFile(final); err != nil || string(data) != "source" {
+		t.Fatalf("protected input = %q, err = %v", data, err)
+	}
+}
+
+func TestCommitLauncherOutputRechecksProtectedRoot(t *testing.T) {
+	parent := t.TempDir()
+	root := filepath.Join(parent, "source")
+	final := filepath.Join(root, "main.go")
+	writeLauncherTestFile(t, final, "source")
+	stage, cleanup, err := stageLauncherOutput(filepath.Join(parent, "launcher"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+	if err := os.WriteFile(stage, []byte("launcher"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	protection := launcherOutputProtection{Roots: []string{root}}
+	if err := commitLauncherOutput(stage, final, protection); err == nil || !strings.Contains(err.Error(), "build input") {
+		t.Fatalf("protected root commit error = %v", err)
+	}
+	if data, err := os.ReadFile(final); err != nil || string(data) != "source" {
+		t.Fatalf("protected root input = %q, err = %v", data, err)
+	}
+}

--- a/cmd/spx/internal/command/buildlauncher_output_windows.go
+++ b/cmd/spx/internal/command/buildlauncher_output_windows.go
@@ -1,0 +1,104 @@
+//go:build windows
+
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package command
+
+import (
+	"os"
+	"strings"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+func outputPathsEqual(left, right string) bool {
+	return strings.EqualFold(left, right)
+}
+
+func launcherOutputPathIsReparse(path string) (bool, error) {
+	name, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return false, err
+	}
+	attrs, err := windows.GetFileAttributes(name)
+	if err != nil {
+		return false, err
+	}
+	return attrs&windows.FILE_ATTRIBUTE_REPARSE_POINT != 0, nil
+}
+
+func launcherOutputAliasAllowed(existing, resolved string) bool {
+	return false
+}
+
+// launchpack validates the PE header before this size check.
+func launcherStageIsExecutable(info os.FileInfo) bool {
+	return info.Size() > 0
+}
+
+var replaceFileW = windows.NewLazySystemDLL("kernel32.dll").NewProc("ReplaceFileW")
+
+const replaceFileWriteThrough = 1
+
+func replaceExistingLauncherOutput(stage, final string) error {
+	finalName, err := windows.UTF16PtrFromString(final)
+	if err != nil {
+		return err
+	}
+	stageName, err := windows.UTF16PtrFromString(stage)
+	if err != nil {
+		return err
+	}
+	// ReplaceFileW performs a single replacement while retaining the old file
+	// until the operation commits; no delete/rename empty window is exposed.
+	result, _, callErr := replaceFileW.Call(
+		uintptr(unsafe.Pointer(finalName)), uintptr(unsafe.Pointer(stageName)), 0, replaceFileWriteThrough, 0, 0,
+	)
+	if result != 0 {
+		return nil
+	}
+	if callErr != nil {
+		return callErr
+	}
+	return windows.GetLastError()
+}
+
+func moveLauncherOutput(stage, final string) error {
+	stageName, err := windows.UTF16PtrFromString(stage)
+	if err != nil {
+		return err
+	}
+	finalName, err := windows.UTF16PtrFromString(final)
+	if err != nil {
+		return err
+	}
+	return windows.MoveFileEx(stageName, finalName, windows.MOVEFILE_REPLACE_EXISTING|windows.MOVEFILE_WRITE_THROUGH)
+}
+
+func commitLauncherOutputPlatform(stage, final string) error {
+	if _, err := os.Lstat(final); err == nil {
+		if err := replaceExistingLauncherOutput(stage, final); err == nil {
+			return nil
+		} else if err != windows.ERROR_FILE_NOT_FOUND && err != windows.ERROR_PATH_NOT_FOUND {
+			return err
+		}
+	}
+	// MOVEFILE_REPLACE_EXISTING handles a destination which appears after the
+	// check above, while WRITE_THROUGH asks Windows to flush the move metadata.
+	return moveLauncherOutput(stage, final)
+}

--- a/cmd/spx/internal/command/buildlauncher_test.go
+++ b/cmd/spx/internal/command/buildlauncher_test.go
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package command
+
+import (
+	"context"
+	"embed"
+	"flag"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/goplus/spx/v3/internal/launchpack"
+)
+
+func TestBuildLauncherDispatchesBeforeLegacySetup(t *testing.T) {
+	t.Setenv("GOFLAGS", "")
+	projectDir := t.TempDir()
+	otherModule := t.TempDir()
+	repoRoot := findSPXRoot(t)
+	writeLauncherTestFile(t, filepath.Join(projectDir, "go.mod"), "module example.com/game\n\ngo 1.25.0\n\nrequire github.com/goplus/spx/v3 v3.0.0\n\nreplace github.com/goplus/spx/v3 => "+filepath.ToSlash(repoRoot)+"\n")
+	writeLauncherTestFile(t, filepath.Join(otherModule, "go.mod"), "module example.com/other\n\ngo 1.25.0\n")
+	goWork := filepath.Join(t.TempDir(), "go.work")
+	writeLauncherTestFile(t, goWork, "go 1.25.0\n\nuse (\n\t"+filepath.ToSlash(projectDir)+"\n\t"+filepath.ToSlash(otherModule)+"\n)\n")
+	t.Setenv("GOWORK", goWork)
+	writeLauncherTestFile(t, filepath.Join(projectDir, "gox.mod"), "xgo 1.8.0\n\nproject main.spx Game github.com/goplus/spx/v3 math\n\nclass -embed *.spx SpriteImpl\n\npack assets index.json\n")
+	writeLauncherTestFile(t, filepath.Join(projectDir, "main.spx"), "onStart => {}\n")
+	writeLauncherTestFile(t, filepath.Join(projectDir, "Hero.spx"), "when green flag => {}\n")
+	writeLauncherTestFile(t, filepath.Join(projectDir, "assets", "index.json"), "{}\n")
+	writeLauncherTestFile(t, filepath.Join(projectDir, "assets", "hero.png"), "asset")
+	output := filepath.Join(projectDir, "bin", "game"+executableSuffix(runtime.GOOS))
+
+	oldFlags, oldArgs := flag.CommandLine, os.Args
+	flag.CommandLine = flag.NewFlagSet("spx", flag.ContinueOnError)
+	flag.CommandLine.SetOutput(io.Discard)
+	os.Args = []string{"spx", "buildlauncher", "--path", projectDir, "-o", output, "-v"}
+	t.Cleanup(func() { flag.CommandLine, os.Args = oldFlags, oldArgs })
+
+	canonicalProjectDir, err := canonicalDirectory(projectDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	called := false
+	cmd := &CmdTool{launcherBuilder: func(_ context.Context, cfg launchpack.Config) (launchpack.Result, error) {
+		called = true
+		if cfg.ProjectDir != canonicalProjectDir || cfg.ProjectFile != filepath.Join(canonicalProjectDir, "main.spx") || cfg.PackDir != "assets" || cfg.PackIndex != "index.json" {
+			t.Fatalf("launcher config = %#v", cfg)
+		}
+		if len(cfg.BuildFlags) != 1 || cfg.BuildFlags[0] != "-v=true" {
+			t.Fatalf("launcher build flags = %#v, want [-v=true]", cfg.BuildFlags)
+		}
+		if cfg.VerifyGraph == nil {
+			t.Fatal("launcher graph verifier is nil")
+		}
+		if err := cfg.VerifyGraph(context.Background()); err != nil {
+			t.Fatalf("verify launcher graph: %v", err)
+		}
+		if cfg.Output == output || !strings.Contains(filepath.Base(cfg.Output), "spx-launchpack") {
+			t.Fatalf("launcher staging output = %q", cfg.Output)
+		}
+		if err := os.MkdirAll(filepath.Dir(cfg.Output), 0o755); err != nil {
+			return launchpack.Result{}, err
+		}
+		if err := os.WriteFile(cfg.Output, []byte("launcher"), 0o755); err != nil {
+			return launchpack.Result{}, err
+		}
+		return launchpack.Result{Output: cfg.Output}, nil
+	}}
+	if err := cmd.RunCmd("spx", ".spx", "test", embed.FS{}, "", "project"); err != nil {
+		t.Fatal(err)
+	}
+	if !called {
+		t.Fatal("injected launcher builder was not called")
+	}
+	if got, err := os.ReadFile(output); err != nil || string(got) != "launcher" {
+		t.Fatalf("output = %q, err = %v", got, err)
+	}
+	if cmd.ProjectDir != "" || cmd.CmdPath != "" || cmd.LibPath != "" {
+		t.Fatalf("legacy setup ran: project=%q cmd=%q lib=%q", cmd.ProjectDir, cmd.CmdPath, cmd.LibPath)
+	}
+}
+
+func TestValidateBuildLauncherArgs(t *testing.T) {
+	if err := validateBuildLauncherArgs(ExtraArgs{Build: launcherStringPointer("normal"), Mode: launcherStringPointer("none"), Target: launcherStringPointer("esp32")}); err != nil {
+		t.Fatal(err)
+	}
+	for _, test := range []struct {
+		name string
+		args ExtraArgs
+	}{
+		{name: "arch", args: ExtraArgs{Arch: launcherStringPointer("arm64")}},
+		{name: "tags", args: ExtraArgs{Tags: launcherStringPointer("pure_engine")}},
+		{name: "servermode", args: ExtraArgs{ServerMode: launcherBoolPointer(true)}},
+		{name: "build", args: ExtraArgs{Build: launcherStringPointer("fast")}},
+		{name: "mode", args: ExtraArgs{Mode: launcherStringPointer("worker")}},
+		{name: "target", args: ExtraArgs{Target: launcherStringPointer("web")}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			err := validateBuildLauncherArgs(test.args)
+			if err == nil || !strings.Contains(err.Error(), "not supported") || !strings.Contains(err.Error(), "-"+test.name) {
+				t.Fatalf("validateBuildLauncherArgs(%s) error = %v", test.name, err)
+			}
+		})
+	}
+}
+
+func TestBuildLauncherRejectsPositionalArgs(t *testing.T) {
+	oldFlags, oldArgs := flag.CommandLine, os.Args
+	flag.CommandLine = flag.NewFlagSet("spx", flag.ContinueOnError)
+	flag.CommandLine.SetOutput(io.Discard)
+	os.Args = []string{"spx", "buildlauncher", "extra"}
+	t.Cleanup(func() { flag.CommandLine, os.Args = oldFlags, oldArgs })
+
+	err := (&CmdTool{}).RunCmd("spx", ".spx", "test", embed.FS{}, "", "project")
+	if err == nil || !strings.Contains(err.Error(), "unexpected positional arguments") {
+		t.Fatalf("positional argument error = %v", err)
+	}
+}
+
+func TestBuildLauncherBuildFlags(t *testing.T) {
+	if got := buildLauncherBuildFlags(ExtraArgs{Verbose: launcherBoolPointer(true)}); len(got) != 1 || got[0] != "-v=true" {
+		t.Fatalf("verbose build flags = %#v", got)
+	}
+	if got := buildLauncherBuildFlags(ExtraArgs{}); got != nil {
+		t.Fatalf("default build flags = %#v, want nil", got)
+	}
+}
+
+func TestBuildLauncherFailurePreservesExistingOutput(t *testing.T) {
+	projectDir := t.TempDir()
+	output := filepath.Join(projectDir, "game")
+	writeLauncherTestFile(t, output, "old")
+	stage, cleanup, err := stageLauncherOutput(output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(stage, []byte("new"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cleanup()
+	if got, err := os.ReadFile(output); err != nil || string(got) != "old" {
+		t.Fatalf("existing output = %q, err = %v", got, err)
+	}
+	stage, cleanup, err = stageLauncherOutput(output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+	if err := os.WriteFile(stage, []byte("new"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := commitLauncherOutput(stage, output, launcherOutputProtection{}); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := os.ReadFile(output); err != nil || string(got) != "new" {
+		t.Fatalf("committed output = %q, err = %v", got, err)
+	}
+}
+
+func findSPXRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			if _, err := os.Stat(filepath.Join(dir, "cmd", "ispxnative", "main.go")); err == nil {
+				return dir
+			}
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("SPX source root not found")
+		}
+		dir = parent
+	}
+}
+
+func writeLauncherTestFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func launcherStringPointer(value string) *string { return &value }
+
+func launcherBoolPointer(value bool) *bool { return &value }

--- a/cmd/spx/internal/command/cmd.go
+++ b/cmd/spx/internal/command/cmd.go
@@ -54,6 +54,8 @@ type CmdTool struct {
 	LibPath    string
 	BinPostfix string
 
+	launcherBuilder launcherBuilder
+
 	// CLI args.
 	Args ExtraArgs
 
@@ -94,6 +96,16 @@ func (cmd *CmdTool) RunCmd(projectName, fileSuffix, version string, fs embed.FS,
 	}
 	if cmd.Args.Verbose != nil && *cmd.Args.Verbose {
 		enableDebugLogging()
+	}
+	if cmd.Args.CmdName == "buildlauncher" {
+		if *help {
+			return nil
+		}
+		if err := cmd.runBuildLauncher(); err != nil {
+			logErrorf("Building launcher: %v", err)
+			return err
+		}
+		return nil
 	}
 
 	if cmd.Args.CmdName == "init" {

--- a/docs/en/dev/engine/buildlauncher.md
+++ b/docs/en/dev/engine/buildlauncher.md
@@ -1,0 +1,30 @@
+# `spx buildlauncher`
+
+`spx buildlauncher` creates a self-contained host launcher without starting
+Godot and without building or running an XGo project driver.
+
+```sh
+spx buildlauncher --path ./game
+spx buildlauncher --path ./game -o ./bin/game
+```
+
+The default output is `./game/.builds/game` (with `.exe` on Windows). A
+relative `-o` path is resolved from the current directory. The command builds
+in a private staging directory beside the requested output and atomically
+replaces the old file only after validation. The output cannot overwrite SPX
+project sources, project configuration, module metadata, selected bridge
+sources, or the pack directory.
+
+The target module must contain `gox.mod` or `gop.mod` with a `.spx` project and
+its `pack` declaration. Every top-level `.spx` file and every file under the
+declared pack directory is included in the launcher. The bridge is built from
+the SPX module selected by the active Go graph, whether it comes from the
+module cache, the main module, or a local replacement. No local XGo driver is
+required.
+The command freezes `GOWORK` and `GOFLAGS` for the invocation and verifies the
+module selection and graph metadata before and after both Go builds. The built
+bridge and payload are content-digested.
+
+Runtime assets are resolved by the same local-manifest, source-checkout, and
+pinned-release/cache policy used by the packaging service. Set
+`SPX_RUNTIME_OFFLINE=1` to prevent network access.

--- a/docs/zh/dev/engine/buildlauncher.md
+++ b/docs/zh/dev/engine/buildlauncher.md
@@ -1,0 +1,24 @@
+# `spx buildlauncher`
+
+`spx buildlauncher` 不启动 Godot，也不构建或运行 XGo project driver，直接
+生成包含 Engine、PCK、bridge 和项目归档的自包含 host launcher。
+
+```bash
+spx buildlauncher --path ./game
+spx buildlauncher --path ./game -o ./bin/game
+```
+
+默认输出为 `./game/.builds/game`（Windows 自动加 `.exe`）。相对 `-o` 路径
+相对于当前目录解析。命令在目标目录内私有 staging 目录构建，验证成功后原子
+替换旧文件；构建失败不会破坏旧产物。输出不能覆盖 `.spx` 源码、项目配置、
+module 元数据、选中的 bridge 源码或 pack 目录。
+
+目标 module 必须包含 `gox.mod` 或 `gop.mod`，其中声明 `.spx` project 和
+`pack`。所有顶层 `.spx` 文件以及 pack 目录下的文件都会进入 launcher。
+bridge 使用当前 Go graph 选中的 SPX module 构建，支持 module cache、main
+module 和 local replacement，不依赖本地 XGo driver。
+命令固定本次调用的 `GOWORK` 和 `GOFLAGS`，并在 bridge 与 launcher 构建前后
+校验 module 选择和 graph 元数据；bridge 与 payload 通过内容摘要绑定。
+
+runtime asset 遵循 packaging service 的 local manifest、source checkout、
+pinned release/cache 顺序。设置 `SPX_RUNTIME_OFFLINE=1` 可禁止联网。


### PR DESCRIPTION
## Summary

- add spx buildlauncher without starting Godot or requiring a local XGo driver
- freeze and verify Go module graph metadata across bridge and launcher builds
- protect project inputs with private staging and atomic output replacement
- document the standalone launcher workflow in English and Chinese

Built on the launchpack service merged in #1766.

## Verification

- go test -count=1 -race ./...
- go vet ./cmd/spx/internal/command ./internal/launchpack
- Windows amd64 pure_engine cross-compile
- gofmt and git diff checks