### PR TITLE
fix: propagate cross-thread task panics

### DIFF
--- a/internal/coroutine/wait.go
+++ b/internal/coroutine/wait.go
@@ -38,6 +38,18 @@ type WaitJob struct {
 	Frame int64   // Scheduler frame recorded for a frame job.
 }
 
+type taskResult struct {
+	panicValue any
+}
+
+func runTask(fn func()) (result taskResult) {
+	defer func() {
+		result.panicValue = recover()
+	}()
+	fn()
+	return result
+}
+
 // Wait suspends the current coroutine for the given amount of level time, in
 // seconds.
 func (p *Coroutines) Wait(t float64) {
@@ -78,28 +90,35 @@ func (p *Coroutines) WaitMainThread(call func()) {
 	}
 
 	jobID := p.nextWaitJobID()
-	done := make(chan struct{}, 1)
+	done := make(chan taskResult, 1)
 	me := p.currentCoroutineThread()
 	job := &WaitJob{
 		Th:   me,
 		Id:   jobID,
 		Type: waitTypeMainThread,
 		Call: func() {
+			result := taskResult{}
+			defer func() { done <- result }()
 			if p.isThreadCanceled(me) {
 				return
 			}
-			call()
-			done <- struct{}{}
+			result = runTask(call)
 		},
 	}
 	p.enqueuePriorityJob(job)
 
 	if me == nil {
-		<-done
+		result := <-done
+		if result.panicValue != nil {
+			panic(result.panicValue)
+		}
 		return
 	}
 	select {
-	case <-done:
+	case result := <-done:
+		if result.panicValue != nil {
+			panic(result.panicValue)
+		}
 	case <-me.Context().Done():
 		panic(ErrAbortThread)
 	}
@@ -113,12 +132,20 @@ func (p *Coroutines) WaitToDo(fn func()) {
 		fn()
 		return
 	}
+	results := make(chan taskResult, 1)
 	p.setThreadState(me, threadBlocked)
 	go func() {
-		fn()
+		result := runTask(fn)
+		// Publish the result before waking the waiter. The buffered channel also
+		// lets a canceled waiter finish without leaking this worker goroutine.
+		results <- result
 		p.markRunnableAndResume(me)
 	}()
 	p.Yield(me)
+	result := <-results
+	if result.panicValue != nil {
+		panic(result.panicValue)
+	}
 }
 
 // WaitYield suspends me until an Update pass processes its yield job.

