### PR TITLE
fix(event): avoid managed queue deadlock

### DIFF
--- a/internal/core/event/queue.go
+++ b/internal/core/event/queue.go
@@ -174,3 +174,16 @@ func EnqueueWithPolicy[T any](ch chan T, item T, policy QueuePolicy, stats *Queu
 		return false
 	}
 }
+
+// EnqueueWithPolicyNonBlocking applies policy without waiting for queue
+// capacity. QueueBlock is therefore treated as QueueDropNewest when the
+// queue is full. This is intended for callers, such as cooperative scheduler
+// coroutines, that must release their execution slot instead of blocking.
+// EnqueueWithPolicy retains the blocking QueueBlock behavior for callers that
+// can safely wait.
+func EnqueueWithPolicyNonBlocking[T any](ch chan T, item T, policy QueuePolicy, stats *QueueStats, dropOldestMu *sync.Mutex) bool {
+	if policy == QueueBlock {
+		policy = QueueDropNewest
+	}
+	return EnqueueWithPolicy(ch, item, policy, stats, dropOldestMu)
+}

--- a/internal/core/event/queue.go
+++ b/internal/core/event/queue.go
@@ -175,12 +175,7 @@ func EnqueueWithPolicy[T any](ch chan T, item T, policy QueuePolicy, stats *Queu
 	}
 }
 
