### PR TITLE
refactor: extract driver-bundle contract

### DIFF
--- a/.github/actions/driver-bundle/action.yml
+++ b/.github/actions/driver-bundle/action.yml
@@ -1,0 +1,58 @@
+name: Package and verify driver bundle
+description: Build a deterministic Engine/PCK/bridge driver ZIP and verify it.
+inputs:
+  engine:
+    description: Path to the canonical Engine input
+    required: true
+  pack:
+    description: Path to the canonical runtime PCK input
+    required: true
+  bridge:
+    description: Path to the canonical interpreter bridge input
+    required: true
+  output:
+    description: Output driver ZIP path
+    required: true
+  descriptor:
+    description: Output driver descriptor JSON path
+    required: true
+  goos:
+    description: Target GOOS
+    required: true
+  goarch:
+    description: Target GOARCH
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Package driver bundle
+      shell: bash
+      env:
+        ENGINE_PATH: ${{ inputs.engine }}
+        PACK_PATH: ${{ inputs.pack }}
+        BRIDGE_PATH: ${{ inputs.bridge }}
+        OUTPUT_PATH: ${{ inputs.output }}
+        DESCRIPTOR_PATH: ${{ inputs.descriptor }}
+        TARGET_GOOS: ${{ inputs.goos }}
+        TARGET_GOARCH: ${{ inputs.goarch }}
+      run: |
+        set -euo pipefail
+        go run ./.github/scripts/driverbundle package \
+          --engine "$ENGINE_PATH" \
+          --pack "$PACK_PATH" \
+          --bridge "$BRIDGE_PATH" \
+          --output "$OUTPUT_PATH" \
+          --descriptor "$DESCRIPTOR_PATH" \
+          --goos "$TARGET_GOOS" \
+          --goarch "$TARGET_GOARCH"
+
+    - name: Verify driver bundle
+      shell: bash
+      env:
+        OUTPUT_PATH: ${{ inputs.output }}
+        DESCRIPTOR_PATH: ${{ inputs.descriptor }}
+      run: |
+        set -euo pipefail
+        go run ./.github/scripts/driverbundle verify \
+          --output "$OUTPUT_PATH" \
+          --descriptor "$DESCRIPTOR_PATH"

