### PR TITLE
fix(web): ignore directory entries during project sync

### DIFF
--- a/cmd/ispx/web/game.js
+++ b/cmd/ispx/web/game.js
@@ -275,6 +275,11 @@ class GameApp {
         /** @type FilesMeta */
         const filesMeta = {};
         Object.entries(files).forEach(([path, { lastModified, content }]) => {
+            // ZIP readers expose directory entries with a trailing slash. They
+            // are not files and cannot be written to the engine filesystem.
+            if (path.endsWith('/')) {
+                return;
+            }
             filesMeta[path] = { lastModified };
             const savedFileMeta = savedFilesMeta[path];
             if (savedFileMeta != null && savedFileMeta.lastModified === lastModified) {


### PR DESCRIPTION
## Summary

Ignore project entries whose paths end with `/` before syncing files into the Web engine filesystem.

## Background

Builder may pass ZIP directory entries directly to `GameApp.InitGame`. Unlike the local `runweb` Lab adapter, this input is not pre-filtered.

Writing a directory entry such as `assets/.../=/` as a file causes an `EISDIR` error and interrupts the remaining asset synchronization.

## Testing

- `node --check cmd/ispx/web/game.js`