### PR TITLE
fix(svg): render zero-sized costumes as transparent

### DIFF
--- a/godot_modules/spx/spx_image_loader_svg.cpp
+++ b/godot_modules/spx/spx_image_loader_svg.cpp
@@ -85,9 +85,13 @@ Error SpxImageLoaderSVG::create_image_from_utf8_buffer(Ref<Image> p_image, const
 
 	uint32_t width = document->width();
 	uint32_t height = document->height();
-	// check the invalid svg file
+	// Treat Scratch's zero-sized costumes as transparent images.
 	if (width == 0 || height == 0) {
-		return ERR_INVALID_DATA;
+		PackedByteArray transparent_pixel;
+		transparent_pixel.resize(4);
+		transparent_pixel.fill(0);
+		p_image->set_data(1, 1, false, Image::FORMAT_RGBA8, transparent_pixel);
+		return OK;
 	}
 
 	const double scaled_width = (double)width * p_scale;

--- a/godot_modules/spx/tests/test_spx_svg.h
+++ b/godot_modules/spx/tests/test_spx_svg.h
@@ -66,6 +66,16 @@ TEST_CASE("[SPX] SVG loading keeps unpremultiplied RGBA data") {
 	CHECK(pixel.a == doctest::Approx(0.5f).epsilon(0.05f));
 }
 
+TEST_CASE("[SPX] SVG loading turns a zero-sized costume into a transparent texture") {
+	Ref<Image> image = memnew(Image());
+	const String svg = "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"0\" height=\"0\" viewBox=\"0 0 0 0\"><g fill=\"none\"/></svg>";
+
+	CHECK(SpxImageLoaderSVG::create_image_from_string(image, svg, 1.0f, false, HashMap<Color, Color>()) == OK);
+	CHECK(image->get_width() == 1);
+	CHECK(image->get_height() == 1);
+	CHECK(image->get_pixel(0, 0).a == 0.0f);
+}
+
 TEST_CASE("[SPX] SVG loading rejects oversized rasterization") {
 	Ref<Image> image = memnew(Image());
 	const String svg = "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"20000\" height=\"20000\"><rect width=\"20000\" height=\"20000\" fill=\"#000\"/></svg>";


### PR DESCRIPTION
## Summary

- Treat zero-sized Scratch SVG costumes as transparent images.
- Prevent the previous costume texture from remaining visible.
- Add a regression test for zero-sized SVG loading.

## Root cause

Scratch empty costumes can be represented as zero-sized SVGs. The SVG loader returned `ERR_INVALID_DATA`, so the texture update failed and left the previous costume visible.

## Testing

- Targeted SVG regression test: 1 test case, 4 assertions passed.
- Full SPX test suite: 50 test cases, 304 assertions passed.
- Built, imported, and started fixture `447630265` with the rebuilt macOS x86_64 engine.

Fixes goplus/sb2xbp#715