### PR TITLE
fix(font): relax font family name validation

### DIFF
--- a/internal/core/project/fonts.go
+++ b/internal/core/project/fonts.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"slices"
 	"sort"
 	"strings"
 
@@ -149,10 +150,8 @@ func verifyFontFace(fs spxfs.Dir, facePath string) error {
 }
 
 func verifyFontFaceInEngine(assetDir, facePath string) error {
-	for _, candidate := range configAssetPaths(assetDir, facePath) {
-		if engine.HasFile(candidate) {
-			return nil
-		}
+	if slices.ContainsFunc(configAssetPaths(assetDir, facePath), engine.HasFile) {
+		return nil
 	}
 	return os.ErrNotExist
 }
@@ -212,14 +211,6 @@ func sortFontFamilyNames(names []string) {
 func validateFontFamilyName(name string) (string, error) {
 	if name == "" {
 		return "", fmt.Errorf("font family name must be non-empty")
-	}
-	if strings.ContainsAny(name, "\\/") {
-		return "", fmt.Errorf("font family name %q must be one path segment", name)
-	}
-	for _, r := range name {
-		if r < 0x20 || r == 0x7f {
-			return "", fmt.Errorf("font family name %q contains a control character", name)
-		}
 	}
 	folded := asciiFold(name)
 	if folded == defaultFontFamilyName {


### PR DESCRIPTION
## Problem

Project font family names were rejected when they contained path separators or
control characters, which is stricter than needed for the current font loading
behavior. The engine asset lookup also used a manual candidate loop.

## Approach

- Use `slices.ContainsFunc` for engine font-face lookup.
- Remove the extra path-segment and control-character restrictions from font
  family name validation.
- Keep non-empty names, the reserved `default` name, and ASCII case-folding
  conflict checks.

## Tests

- `go test ./internal/core/project`
- `gofmt -w internal/core/project/fonts.go`
- `git diff --check`

Automation notice: An AI agent prepared this submission at the direction of the
user for relaxing project font-family validation.