### PR TITLE
fix: contain engine callback panics

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -180,16 +180,19 @@ func onUpdate(delta float64) {
 }
 
 func onDestroy() {
+	defer CheckPanic()
 	game.OnEngineDestroy()
 }
 
 func onPaused(isPaused bool) {
+	defer CheckPanic()
 	game.OnEnginePause(isPaused)
 }
 
 func onReset() {
+	defer CheckPanic()
+	defer gde.Unlink()
 	game.OnEngineReset()
-	gde.Unlink()
 }
 
 func updateTime(delta float64) {


### PR DESCRIPTION
## Summary
- contain panic paths in destroy, pause, and reset engine callbacks
- ensure reset unlink cleanup runs even when game reset panics

## Verification
- make generate
- go test ./...