### PR TITLE
chore: ignore SCons temporary object files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ xgo_autogen*.go
 
 # SCons writes custom-module object files next to their sources.
 /godot_modules/**/*.o
+/godot_modules/**/*.o.tmp
 /godot_modules/**/*.os
 /godot_modules/**/*.ox
 /godot_modules/**/*.obj


### PR DESCRIPTION
## Summary

- Ignore `.o.tmp` files generated by SCons under `godot_modules`
- Prevent temporary compiler artifacts from appearing as Git changes

## Verification

- Verified a representative `.o.tmp` path with `git check-ignore`
- Ran `git diff --check`

No build was run because this change only updates `.gitignore`.