### PR TITLE
fix(ispxnative): scope duplicate linker flag to Windows

### DIFF
--- a/cmd/ispxnative/build.sh
+++ b/cmd/ispxnative/build.sh
@@ -19,7 +19,7 @@ case "${GOOS}" in
 esac
 
 LDFLAGS=""
-if [[ "${GOOS}" != "darwin" ]]; then
+if [[ "${GOOS}" == "windows" ]]; then
     LDFLAGS="-extldflags=-Wl,--allow-multiple-definition"
 fi
 


### PR DESCRIPTION
## Summary

Apply --allow-multiple-definition only to Windows c-shared builds. Linux uses its native linker defaults, matching the other SPX bridge build paths.

## Verification

- bash -n cmd/ispxnative/build.sh
- git diff --check