--- a/internal/coroutine/wait.go
+++ b/internal/coroutine/wait.go
@@ -40,13 +40,16 @@ type WaitJob struct {
 
 type taskResult struct {
 	panicValue any
+	panicked   bool
 }
 
 func runTask(fn func()) (result taskResult) {
+	result.panicked = true
 	defer func() {
 		result.panicValue = recover()
 	}()
 	fn()
+	result.panicked = false
 	return result
 }
 
@@ -109,14 +112,14 @@ func (p *Coroutines) WaitMainThread(call func()) {
 
 	if me == nil {
 		result := <-done
-		if result.panicValue != nil {
+		if result.panicked {
 			panic(result.panicValue)
 		}
 		return
 	}
 	select {
 	case result := <-done:
-		if result.panicValue != nil {
+		if result.panicked {
 			panic(result.panicValue)
 		}
 	case <-me.Context().Done():
@@ -143,7 +146,7 @@ func (p *Coroutines) WaitToDo(fn func()) {
 	}()
 	p.Yield(me)
 	result := <-results
-	if result.panicValue != nil {
+	if result.panicked {
 		panic(result.panicValue)
 	}
 }

--- a/internal/coroutine/wait_mainthread_native_test.go
+++ b/internal/coroutine/wait_mainthread_native_test.go
@@ -207,3 +207,31 @@ func TestWaitMainThreadCanceledCoroutineDropsQueuedCall(t *testing.T) {
 		t.Fatal("canceled coroutine continued after WaitMainThread")
 	}
 }
+
+func TestWaitMainThreadPropagatesCallbackPanic(t *testing.T) {
+	setMainThreadForTest(t, false)
+	co := New(nil)
+	co.OnInited()
+	returned := make(chan any, 1)
+	go func() {
+		defer func() { returned <- recover() }()
+		co.WaitMainThread(func() { panic("main-thread failure") })
+	}()
+
+	deadline := time.Now().Add(time.Second)
+	for co.currentJobs.Count() == 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("WaitMainThread did not enqueue worker call")
+		}
+		runtime.Gosched()
+	}
+	co.Update()
+	select {
+	case recovered := <-returned:
+		if recovered != "main-thread failure" {
+			t.Fatalf("panic = %v, want callback panic", recovered)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("WaitMainThread caller remained blocked after callback panic")
+	}
+}

--- a/internal/coroutine/wait_mainthread_native_test.go
+++ b/internal/coroutine/wait_mainthread_native_test.go
@@ -235,3 +235,37 @@ func TestWaitMainThreadPropagatesCallbackPanic(t *testing.T) {
 		t.Fatal("WaitMainThread caller remained blocked after callback panic")
 	}
 }
+
+func TestWaitMainThreadPropagatesNilCallbackPanic(t *testing.T) {
+	t.Setenv("GODEBUG", "panicnil=1")
+	setMainThreadForTest(t, false)
+	co := New(nil)
+	co.OnInited()
+	returned := make(chan bool, 1)
+	go func() {
+		panicked := true
+		defer func() {
+			_ = recover()
+			returned <- panicked
+		}()
+		co.WaitMainThread(func() { panic(nil) })
+		panicked = false
+	}()
+
+	deadline := time.Now().Add(time.Second)
+	for co.currentJobs.Count() == 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("WaitMainThread did not enqueue worker call")
+		}
+		runtime.Gosched()
+	}
+	co.Update()
+	select {
+	case panicked := <-returned:
+		if !panicked {
+			t.Fatal("WaitMainThread returned normally after a nil callback panic")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("WaitMainThread caller remained blocked after nil callback panic")
+	}
+}

--- a/internal/coroutine/wait_todo_panic_test.go
+++ b/internal/coroutine/wait_todo_panic_test.go
@@ -1,0 +1,28 @@
+package coroutine
+
+import (
+	"testing"
+	"time"
+)
+
+func TestWaitToDoPropagatesWorkerPanic(t *testing.T) {
+	panicReported := make(chan any, 1)
+	co := New(func(name, stack string) { panicReported <- "worker failure" })
+	co.OnInited()
+	co.CreateAndStart(true, "caller", func(me Thread) int {
+		co.WaitToDo(func() { panic("worker failure") })
+		return 0
+	})
+
+	select {
+	case recovered := <-panicReported:
+		if recovered != "worker failure" {
+			t.Fatalf("panic report = %v, want worker failure", recovered)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("worker panic did not complete the waiting coroutine")
+	}
+	if !co.AbortAllAndWait(time.Second) {
+		t.Fatal("coroutine did not stop during cleanup")
+	}
+}

--- a/internal/coroutine/wait_todo_panic_test.go
+++ b/internal/coroutine/wait_todo_panic_test.go
@@ -5,6 +5,17 @@ import (
 	"time"
 )
 
+func TestRunTaskTracksNilPanic(t *testing.T) {
+	t.Setenv("GODEBUG", "panicnil=1")
+	result := runTask(func() { panic(nil) })
+	if !result.panicked {
+		t.Fatal("runTask treated a nil panic as successful completion")
+	}
+	if result.panicValue != nil {
+		t.Fatalf("panic value = %v, want nil", result.panicValue)
+	}
+}
+
 func TestWaitToDoPropagatesWorkerPanic(t *testing.T) {
 	panicReported := make(chan any, 1)
 	co := New(func(name, stack string) { panicReported <- "worker failure" })
@@ -24,5 +35,28 @@ func TestWaitToDoPropagatesWorkerPanic(t *testing.T) {
 	}
 	if !co.AbortAllAndWait(time.Second) {
 		t.Fatal("coroutine did not stop during cleanup")
+	}
+}
+
+func TestWaitToDoPropagatesNilWorkerPanic(t *testing.T) {
+	t.Setenv("GODEBUG", "panicnil=1")
+	co := New(func(string, string) {})
+	co.OnInited()
+	continued := make(chan struct{}, 1)
+	thread := co.CreateAndStart(true, "caller", func(Thread) int {
+		co.WaitToDo(func() { panic(nil) })
+		continued <- struct{}{}
+		return 0
+	})
+
+	select {
+	case <-thread.done:
+	case <-time.After(time.Second):
+		t.Fatal("nil worker panic did not complete the waiting coroutine")
+	}
+	select {
+	case <-continued:
+		t.Fatal("coroutine continued after a nil worker panic")
+	default:
 	}
 }


### PR DESCRIPTION
## Summary
- preserve task panic values when crossing the main-thread scheduler boundary
- add coverage for native and todo task panic paths

## Verification
- make generate
- go test ./...
- go test -race ./internal/coroutine