### PR TITLE
fix(template): declare dummy 3D physics backend

### DIFF
--- a/cmd/spx/template/project/project.godot
+++ b/cmd/spx/template/project/project.godot
@@ -24,6 +24,10 @@ window/size/viewport_height=360
 obs_enable_combined_recording=true
 realtime_mode=true
 
+[physics]
+
+3d/physics_engine="Dummy"
+
 [rendering]
 
 environment/defaults/default_clear_color=Color(1, 1, 1, 1)


### PR DESCRIPTION
## Summary
- declare the Dummy 3D physics backend in the generated project template
- suppress the expected fallback warning for the 2D-only SPX runtime

## Verification
- `go test ./cmd/spx/internal/...`
- Godot headless smoke run no longer emits the PhysicsServer3D fallback warning

The template runtime intentionally disables 3D physics; this setting keeps that behavior explicit.