### PR TITLE
fix(fs/zip): harden remote archive cache

### DIFF
--- a/fs/zip/fs.go
+++ b/fs/zip/fs.go
@@ -25,7 +25,7 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"path"
+	"path/filepath"
 	"syscall"
 
 	"github.com/goplus/spx/v3/fs"
@@ -62,54 +62,209 @@ func (zipf *FS) Close() error {
 
 // OpenHttp opens hzip:<domain>/<path>
 // OpenHttp("open.qiniu.us/weather/res.zip")
-func OpenHttp(url string) (fs.Dir, error) {
-	return openHttpWith(url, "http://")
+func OpenHttp(remotePath string) (fs.Dir, error) {
+	return openHttpWith(remotePath, "http://")
 }
 
 // OpenHttps opens hzips:<domain>/<path>
 // OpenHttps("open.qiniu.us/weather/res.zip")
-func OpenHttps(url string) (fs.Dir, error) {
-	return openHttpWith(url, "https://")
+func OpenHttps(remotePath string) (fs.Dir, error) {
+	return openHttpWith(remotePath, "https://")
 }
 
-func openHttpWith(url string, schema string) (dir fs.Dir, err error) {
-	local := spxBaseDir + url
-	dir, err = Open(local)
-	if err == nil {
-		return
+func openHttpWith(remotePath string, schema string) (dir fs.Dir, err error) {
+	remote, cacheKey, err := parseRemoteURL(remotePath, schema)
+	if err != nil {
+		return nil, err
+	}
+	local, err := remoteCachePath(spxBaseDir, schema, cacheKey)
+	if err != nil {
+		return nil, err
+	}
+	if dir, ok := openCached(local); ok {
+		return dir, nil
 	}
 
-	remote := schema + url
-	resp, err := http.Get(remote)
+	client := remoteHTTPClient
+	client = remoteClientForScheme(client, schema)
+	resp, err := client.Get(remote)
 	if err != nil {
-		return
+		return nil, fmt.Errorf("zip: download %s: %w", remote, err)
 	}
-	defer resp.Body.Close()
+	if resp.Body != nil {
+		defer resp.Body.Close()
+	}
+	if err := checkFinalRemoteScheme(resp, schema); err != nil {
+		return nil, err
+	}
+	if err := checkRemoteHTTPResponse(resp, remote); err != nil {
+		return nil, err
+	}
 
-	err = saveTo(local, resp)
-	if err != nil {
-		return
+	if err := saveTo(local, resp); err != nil {
+		return nil, err
 	}
 	return Open(local)
 }
 
 func saveTo(local string, resp *http.Response) (err error) {
-	dir := path.Dir(local)
-	os.MkdirAll(dir, 0777)
-
-	f, err := os.Create(local)
-	if err != nil {
-		return
+	if local == "" || !filepath.IsAbs(local) {
+		return fmt.Errorf("zip: cache path must be absolute: %q", local)
 	}
-	defer f.Close()
+	if err := checkRemoteHTTPResponse(resp, "remote archive"); err != nil {
+		return err
+	}
+	if resp.Body == nil {
+		return fmt.Errorf("zip: HTTP response has no body")
+	}
+	cacheDir := filepath.Dir(local)
+	if err := ensureCacheDirectories(cacheDir); err != nil {
+		return err
+	}
+	f, err := os.CreateTemp(cacheDir, ".zip-cache-*")
+	if err != nil {
+		return fmt.Errorf("zip: create cache temporary file: %w", err)
+	}
+	tmpPath := f.Name()
+	committed := false
+	fileClosed := false
+	defer func() {
+		if !fileClosed {
+			if closeErr := f.Close(); err == nil && closeErr != nil {
+				err = fmt.Errorf("zip: close cache temporary file: %w", closeErr)
+			}
+		}
+		if !committed {
+			_ = os.Remove(tmpPath)
+		}
+	}()
 
-	_, err = io.Copy(f, resp.Body)
-	return
+	limit := remoteMaxBytes()
+	n, copyErr := io.Copy(f, io.LimitReader(resp.Body, limit+1))
+	if copyErr != nil {
+		return fmt.Errorf("zip: download remote archive: %w", copyErr)
+	}
+	if n > limit {
+		return fmt.Errorf("%w: response exceeds limit %d", ErrRemoteSizeLimit, limit)
+	}
+	if err := f.Sync(); err != nil {
+		return fmt.Errorf("zip: sync cache temporary file: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("zip: close cache temporary file: %w", err)
+	}
+	fileClosed = true
+
+	archive, err := Open(tmpPath)
+	if err != nil {
+		return fmt.Errorf("zip: downloaded response is not a valid ZIP: %w", err)
+	}
+	if closeErr := archive.Close(); closeErr != nil {
+		return fmt.Errorf("zip: close downloaded ZIP: %w", closeErr)
+	}
+	if err := publishCacheFile(tmpPath, local); err != nil {
+		return err
+	}
+	committed = true
+	return nil
 }
 
-var (
-	spxBaseDir = os.Getenv("HOME") + "/.spx/"
-)
+func openCached(local string) (fs.Dir, bool) {
+	info, err := os.Lstat(local)
+	if err != nil || info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+		return nil, false
+	}
+	dir, err := Open(local)
+	if err != nil {
+		return nil, false
+	}
+	return dir, true
+}
+
+func remoteCachePath(base, schema, cacheKey string) (string, error) {
+	if base == "" || !filepath.IsAbs(base) {
+		return "", fmt.Errorf("zip: cache directory must be an absolute clean path: %q", base)
+	}
+	base = filepath.Clean(base)
+	if len(cacheKey) != 64 {
+		return "", fmt.Errorf("zip: invalid remote cache key")
+	}
+	var protocol string
+	switch schema {
+	case "http://":
+		protocol = "http"
+	case "https://":
+		protocol = "https"
+	default:
+		return "", fmt.Errorf("zip: unsupported remote transport %q", schema)
+	}
+	return filepath.Join(base, protocol, cacheKey+".zip"), nil
+}
+
+func ensureCacheDirectories(protocolDir string) error {
+	base := filepath.Dir(protocolDir)
+	for _, dir := range []string{base, protocolDir} {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			return fmt.Errorf("zip: create cache directory %s: %w", dir, err)
+		}
+		info, err := os.Lstat(dir)
+		if err != nil {
+			return fmt.Errorf("zip: inspect cache directory %s: %w", dir, err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+			return fmt.Errorf("zip: cache directory is not a real directory: %s", dir)
+		}
+		if err := os.Chmod(dir, 0o700); err != nil {
+			return fmt.Errorf("zip: protect cache directory %s: %w", dir, err)
+		}
+	}
+	return nil
+}
+
+func publishCacheFile(tmpPath, local string) error {
+	renameErr := os.Rename(tmpPath, local)
+	if renameErr == nil {
+		return nil
+	} else if !isWindowsRenameConflict(renameErr) {
+		return fmt.Errorf("zip: publish cache archive: %w", renameErr)
+	}
+
+	// Windows cannot replace an existing file with Rename. Remove only the
+	// target directory entry (never follow a symlink), then retry in the same
+	// directory. POSIX uses the atomic replacement above.
+	info, statErr := os.Lstat(local)
+	if statErr != nil {
+		return fmt.Errorf("zip: publish cache archive: %w", renameErr)
+	}
+	if info.Mode()&os.ModeSymlink == 0 && !info.Mode().IsRegular() {
+		return fmt.Errorf("zip: cache target is not a regular file: %s", local)
+	}
+	if removeErr := os.Remove(local); removeErr != nil {
+		return fmt.Errorf("zip: replace cache archive: %w", removeErr)
+	}
+	if renameErr := os.Rename(tmpPath, local); renameErr != nil {
+		return fmt.Errorf("zip: publish cache archive: %w", renameErr)
+	}
+	return nil
+}
+
+func isWindowsRenameConflict(err error) bool {
+	// os.Rename reports an existence error on Windows; on other platforms a
+	// failed rename should be returned unchanged rather than deleting a target.
+	return os.IsExist(err)
+}
+
+func defaultSPXBaseDir() string {
+	if home := os.Getenv("HOME"); home != "" && filepath.IsAbs(home) {
+		return filepath.Join(home, ".spx")
+	}
+	if cache, err := os.UserCacheDir(); err == nil && cache != "" && filepath.IsAbs(cache) {
+		return filepath.Join(cache, "spx")
+	}
+	return filepath.Join(os.TempDir(), "spx")
+}
+
+var spxBaseDir = defaultSPXBaseDir()
 
 func init() {
 	fs.RegisterSchema("zip", Open)

--- a/fs/zip/fs.go
+++ b/fs/zip/fs.go
@@ -72,44 +72,34 @@ func OpenHttps(remotePath string) (fs.Dir, error) {
 	return openHttpWith(remotePath, "https://")
 }
 
-func openHttpWith(remotePath string, schema string) (dir fs.Dir, err error) {
-	remote, cacheKey, err := parseRemoteURL(remotePath, schema)
+func openHttpWith(remotePath, scheme string) (fs.Dir, error) {
+	remote, cacheKey, err := parseRemoteURL(remotePath, scheme)
 	if err != nil {
 		return nil, err
 	}
-	local, err := remoteCachePath(spxBaseDir, schema, cacheKey)
+	cachePath, err := remoteCachePath(spxBaseDir, scheme, cacheKey)
 	if err != nil {
 		return nil, err
 	}
-	if dir, ok := openCached(local); ok {
+	if dir, ok := openCached(cachePath); ok {
 		return dir, nil
 	}
 
-	client := remoteHTTPClient
-	client = remoteClientForScheme(client, schema)
-	resp, err := client.Get(remote)
+	resp, err := getRemote(remote, scheme)
 	if err != nil {
 		return nil, fmt.Errorf("zip: download %s: %w", remote, err)
 	}
-	if resp.Body != nil {
-		defer resp.Body.Close()
-	}
-	if err := checkFinalRemoteScheme(resp, schema); err != nil {
-		return nil, err
-	}
-	if err := checkRemoteHTTPResponse(resp, remote); err != nil {
-		return nil, err
-	}
+	defer resp.Body.Close()
 
-	if err := saveTo(local, resp); err != nil {
+	if err := saveTo(cachePath, resp); err != nil {
 		return nil, err
 	}
-	return Open(local)
+	return Open(cachePath)
 }
 
-func saveTo(local string, resp *http.Response) (err error) {
-	if local == "" || !filepath.IsAbs(local) {
-		return fmt.Errorf("zip: cache path must be absolute: %q", local)
+func saveTo(cachePath string, resp *http.Response) (err error) {
+	if cachePath == "" || !filepath.IsAbs(cachePath) {
+		return fmt.Errorf("zip: cache path must be absolute: %q", cachePath)
 	}
 	if err := checkRemoteHTTPResponse(resp, "remote archive"); err != nil {
 		return err
@@ -117,7 +107,7 @@ func saveTo(local string, resp *http.Response) (err error) {
 	if resp.Body == nil {
 		return fmt.Errorf("zip: HTTP response has no body")
 	}
-	cacheDir := filepath.Dir(local)
+	cacheDir := filepath.Dir(cachePath)
 	if err := ensureCacheDirectories(cacheDir); err != nil {
 		return err
 	}
@@ -162,26 +152,26 @@ func saveTo(local string, resp *http.Response) (err error) {
 	if closeErr := archive.Close(); closeErr != nil {
 		return fmt.Errorf("zip: close downloaded ZIP: %w", closeErr)
 	}
-	if err := publishCacheFile(tmpPath, local); err != nil {
+	if err := publishCacheFile(tmpPath, cachePath); err != nil {
 		return err
 	}
 	committed = true
 	return nil
 }
 
-func openCached(local string) (fs.Dir, bool) {
-	info, err := os.Lstat(local)
+func openCached(cachePath string) (fs.Dir, bool) {
+	info, err := os.Lstat(cachePath)
 	if err != nil || info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
 		return nil, false
 	}
-	dir, err := Open(local)
+	dir, err := Open(cachePath)
 	if err != nil {
 		return nil, false
 	}
 	return dir, true
 }
 
-func remoteCachePath(base, schema, cacheKey string) (string, error) {
+func remoteCachePath(base, scheme, cacheKey string) (string, error) {
 	if base == "" || !filepath.IsAbs(base) {
 		return "", fmt.Errorf("zip: cache directory must be an absolute clean path: %q", base)
 	}
@@ -190,13 +180,13 @@ func remoteCachePath(base, schema, cacheKey string) (string, error) {
 		return "", fmt.Errorf("zip: invalid remote cache key")
 	}
 	var protocol string
-	switch schema {
+	switch scheme {
 	case "http://":
 		protocol = "http"
 	case "https://":
 		protocol = "https"
 	default:
-		return "", fmt.Errorf("zip: unsupported remote transport %q", schema)
+		return "", fmt.Errorf("zip: unsupported remote transport %q", scheme)
 	}
 	return filepath.Join(base, protocol, cacheKey+".zip"), nil
 }
@@ -229,9 +219,7 @@ func publishCacheFile(tmpPath, local string) error {
 		return fmt.Errorf("zip: publish cache archive: %w", renameErr)
 	}
 
-	// Windows cannot replace an existing file with Rename. Remove only the
-	// target directory entry (never follow a symlink), then retry in the same
-	// directory. POSIX uses the atomic replacement above.
+	// Windows needs an explicit remove before replacing the target.
 	info, statErr := os.Lstat(local)
 	if statErr != nil {
 		return fmt.Errorf("zip: publish cache archive: %w", renameErr)

--- a/fs/zip/fs_js.go
+++ b/fs/zip/fs_js.go
@@ -63,26 +63,16 @@ func OpenHttps(remotePath string) (fs.Dir, error) {
 	return openHttpWith(remotePath, "https://")
 }
 
-func openHttpWith(remotePath string, schema string) (dir fs.Dir, err error) {
-	remote, _, err := parseRemoteURL(remotePath, schema)
+func openHttpWith(remotePath, scheme string) (fs.Dir, error) {
+	remote, _, err := parseRemoteURL(remotePath, scheme)
 	if err != nil {
 		return nil, err
 	}
-	client := remoteHTTPClient
-	client = remoteClientForScheme(client, schema)
-	resp, err := client.Get(remote)
+	resp, err := getRemote(remote, scheme)
 	if err != nil {
 		return nil, err
 	}
-	if resp.Body != nil {
-		defer resp.Body.Close()
-	}
-	if err := checkFinalRemoteScheme(resp, schema); err != nil {
-		return nil, err
-	}
-	if err := checkRemoteHTTPResponse(resp, remote); err != nil {
-		return nil, err
-	}
+	defer resp.Body.Close()
 	body, err := readRemoteBody(resp)
 	if err != nil {
 		return nil, err

--- a/fs/zip/fs_js.go
+++ b/fs/zip/fs_js.go
@@ -21,7 +21,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"net/http"
 	"syscall"
 
 	"github.com/goplus/spx/v3/fs"
@@ -54,24 +53,37 @@ func (zipf *FS) Close() error {
 
 // OpenHttp opens hzip:<domain>/<path>
 // OpenHttp("open.qiniu.us/weather/res.zip")
-func OpenHttp(url string) (fs.Dir, error) {
-	return openHttpWith(url, "http://")
+func OpenHttp(remotePath string) (fs.Dir, error) {
+	return openHttpWith(remotePath, "http://")
 }
 
 // OpenHttps opens hzips:<domain>/<path>
 // OpenHttps("open.qiniu.us/weather/res.zip")
-func OpenHttps(url string) (fs.Dir, error) {
-	return openHttpWith(url, "https://")
+func OpenHttps(remotePath string) (fs.Dir, error) {
+	return openHttpWith(remotePath, "https://")
 }
 
-func openHttpWith(url string, schema string) (dir fs.Dir, err error) {
-	remote := schema + url
-	resp, err := http.Get(remote)
+func openHttpWith(remotePath string, schema string) (dir fs.Dir, err error) {
+	remote, _, err := parseRemoteURL(remotePath, schema)
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
-	body, err := io.ReadAll(resp.Body)
+	client := remoteHTTPClient
+	client = remoteClientForScheme(client, schema)
+	resp, err := client.Get(remote)
+	if err != nil {
+		return nil, err
+	}
+	if resp.Body != nil {
+		defer resp.Body.Close()
+	}
+	if err := checkFinalRemoteScheme(resp, schema); err != nil {
+		return nil, err
+	}
+	if err := checkRemoteHTTPResponse(resp, remote); err != nil {
+		return nil, err
+	}
+	body, err := readRemoteBody(resp)
 	if err != nil {
 		return nil, err
 	}

--- a/fs/zip/http_common.go
+++ b/fs/zip/http_common.go
@@ -30,19 +30,15 @@ import (
 )
 
 const (
-	// MaxRemoteZipBytes bounds the amount of data accepted from an hzip/hzips
-	// response. The limit applies even when the server omits Content-Length.
+	// MaxRemoteZipBytes limits downloaded archive data.
 	MaxRemoteZipBytes int64 = 512 << 20
 )
 
 var (
-	// remoteHTTPClient is a package test hook. A nil value follows
-	// http.DefaultClient at request time, preserving the standard library's
-	// transport, proxy, cookie jar, and redirect configuration.
+	// remoteHTTPClient is a test hook; nil uses http.DefaultClient.
 	remoteHTTPClient  *http.Client
 	remoteHTTPTimeout = 5 * time.Minute
-	// maxRemoteZipBytes is kept separate from the public default to make the
-	// bound straightforward to exercise in tests.
+	// maxRemoteZipBytes allows a test-only limit override.
 	maxRemoteZipBytes int64 = MaxRemoteZipBytes
 
 	ErrInvalidRemoteURL = errors.New("zip: invalid remote URL")
@@ -73,8 +69,7 @@ func remoteMaxBytes() int64 {
 	return MaxRemoteZipBytes
 }
 
-// parseRemoteURL accepts the historical hzip form (host/path) and turns it
-// into an absolute URL. The original URL is never used as a filesystem path.
+// parseRemoteURL validates the legacy host/path form.
 func parseRemoteURL(raw, schema string) (remote, cacheKey string, err error) {
 	var expectedScheme string
 	switch schema {
@@ -136,14 +131,35 @@ func parseRemoteURL(raw, schema string) (remote, cacheKey string, err error) {
 		}
 	}
 
-	// Host names are case-insensitive. Keeping one canonical representation
-	// makes equivalent URLs share a cache entry while retaining the protocol in
-	// the key so hzip and hzips can never collide.
+	// Keep the protocol in the key so HTTP and HTTPS never share a cache entry.
 	canonicalURL := *parsed
 	canonicalURL.Host = strings.ToLower(parsed.Host)
 	remote = canonicalURL.String()
 	digest := sha256.Sum256([]byte(remote))
 	return remote, hex.EncodeToString(digest[:]), nil
+}
+
+func getRemote(remote, scheme string) (*http.Response, error) {
+	resp, err := remoteClientForScheme(remoteHTTPClient, scheme).Get(remote)
+	if err != nil {
+		return nil, err
+	}
+	if err := checkFinalRemoteScheme(resp, scheme); err != nil {
+		if resp != nil && resp.Body != nil {
+			_ = resp.Body.Close()
+		}
+		return nil, err
+	}
+	if err := checkRemoteHTTPResponse(resp, remote); err != nil {
+		if resp != nil && resp.Body != nil {
+			_ = resp.Body.Close()
+		}
+		return nil, err
+	}
+	if resp.Body == nil {
+		return nil, fmt.Errorf("zip: HTTP response has no body")
+	}
+	return resp, nil
 }
 
 func checkRemoteHTTPResponse(resp *http.Response, remote string) error {
@@ -181,7 +197,7 @@ func readRemoteBody(resp *http.Response) ([]byte, error) {
 	return body, nil
 }
 
-func remoteClientForScheme(client *http.Client, schema string) *http.Client {
+func remoteClientForScheme(client *http.Client, scheme string) *http.Client {
 	if client == nil {
 		client = http.DefaultClient
 	}
@@ -196,7 +212,7 @@ func remoteClientForScheme(client *http.Client, schema string) *http.Client {
 	if clone.Timeout <= 0 || clone.Timeout > timeout {
 		clone.Timeout = timeout
 	}
-	if schema != "https://" {
+	if scheme != "https://" {
 		return &clone
 	}
 	previous := clone.CheckRedirect

--- a/fs/zip/http_common.go
+++ b/fs/zip/http_common.go
@@ -36,9 +36,11 @@ const (
 )
 
 var (
-	// remoteHTTPClient is a variable so embedders and package tests can provide
-	// a transport without changing the public OpenHttp/OpenHttps API.
-	remoteHTTPClient = &http.Client{Timeout: 5 * time.Minute}
+	// remoteHTTPClient is a package test hook. A nil value follows
+	// http.DefaultClient at request time, preserving the standard library's
+	// transport, proxy, cookie jar, and redirect configuration.
+	remoteHTTPClient  *http.Client
+	remoteHTTPTimeout = 5 * time.Minute
 	// maxRemoteZipBytes is kept separate from the public default to make the
 	// bound straightforward to exercise in tests.
 	maxRemoteZipBytes int64 = MaxRemoteZipBytes
@@ -148,7 +150,7 @@ func checkRemoteHTTPResponse(resp *http.Response, remote string) error {
 	if resp == nil {
 		return fmt.Errorf("zip: nil HTTP response")
 	}
-	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+	if resp.StatusCode != http.StatusOK {
 		status := resp.Status
 		if status == "" {
 			status = http.StatusText(resp.StatusCode)
@@ -183,10 +185,20 @@ func remoteClientForScheme(client *http.Client, schema string) *http.Client {
 	if client == nil {
 		client = http.DefaultClient
 	}
-	if schema != "https://" {
-		return client
+	if client == nil {
+		client = &http.Client{}
 	}
 	clone := *client
+	timeout := remoteHTTPTimeout
+	if timeout <= 0 {
+		timeout = 5 * time.Minute
+	}
+	if clone.Timeout <= 0 || clone.Timeout > timeout {
+		clone.Timeout = timeout
+	}
+	if schema != "https://" {
+		return &clone
+	}
 	previous := clone.CheckRedirect
 	clone.CheckRedirect = func(req *http.Request, via []*http.Request) error {
 		if req == nil || req.URL == nil || req.URL.Scheme != "https" {

--- a/fs/zip/http_common.go
+++ b/fs/zip/http_common.go
@@ -1,0 +1,224 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zip
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+	"unicode"
+)
+
+const (
+	// MaxRemoteZipBytes bounds the amount of data accepted from an hzip/hzips
+	// response. The limit applies even when the server omits Content-Length.
+	MaxRemoteZipBytes int64 = 512 << 20
+)
+
+var (
+	// remoteHTTPClient is a variable so embedders and package tests can provide
+	// a transport without changing the public OpenHttp/OpenHttps API.
+	remoteHTTPClient = &http.Client{Timeout: 5 * time.Minute}
+	// maxRemoteZipBytes is kept separate from the public default to make the
+	// bound straightforward to exercise in tests.
+	maxRemoteZipBytes int64 = MaxRemoteZipBytes
+
+	ErrInvalidRemoteURL = errors.New("zip: invalid remote URL")
+	ErrHTTPStatus       = errors.New("zip: unexpected HTTP status")
+	ErrRemoteSizeLimit  = errors.New("zip: remote archive too large")
+	ErrInsecureRedirect = errors.New("zip: insecure HTTPS redirect")
+)
+
+type remoteHTTPStatusError struct {
+	URL        string
+	StatusCode int
+	Status     string
+}
+
+func (e *remoteHTTPStatusError) Error() string {
+	if e.Status != "" {
+		return fmt.Sprintf("zip: GET %s: unexpected HTTP status %s", e.URL, e.Status)
+	}
+	return fmt.Sprintf("zip: GET %s: unexpected HTTP status %d", e.URL, e.StatusCode)
+}
+
+func (e *remoteHTTPStatusError) Unwrap() error { return ErrHTTPStatus }
+
+func remoteMaxBytes() int64 {
+	if maxRemoteZipBytes > 0 {
+		return maxRemoteZipBytes
+	}
+	return MaxRemoteZipBytes
+}
+
+// parseRemoteURL accepts the historical hzip form (host/path) and turns it
+// into an absolute URL. The original URL is never used as a filesystem path.
+func parseRemoteURL(raw, schema string) (remote, cacheKey string, err error) {
+	var expectedScheme string
+	switch schema {
+	case "http://":
+		expectedScheme = "http"
+	case "https://":
+		expectedScheme = "https"
+	default:
+		return "", "", fmt.Errorf("%w: unsupported transport %q", ErrInvalidRemoteURL, schema)
+	}
+	authority := raw
+	if query := strings.IndexAny(authority, "?#"); query >= 0 {
+		authority = authority[:query]
+	}
+	if raw == "" || strings.Contains(authority, "://") || strings.HasPrefix(raw, "/") || strings.HasPrefix(raw, `\`) {
+		return "", "", fmt.Errorf("%w: expected host/path, got %q", ErrInvalidRemoteURL, raw)
+	}
+	if strings.ContainsAny(raw, `\`) || strings.Contains(raw, "#") {
+		return "", "", fmt.Errorf("%w: unsupported path character in %q", ErrInvalidRemoteURL, raw)
+	}
+	for _, r := range raw {
+		if unicode.IsControl(r) || unicode.IsSpace(r) {
+			return "", "", fmt.Errorf("%w: control or whitespace character in URL", ErrInvalidRemoteURL)
+		}
+	}
+
+	parsed, parseErr := url.Parse(schema + raw)
+	if parseErr != nil {
+		return "", "", fmt.Errorf("%w: %v", ErrInvalidRemoteURL, parseErr)
+	}
+	if parsed.Scheme != expectedScheme || parsed.Opaque != "" || parsed.Host == "" || parsed.User != nil || parsed.Fragment != "" {
+		return "", "", fmt.Errorf("%w: URL must contain only a host, path, and query", ErrInvalidRemoteURL)
+	}
+	host := parsed.Hostname()
+	if host == "" || host == "." || host == ".." {
+		return "", "", fmt.Errorf("%w: missing or invalid host", ErrInvalidRemoteURL)
+	}
+	for _, r := range host {
+		if unicode.IsControl(r) || unicode.IsSpace(r) {
+			return "", "", fmt.Errorf("%w: invalid host", ErrInvalidRemoteURL)
+		}
+	}
+
+	decodedPath, pathErr := url.PathUnescape(parsed.EscapedPath())
+	if pathErr != nil {
+		return "", "", fmt.Errorf("%w: invalid escaped path: %v", ErrInvalidRemoteURL, pathErr)
+	}
+	if strings.ContainsAny(decodedPath, `\`) {
+		return "", "", fmt.Errorf("%w: backslash in path", ErrInvalidRemoteURL)
+	}
+	for _, r := range decodedPath {
+		if unicode.IsControl(r) {
+			return "", "", fmt.Errorf("%w: control character in path", ErrInvalidRemoteURL)
+		}
+	}
+	for _, segment := range strings.Split(decodedPath, "/") {
+		if segment == "." || segment == ".." {
+			return "", "", fmt.Errorf("%w: path traversal segment in URL", ErrInvalidRemoteURL)
+		}
+	}
+
+	// Host names are case-insensitive. Keeping one canonical representation
+	// makes equivalent URLs share a cache entry while retaining the protocol in
+	// the key so hzip and hzips can never collide.
+	canonicalURL := *parsed
+	canonicalURL.Host = strings.ToLower(parsed.Host)
+	remote = canonicalURL.String()
+	digest := sha256.Sum256([]byte(remote))
+	return remote, hex.EncodeToString(digest[:]), nil
+}
+
+func checkRemoteHTTPResponse(resp *http.Response, remote string) error {
+	if resp == nil {
+		return fmt.Errorf("zip: nil HTTP response")
+	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		status := resp.Status
+		if status == "" {
+			status = http.StatusText(resp.StatusCode)
+		}
+		return &remoteHTTPStatusError{URL: remote, StatusCode: resp.StatusCode, Status: status}
+	}
+	if resp.ContentLength > remoteMaxBytes() {
+		return fmt.Errorf("%w: response length %d exceeds limit %d", ErrRemoteSizeLimit, resp.ContentLength, remoteMaxBytes())
+	}
+	return nil
+}
+
+func readRemoteBody(resp *http.Response) ([]byte, error) {
+	if err := checkRemoteHTTPResponse(resp, "remote archive"); err != nil {
+		return nil, err
+	}
+	if resp.Body == nil {
+		return nil, fmt.Errorf("zip: HTTP response has no body")
+	}
+	limit := remoteMaxBytes()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, limit+1))
+	if err != nil {
+		return nil, fmt.Errorf("zip: read remote archive: %w", err)
+	}
+	if int64(len(body)) > limit {
+		return nil, fmt.Errorf("%w: response exceeds limit %d", ErrRemoteSizeLimit, limit)
+	}
+	return body, nil
+}
+
+func remoteClientForScheme(client *http.Client, schema string) *http.Client {
+	if client == nil {
+		client = http.DefaultClient
+	}
+	if schema != "https://" {
+		return client
+	}
+	clone := *client
+	previous := clone.CheckRedirect
+	clone.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if req == nil || req.URL == nil || req.URL.Scheme != "https" {
+			var target any
+			if req != nil {
+				target = req.URL
+			}
+			return fmt.Errorf("%w: HTTPS URL redirected to %q", ErrInsecureRedirect, target)
+		}
+		if previous != nil {
+			if err := previous(req, via); err != nil {
+				return err
+			}
+			if req.URL == nil || req.URL.Scheme != "https" {
+				return fmt.Errorf("%w: redirect callback selected %q", ErrInsecureRedirect, req.URL)
+			}
+			return nil
+		}
+		if len(via) >= 10 {
+			return fmt.Errorf("%w: stopped after 10 redirects", http.ErrUseLastResponse)
+		}
+		return nil
+	}
+	return &clone
+}
+
+func checkFinalRemoteScheme(resp *http.Response, schema string) error {
+	if schema != "https://" || resp == nil || resp.Request == nil || resp.Request.URL == nil {
+		return nil
+	}
+	if resp.Request.URL.Scheme != "https" {
+		return fmt.Errorf("%w: HTTPS URL resolved to %q", ErrInsecureRedirect, resp.Request.URL)
+	}
+	return nil
+}

--- a/fs/zip/http_test.go
+++ b/fs/zip/http_test.go
@@ -21,6 +21,7 @@ package zip
 import (
 	"archive/zip"
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"net/http"
@@ -33,7 +34,23 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 )
+
+type zipRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f zipRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+type zipContextBody struct{ ctx context.Context }
+
+func (b zipContextBody) Read([]byte) (int, error) {
+	<-b.ctx.Done()
+	return 0, b.ctx.Err()
+}
+
+func (zipContextBody) Close() error { return nil }
 
 func TestOpenHTTPRejectsPathTraversalBeforeRequest(t *testing.T) {
 	root := t.TempDir()
@@ -92,6 +109,33 @@ func TestOpenHTTPStatusDoesNotPopulateCache(t *testing.T) {
 	}
 	if _, statErr := os.Stat(spxBaseDir); !errors.Is(statErr, os.ErrNotExist) {
 		t.Fatalf("cache root stat error = %v, want not exist", statErr)
+	}
+}
+
+func TestOpenHTTPRejectsPartialAndEmptySuccessResponses(t *testing.T) {
+	for _, status := range []int{http.StatusPartialContent, http.StatusNoContent} {
+		status := status
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			root := t.TempDir()
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(status)
+				if status == http.StatusPartialContent {
+					_, _ = io.WriteString(w, "partial")
+				}
+			}))
+			defer server.Close()
+			oldBase := spxBaseDir
+			spxBaseDir = filepath.Join(root, "cache")
+			t.Cleanup(func() { spxBaseDir = oldBase })
+
+			_, err := OpenHttp(server.Listener.Addr().String() + "/archive.zip")
+			if !errors.Is(err, ErrHTTPStatus) {
+				t.Fatalf("OpenHttp status %d error = %v, want ErrHTTPStatus", status, err)
+			}
+			if _, statErr := os.Stat(spxBaseDir); !errors.Is(statErr, os.ErrNotExist) {
+				t.Fatalf("cache root stat error = %v, want not exist", statErr)
+			}
+		})
 	}
 }
 
@@ -274,6 +318,59 @@ func TestHTTPSClientRejectsDowngradeRedirect(t *testing.T) {
 	request := &http.Request{URL: redirectURL}
 	if err := client.CheckRedirect(request, []*http.Request{{URL: requestURL}}); !errors.Is(err, ErrInsecureRedirect) {
 		t.Fatalf("CheckRedirect error = %v, want ErrInsecureRedirect", err)
+	}
+}
+
+func TestRemoteClientPreservesConfigurationAndBoundsTimeout(t *testing.T) {
+	transport := http.RoundTripper(http.DefaultTransport)
+	redirect := func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+	original := &http.Client{
+		Transport:     transport,
+		CheckRedirect: redirect,
+		Timeout:       10 * time.Minute,
+	}
+
+	client := remoteClientForScheme(original, "http://")
+	if client == original {
+		t.Fatal("remoteClientForScheme returned the caller's mutable client")
+	}
+	if client.Transport != transport || client.CheckRedirect == nil {
+		t.Fatal("remote client did not preserve transport and redirect configuration")
+	}
+	if got, want := client.Timeout, 5*time.Minute; got != want {
+		t.Fatalf("remote client timeout = %v, want %v", got, want)
+	}
+	if got := original.Timeout; got != 10*time.Minute {
+		t.Fatalf("original client timeout changed to %v", got)
+	}
+
+	original.Timeout = time.Second
+	client = remoteClientForScheme(original, "http://")
+	if got := client.Timeout; got != time.Second {
+		t.Fatalf("short caller timeout was changed to %v", got)
+	}
+}
+
+func TestRemoteClientTimeoutCoversResponseBody(t *testing.T) {
+	original := &http.Client{
+		Transport: zipRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Status:     "200 OK",
+				Body:       zipContextBody{ctx: req.Context()},
+				Request:    req,
+			}, nil
+		}),
+		Timeout: 25 * time.Millisecond,
+	}
+	client := remoteClientForScheme(original, "http://")
+	resp, err := client.Get("http://example.test/archive.zip")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	defer resp.Body.Close()
+	if _, err := io.ReadAll(resp.Body); err == nil {
+		t.Fatal("response body read succeeded after timeout")
 	}
 }
 

--- a/fs/zip/http_test.go
+++ b/fs/zip/http_test.go
@@ -1,0 +1,377 @@
+//go:build !js
+
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zip
+
+import (
+	"archive/zip"
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+func TestOpenHTTPRejectsPathTraversalBeforeRequest(t *testing.T) {
+	root := t.TempDir()
+	cache := filepath.Join(root, "cache")
+	victim := filepath.Join(root, "victim.zip")
+	if err := os.WriteFile(victim, []byte("keep"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		requests.Add(1)
+	}))
+	defer server.Close()
+
+	oldBase := spxBaseDir
+	spxBaseDir = cache
+	t.Cleanup(func() { spxBaseDir = oldBase })
+
+	_, err := OpenHttp(server.Listener.Addr().String() + "/../victim.zip")
+	if !errors.Is(err, ErrInvalidRemoteURL) {
+		t.Fatalf("OpenHttp error = %v, want ErrInvalidRemoteURL", err)
+	}
+	if got := requests.Load(); got != 0 {
+		t.Fatalf("server requests = %d, want 0", got)
+	}
+	if got, readErr := os.ReadFile(victim); readErr != nil || string(got) != "keep" {
+		t.Fatalf("victim changed: %q, err=%v", got, readErr)
+	}
+}
+
+func TestOpenHTTPRejectsEmbeddedAbsoluteURL(t *testing.T) {
+	for _, raw := range []string{
+		"https://example.test/archive.zip",
+		"//example.test/archive.zip",
+		"example.test/../../archive.zip",
+		"example.test/%2e%2e/archive.zip",
+		"example.test\\archive.zip",
+	} {
+		if _, _, err := parseRemoteURL(raw, "http://"); !errors.Is(err, ErrInvalidRemoteURL) {
+			t.Errorf("parseRemoteURL(%q) error = %v, want ErrInvalidRemoteURL", raw, err)
+		}
+	}
+}
+
+func TestOpenHTTPStatusDoesNotPopulateCache(t *testing.T) {
+	root := t.TempDir()
+	server := httptest.NewServer(http.NotFoundHandler())
+	defer server.Close()
+	oldBase := spxBaseDir
+	spxBaseDir = filepath.Join(root, "cache")
+	t.Cleanup(func() { spxBaseDir = oldBase })
+
+	_, err := OpenHttp(server.Listener.Addr().String() + "/missing.zip")
+	if !errors.Is(err, ErrHTTPStatus) {
+		t.Fatalf("OpenHttp error = %v, want ErrHTTPStatus", err)
+	}
+	if _, statErr := os.Stat(spxBaseDir); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("cache root stat error = %v, want not exist", statErr)
+	}
+}
+
+func TestOpenHTTPInvalidZipDoesNotPublish(t *testing.T) {
+	root := t.TempDir()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "this is not a zip")
+	}))
+	defer server.Close()
+	oldBase := spxBaseDir
+	spxBaseDir = filepath.Join(root, "cache")
+	t.Cleanup(func() { spxBaseDir = oldBase })
+
+	_, err := OpenHttp(server.Listener.Addr().String() + "/invalid.zip")
+	if err == nil || !strings.Contains(err.Error(), "valid ZIP") {
+		t.Fatalf("OpenHttp error = %v, want invalid ZIP error", err)
+	}
+	entries, readErr := os.ReadDir(filepath.Join(spxBaseDir, "http"))
+	if readErr != nil {
+		t.Fatalf("ReadDir cache = %v", readErr)
+	}
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), ".zip-cache-") || strings.HasSuffix(entry.Name(), ".zip") {
+			t.Fatalf("invalid response published cache entry %q", entry.Name())
+		}
+	}
+}
+
+func TestOpenHTTPDownloadsAndCachesByCanonicalURL(t *testing.T) {
+	root := t.TempDir()
+	cache := filepath.Join(root, "cache")
+	archive := testRemoteZip(t, "hello.txt", "hello")
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		if r.URL.Path != "/assets/archive.zip" {
+			t.Errorf("request path = %q, want /assets/archive.zip", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(archive)
+	}))
+	defer server.Close()
+	oldBase := spxBaseDir
+	spxBaseDir = cache
+	t.Cleanup(func() { spxBaseDir = oldBase })
+
+	raw := server.Listener.Addr().String() + "/assets/archive.zip"
+	dir, err := OpenHttp(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := readRemoteEntry(t, dir, "hello.txt"); got != "hello" {
+		t.Fatalf("cached entry = %q, want hello", got)
+	}
+	if err := dir.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	dir, err = OpenHttp(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = dir.Close()
+	if got := requests.Load(); got != 1 {
+		t.Fatalf("server requests = %d, want 1 after cache hit", got)
+	}
+
+	_, key, err := parseRemoteURL(raw, "http://")
+	if err != nil {
+		t.Fatal(err)
+	}
+	local, err := remoteCachePath(cache, "http://", key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Lstat(local)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+		t.Fatalf("cache target mode = %v, want regular non-symlink", info.Mode())
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("cache target permissions = %o, want 600", info.Mode().Perm())
+	}
+}
+
+func TestOpenHTTPDoesNotFollowCacheSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink semantics differ on Windows")
+	}
+	root := t.TempDir()
+	cache := filepath.Join(root, "cache")
+	victim := filepath.Join(root, "victim.zip")
+	if err := os.WriteFile(victim, []byte("victim"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	archive := testRemoteZip(t, "safe.txt", "safe")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(archive)
+	}))
+	defer server.Close()
+	oldBase := spxBaseDir
+	spxBaseDir = cache
+	t.Cleanup(func() { spxBaseDir = oldBase })
+
+	raw := server.Listener.Addr().String() + "/safe.zip"
+	_, key, err := parseRemoteURL(raw, "http://")
+	if err != nil {
+		t.Fatal(err)
+	}
+	local, err := remoteCachePath(cache, "http://", key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := ensureCacheDirectories(filepath.Dir(local)); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(victim, local); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+
+	dir, err := OpenHttp(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = dir.Close()
+	info, err := os.Lstat(local)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		t.Fatal("cache symlink was followed or retained")
+	}
+	if got, readErr := os.ReadFile(victim); readErr != nil || string(got) != "victim" {
+		t.Fatalf("victim changed: %q, err=%v", got, readErr)
+	}
+}
+
+func TestOpenHTTPEnforcesResponseLimitWithoutContentLength(t *testing.T) {
+	root := t.TempDir()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		for i := 0; i < 64; i++ {
+			_, _ = w.Write([]byte("0123456789"))
+		}
+	}))
+	defer server.Close()
+	oldBase, oldLimit := spxBaseDir, maxRemoteZipBytes
+	spxBaseDir = filepath.Join(root, "cache")
+	maxRemoteZipBytes = 32
+	t.Cleanup(func() {
+		spxBaseDir = oldBase
+		maxRemoteZipBytes = oldLimit
+	})
+
+	_, err := OpenHttp(server.Listener.Addr().String() + "/large.zip")
+	if !errors.Is(err, ErrRemoteSizeLimit) {
+		t.Fatalf("OpenHttp error = %v, want ErrRemoteSizeLimit", err)
+	}
+}
+
+func TestHTTPSClientRejectsDowngradeRedirect(t *testing.T) {
+	downgrade := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Fatal("downgrade target was contacted")
+	}))
+	defer downgrade.Close()
+	client := remoteClientForScheme(&http.Client{}, "https://")
+	requestURL, err := url.Parse("https://example.test/archive.zip")
+	if err != nil {
+		t.Fatal(err)
+	}
+	redirectURL, err := url.Parse(downgrade.URL + "/archive.zip")
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := &http.Request{URL: redirectURL}
+	if err := client.CheckRedirect(request, []*http.Request{{URL: requestURL}}); !errors.Is(err, ErrInsecureRedirect) {
+		t.Fatalf("CheckRedirect error = %v, want ErrInsecureRedirect", err)
+	}
+}
+
+func TestOpenHTTPConcurrentDownloadsPublishCompleteArchive(t *testing.T) {
+	root := t.TempDir()
+	archive := testRemoteZip(t, "concurrent.txt", strings.Repeat("x", 1024))
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		_, _ = w.Write(archive)
+	}))
+	defer server.Close()
+	oldBase := spxBaseDir
+	spxBaseDir = filepath.Join(root, "cache")
+	t.Cleanup(func() { spxBaseDir = oldBase })
+
+	raw := server.Listener.Addr().String() + "/concurrent.zip"
+	const callers = 8
+	var wait sync.WaitGroup
+	errs := make(chan error, callers)
+	for i := 0; i < callers; i++ {
+		wait.Add(1)
+		go func() {
+			defer wait.Done()
+			dir, err := OpenHttp(raw)
+			if err != nil {
+				errs <- err
+				return
+			}
+			defer dir.Close()
+			file, err := dir.Open("concurrent.txt")
+			if err != nil {
+				errs <- err
+				return
+			}
+			_, err = io.ReadAll(file)
+			_ = file.Close()
+			if err != nil {
+				errs <- err
+			}
+		}()
+	}
+	wait.Wait()
+	close(errs)
+	for err := range errs {
+		t.Errorf("concurrent OpenHttp error: %v", err)
+	}
+	if requests.Load() == 0 {
+		t.Fatal("server was not contacted")
+	}
+}
+
+func TestParseRemoteURLCanonicalizesHostAndSeparatesProtocols(t *testing.T) {
+	_, httpKey, err := parseRemoteURL("Example.TEST/assets/a.zip?token=1", "http://")
+	if err != nil {
+		t.Fatal(err)
+	}
+	remote, httpsKey, err := parseRemoteURL("example.test/assets/a.zip?token=1", "https://")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if remote != "https://example.test/assets/a.zip?token=1" {
+		t.Fatalf("canonical remote = %q", remote)
+	}
+	if httpKey == httpsKey {
+		t.Fatal("HTTP and HTTPS cache keys collided")
+	}
+}
+
+func testRemoteZip(t *testing.T, name, contents string) []byte {
+	t.Helper()
+	var buffer bytes.Buffer
+	writer := zip.NewWriter(&buffer)
+	entry, err := writer.Create(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.WriteString(entry, contents); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buffer.Bytes()
+}
+
+func readRemoteEntry(t *testing.T, dir interface {
+	Open(string) (io.ReadCloser, error)
+}, name string) string {
+	t.Helper()
+	file, err := dir.Open(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	data, err := io.ReadAll(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}


### PR DESCRIPTION
Summary:
- Replace URL-derived cache paths with protocol-separated SHA-256 cache keys.
- Validate URL syntax, HTTPS redirects, response status, size, and ZIP structure.
- Use private temporary files and atomic publication.
- Share one bounded HTTP fetch path across native and Web builds.

Testing:
- make generate
- go test ./...
- go test -race ./fs/zip
- git diff --check
