### PR TITLE
refactor(env): add deterministic command environment helpers

### DIFF
--- a/internal/envutil/env.go
+++ b/internal/envutil/env.go
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package envutil contains the small, deterministic environment operations
+// shared by SPX's driver and launcher paths.
+package envutil
+
+import (
+	"os"
+	"runtime"
+	"strings"
+)
+
+// NeutralGOFLAGS overrides persisted GOFLAGS without changing command behavior.
+const NeutralGOFLAGS = "-x=false"
+
+// Assignment describes one environment value to append after replacing all
+// existing entries with the same key.
+type Assignment struct {
+	Key   string
+	Value string
+}
+
+func resolve(env []string) []string {
+	if env == nil {
+		return os.Environ()
+	}
+	return env
+}
+
+func canonicalKey(key string) string {
+	if runtime.GOOS == "windows" {
+		return strings.ToLower(key)
+	}
+	return key
+}
+
+// Lookup finds one key and reports whether it occurred more than once.
+func Lookup(env []string, key string) (value string, found, duplicate bool) {
+	key = canonicalKey(key)
+	for _, entry := range env {
+		name, current, ok := strings.Cut(entry, "=")
+		if !ok || canonicalKey(name) != key {
+			continue
+		}
+		if found {
+			return "", true, true
+		}
+		value, found = current, true
+	}
+	return value, found, false
+}
+
+// HasNonEmpty reports whether any occurrence of key has a non-empty value.
+func HasNonEmpty(env []string, key string) bool {
+	key = canonicalKey(key)
+	for _, entry := range resolve(env) {
+		name, value, ok := strings.Cut(entry, "=")
+		if ok && canonicalKey(name) == key && value != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func filter(env []string, reject func(string) bool) []string {
+	base := resolve(env)
+	filtered := make([]string, 0, len(base))
+	for _, entry := range base {
+		key, _, ok := strings.Cut(entry, "=")
+		if ok && reject(key) {
+			continue
+		}
+		filtered = append(filtered, entry)
+	}
+	return filtered
+}
+
+// Without removes entries whose key is one of keys.
+func Without(env []string, keys ...string) []string {
+	set := make(map[string]struct{}, len(keys))
+	for _, key := range keys {
+		set[canonicalKey(key)] = struct{}{}
+	}
+	return filter(env, func(key string) bool {
+		_, found := set[canonicalKey(key)]
+		return found
+	})
+}
+
+// WithoutPrefixes removes entries whose key starts with any prefix.
+func WithoutPrefixes(env []string, prefixes ...string) []string {
+	return filter(env, func(key string) bool {
+		key = canonicalKey(key)
+		for _, prefix := range prefixes {
+			if strings.HasPrefix(key, canonicalKey(prefix)) {
+				return true
+			}
+		}
+		return false
+	})
+}
+
+// SetMany replaces each assignment key and appends its value in declaration
+// order. Empty values are intentional and are retained.
+func SetMany(env []string, assignments ...Assignment) []string {
+	return setManyWithout(env, nil, assignments...)
+}
+
+func setManyWithout(env []string, removeKeys []string, assignments ...Assignment) []string {
+	last := make(map[string]int, len(removeKeys)+len(assignments))
+	for _, key := range removeKeys {
+		last[canonicalKey(key)] = -1
+	}
+	for i, assignment := range assignments {
+		last[canonicalKey(assignment.Key)] = i
+	}
+	result := filter(env, func(key string) bool {
+		_, changed := last[canonicalKey(key)]
+		return changed
+	})
+	for i, assignment := range assignments {
+		if last[canonicalKey(assignment.Key)] == i {
+			result = append(result, assignment.Key+"="+assignment.Value)
+		}
+	}
+	return result
+}
+
+// HostGoEnvironment returns the deterministic environment for a host Go
+// command. Ambient graph, target, and CGO selection cannot leak into it.
+func HostGoEnvironment(env []string, goWork string, cgoEnabled bool, removeKeys ...string) []string {
+	cgo := "0"
+	if cgoEnabled {
+		cgo = "1"
+	}
+	return setManyWithout(env, removeKeys,
+		Assignment{Key: "GOFLAGS", Value: NeutralGOFLAGS},
+		Assignment{Key: "GOWORK", Value: goWork},
+		Assignment{Key: "GOOS", Value: runtime.GOOS},
+		Assignment{Key: "GOARCH", Value: runtime.GOARCH},
+		Assignment{Key: "CGO_ENABLED", Value: cgo},
+	)
+}

--- a/internal/envutil/env_test.go
+++ b/internal/envutil/env_test.go
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package envutil
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestLookupReportsDuplicatesWithoutLosingValue(t *testing.T) {
+	value, found, duplicate := Lookup([]string{"A=one", "B=two", "A=three"}, "A")
+	if value != "" || !found || !duplicate {
+		t.Fatalf("Lookup duplicate = %q, %t, %t", value, found, duplicate)
+	}
+	if value, found, duplicate := Lookup([]string{"A=one"}, "A"); value != "one" || !found || duplicate {
+		t.Fatalf("Lookup single = %q, %t, %t", value, found, duplicate)
+	}
+}
+
+func TestHasNonEmptyChecksEveryOccurrence(t *testing.T) {
+	if !HasNonEmpty([]string{"A=", "A=value"}, "A") {
+		t.Fatal("HasNonEmpty missed a later non-empty value")
+	}
+	if HasNonEmpty([]string{"A=", "B=value"}, "A") {
+		t.Fatal("HasNonEmpty accepted only empty values")
+	}
+}
+
+func TestSetManyReplacesKeysAndPreservesOrder(t *testing.T) {
+	got := SetMany([]string{"A=old", "malformed", "B=keep", "A=duplicate"}, Assignment{Key: "A", Value: "new"}, Assignment{Key: "C", Value: ""})
+	want := []string{"malformed", "B=keep", "A=new", "C="}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("SetMany = %#v, want %#v", got, want)
+	}
+}
+
+func TestSetManyUsesLastDuplicateAssignment(t *testing.T) {
+	got := SetMany([]string{"A=old", "B=keep"}, Assignment{Key: "A", Value: "first"}, Assignment{Key: "C", Value: "value"}, Assignment{Key: "A", Value: "last"})
+	want := []string{"B=keep", "C=value", "A=last"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("SetMany duplicates = %#v, want %#v", got, want)
+	}
+}
+
+func TestWithoutPrefixes(t *testing.T) {
+	got := WithoutPrefixes([]string{"CGO_ENABLED=1", "CGO_CFLAGS=x", "PATH=/bin"}, "CGO_")
+	want := []string{"PATH=/bin"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("WithoutPrefixes = %#v, want %#v", got, want)
+	}
+}
+
+func TestEnvironmentKeyComparisonMatchesPlatform(t *testing.T) {
+	value, found, duplicate := Lookup([]string{"spx_flag=on"}, "SPX_FLAG")
+	wantValue, wantFound := "", false
+	if runtime.GOOS == "windows" {
+		wantValue, wantFound = "on", true
+	}
+	if value != wantValue || found != wantFound || duplicate {
+		t.Fatalf("Lookup case variant = %q, %t, %t; want %q, %t, false", value, found, duplicate, wantValue, wantFound)
+	}
+
+	got := SetMany([]string{"Path=/old"}, Assignment{Key: "PATH", Value: "/new"})
+	want := []string{"Path=/old", "PATH=/new"}
+	if runtime.GOOS == "windows" {
+		want = []string{"PATH=/new"}
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("SetMany case variants = %#v, want %#v", got, want)
+	}
+
+	got = WithoutPrefixes([]string{"cgo_cflags=-unsafe", "PATH=/bin"}, "CGO_")
+	want = []string{"cgo_cflags=-unsafe", "PATH=/bin"}
+	if runtime.GOOS == "windows" {
+		want = []string{"PATH=/bin"}
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("WithoutPrefixes case variants = %#v, want %#v", got, want)
+	}
+}
+
+func TestHostGoEnvironmentPinsGraphAndTarget(t *testing.T) {
+	got := HostGoEnvironment([]string{"PATH=/bin", "GOFLAGS=-mod=vendor", "GOWORK=/ambient", "GOOS=plan9", "GOARCH=386", "CGO_ENABLED=1", "SECRET=remove"}, "/graph/go.work", false, "SECRET")
+	want := []string{"PATH=/bin", "GOFLAGS=" + NeutralGOFLAGS, "GOWORK=/graph/go.work", "GOOS=" + runtime.GOOS, "GOARCH=" + runtime.GOARCH, "CGO_ENABLED=0"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("HostGoEnvironment = %#v, want %#v", got, want)
+	}
+}
+
+func TestHostGoEnvironmentOverridesPersistedGOFLAGS(t *testing.T) {
+	goCommand, err := exec.LookPath("go")
+	if err != nil {
+		t.Skip(err)
+	}
+	goEnv := filepath.Join(t.TempDir(), "go.env")
+	if err := os.WriteFile(goEnv, []byte("GOFLAGS=-buildvcs=false\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	base := SetMany(os.Environ(), Assignment{Key: "GOENV", Value: goEnv})
+	command := exec.Command(goCommand, "env", "GOFLAGS")
+	command.Env = HostGoEnvironment(base, "off", false)
+	output, err := command.Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.TrimSpace(string(output)); got != NeutralGOFLAGS {
+		t.Fatalf("go env GOFLAGS = %q, want %q", got, NeutralGOFLAGS)
+	}
+}


### PR DESCRIPTION
## Summary

- add a small internal package for deterministic environment lookup, filtering, and assignment
- centralize host Go command isolation for GOFLAGS, GOWORK, target, and CGO variables
- cover duplicate keys, ordering, platform case rules, and persisted GOFLAGS

This is P1 of the project-driver split for #1741. It introduces only the shared primitive; consumers remain unchanged, so production behavior is unchanged.

## Validation

- GOWORK=off go test -mod=readonly -count=1 ./internal/envutil
- GOWORK=off go vet -mod=readonly ./internal/envutil
- full repository Go and script tests
- repository Go builds, including cmd/ispx and cmd/ispxnative
- Windows amd64 cross-compilation of the package tests

The local generate-clean check differs only for the pre-existing binary export.types under the local generator toolchain; that generated file is not part of this PR. GitHub CI uses the repository-locked toolchain.