-// EnqueueWithPolicyNonBlocking applies policy without waiting for queue
-// capacity. QueueBlock is therefore treated as QueueDropNewest when the
-// queue is full. This is intended for callers, such as cooperative scheduler
-// coroutines, that must release their execution slot instead of blocking.
-// EnqueueWithPolicy retains the blocking QueueBlock behavior for callers that
-// can safely wait.
+// EnqueueWithPolicyNonBlocking never waits; Block drops newest when full.
 func EnqueueWithPolicyNonBlocking[T any](ch chan T, item T, policy QueuePolicy, stats *QueueStats, dropOldestMu *sync.Mutex) bool {
 	if policy == QueueBlock {
 		policy = QueueDropNewest

--- a/internal/core/event/queue_test.go
+++ b/internal/core/event/queue_test.go
@@ -107,6 +107,58 @@ func TestEnqueueWithPolicyBlock(t *testing.T) {
 	}
 }
 
+func TestEnqueueWithPolicyNonBlockingDoesNotWaitForCapacity(t *testing.T) {
+	ch := make(chan int, 1)
+	ch <- 1
+	var stats QueueStats
+	stats.Reset()
+
+	done := make(chan bool, 1)
+	go func() {
+		done <- EnqueueWithPolicyNonBlocking(ch, 2, QueueBlock, &stats, nil)
+	}()
+
+	select {
+	case accepted := <-done:
+		if accepted {
+			t.Fatal("full non-blocking QueueBlock unexpectedly accepted an item")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("non-blocking QueueBlock waited for capacity")
+	}
+	if got := <-ch; got != 1 {
+		t.Fatalf("queue retained %d, want 1", got)
+	}
+	if stats.DroppedTotal() != 1 {
+		t.Fatalf("DroppedTotal = %d, want 1", stats.DroppedTotal())
+	}
+}
+
+func TestEnqueueWithPolicyNonBlockingAcceptsWhenCapacityIsAvailable(t *testing.T) {
+	ch := make(chan int, 1)
+	var stats QueueStats
+
+	if !EnqueueWithPolicyNonBlocking(ch, 7, QueueBlock, &stats, nil) {
+		t.Fatal("available non-blocking QueueBlock capacity was rejected")
+	}
+	if got := <-ch; got != 7 {
+		t.Fatalf("queue retained %d, want 7", got)
+	}
+	if stats.EnqueuedTotal() != 1 || stats.DroppedTotal() != 0 {
+		t.Fatalf("unexpected queue stats: enqueued=%d dropped=%d", stats.EnqueuedTotal(), stats.DroppedTotal())
+	}
+}
+
+func TestEnqueueWithPolicyNonBlockingHandlesNilChannel(t *testing.T) {
+	var stats QueueStats
+	if EnqueueWithPolicyNonBlocking[int](nil, 1, QueueBlock, &stats, nil) {
+		t.Fatal("nil channel enqueue unexpectedly succeeded")
+	}
+	if stats.EnqueuedTotal() != 0 || stats.DroppedTotal() != 0 {
+		t.Fatalf("nil channel changed queue stats: enqueued=%d dropped=%d", stats.EnqueuedTotal(), stats.DroppedTotal())
+	}
+}
+
 func TestSnapshot(t *testing.T) {
 	var stats QueueStats
 	stats.Reset()

--- a/runtime_queue.go
+++ b/runtime_queue.go
@@ -57,5 +57,19 @@ func (p *Game) eventQueueSnapshot() eventQueueSnapshot {
 }
 
 func (p *Game) queueEventWithPolicy(ev event) bool {
+	policy := p.gameRuntimeState.EventQueuePolicy
+	// A managed coroutine owns the scheduler run slot while it executes. A
+	// blocking send on a full event queue would hold that slot forever, so use
+	// the non-blocking variant for this caller only. Ordinary goroutines retain
+	// QueueBlock's backpressure semantics.
+	if policy == coreevent.QueueBlock && gco != nil && gco.IsInCoroutine() {
+		return coreevent.EnqueueWithPolicyNonBlocking(
+			p.events,
+			ev,
+			policy,
+			&p.gameRuntimeState.EventQueueStats,
+			&p.gameRuntimeState.EventQueueMu,
+		)
+	}
 	return coreevent.EnqueueWithPolicy(p.events, ev, p.gameRuntimeState.EventQueuePolicy, &p.gameRuntimeState.EventQueueStats, &p.gameRuntimeState.EventQueueMu)
 }

--- a/runtime_queue.go
+++ b/runtime_queue.go
@@ -58,10 +58,7 @@ func (p *Game) eventQueueSnapshot() eventQueueSnapshot {
 
 func (p *Game) queueEventWithPolicy(ev event) bool {
 	policy := p.gameRuntimeState.EventQueuePolicy
-	// A managed coroutine owns the scheduler run slot while it executes. A
-	// blocking send on a full event queue would hold that slot forever, so use
-	// the non-blocking variant for this caller only. Ordinary goroutines retain
-	// QueueBlock's backpressure semantics.
+	// A managed send must release the scheduler slot when the queue is full.
 	if policy == coreevent.QueueBlock && gco != nil && gco.IsInCoroutine() {
 		return coreevent.EnqueueWithPolicyNonBlocking(
 			p.events,
@@ -71,5 +68,11 @@ func (p *Game) queueEventWithPolicy(ev event) bool {
 			&p.gameRuntimeState.EventQueueMu,
 		)
 	}
-	return coreevent.EnqueueWithPolicy(p.events, ev, p.gameRuntimeState.EventQueuePolicy, &p.gameRuntimeState.EventQueueStats, &p.gameRuntimeState.EventQueueMu)
+	return coreevent.EnqueueWithPolicy(
+		p.events,
+		ev,
+		policy,
+		&p.gameRuntimeState.EventQueueStats,
+		&p.gameRuntimeState.EventQueueMu,
+	)
 }

--- a/runtime_queue_test.go
+++ b/runtime_queue_test.go
@@ -26,8 +26,7 @@ func TestQueueBlockDoesNotBlockManagedCoroutine(t *testing.T) {
 			t.Fatal("managed QueueBlock producer accepted an item into a full queue")
 		}
 	case <-time.After(time.Second):
-		// Release a direct-send implementation so cleanup cannot strand the
-		// scheduler lock after reporting the regression.
+		// Unblock an implementation that still holds the scheduler lock.
 		<-game.events
 		t.Fatal("managed QueueBlock producer blocked while holding the scheduler run slot")
 	}

--- a/runtime_queue_test.go
+++ b/runtime_queue_test.go
@@ -1,0 +1,69 @@
+package spx
+
+import (
+	"testing"
+	"time"
+
+	coreevent "github.com/goplus/spx/v3/internal/core/event"
+	"github.com/goplus/spx/v3/internal/coroutine"
+)
+
+func TestQueueBlockDoesNotBlockManagedCoroutine(t *testing.T) {
+	co, game := setupRuntimeEventGame(t)
+	game.events = make(chan event, 1)
+	game.events <- &eventTimer{Time: 1}
+	game.setEventQueuePolicy(coreevent.QueueBlock)
+
+	done := make(chan bool, 1)
+	thread := co.Create("managed-producer", func(coroutine.Thread) int {
+		done <- game.queueEventWithPolicy(&eventTimer{Time: 2})
+		return 0
+	})
+
+	select {
+	case accepted := <-done:
+		if accepted {
+			t.Fatal("managed QueueBlock producer accepted an item into a full queue")
+		}
+	case <-time.After(time.Second):
+		// Release a direct-send implementation so cleanup cannot strand the
+		// scheduler lock after reporting the regression.
+		<-game.events
+		t.Fatal("managed QueueBlock producer blocked while holding the scheduler run slot")
+	}
+	co.Join(thread)
+
+	if got := game.gameRuntimeState.EventQueueStats.DroppedTotal(); got != 1 {
+		t.Fatalf("DroppedTotal = %d, want 1", got)
+	}
+	if got := <-game.events; got.(*eventTimer).Time != 1 {
+		t.Fatal("managed fallback changed the existing queue item")
+	}
+}
+
+func TestQueueBlockStillBlocksExternalCaller(t *testing.T) {
+	_, game := setupRuntimeEventGame(t)
+	game.events = make(chan event, 1)
+	game.events <- &eventTimer{Time: 1}
+	game.setEventQueuePolicy(coreevent.QueueBlock)
+
+	done := make(chan bool, 1)
+	go func() {
+		done <- game.queueEventWithPolicy(&eventTimer{Time: 2})
+	}()
+
+	select {
+	case <-done:
+		t.Fatal("external QueueBlock caller returned before capacity was available")
+	case <-time.After(50 * time.Millisecond):
+	}
+	<-game.events
+	select {
+	case accepted := <-done:
+		if !accepted {
+			t.Fatal("external QueueBlock caller did not enqueue after capacity was released")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("external QueueBlock caller did not resume after capacity was released")
+	}
+}

--- a/runtime_queue_test.go
+++ b/runtime_queue_test.go
@@ -47,10 +47,17 @@ func TestQueueBlockStillBlocksExternalCaller(t *testing.T) {
 	game.events <- &eventTimer{Time: 1}
 	game.setEventQueuePolicy(coreevent.QueueBlock)
 
+	started := make(chan struct{})
 	done := make(chan bool, 1)
 	go func() {
+		close(started)
 		done <- game.queueEventWithPolicy(&eventTimer{Time: 2})
 	}()
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("external QueueBlock caller did not start")
+	}
 
 	select {
 	case <-done:


### PR DESCRIPTION
Summary:
- Keep QueueBlock backpressure for external callers.
- Use a non-blocking fallback for managed coroutine producers so the scheduler run slot is never held by a full event queue.
- Add queue and scheduler regression coverage.

Testing:
- make generate
- go test ./...
- go test -race ./internal/core/event
- git diff --check
