### PR TITLE
fix: adjust sprite color threshold

### DIFF
--- a/sprite.go
+++ b/sprite.go
@@ -104,7 +104,7 @@ const (
 )
 
 const (
-	colorThreshold = 0.1
+	colorThreshold = 0.01
 	alphaThreshold = 0.05
 )
 


### PR DESCRIPTION
## Summary
Lower the sprite color matching threshold from `0.1` to `0.01` to fix sensitivity-related behavior in sprite color processing.

## Changes
- Updated `sprite.go`:
  - `colorThreshold = 0.1` -> `colorThreshold = 0.01`

## Why
The previous threshold was too high and could cause incorrect color matching behavior in edge cases.

## Impact
- No API or signature changes.
- Logic change is isolated to a constant affecting sprite color thresholding behavior.

## Validation
- Not run in this patch set; this is a constant-level behavior adjustment.