### PR TITLE
fix(engine): resolve legacy asset paths canonically

### DIFF
--- a/cmd/spx/internal/command/run.go
+++ b/cmd/spx/internal/command/run.go
@@ -33,7 +33,6 @@ import (
 	"github.com/goplus/spx/v3/cmd/spx/internal/runtimeasset"
 	"github.com/goplus/spx/v3/cmd/spx/internal/util"
 	"github.com/goplus/spx/v3/internal/interpruntime"
-	"github.com/goplus/spx/v3/internal/scaffold"
 )
 
 var prepareEmbeddedRuntimeAssets = runtimeasset.Prepare
@@ -47,15 +46,9 @@ func (cmd *CmdTool) RunPackMode(pargs ...string) error {
 	if err != nil {
 		return err
 	}
-	dllPath := path.Join(cmd.RuntimeTempDir, filepath.Base(cmd.LibPath))
-	if err := util.CopyFile(cmd.LibPath, dllPath); err != nil {
-		return err
-	}
-	extensionPath := path.Join(cmd.RuntimeTempDir, "runtime.gdextension")
-	if err := util.CopyFile(path.Join(cmd.ProjectDir, "runtime.gdextension.txt"), extensionPath); err != nil {
-		return err
-	}
-	if err := prepareRuntimeExtensionList(cmd.RuntimeTempDir); err != nil {
+	if err := interpruntime.PrepareSession(interpruntime.SessionConfig{
+		Roots: roots, BridgePath: cmd.LibPath,
+	}); err != nil {
 		return err
 	}
 
@@ -301,18 +294,6 @@ func (cmd *CmdTool) interpretedRoots() (interpruntime.Roots, error) {
 		AssetDir:   filepath.Join(projectDir, "assets"),
 		SessionDir: filepath.Clean(sessionDir),
 	}, nil
-}
-
-func prepareRuntimeExtensionList(runtimeDir string) error {
-	projectDataDir := filepath.Join(runtimeDir, ".godot")
-	if err := os.MkdirAll(projectDataDir, 0o755); err != nil {
-		return fmt.Errorf("failed to create runtime project data directory: %w", err)
-	}
-	listPath := filepath.Join(projectDataDir, "extension_list.cfg")
-	if err := os.WriteFile(listPath, []byte(scaffold.RuntimeExtensionList()), 0o644); err != nil {
-		return fmt.Errorf("failed to write runtime extension list: %w", err)
-	}
-	return nil
 }
 
 // runWebCommand exports before serving.

--- a/cmd/spx/internal/command/run_test.go
+++ b/cmd/spx/internal/command/run_test.go
@@ -341,9 +341,6 @@ func TestRunPackModeUsesSessionEnvironment(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	if err := os.WriteFile(filepath.Join(generatedDir, "runtime.gdextension.txt"), []byte("extension"), 0o644); err != nil {
-		t.Fatal(err)
-	}
 
 	logPath := filepath.Join(t.TempDir(), "runtime.log")
 	runtimePath := filepath.Join(t.TempDir(), "runtime"+executableSuffix(runtime.GOOS))
@@ -376,6 +373,21 @@ func TestRunPackModeUsesSessionEnvironment(t *testing.T) {
 	} {
 		if !strings.Contains(string(log), want+"\n") {
 			t.Fatalf("runtime log = %q, want %q", log, want)
+		}
+	}
+
+	for file, want := range map[string]string{
+		filepath.Join(sessionDir, "runtime.gdextension"):          scaffold.SessionRuntimeGDExtension(),
+		filepath.Join(sessionDir, "gdspx.gdextension"):            scaffold.ProjectGDExtension(),
+		filepath.Join(sessionDir, ".godot", "extension_list.cfg"): scaffold.SessionExtensionList(),
+		filepath.Join(sessionDir, "lib", filepath.Base(libPath)):  "bridge",
+	} {
+		got, err := os.ReadFile(file)
+		if err != nil {
+			t.Fatalf("read %s: %v", file, err)
+		}
+		if string(got) != want {
+			t.Fatalf("%s = %q, want %q", file, got, want)
 		}
 	}
 }

--- a/internal/engine/path.go
+++ b/internal/engine/path.go
@@ -181,7 +181,11 @@ func buildFilesystemAssetPath(relPath string) string {
 		if err != nil || info.Mode()&os.ModeSymlink != 0 {
 			return ""
 		}
-		canonicalPath, err := filepath.EvalSymlinks(filepath.FromSlash(resolvedPath))
+		absolutePath, err := filepath.Abs(filepath.FromSlash(resolvedPath))
+		if err != nil {
+			return ""
+		}
+		canonicalPath, err := filepath.EvalSymlinks(absolutePath)
 		if err != nil || !isWithinRoot(cleanFilesystemPath(canonicalPath), canonicalRoot) {
 			return ""
 		}

--- a/internal/engine/path_filesystem.go
+++ b/internal/engine/path_filesystem.go
@@ -66,9 +66,12 @@ func setLegacyFilesystemAssetDir(dir string) {
 		if err == nil {
 			assetPaths.canonicalProjectRoot = cleanFilesystemPath(projectRoot)
 		}
-		compatibilityRoot, compatErr := filepath.EvalSymlinks(filepath.FromSlash(assetPaths.compatibilityRoot))
+		compatibilityRootPath, compatErr := filepath.Abs(filepath.FromSlash(assetPaths.compatibilityRoot))
 		if compatErr == nil {
-			assetPaths.canonicalCompatibilityRoot = cleanFilesystemPath(compatibilityRoot)
+			compatibilityRootPath, compatErr = filepath.EvalSymlinks(compatibilityRootPath)
+		}
+		if compatErr == nil {
+			assetPaths.canonicalCompatibilityRoot = cleanFilesystemPath(compatibilityRootPath)
 		}
 	}
 }

--- a/internal/engine/path_filesystem_test.go
+++ b/internal/engine/path_filesystem_test.go
@@ -24,7 +24,7 @@ import (
 	"testing"
 )
 
-func TestLegacyFilesystemRootsRejectSymlinkEscape(t *testing.T) {
+func TestLegacyFilesystemRootsResolveAssetsWithoutSymlinkEscape(t *testing.T) {
 	original := assetPaths
 	t.Cleanup(func() {
 		assetPaths = original
@@ -39,6 +39,10 @@ func TestLegacyFilesystemRootsRejectSymlinkEscape(t *testing.T) {
 	if err := os.Mkdir(sessionDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
+	assetPath := filepath.Join(assetDir, "inside.png")
+	if err := os.WriteFile(assetPath, []byte("inside"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	externalDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(externalDir, "outside.png"), []byte("outside"), 0o644); err != nil {
 		t.Fatal(err)
@@ -48,6 +52,9 @@ func TestLegacyFilesystemRootsRejectSymlinkEscape(t *testing.T) {
 	}
 	t.Chdir(sessionDir)
 	setLegacyFilesystemAssetDir("assets")
+	if got, want := buildFilesystemAssetPath("inside.png"), filepath.Join("..", "assets", "inside.png"); got != want {
+		t.Fatalf("buildFilesystemAssetPath() = %q, want %q", got, want)
+	}
 	if got := buildFilesystemAssetPath("linked/outside.png"); got != "" {
 		t.Fatalf("buildFilesystemAssetPath() followed legacy symlink escape: %q", got)
 	}


### PR DESCRIPTION
## Problem

`spx runnative` compiled a fresh project dylib, but the runtime could load the interpreter bridge from `$GOPATH/bin` instead.

Valid legacy relative asset paths could also be rejected because they were compared with an absolute project root.

## Changes

- Prepare an isolated runtime session.
- Copy the freshly compiled dylib into `.temp/lib`.
- Configure the session to load that dylib explicitly.
- Canonicalize relative asset paths before boundary checks.
- Preserve symlink escape protection.

This does not change `spx run`, which continues to use the installed interpreter bridge.

## Verification

- `go test ./...`
- `go test -tags=packmode ./internal/engine`
- Confirmed that `runnative` loads `.temp/lib/gdspx-darwin-amd64.dylib`.
- Verified project `374645340` with native runtime.