--- a/.github/scripts/driverbundle/files.go
+++ b/.github/scripts/driverbundle/files.go
@@ -1,0 +1,225 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"hash"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"github.com/goplus/spx/v3/internal/driverbundle"
+)
+
+func openRegularFile(path string) (*os.File, os.FileInfo, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+		return nil, nil, &notRegularError{path: path}
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	opened, err := file.Stat()
+	if err != nil {
+		_ = file.Close()
+		return nil, nil, err
+	}
+	if !os.SameFile(info, opened) {
+		_ = file.Close()
+		return nil, nil, &changedFileError{path: path}
+	}
+	return file, info, nil
+}
+
+func readRegularFile(path string) ([]byte, error) {
+	file, _, err := openRegularFile(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	data, err := io.ReadAll(io.LimitReader(file, driverbundle.MaxManifestSize+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > driverbundle.MaxManifestSize {
+		return nil, fmt.Errorf("descriptor exceeds %d-byte limit", driverbundle.MaxManifestSize)
+	}
+	return data, nil
+}
+
+func rejectOutputAliases(outputPath, descriptorPath string, inputs ...string) error {
+	outputs := []string{outputPath, descriptorPath}
+	absoluteOutputs := make([]string, len(outputs))
+	for i, path := range outputs {
+		value, err := filepath.Abs(path)
+		if err != nil {
+			return err
+		}
+		absoluteOutputs[i] = filepath.Clean(value)
+	}
+	if absoluteOutputs[0] == absoluteOutputs[1] {
+		return &aliasError{first: outputPath, second: descriptorPath}
+	}
+	for outputIndex, output := range outputs {
+		for _, input := range inputs {
+			inputAbs, err := filepath.Abs(input)
+			if err != nil {
+				return err
+			}
+			if absoluteOutputs[outputIndex] == filepath.Clean(inputAbs) {
+				return &aliasError{first: output, second: input}
+			}
+			outputInfo, outputErr := os.Stat(output)
+			inputInfo, inputErr := os.Stat(input)
+			if outputErr == nil && inputErr == nil && os.SameFile(outputInfo, inputInfo) {
+				return &aliasError{first: output, second: input}
+			}
+		}
+	}
+	return nil
+}
+
+func ensureParent(path string) error {
+	return os.MkdirAll(filepath.Dir(path), 0o755)
+}
+
+func atomicWrite(path string, data []byte, mode os.FileMode) error {
+	temporary, err := os.CreateTemp(filepath.Dir(path), "."+filepath.Base(path)+".tmp-")
+	if err != nil {
+		return err
+	}
+	temporaryPath := temporary.Name()
+	committed := false
+	defer func() {
+		_ = temporary.Close()
+		if !committed {
+			_ = os.Remove(temporaryPath)
+		}
+	}()
+	if _, err := temporary.Write(data); err != nil {
+		return err
+	}
+	if err := temporary.Chmod(mode); err != nil {
+		return err
+	}
+	if err := temporary.Sync(); err != nil {
+		return err
+	}
+	if err := temporary.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(temporaryPath, path); err != nil {
+		return err
+	}
+	committed = true
+	if err := syncDirectory(filepath.Dir(path)); err != nil && runtime.GOOS != "windows" {
+		return err
+	}
+	return nil
+}
+
+func copyRegularFile(source, destination string) error {
+	if filepath.Clean(source) == filepath.Clean(destination) {
+		return errors.New("source and destination are the same path")
+	}
+	input, info, err := openRegularFile(source)
+	if err != nil {
+		return err
+	}
+	defer input.Close()
+	if err := ensureParent(destination); err != nil {
+		return err
+	}
+	temporary, err := os.CreateTemp(filepath.Dir(destination), "."+filepath.Base(destination)+".tmp-")
+	if err != nil {
+		return err
+	}
+	temporaryPath := temporary.Name()
+	committed := false
+	defer func() {
+		_ = temporary.Close()
+		if !committed {
+			_ = os.Remove(temporaryPath)
+		}
+	}()
+	count, err := io.Copy(temporary, input)
+	if err != nil {
+		return err
+	}
+	if count != info.Size() {
+		return fmt.Errorf("copied size %d, want %d", count, info.Size())
+	}
+	if err := temporary.Chmod(0o644); err != nil {
+		return err
+	}
+	if err := temporary.Sync(); err != nil {
+		return err
+	}
+	if err := temporary.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(temporaryPath, destination); err != nil {
+		return err
+	}
+	committed = true
+	return nil
+}
+
+type digestWriter struct {
+	writer io.Writer
+	digest hash.Hash
+	size   int64
+}
+
+func (w *digestWriter) Write(data []byte) (int, error) {
+	count, err := w.writer.Write(data)
+	if count > 0 {
+		if _, digestErr := w.digest.Write(data[:count]); err == nil {
+			err = digestErr
+		}
+		w.size += int64(count)
+	}
+	return count, err
+}
+
+func syncDirectory(path string) error {
+	directory, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer directory.Close()
+	return directory.Sync()
+}
+
+type notRegularError struct{ path string }
+
+func (e *notRegularError) Error() string { return e.path + " is not a regular non-symlink file" }
+
+type changedFileError struct{ path string }
+
+func (e *changedFileError) Error() string { return e.path + " changed while opening" }
+
+type aliasError struct{ first, second string }
+
+func (e *aliasError) Error() string { return "paths alias: " + e.first + " and " + e.second }

--- a/.github/scripts/driverbundle/main.go
+++ b/.github/scripts/driverbundle/main.go
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Command driverbundle packages and verifies the host driver bundle.
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		usage(os.Stderr)
+		os.Exit(2)
+	}
+
+	var err error
+	switch os.Args[1] {
+	case "package":
+		err = runPackage(os.Args[2:])
+	case "verify":
+		err = runVerify(os.Args[2:])
+	case "assemble":
+		err = runAssemble(os.Args[2:])
+	case "verify-release":
+		err = runVerifyRelease(os.Args[2:])
+	case "-h", "--help", "help":
+		usage(os.Stdout)
+		return
+	default:
+		err = fmt.Errorf("unknown command %q (want package, verify, assemble, or verify-release)", os.Args[1])
+	}
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func usage(output io.Writer) {
+	fmt.Fprintln(output, "usage: driverbundle package|verify|assemble|verify-release [flags]")
+}

--- a/.github/scripts/driverbundle/main_test.go
+++ b/.github/scripts/driverbundle/main_test.go
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"archive/zip"
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/goplus/spx/v3/internal/driverbundle"
+	"github.com/goplus/spx/v3/internal/release"
+)
+
+func TestPackageAndVerifyIsDeterministic(t *testing.T) {
+	directory := t.TempDir()
+	runtimeVersion := release.DefaultRuntimeLock().RuntimeVersion
+	enginePath := filepath.Join(directory, "gdspxrt"+runtimeVersion)
+	packPath := filepath.Join(directory, "gdspxrt"+runtimeVersion+".pck")
+	bridgePath := filepath.Join(directory, "gdspx-linux-amd64.so")
+	for path, data := range map[string][]byte{
+		enginePath: []byte("engine bytes"),
+		packPath:   []byte("pack bytes"),
+		bridgePath: []byte("bridge bytes"),
+	} {
+		if err := os.WriteFile(path, data, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	outputPath := filepath.Join(directory, "spx-driver-linux-amd64.zip")
+	descriptorPath := filepath.Join(directory, "bundle.json")
+	args := []string{
+		"--engine", enginePath, "--pack", packPath, "--bridge", bridgePath,
+		"--output", outputPath, "--descriptor", descriptorPath,
+		"--goos", "linux", "--goarch", "amd64",
+	}
+	if err := runPackage(args); err != nil {
+		t.Fatalf("package: %v", err)
+	}
+	firstZIP, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstDescriptor, err := os.ReadFile(descriptorPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := runVerify([]string{"--output", outputPath, "--descriptor", descriptorPath}); err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+
+	secondOutput := filepath.Join(directory, "second", "spx-driver-linux-amd64.zip")
+	secondDescriptor := filepath.Join(directory, "second", "bundle.json")
+	secondArgs := append([]string{}, args...)
+	for i := range secondArgs {
+		if secondArgs[i] == outputPath {
+			secondArgs[i] = secondOutput
+		}
+		if secondArgs[i] == descriptorPath {
+			secondArgs[i] = secondDescriptor
+		}
+	}
+	if err := runPackage(secondArgs); err != nil {
+		t.Fatalf("second package: %v", err)
+	}
+	secondZIP, err := os.ReadFile(secondOutput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondDescriptorData, err := os.ReadFile(secondDescriptor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(firstZIP, secondZIP) || !bytes.Equal(firstDescriptor, secondDescriptorData) {
+		t.Fatal("package output is not deterministic")
+	}
+
+	bundle, err := driverbundle.ParseBundle(firstDescriptor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(bundle.Files) != 3 || bundle.Files[0].Mode != 0o755 || bundle.Files[1].Mode != 0o644 || bundle.Files[2].Mode != 0o755 {
+		t.Fatalf("descriptor files = %#v", bundle.Files)
+	}
+	archive, err := zip.OpenReader(outputPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer archive.Close()
+	for i, entry := range archive.File {
+		if entry.Name != bundle.Files[i].Name || entry.Mode().Perm() != os.FileMode(bundle.Files[i].Mode) {
+			t.Fatalf("ZIP entry %d = %q mode %#o", i, entry.Name, entry.Mode().Perm())
+		}
+		if !entry.Modified.Equal(time.Date(1980, time.January, 1, 0, 0, 0, 0, time.UTC)) {
+			t.Fatalf("ZIP entry %q modified = %s", entry.Name, entry.Modified)
+		}
+	}
+}
+
+func TestPackageRejectsNonCanonicalBasename(t *testing.T) {
+	directory := t.TempDir()
+	for _, name := range []string{"engine", "pack", "bridge"} {
+		if err := os.WriteFile(filepath.Join(directory, name), []byte(name), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	err := runPackage([]string{
+		"--engine", filepath.Join(directory, "engine"),
+		"--pack", filepath.Join(directory, "pack"),
+		"--bridge", filepath.Join(directory, "bridge"),
+		"--output", filepath.Join(directory, "spx-driver-linux-amd64.zip"),
+		"--descriptor", filepath.Join(directory, "bundle.json"),
+		"--goos", "linux", "--goarch", "amd64",
+	})
+	if err == nil {
+		t.Fatal("accepted non-canonical input basenames")
+	}
+}

--- a/.github/scripts/driverbundle/package.go
+++ b/.github/scripts/driverbundle/package.go
@@ -1,0 +1,206 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"archive/zip"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/goplus/spx/v3/internal/driverbundle"
+	"github.com/goplus/spx/v3/internal/release"
+)
+
+var zipEpoch = time.Date(1980, time.January, 1, 0, 0, 0, 0, time.UTC)
+
+func runPackage(args []string) error {
+	flags := flag.NewFlagSet("driverbundle package", flag.ContinueOnError)
+	flags.SetOutput(os.Stderr)
+	var enginePath, packPath, bridgePath, outputPath, descriptorPath, goos, goarch string
+	flags.StringVar(&enginePath, "engine", "", "Engine input path")
+	flags.StringVar(&packPath, "pack", "", "runtime PCK input path")
+	flags.StringVar(&bridgePath, "bridge", "", "interpreter bridge input path")
+	flags.StringVar(&outputPath, "output", "", "output ZIP path")
+	flags.StringVar(&descriptorPath, "descriptor", "", "output descriptor JSON path")
+	flags.StringVar(&goos, "goos", "", "target GOOS")
+	flags.StringVar(&goarch, "goarch", "", "target GOARCH")
+	flags.Usage = func() {
+		fmt.Fprintln(flags.Output(), "usage: driverbundle package --engine PATH --pack PATH --bridge PATH --output ZIP --descriptor JSON --goos GOOS --goarch GOARCH")
+		flags.PrintDefaults()
+	}
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return fmt.Errorf("unexpected positional arguments: %s", strings.Join(flags.Args(), " "))
+	}
+	paths := []string{enginePath, packPath, bridgePath, outputPath, descriptorPath}
+	for _, path := range paths {
+		if strings.TrimSpace(path) == "" {
+			return errors.New("engine, pack, bridge, output, and descriptor paths are required")
+		}
+	}
+	lock := release.DefaultRuntimeLock()
+	spec, err := driverbundle.HostSpecFor(lock.RuntimeVersion, goos, goarch)
+	if err != nil {
+		return err
+	}
+	if err := validateInputBasenames(spec, enginePath, packPath, bridgePath, outputPath); err != nil {
+		return err
+	}
+	if err := rejectOutputAliases(outputPath, descriptorPath, enginePath, packPath, bridgePath); err != nil {
+		return err
+	}
+	if err := ensureParent(outputPath); err != nil {
+		return fmt.Errorf("prepare ZIP output: %w", err)
+	}
+	if err := ensureParent(descriptorPath); err != nil {
+		return fmt.Errorf("prepare descriptor output: %w", err)
+	}
+
+	temporary, err := os.CreateTemp(filepath.Dir(outputPath), "."+filepath.Base(outputPath)+".tmp-")
+	if err != nil {
+		return fmt.Errorf("create temporary ZIP: %w", err)
+	}
+	temporaryPath := temporary.Name()
+	committed := false
+	defer func() {
+		_ = temporary.Close()
+		if !committed {
+			_ = os.Remove(temporaryPath)
+		}
+	}()
+
+	outerDigest := sha256.New()
+	outer := &digestWriter{writer: temporary, digest: outerDigest}
+	archive := zip.NewWriter(outer)
+	files := make([]driverbundle.File, 0, 3)
+
+	engine, err := addZipFile(archive, enginePath, spec.Engine.Name, spec.Engine.Mode)
+	if err != nil {
+		return fmt.Errorf("package Engine: %w", err)
+	}
+	files = append(files, engine)
+	pack, err := addZipFile(archive, packPath, spec.Pack.Name, spec.Pack.Mode)
+	if err != nil {
+		return fmt.Errorf("package PCK: %w", err)
+	}
+	files = append(files, pack)
+	bridge, err := addZipFile(archive, bridgePath, spec.Bridge.Name, spec.Bridge.Mode)
+	if err != nil {
+		return fmt.Errorf("package bridge: %w", err)
+	}
+	files = append(files, bridge)
+	if err := archive.Close(); err != nil {
+		return fmt.Errorf("close ZIP: %w", err)
+	}
+	if err := temporary.Chmod(0o644); err != nil {
+		return fmt.Errorf("set ZIP mode: %w", err)
+	}
+	if err := temporary.Sync(); err != nil {
+		return fmt.Errorf("sync ZIP: %w", err)
+	}
+	if err := temporary.Close(); err != nil {
+		return fmt.Errorf("close temporary ZIP: %w", err)
+	}
+
+	interfaceDigest, err := driverbundle.ComputeEngineInterfaceDigestFromSHA256(engine.SHA256, pack.SHA256)
+	if err != nil {
+		return fmt.Errorf("identify Engine interface: %w", err)
+	}
+	bundle := driverbundle.Bundle{
+		GOOS: goos, GOARCH: goarch, Name: filepath.Base(outputPath),
+		Size: outer.size, SHA256: hex.EncodeToString(outerDigest.Sum(nil)),
+		EngineInterfaceDigest: interfaceDigest, Files: files,
+	}
+	if err := bundle.ValidateForRuntime(lock.RuntimeVersion); err != nil {
+		return fmt.Errorf("validate generated descriptor: %w", err)
+	}
+	descriptor, err := bundle.JSON()
+	if err != nil {
+		return fmt.Errorf("encode descriptor: %w", err)
+	}
+	if err := os.Rename(temporaryPath, outputPath); err != nil {
+		return fmt.Errorf("publish ZIP %s: %w", outputPath, err)
+	}
+	committed = true
+	if err := atomicWrite(descriptorPath, descriptor, 0o644); err != nil {
+		return fmt.Errorf("publish descriptor %s: %w", descriptorPath, err)
+	}
+	return nil
+}
+
+func validateInputBasenames(spec driverbundle.HostSpec, enginePath, packPath, bridgePath, outputPath string) error {
+	validDigest := strings.Repeat("0", sha256.Size*2)
+	interfaceDigest, err := driverbundle.ComputeEngineInterfaceDigestFromSHA256(validDigest, validDigest)
+	if err != nil {
+		return err
+	}
+	bundle := driverbundle.Bundle{
+		GOOS: spec.GOOS, GOARCH: spec.GOARCH, Name: filepath.Base(outputPath), Size: 1,
+		SHA256: validDigest, EngineInterfaceDigest: interfaceDigest,
+		Files: []driverbundle.File{
+			{Name: filepath.Base(enginePath), Mode: spec.Engine.Mode, Size: 1, SHA256: validDigest},
+			{Name: filepath.Base(packPath), Mode: spec.Pack.Mode, Size: 1, SHA256: validDigest},
+			{Name: filepath.Base(bridgePath), Mode: spec.Bridge.Mode, Size: 1, SHA256: validDigest},
+		},
+	}
+	if err := bundle.ValidateForRuntime(spec.RuntimeVersion); err != nil {
+		return fmt.Errorf("validate input basenames: %w", err)
+	}
+	return nil
+}
+
+func addZipFile(archive *zip.Writer, sourcePath, name string, mode uint32) (driverbundle.File, error) {
+	input, info, err := openRegularFile(sourcePath)
+	if err != nil {
+		return driverbundle.File{}, err
+	}
+	header := &zip.FileHeader{Name: name, Method: zip.Store}
+	header.SetMode(os.FileMode(mode))
+	header.SetModTime(zipEpoch)
+	entry, err := archive.CreateHeader(header)
+	if err != nil {
+		_ = input.Close()
+		return driverbundle.File{}, err
+	}
+	fileDigest := sha256.New()
+	count, copyErr := io.Copy(io.MultiWriter(entry, fileDigest), input)
+	finalInfo, statErr := input.Stat()
+	closeErr := input.Close()
+	if copyErr != nil {
+		return driverbundle.File{}, copyErr
+	}
+	if statErr != nil {
+		return driverbundle.File{}, statErr
+	}
+	if closeErr != nil {
+		return driverbundle.File{}, closeErr
+	}
+	if count != info.Size() || finalInfo.Size() != info.Size() {
+		return driverbundle.File{}, fmt.Errorf("source changed while reading (size %d, want %d)", count, info.Size())
+	}
+	return driverbundle.File{Name: name, Mode: mode, Size: count, SHA256: hex.EncodeToString(fileDigest.Sum(nil))}, nil
+}

--- a/.github/scripts/driverbundle/release.go
+++ b/.github/scripts/driverbundle/release.go
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/goplus/spx/v3/internal/driverbundle"
+	"github.com/goplus/spx/v3/internal/release"
+)
+
+type descriptorInputs []string
+
+func (v *descriptorInputs) String() string { return strings.Join(*v, ",") }
+
+func (v *descriptorInputs) Set(value string) error {
+	if strings.TrimSpace(value) == "" {
+		return errors.New("descriptor path must not be empty")
+	}
+	*v = append(*v, value)
+	return nil
+}
+
+func runAssemble(args []string) error {
+	flags := flag.NewFlagSet("driverbundle assemble", flag.ContinueOnError)
+	flags.SetOutput(os.Stderr)
+	lockPath := "internal/release/runtime.lock.json"
+	spxVersion := release.DefaultReleaseMeta().SPXVersion
+	manifestPath := ""
+	var descriptors descriptorInputs
+	flags.StringVar(&lockPath, "lock", lockPath, "runtime lock JSON")
+	flags.StringVar(&spxVersion, "spx-version", spxVersion, "SPX release version")
+	flags.StringVar(&manifestPath, "manifest", "", "output driver-manifest.json path")
+	flags.Var(&descriptors, "descriptor", "bundle descriptor JSON path; repeat exactly four times")
+	flags.Usage = func() {
+		fmt.Fprintln(flags.Output(), "usage: driverbundle assemble --manifest PATH --spx-version VERSION --descriptor JSON ...")
+		flags.PrintDefaults()
+	}
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return fmt.Errorf("unexpected positional arguments: %s", strings.Join(flags.Args(), " "))
+	}
+	if strings.TrimSpace(manifestPath) == "" {
+		return errors.New("manifest path is required")
+	}
+	targets := driverbundle.SupportedTargets()
+	if len(descriptors) != len(targets) {
+		return fmt.Errorf("descriptor count = %d, want %d", len(descriptors), len(targets))
+	}
+	lock, err := loadDriverLock(lockPath)
+	if err != nil {
+		return err
+	}
+
+	bundles := make([]driverbundle.Bundle, 0, len(descriptors))
+	seen := make(map[string]struct{}, len(descriptors))
+	sources := make(map[string]string, len(descriptors))
+	for _, descriptorPath := range descriptors {
+		data, err := readRegularFile(descriptorPath)
+		if err != nil {
+			return fmt.Errorf("read descriptor %s: %w", descriptorPath, err)
+		}
+		bundle, err := driverbundle.ParseBundle(data)
+		if err != nil {
+			return fmt.Errorf("parse descriptor %s: %w", descriptorPath, err)
+		}
+		key := bundle.GOOS + "/" + bundle.GOARCH
+		if _, ok := seen[key]; ok {
+			return fmt.Errorf("duplicate driver target %s/%s", bundle.GOOS, bundle.GOARCH)
+		}
+		zipPath := filepath.Join(filepath.Dir(descriptorPath), bundle.Name)
+		seen[key] = struct{}{}
+		sources[key] = zipPath
+		bundles = append(bundles, bundle)
+	}
+	slices.SortFunc(bundles, compareDriverBundles)
+	manifest := driverbundle.Manifest{
+		Schema:         driverbundle.ManifestSchema,
+		SPXVersion:     spxVersion,
+		RuntimeVersion: lock.RuntimeVersion,
+		Bundles:        bundles,
+	}
+	manifestData, err := manifest.JSON()
+	if err != nil {
+		return err
+	}
+	if err := ensureParent(manifestPath); err != nil {
+		return fmt.Errorf("prepare manifest output: %w", err)
+	}
+	for _, bundle := range bundles {
+		key := bundle.GOOS + "/" + bundle.GOARCH
+		destination := filepath.Join(filepath.Dir(manifestPath), bundle.Name)
+		if err := copyRegularFile(sources[key], destination); err != nil {
+			return fmt.Errorf("copy %s/%s bundle: %w", bundle.GOOS, bundle.GOARCH, err)
+		}
+		if err := verifyBundleFileForRuntime(destination, bundle, lock.RuntimeVersion); err != nil {
+			return fmt.Errorf("verify copied %s/%s bundle: %w", bundle.GOOS, bundle.GOARCH, err)
+		}
+	}
+	if err := atomicWrite(manifestPath, manifestData, 0o644); err != nil {
+		return fmt.Errorf("write driver manifest: %w", err)
+	}
+	return nil
+}
+
+func loadDriverLock(path string) (release.RuntimeLock, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return release.RuntimeLock{}, fmt.Errorf("read runtime lock: %w", err)
+	}
+	lock, err := release.ParseRuntimeLock(data)
+	if err != nil {
+		return release.RuntimeLock{}, err
+	}
+	return lock, nil
+}
+
+func compareDriverBundles(a, b driverbundle.Bundle) int {
+	return strings.Compare(a.GOOS+"/"+a.GOARCH, b.GOOS+"/"+b.GOARCH)
+}

--- a/.github/scripts/driverbundle/verify.go
+++ b/.github/scripts/driverbundle/verify.go
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/goplus/spx/v3/internal/driverbundle"
+	"github.com/goplus/spx/v3/internal/release"
+	"github.com/goplus/spx/v3/internal/runtimebundle"
+)
+
+func runVerify(args []string) error {
+	flags := flag.NewFlagSet("driverbundle verify", flag.ContinueOnError)
+	flags.SetOutput(os.Stderr)
+	var zipPath, descriptorPath string
+	flags.StringVar(&zipPath, "output", "", "ZIP path to verify")
+	flags.StringVar(&descriptorPath, "descriptor", "", "descriptor JSON path")
+	flags.Usage = func() {
+		fmt.Fprintln(flags.Output(), "usage: driverbundle verify --output ZIP --descriptor JSON")
+		flags.PrintDefaults()
+	}
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return fmt.Errorf("unexpected positional arguments: %s", strings.Join(flags.Args(), " "))
+	}
+	if strings.TrimSpace(zipPath) == "" || strings.TrimSpace(descriptorPath) == "" {
+		return errors.New("output and descriptor paths are required")
+	}
+
+	descriptorData, err := readRegularFile(descriptorPath)
+	if err != nil {
+		return fmt.Errorf("read descriptor: %w", err)
+	}
+	bundle, err := driverbundle.ParseBundle(descriptorData)
+	if err != nil {
+		return fmt.Errorf("parse descriptor: %w", err)
+	}
+	return verifyBundleFile(zipPath, bundle)
+}
+
+// verifyBundleFile verifies a ZIP against a trusted bundle descriptor.  The
+// descriptor may come from the packaging job or from an aggregate release
+// manifest; both paths use the same byte-level checks.
+func verifyBundleFile(zipPath string, bundle driverbundle.Bundle) error {
+	lock := release.DefaultRuntimeLock()
+	return verifyBundleFileForRuntime(zipPath, bundle, lock.RuntimeVersion)
+}
+
+func verifyBundleFileForRuntime(zipPath string, bundle driverbundle.Bundle, runtimeVersion string) error {
+	if err := bundle.ValidateForRuntime(runtimeVersion); err != nil {
+		return fmt.Errorf("validate descriptor: %w", err)
+	}
+	if filepath.Base(zipPath) != bundle.Name {
+		return fmt.Errorf("ZIP basename %q does not match descriptor name %q", filepath.Base(zipPath), bundle.Name)
+	}
+
+	archiveFile, archiveInfo, err := openRegularFile(zipPath)
+	if err != nil {
+		return fmt.Errorf("open ZIP: %w", err)
+	}
+	defer archiveFile.Close()
+	if archiveInfo.Size() != bundle.Size {
+		return fmt.Errorf("ZIP size = %d, want descriptor size %d", archiveInfo.Size(), bundle.Size)
+	}
+	outerDigest := sha256.New()
+	if _, err := io.Copy(outerDigest, archiveFile); err != nil {
+		return fmt.Errorf("hash ZIP: %w", err)
+	}
+	if got := hex.EncodeToString(outerDigest.Sum(nil)); got != bundle.SHA256 {
+		return fmt.Errorf("ZIP SHA-256 = %s, want descriptor %s", got, bundle.SHA256)
+	}
+
+	expected := runtimebundle.Bundle{
+		Schema: runtimebundle.SchemaV1, Namespace: runtimebundle.NamespaceDriver,
+		Entries: runtimeEntries(bundle.Files),
+	}
+	_, err = runtimebundle.VerifyZipReader(archiveFile, archiveInfo.Size(), runtimebundle.VerifyOptions{Expected: &expected})
+	if err != nil {
+		return fmt.Errorf("verify ZIP with runtimebundle: %w", err)
+	}
+	interfaceDigest, err := driverbundle.ComputeEngineInterfaceDigestFromSHA256(bundle.Files[0].SHA256, bundle.Files[1].SHA256)
+	if err != nil {
+		return fmt.Errorf("identify Engine interface: %w", err)
+	}
+	if interfaceDigest != bundle.EngineInterfaceDigest {
+		return fmt.Errorf("Engine interface digest = %s, want descriptor %s", interfaceDigest, bundle.EngineInterfaceDigest)
+	}
+	return nil
+}
+
+func runtimeEntries(files []driverbundle.File) []runtimebundle.Entry {
+	entries := make([]runtimebundle.Entry, len(files))
+	for i, file := range files {
+		entries[i] = runtimebundle.Entry{Name: file.Name, Mode: file.Mode, Size: file.Size, SHA256: file.SHA256}
+	}
+	return entries
+}

--- a/.github/scripts/driverbundle/verify_release.go
+++ b/.github/scripts/driverbundle/verify_release.go
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/goplus/spx/v3/internal/driverbundle"
+)
+
+func runVerifyRelease(args []string) error {
+	flags := flag.NewFlagSet("driverbundle verify-release", flag.ContinueOnError)
+	flags.SetOutput(os.Stderr)
+	directory, expectedVersion := ".", ""
+	lockPath := "internal/release/runtime.lock.json"
+	flags.StringVar(&lockPath, "lock", lockPath, "runtime lock JSON")
+	flags.StringVar(&directory, "directory", directory, "download directory")
+	flags.StringVar(&expectedVersion, "spx-version", "", "expected SPX release version")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return fmt.Errorf("unexpected positional arguments: %s", strings.Join(flags.Args(), " "))
+	}
+	if strings.TrimSpace(expectedVersion) == "" {
+		return fmt.Errorf("--spx-version is required")
+	}
+	manifestPath := filepath.Join(directory, driverbundle.ManifestName)
+	data, err := readRegularFile(manifestPath)
+	if err != nil {
+		return fmt.Errorf("read SPX driver manifest: %w", err)
+	}
+	lock, err := loadDriverLock(lockPath)
+	if err != nil {
+		return err
+	}
+	manifest, err := driverbundle.ParseForVersions(data, expectedVersion, lock.RuntimeVersion)
+	if err != nil {
+		return fmt.Errorf("parse SPX driver manifest: %w", err)
+	}
+
+	for _, bundle := range manifest.Bundles {
+		zipPath := filepath.Join(directory, bundle.Name)
+		if err := verifyBundleFileForRuntime(zipPath, bundle, lock.RuntimeVersion); err != nil {
+			return fmt.Errorf("verify SPX driver %s/%s: %w", bundle.GOOS, bundle.GOARCH, err)
+		}
+	}
+	return nil
+}

--- a/.github/scripts/driverbundle/verify_release_test.go
+++ b/.github/scripts/driverbundle/verify_release_test.go
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"archive/zip"
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/goplus/spx/v3/internal/driverbundle"
+	"github.com/goplus/spx/v3/internal/release"
+)
+
+func TestVerifyReleaseChecksVersionsAndBundles(t *testing.T) {
+	lock, err := release.RuntimeLockForVersion("2.4.3")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	directory := t.TempDir()
+	lockPath := filepath.Join(t.TempDir(), "runtime.lock.json")
+	lockData, err := lock.JSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(lockPath, lockData, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	targets := [][2]string{{"darwin", "amd64"}, {"darwin", "arm64"}, {"linux", "amd64"}, {"windows", "amd64"}}
+	bundles := make([]driverbundle.Bundle, 0, len(targets))
+	for _, target := range targets {
+		bundles = append(bundles, writeReleaseTestBundle(t, directory, lock, target[0], target[1]))
+	}
+	manifest := driverbundle.Manifest{
+		Schema: driverbundle.ManifestSchema, SPXVersion: "v3.2.4", RuntimeVersion: lock.RuntimeVersion,
+		Bundles: bundles,
+	}
+	manifestData, err := manifest.JSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(directory, driverbundle.ManifestName), manifestData, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	args := []string{"--lock", lockPath, "--directory", directory, "--spx-version", manifest.SPXVersion}
+	if err := runVerifyRelease(args); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(directory, "spx_web.zip"), []byte("product"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := runVerifyRelease(args); err != nil {
+		t.Fatalf("driver verification rejected another SPX release asset: %v", err)
+	}
+	if err := runVerifyRelease([]string{"--lock", lockPath, "--directory", directory, "--spx-version", "v9.9.9"}); err == nil {
+		t.Fatal("accepted mismatched SPX version")
+	}
+	otherLock, err := release.RuntimeLockForVersion("2.4.2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	otherLockData, err := otherLock.JSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	otherLockPath := filepath.Join(t.TempDir(), "runtime.lock.json")
+	if err := os.WriteFile(otherLockPath, otherLockData, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := runVerifyRelease([]string{"--lock", otherLockPath, "--directory", directory, "--spx-version", manifest.SPXVersion}); err == nil {
+		t.Fatal("accepted mismatched runtime version")
+	}
+
+	if err := os.WriteFile(filepath.Join(directory, bundles[0].Name), []byte("tampered"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := runVerifyRelease(args); err == nil {
+		t.Fatal("accepted tampered release")
+	}
+}
+
+func writeReleaseTestBundle(t *testing.T, directory string, lock release.RuntimeLock, goos, goarch string) driverbundle.Bundle {
+	t.Helper()
+	spec, err := release.HostRuntimeSpecFor(lock, goos, goarch)
+	if err != nil {
+		t.Fatal(err)
+	}
+	extension := map[string]string{"darwin": ".dylib", "linux": ".so", "windows": ".dll"}[goos]
+	names := [3]string{spec.RuntimeName, spec.PackName, "gdspx-" + goos + "-" + goarch + extension}
+	modes := [3]uint32{0o755, 0o644, 0o755}
+	name := "spx-driver-" + goos + "-" + goarch + ".zip"
+	path := filepath.Join(directory, name)
+	output, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	archive := zip.NewWriter(output)
+	files := make([]driverbundle.File, 0, len(names))
+	for i, name := range names {
+		data := []byte(name + " bytes")
+		header := &zip.FileHeader{Name: name, Method: zip.Store, Modified: zipEpoch}
+		header.SetMode(os.FileMode(modes[i]))
+		writer, err := archive.CreateHeader(header)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := writer.Write(data); err != nil {
+			t.Fatal(err)
+		}
+		digest := sha256.Sum256(data)
+		files = append(files, driverbundle.File{Name: name, Mode: modes[i], Size: int64(len(data)), SHA256: hex.EncodeToString(digest[:])})
+	}
+	if err := archive.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := output.Close(); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest := sha256.Sum256(data)
+	interfaceDigest, err := driverbundle.ComputeEngineInterfaceDigestFromSHA256(files[0].SHA256, files[1].SHA256)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return driverbundle.Bundle{
+		GOOS: goos, GOARCH: goarch, Name: name, Size: int64(len(data)), SHA256: hex.EncodeToString(digest[:]),
+		EngineInterfaceDigest: interfaceDigest, Files: files,
+	}
+}

--- a/.github/scripts/driverbundle/workflow_test.py
+++ b/.github/scripts/driverbundle/workflow_test.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+ACTION = ROOT / "actions" / "driver-bundle" / "action.yml"
+
+
+class DriverBundleActionTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.action = ACTION.read_text(encoding="utf-8")
+
+    def test_inputs_are_the_complete_packaging_contract(self):
+        inputs = self.action.split("inputs:\n", 1)[1].split("runs:\n", 1)[0]
+        names = re.findall(r"^  ([a-z][a-z0-9-]*):\s*$", inputs, re.MULTILINE)
+        self.assertEqual(
+            names,
+            ["engine", "pack", "bridge", "output", "descriptor", "goos", "goarch"],
+        )
+        self.assertEqual(inputs.count("required: true"), len(names))
+
+    def test_composite_action_wires_package_then_verify(self):
+        self.assertIn("using: composite", self.action)
+        self.assertEqual(self.action.count("shell: bash"), 2)
+
+        for mapping in (
+            "ENGINE_PATH: ${{ inputs.engine }}",
+            "PACK_PATH: ${{ inputs.pack }}",
+            "BRIDGE_PATH: ${{ inputs.bridge }}",
+            "OUTPUT_PATH: ${{ inputs.output }}",
+            "DESCRIPTOR_PATH: ${{ inputs.descriptor }}",
+            "TARGET_GOOS: ${{ inputs.goos }}",
+            "TARGET_GOARCH: ${{ inputs.goarch }}",
+        ):
+            self.assertIn(mapping, self.action)
+
+        commands = (
+            "go run ./.github/scripts/driverbundle package",
+            "go run ./.github/scripts/driverbundle verify",
+        )
+        for command in commands:
+            self.assertEqual(self.action.count(command), 1)
+
+        package_step = self.action.split(commands[0], 1)[1].split(commands[1], 1)[0]
+        for argument in (
+            '--engine "$ENGINE_PATH"',
+            '--pack "$PACK_PATH"',
+            '--bridge "$BRIDGE_PATH"',
+            '--output "$OUTPUT_PATH"',
+            '--descriptor "$DESCRIPTOR_PATH"',
+            '--goos "$TARGET_GOOS"',
+            '--goarch "$TARGET_GOARCH"',
+        ):
+            self.assertIn(argument, package_step)
+
+        verify_step = self.action.split(commands[1], 1)[1]
+        for argument in ('--output "$OUTPUT_PATH"', '--descriptor "$DESCRIPTOR_PATH"'):
+            self.assertIn(argument, verify_step)
+
+    def test_action_is_not_coupled_to_release_activation(self):
+        for activation in ("standalone/prepare", "release_driver", "gh release"):
+            self.assertNotIn(activation, self.action)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -50,12 +50,14 @@ jobs:
       - name: Test Go code
         shell: bash
         run: |
+          go test -v ./.github/scripts/driverbundle
           go test -v .github/scripts/runtime/manifest.go .github/scripts/runtime/manifest_test.go
           go test -v .github/scripts/runtime/resolution.go .github/scripts/runtime/resolution_test.go
           go test -v .github/scripts/runtime/version.go .github/scripts/runtime/version_test.go
           PYTHONDONTWRITEBYTECODE=1 python3 .github/scripts/runtime_build_contract_test.py
           PYTHONDONTWRITEBYTECODE=1 python3 .github/scripts/release/workflow_test.py
           PYTHONDONTWRITEBYTECODE=1 python3 .github/scripts/release_bump_test.py
+          PYTHONDONTWRITEBYTECODE=1 python3 .github/scripts/driverbundle/workflow_test.py
           go run .github/scripts/runtime/digest.go pack-source HEAD >/dev/null
           go run .github/scripts/runtime/digest.go build-recipe HEAD >/dev/null
           go test -v $(go list ./... | grep -v /internal/webffi)

--- a/internal/driverbundle/digest.go
+++ b/internal/driverbundle/digest.go
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package driverbundle
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+)
+
+// ComputeEngineInterfaceDigest identifies an Engine/PCK pair.
+func ComputeEngineInterfaceDigest(engine, pack []byte) string {
+	engineDigest := sha256.Sum256(engine)
+	packDigest := sha256.Sum256(pack)
+	return computeEngineInterfaceDigest(engineDigest, packDigest)
+}
+
+// ComputeEngineInterfaceDigestFromSHA256 identifies an Engine/PCK pair from
+// their verified content digests.
+func ComputeEngineInterfaceDigestFromSHA256(engine, pack string) (string, error) {
+	engineDigest, err := decodeSHA256(engine)
+	if err != nil {
+		return "", fmt.Errorf("invalid Engine SHA-256: %w", err)
+	}
+	packDigest, err := decodeSHA256(pack)
+	if err != nil {
+		return "", fmt.Errorf("invalid PCK SHA-256: %w", err)
+	}
+	return computeEngineInterfaceDigest(engineDigest, packDigest), nil
+}
+
+func decodeSHA256(value string) ([sha256.Size]byte, error) {
+	var digest [sha256.Size]byte
+	if err := validateSHA256(value); err != nil {
+		return digest, err
+	}
+	_, err := hex.Decode(digest[:], []byte(value))
+	return digest, err
+}
+
+func computeEngineInterfaceDigest(engine, pack [sha256.Size]byte) string {
+	hasher := sha256.New()
+	hasher.Write([]byte(EngineInterfaceDigestDomain))
+	hasher.Write(engine[:])
+	hasher.Write(pack[:])
+	return hex.EncodeToString(hasher.Sum(nil))
+}

--- a/internal/driverbundle/identity.go
+++ b/internal/driverbundle/identity.go
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package driverbundle
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+
+	"golang.org/x/mod/module"
+	"golang.org/x/mod/semver"
+)
+
+// Target identifies one host supported by the published driver bundle.
+type Target struct {
+	GOOS   string
+	GOARCH string
+}
+
+// Component identifies one file in a combined Engine/PCK/bridge bundle.
+type Component struct {
+	Name string
+	Mode uint32
+}
+
+// HostSpec is the canonical platform and component naming contract shared by
+// manifest validation, release packaging, and launcher materialization.
+type HostSpec struct {
+	Target
+	RuntimeVersion string
+	BundleName     string
+	Engine         Component
+	Pack           Component
+	Bridge         Component
+}
+
+// SupportedTargets returns a copy of the supported host list in release order.
+func SupportedTargets() []Target {
+	result := make([]Target, len(supportedTargets))
+	copy(result, supportedTargets[:])
+	return result
+}
+
+// HostSpecFor returns the canonical component names and modes for one host.
+func HostSpecFor(runtimeVersion, goos, goarch string) (HostSpec, error) {
+	if err := validateRuntimeVersion(runtimeVersion); err != nil {
+		return HostSpec{}, err
+	}
+	for _, target := range supportedTargets {
+		if target.GOOS != goos || target.GOARCH != goarch {
+			continue
+		}
+		names := expectedFileNames(runtimeVersion, goos, goarch)
+		return HostSpec{
+			Target:         Target{GOOS: goos, GOARCH: goarch},
+			RuntimeVersion: runtimeVersion,
+			BundleName:     expectedBundleName(goos, goarch),
+			Engine:         Component{Name: names[0], Mode: 0o755},
+			Pack:           Component{Name: names[1], Mode: 0o644},
+			Bridge:         Component{Name: names[2], Mode: 0o755},
+		}, nil
+	}
+	return HostSpec{}, fmt.Errorf("unsupported driver target %s/%s", goos, goarch)
+}
+
+func validateSPXVersion(value string) error {
+	if !strings.HasPrefix(value, "v") || !semver.IsValid(value) || semver.Canonical(value) != value || module.IsPseudoVersion(value) {
+		return fmt.Errorf("invalid SPX version %q", value)
+	}
+	return nil
+}
+
+func validateRuntimeVersion(value string) error {
+	if !runtimeVersionPattern.MatchString(value) || !semver.IsValid("v"+value) {
+		return fmt.Errorf("invalid runtime version %q", value)
+	}
+	return nil
+}
+
+func expectedBundleName(goos, goarch string) string {
+	return "spx-driver-" + goos + "-" + goarch + ".zip"
+}
+
+func expectedFileNames(runtimeVersion, goos, goarch string) [3]string {
+	engine := "gdspxrt" + runtimeVersion
+	if goos == "windows" {
+		engine += ".exe"
+	}
+	extension := map[string]string{"darwin": ".dylib", "linux": ".so", "windows": ".dll"}[goos]
+	return [3]string{engine, "gdspxrt" + runtimeVersion + ".pck", "gdspx-" + goos + "-" + goarch + extension}
+}
+
+func validateSHA256(value string) error {
+	if len(value) != sha256.Size*2 || value != strings.ToLower(value) {
+		return errors.New("must be a lower-case 64-hex-character digest")
+	}
+	if _, err := hex.DecodeString(value); err != nil {
+		return errors.New("must be a lower-case 64-hex-character digest")
+	}
+	return nil
+}
+
+func validateBundleName(name string) error {
+	if err := validateBaseName(name); err != nil || !strings.HasSuffix(name, ".zip") {
+		return fmt.Errorf("invalid bundle name %q", name)
+	}
+	return nil
+}
+
+func validateBaseName(name string) error {
+	if name == "" || name == "." || name == ".." || strings.ContainsAny(name, "/\\\x00<>:\"|?*") || name != strings.TrimSpace(name) {
+		return errors.New("must be a portable basename")
+	}
+	for _, r := range name {
+		if r < 0x20 {
+			return errors.New("contains a control character")
+		}
+	}
+	return nil
+}

--- a/internal/driverbundle/manifest.go
+++ b/internal/driverbundle/manifest.go
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package driverbundle describes published SPX project-driver bundles.
+package driverbundle
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/goplus/spx/v3/internal/strictjson"
+)
+
+const (
+	ManifestSchema                    = 1
+	ManifestName                      = "driver-manifest.json"
+	SPXModulePath                     = "github.com/goplus/spx/v3"
+	ReleaseRepository                 = "goplus/spx"
+	EngineInterfaceDigestDomain       = "spx-engine-interface/v1\x00"
+	MaxManifestSize             int64 = 16 << 20
+)
+
+var ErrBundleNotFound = errors.New("driverbundle: bundle not found")
+
+// Manifest identifies all platform bundles shipped with one SPX release.
+type Manifest struct {
+	Schema         int      `json:"schema"`
+	SPXVersion     string   `json:"spx_version"`
+	RuntimeVersion string   `json:"runtime_version"`
+	Bundles        []Bundle `json:"bundles"`
+}
+
+// Bundle identifies one Engine+PCK+bridge ZIP.
+type Bundle struct {
+	GOOS                  string `json:"goos"`
+	GOARCH                string `json:"goarch"`
+	Name                  string `json:"name"`
+	Size                  int64  `json:"size"`
+	SHA256                string `json:"sha256"`
+	EngineInterfaceDigest string `json:"engine_interface_digest"`
+	Files                 []File `json:"files"` // Engine, PCK, then bridge.
+}
+
+// File identifies one regular file in a bundle.
+type File struct {
+	Name   string `json:"name"`
+	Mode   uint32 `json:"mode"`
+	Size   int64  `json:"size"`
+	SHA256 string `json:"sha256"`
+}
+
+// Parse strictly decodes and validates a manifest.
+func Parse(data []byte) (Manifest, error) {
+	if int64(len(data)) > MaxManifestSize {
+		return Manifest{}, fmt.Errorf("driverbundle: manifest exceeds %d-byte limit", MaxManifestSize)
+	}
+	var manifest Manifest
+	if err := strictjson.Decode(data, &manifest); err != nil {
+		return Manifest{}, fmt.Errorf("driverbundle: decode manifest: %w", err)
+	}
+	if err := manifest.Validate(); err != nil {
+		return Manifest{}, err
+	}
+	return manifest, nil
+}
+
+// ParseForVersions strictly decodes a manifest and binds it to the selected
+// driver and runtime versions without repeating structural validation.
+func ParseForVersions(data []byte, spxVersion, runtimeVersion string) (Manifest, error) {
+	manifest, err := Parse(data)
+	if err != nil {
+		return Manifest{}, err
+	}
+	if err := manifest.validateVersions(spxVersion, runtimeVersion); err != nil {
+		return Manifest{}, err
+	}
+	return manifest, nil
+}
+
+// JSON returns canonical, human-readable manifest bytes.
+func (m Manifest) JSON() ([]byte, error) {
+	if err := m.Validate(); err != nil {
+		return nil, err
+	}
+	data, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("driverbundle: encode manifest: %w", err)
+	}
+	return append(data, '\n'), nil
+}
+
+// ParseBundle strictly decodes one platform descriptor.
+func ParseBundle(data []byte) (Bundle, error) {
+	if int64(len(data)) > MaxManifestSize {
+		return Bundle{}, fmt.Errorf("driverbundle: bundle descriptor exceeds %d-byte limit", MaxManifestSize)
+	}
+	var bundle Bundle
+	if err := strictjson.Decode(data, &bundle); err != nil {
+		return Bundle{}, fmt.Errorf("driverbundle: decode bundle: %w", err)
+	}
+	if err := bundle.Validate(); err != nil {
+		return Bundle{}, err
+	}
+	return bundle, nil
+}
+
+// JSON returns canonical, human-readable bundle bytes.
+func (b Bundle) JSON() ([]byte, error) {
+	if err := b.Validate(); err != nil {
+		return nil, err
+	}
+	data, err := json.MarshalIndent(b, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("driverbundle: encode bundle: %w", err)
+	}
+	return append(data, '\n'), nil
+}
+
+// BundleFor returns the bundle for goos/goarch.
+func (m Manifest) BundleFor(goos, goarch string) (Bundle, error) {
+	if err := m.Validate(); err != nil {
+		return Bundle{}, err
+	}
+	for _, bundle := range m.Bundles {
+		if bundle.GOOS == goos && bundle.GOARCH == goarch {
+			return bundle, nil
+		}
+	}
+	return Bundle{}, fmt.Errorf("%w: %s/%s", ErrBundleNotFound, goos, goarch)
+}
+
+// DownloadURL returns the bundle URL in the owning SPX release.
+func (m Manifest) DownloadURL(name string) (string, error) {
+	return ReleaseAssetURL(m.SPXVersion, name)
+}
+
+// ManifestURL returns the manifest URL in the SPX release selected by an exact version.
+func ManifestURL(spxVersion string) (string, error) {
+	return ReleaseAssetURL(spxVersion, ManifestName)
+}
+
+// ReleaseAssetURL returns the canonical SPX release URL for one driver asset.
+func ReleaseAssetURL(spxVersion, name string) (string, error) {
+	if err := validateSPXVersion(spxVersion); err != nil {
+		return "", err
+	}
+	if name == ManifestName {
+		if err := validateBaseName(name); err != nil {
+			return "", err
+		}
+	} else if err := validateBundleName(name); err != nil {
+		return "", err
+	}
+	return "https://github.com/" + ReleaseRepository + "/releases/download/" + spxVersion + "/" + name, nil
+}

--- a/internal/driverbundle/manifest_test.go
+++ b/internal/driverbundle/manifest_test.go
@@ -1,0 +1,201 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package driverbundle
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+const testDigest = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+func testManifest() Manifest {
+	file := func(name string, mode uint32) File {
+		return File{Name: name, Mode: mode, Size: 10, SHA256: testDigest}
+	}
+	bundle := func(goos, goarch, name string) Bundle {
+		names := expectedFileNames("2.4.4", goos, goarch)
+		interfaceDigest, err := ComputeEngineInterfaceDigestFromSHA256(testDigest, testDigest)
+		if err != nil {
+			panic(err)
+		}
+		return Bundle{
+			GOOS: goos, GOARCH: goarch, Name: name, Size: 100, SHA256: testDigest,
+			EngineInterfaceDigest: interfaceDigest,
+			Files:                 []File{file(names[0], 0o755), file(names[1], 0o644), file(names[2], 0o755)},
+		}
+	}
+	return Manifest{
+		Schema: ManifestSchema, SPXVersion: "v3.2.4", RuntimeVersion: "2.4.4",
+		Bundles: []Bundle{
+			bundle("darwin", "amd64", "spx-driver-darwin-amd64.zip"),
+			bundle("darwin", "arm64", "spx-driver-darwin-arm64.zip"),
+			bundle("linux", "amd64", "spx-driver-linux-amd64.zip"),
+			bundle("windows", "amd64", "spx-driver-windows-amd64.zip"),
+		},
+	}
+}
+
+func TestManifestRoundTripLookupAndURL(t *testing.T) {
+	want := testManifest()
+	data, err := want.JSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := Parse(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.SPXVersion != want.SPXVersion || len(got.Bundles) != 4 {
+		t.Fatalf("parsed manifest = %#v", got)
+	}
+	bundle, err := got.BundleFor("linux", "amd64")
+	if err != nil || bundle.Name != "spx-driver-linux-amd64.zip" {
+		t.Fatalf("BundleFor = %#v, %v", bundle, err)
+	}
+	wantURL := "https://github.com/goplus/spx/releases/download/v3.2.4/spx-driver-linux-amd64.zip"
+	if gotURL, err := got.DownloadURL("spx-driver-linux-amd64.zip"); err != nil || gotURL != wantURL {
+		t.Fatalf("DownloadURL = %q, %v, want %q", gotURL, err, wantURL)
+	}
+	wantManifestURL := "https://github.com/goplus/spx/releases/download/v3.2.4/" + ManifestName
+	if gotURL, err := ManifestURL(got.SPXVersion); err != nil || gotURL != wantManifestURL {
+		t.Fatalf("ManifestURL = %q, %v, want %q", gotURL, err, wantManifestURL)
+	}
+	if _, err := got.DownloadURL("../bundle.zip"); err == nil {
+		t.Fatal("DownloadURL accepted an unsafe bundle name")
+	}
+	if _, err := ManifestURL("v3.2"); err == nil {
+		t.Fatal("ManifestURL accepted an invalid SPX version")
+	}
+	if _, err := ManifestURL("v0.0.0-20200101000000-abcdefabcdef"); err == nil {
+		t.Fatal("ManifestURL accepted a pseudo-version")
+	}
+}
+
+func TestBundleRoundTrip(t *testing.T) {
+	want := testManifest().Bundles[0]
+	data, err := want.JSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := ParseBundle(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Name != want.Name || len(got.Files) != 3 {
+		t.Fatalf("bundle = %#v", got)
+	}
+	duplicate := want
+	duplicate.Files[1] = duplicate.Files[0]
+	if err := duplicate.Validate(); err == nil {
+		t.Fatal("accepted duplicate bundle file")
+	}
+}
+
+func TestManifestParseIsStrict(t *testing.T) {
+	data, err := testManifest().JSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for name, mutate := range map[string]func(string) string{
+		"unknown": func(value string) string {
+			return strings.TrimSuffix(value, "\n")[:len(strings.TrimSuffix(value, "\n"))-1] + `,"unknown":true}`
+		},
+		"trailing": func(value string) string { return value + `{}` },
+		"duplicate nested": func(value string) string {
+			return strings.Replace(value, `"name": "spx-driver-darwin-arm64.zip"`, `"name": "spx-driver-darwin-arm64.zip", "name": "spx-driver-darwin-arm64.zip"`, 1)
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := Parse([]byte(mutate(string(data)))); err == nil {
+				t.Fatal("accepted ambiguous JSON")
+			}
+		})
+	}
+	if _, err := Parse(make([]byte, MaxManifestSize+1)); err == nil {
+		t.Fatal("Parse accepted an oversized manifest")
+	}
+	if _, err := ParseBundle(make([]byte, MaxManifestSize+1)); err == nil {
+		t.Fatal("ParseBundle accepted an oversized descriptor")
+	}
+}
+
+func TestManifestValidationMutations(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*Manifest)
+	}{
+		{"schema", func(m *Manifest) { m.Schema++ }},
+		{"version", func(m *Manifest) { m.SPXVersion = "v3.2" }},
+		{"runtime", func(m *Manifest) { m.RuntimeVersion = "v2.4.4" }},
+		{"platform duplicate", func(m *Manifest) { m.Bundles[1].GOOS = m.Bundles[0].GOOS; m.Bundles[1].GOARCH = m.Bundles[0].GOARCH }},
+		{"platform order", func(m *Manifest) { m.Bundles[0], m.Bundles[1] = m.Bundles[1], m.Bundles[0] }},
+		{"bundle path", func(m *Manifest) { m.Bundles[0].Name = "../bundle.zip" }},
+		{"file duplicate", func(m *Manifest) { m.Bundles[0].Files[1].Name = m.Bundles[0].Files[0].Name }},
+		{"file mode", func(m *Manifest) { m.Bundles[0].Files[0].Mode = 0o100755 }},
+		{"file size", func(m *Manifest) { m.Bundles[0].Files[0].Size = 0 }},
+		{"file digest", func(m *Manifest) { m.Bundles[0].Files[0].SHA256 = "bad" }},
+		{"file count", func(m *Manifest) { m.Bundles[0].Files = m.Bundles[0].Files[:2] }},
+		{"interface digest", func(m *Manifest) { m.Bundles[0].EngineInterfaceDigest = "bad" }},
+		{"interface identity", func(m *Manifest) { m.Bundles[0].Files[0].SHA256 = strings.Repeat("b", 64) }},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			candidate := testManifest()
+			test.mutate(&candidate)
+			if err := candidate.Validate(); err == nil {
+				t.Fatal("accepted invalid manifest")
+			}
+		})
+	}
+	if _, err := testManifest().BundleFor("linux", "arm64"); !errors.Is(err, ErrBundleNotFound) {
+		t.Fatalf("BundleFor missing error = %v", err)
+	}
+}
+
+func TestManifestValidateVersions(t *testing.T) {
+	manifest := testManifest()
+	if err := manifest.ValidateVersions("v3.2.4", "2.4.4"); err != nil {
+		t.Fatal(err)
+	}
+	if err := manifest.ValidateVersions("v3.2.5", "2.4.4"); err == nil || !strings.Contains(err.Error(), "SPX version") {
+		t.Fatalf("SPX version mismatch error = %v", err)
+	}
+	if err := manifest.ValidateVersions("v3.2.4", "2.4.3"); err == nil || !strings.Contains(err.Error(), "runtime version") {
+		t.Fatalf("runtime version mismatch error = %v", err)
+	}
+	if err := manifest.ValidateVersions("3.2.4", "2.4.4"); err == nil {
+		t.Fatal("ValidateVersions accepted a non-canonical expected SPX version")
+	}
+}
+
+func TestHostSpecMatchesCanonicalBundleComponents(t *testing.T) {
+	spec, err := HostSpecFor("2.4.4", "linux", "amd64")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if spec.BundleName != "spx-driver-linux-amd64.zip" || spec.Engine.Name != "gdspxrt2.4.4" || spec.Pack.Name != "gdspxrt2.4.4.pck" || spec.Bridge.Name != "gdspx-linux-amd64.so" {
+		t.Fatalf("HostSpecFor = %#v", spec)
+	}
+	if _, err := HostSpecFor("2.4.4", "freebsd", "amd64"); err == nil {
+		t.Fatal("HostSpecFor accepted unsupported target")
+	}
+	if got := SupportedTargets(); len(got) != 4 || got[0].GOOS != "darwin" || got[3].GOOS != "windows" {
+		t.Fatalf("SupportedTargets = %#v", got)
+	}
+}

