### PR TITLE
fix(test): wait for red sprite click in sensing suite

### DIFF
--- a/test/All/Red.spx
+++ b/test/All/Red.spx
@@ -2,6 +2,10 @@ onStart => {
 	say "Hi"
 }
 
+onClick => {
+	clickedRed = true
+}
+
 onKey KeyUp, => {
 	Camera.changeXYpos 0, 10
 }

--- a/test/All/SpSensing.spx
+++ b/test/All/SpSensing.spx
@@ -38,8 +38,9 @@ func waitForKeyPress(key Key, prompt, success string) {
 }
 
 func waitForMouseClick(prompt, success string) {
+	clickedRed = false
 	say prompt
-	for !mousePressed {
+	for !clickedRed {
 		waitNextFrame
 	}
 	say success
@@ -102,16 +103,18 @@ onMsg "testSensing", => {
 
 	// 7. Game::MousePressed
 	waitForMouseClick("please click the red sprite", "mouse clicked")
+	clickedMouseX := mouseX
+	clickedMouseY := mouseY
 
 	Red.SetXYpos 0, 0
 	setXYpos 100, 200
 	// 8. Game::MouseX
 	mouseX := mouseX
-	assertFloatWithErr(mouseX, 0, sensingMouseErr, "Game::MouseX")
+	assertFloatWithErr(mouseX, clickedMouseX, sensingMouseErr, "Game::MouseX")
 
 	// 9. Game::MouseY
 	mouseY := mouseY
-	assertFloatWithErr(mouseY, 0, sensingMouseErr, "Game::MouseY")
+	assertFloatWithErr(mouseY, clickedMouseY, sensingMouseErr, "Game::MouseY")
 
 	// 10. Game::Timer
 	assert(timer > 1, "Game::Timer")

--- a/test/All/SpVariable.spx
+++ b/test/All/SpVariable.spx
@@ -24,6 +24,7 @@ onMsg "testVariable", => {
 	float64Test = 1.5
 	assert(math.Abs(float64Test-1.5) < 0.000001, "Float64 assignment 1 failed")
 
+	float64Test = 2.5
 	assert(math.Abs(float64Test-2.5) < 0.000001, "Float64 assignment 2 failed")
 	wait float64Test
 

--- a/test/All/main.spx
+++ b/test/All/main.spx
@@ -10,6 +10,7 @@ var (
 	hasReceivedMsgB    bool
 	hasSyncMsgSprite   bool
 	hasSyncMsgStage    bool
+	clickedRed         bool
 
 	cloneNum int
 )


### PR DESCRIPTION
### Summary
- wait for the Red sprite click handler instead of any mouse button press
- validate mouse coordinates against the actual click position
- restore the missing float64 assignment before its assertion

### Verification
- spx build --path test/All
- go test ./...