--- a/internal/driverbundle/validation.go
+++ b/internal/driverbundle/validation.go
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package driverbundle
+
+import (
+	"fmt"
+	"regexp"
+)
+
+var supportedTargets = [...]Target{
+	{GOOS: "darwin", GOARCH: "amd64"},
+	{GOOS: "darwin", GOARCH: "arm64"},
+	{GOOS: "linux", GOARCH: "amd64"},
+	{GOOS: "windows", GOARCH: "amd64"},
+}
+
+var (
+	runtimeVersionPattern = regexp.MustCompile(`^[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?$`)
+	platformPattern       = regexp.MustCompile(`^[a-z][a-z0-9._-]*$`)
+)
+
+// Validate checks manifest identity and its four canonical host bundles.
+func (m Manifest) Validate() error {
+	if m.Schema != ManifestSchema {
+		return fmt.Errorf("driverbundle: manifest schema = %d, want %d", m.Schema, ManifestSchema)
+	}
+	if err := validateSPXVersion(m.SPXVersion); err != nil {
+		return fmt.Errorf("driverbundle: %w", err)
+	}
+	if err := validateRuntimeVersion(m.RuntimeVersion); err != nil {
+		return fmt.Errorf("driverbundle: %w", err)
+	}
+	if len(m.Bundles) != len(supportedTargets) {
+		return fmt.Errorf("driverbundle: bundles = %d, want %d", len(m.Bundles), len(supportedTargets))
+	}
+	for i, bundle := range m.Bundles {
+		want := supportedTargets[i]
+		if bundle.GOOS != want.GOOS || bundle.GOARCH != want.GOARCH {
+			return fmt.Errorf("driverbundle: bundle %d target = %s/%s, want %s/%s", i, bundle.GOOS, bundle.GOARCH, want.GOOS, want.GOARCH)
+		}
+		if err := bundle.validateForRuntime(m.RuntimeVersion); err != nil {
+			return fmt.Errorf("driverbundle: bundle %d: %w", i, err)
+		}
+	}
+	return nil
+}
+
+// ValidateVersions binds a manifest to the selected driver and runtime
+// releases. Content integrity is carried by each bundle and file digest.
+func (m Manifest) ValidateVersions(spxVersion, runtimeVersion string) error {
+	if err := m.Validate(); err != nil {
+		return err
+	}
+	return m.validateVersions(spxVersion, runtimeVersion)
+}
+
+func (m Manifest) validateVersions(spxVersion, runtimeVersion string) error {
+	if err := validateSPXVersion(spxVersion); err != nil {
+		return fmt.Errorf("driverbundle: expected %w", err)
+	}
+	if err := validateRuntimeVersion(runtimeVersion); err != nil {
+		return fmt.Errorf("driverbundle: expected %w", err)
+	}
+	if m.SPXVersion != spxVersion {
+		return fmt.Errorf("driverbundle: manifest SPX version = %q, want %q", m.SPXVersion, spxVersion)
+	}
+	if m.RuntimeVersion != runtimeVersion {
+		return fmt.Errorf("driverbundle: manifest runtime version = %q, want %q", m.RuntimeVersion, runtimeVersion)
+	}
+	return nil
+}
+
+// Validate checks a bundle's generic structure.
+func (b Bundle) Validate() error { return b.validateForRuntime("") }
+
+// ValidateForRuntime checks the canonical target names and modes.
+func (b Bundle) ValidateForRuntime(runtimeVersion string) error {
+	if err := validateRuntimeVersion(runtimeVersion); err != nil {
+		return fmt.Errorf("driverbundle: %w", err)
+	}
+	return b.validateForRuntime(runtimeVersion)
+}
+
+func (b Bundle) validateForRuntime(runtimeVersion string) error {
+	if !platformPattern.MatchString(b.GOOS) || !platformPattern.MatchString(b.GOARCH) {
+		return fmt.Errorf("invalid bundle platform %q/%q", b.GOOS, b.GOARCH)
+	}
+	if err := validateBundleName(b.Name); err != nil {
+		return err
+	}
+	var spec HostSpec
+	if runtimeVersion != "" {
+		var err error
+		spec, err = HostSpecFor(runtimeVersion, b.GOOS, b.GOARCH)
+		if err != nil {
+			return err
+		}
+		if b.Name != spec.BundleName {
+			return fmt.Errorf("bundle name = %q, want %q", b.Name, spec.BundleName)
+		}
+	}
+	if b.Size <= 0 {
+		return fmt.Errorf("bundle %q size must be positive", b.Name)
+	}
+	if err := validateSHA256(b.SHA256); err != nil {
+		return fmt.Errorf("bundle %q SHA-256: %w", b.Name, err)
+	}
+	if err := validateSHA256(b.EngineInterfaceDigest); err != nil {
+		return fmt.Errorf("bundle %q engine interface digest: %w", b.Name, err)
+	}
+	if len(b.Files) != 3 {
+		return fmt.Errorf("bundle %q must contain exactly three files", b.Name)
+	}
+	seen := make(map[string]struct{}, len(b.Files))
+	for i, file := range b.Files {
+		if err := file.Validate(); err != nil {
+			return fmt.Errorf("bundle %q file %d: %w", b.Name, i, err)
+		}
+		if _, ok := seen[file.Name]; ok {
+			return fmt.Errorf("bundle %q has duplicate file %q", b.Name, file.Name)
+		}
+		seen[file.Name] = struct{}{}
+	}
+	wantInterface, err := ComputeEngineInterfaceDigestFromSHA256(b.Files[0].SHA256, b.Files[1].SHA256)
+	if err != nil {
+		return fmt.Errorf("bundle %q Engine interface: %w", b.Name, err)
+	}
+	if b.EngineInterfaceDigest != wantInterface {
+		return fmt.Errorf("bundle %q Engine interface digest does not match Engine and PCK", b.Name)
+	}
+	if runtimeVersion == "" {
+		return nil
+	}
+	want := [...]Component{spec.Engine, spec.Pack, spec.Bridge}
+	for i, component := range want {
+		if b.Files[i].Name != component.Name || b.Files[i].Mode != component.Mode {
+			return fmt.Errorf("bundle %q file %d identity does not match target", b.Name, i)
+		}
+	}
+	return nil
+}
+
+// Validate checks one regular file record.
+func (f File) Validate() error {
+	if err := validateBaseName(f.Name); err != nil {
+		return fmt.Errorf("file %q: %w", f.Name, err)
+	}
+	if f.Mode == 0 || f.Mode&^uint32(0o777) != 0 {
+		return fmt.Errorf("file %q has invalid mode %#o", f.Name, f.Mode)
+	}
+	if f.Size <= 0 {
+		return fmt.Errorf("file %q size must be positive", f.Name)
+	}
+	if err := validateSHA256(f.SHA256); err != nil {
+		return fmt.Errorf("file %q SHA-256: %w", f.Name, err)
+	}
+	return nil
+}

--- a/internal/runtimebundle/manifest.go
+++ b/internal/runtimebundle/manifest.go
@@ -102,11 +102,12 @@ const (
 	NamespaceEngine  Namespace = "engine"
 	NamespaceBridge  Namespace = "bridge"
 	NamespaceProject Namespace = "project"
+	NamespaceDriver  Namespace = "driver"
 )
 
 func (n Namespace) valid() bool {
 	switch n {
-	case NamespaceEngine, NamespaceBridge, NamespaceProject:
+	case NamespaceEngine, NamespaceBridge, NamespaceProject, NamespaceDriver:
 		return true
 	default:
 		return false


### PR DESCRIPTION
This is P3 of the project-driver split for #1741.
## Scope
- Add internal/driverbundle package for identity/manifest/validation logic.
- Add .github/scripts/driverbundle command/verification code and tests.
- Add GitHub Action contract and static-check coverage for driver bundle.
- Keep namespace compatibility in runtime bundle manifest handling.

## Notes
- P1 and P2 already merged.
- This PR is intentionally kept minimal and composable for the remaining P4/P5 work.
