### PR TITLE
 fix(web): preserve resource string ownership

### DIFF
--- a/godot_modules/spx/web/godot_js_spx.cpp
+++ b/godot_modules/spx/web/godot_js_spx.cpp
@@ -573,7 +573,6 @@ void gdspx_res_reload_texture(GdString *path) {
 }
 EMSCRIPTEN_KEEPALIVE
 void gdspx_res_free_str(GdString *str) {
-	// Web strings are value-owned; there is no native pointer to release.
 	(void)str;
 }
 EMSCRIPTEN_KEEPALIVE

--- a/godot_modules/spx/web/godot_js_spx.cpp
+++ b/godot_modules/spx/web/godot_js_spx.cpp
@@ -573,7 +573,8 @@ void gdspx_res_reload_texture(GdString *path) {
 }
 EMSCRIPTEN_KEEPALIVE
 void gdspx_res_free_str(GdString *str) {
-	 resMgr->free_str(*str);
+	// Web strings are value-owned; there is no native pointer to release.
+	(void)str;
 }
 EMSCRIPTEN_KEEPALIVE
 void gdspx_res_apply_project_fonts(GdString *default_font_path, GdArray *font_paths, GdArray *font_families, GdArray *preferences, GdString *ret_val) {

--- a/internal/cmd/codegen/generate/gdext/generate.go
+++ b/internal/cmd/codegen/generate/gdext/generate.go
@@ -121,6 +121,7 @@ func generateGdCppFile(projectPath string, templateStr string, ast clang.CHeader
 		"loadProcAddressName":         LoadProcAddressName,
 		"isManagerMethod":             IsManagerMethod,
 		"getManagerName":              GetManagerName,
+		"isWebValueOwnedStringFree":   isWebValueOwnedStringFree,
 		"hasArrayTransformBridgeSpec": HasArrayTransformBridgeSpec,
 		"hasNativeArrayBridgeSpec":    HasNativeArrayBridgeSpec,
 		"getArrayTransformBridgeSpec": func(function *clang.TypedefFunction) ArrayTransformBridgeSpec {
@@ -187,4 +188,11 @@ func generateGdCppFile(projectPath string, templateStr string, ast clang.CHeader
 		return fmt.Errorf("write %s: %w", outputFileName, err)
 	}
 	return nil
+}
+
+// The Web ABI receives a JavaScript string value for this legacy method, not
+// the native return pointer accepted by the native ABI. Keep its generated
+// wrapper as a no-op so regeneration preserves that ownership contract.
+func isWebValueOwnedStringFree(function *clang.TypedefFunction) bool {
+	return function != nil && function.Name == "GDExtensionSpxResFreeStr"
 }

--- a/internal/cmd/codegen/generate/gdext/generate.go
+++ b/internal/cmd/codegen/generate/gdext/generate.go
@@ -121,7 +121,7 @@ func generateGdCppFile(projectPath string, templateStr string, ast clang.CHeader
 		"loadProcAddressName":         LoadProcAddressName,
 		"isManagerMethod":             IsManagerMethod,
 		"getManagerName":              GetManagerName,
-		"isWebValueOwnedStringFree":   isWebValueOwnedStringFree,
+		"isWebOwnedStringFree":        isWebOwnedStringFree,
 		"hasArrayTransformBridgeSpec": HasArrayTransformBridgeSpec,
 		"hasNativeArrayBridgeSpec":    HasNativeArrayBridgeSpec,
 		"getArrayTransformBridgeSpec": func(function *clang.TypedefFunction) ArrayTransformBridgeSpec {
@@ -190,9 +190,7 @@ func generateGdCppFile(projectPath string, templateStr string, ast clang.CHeader
 	return nil
 }
 
-// The Web ABI receives a JavaScript string value for this legacy method, not
-// the native return pointer accepted by the native ABI. Keep its generated
-// wrapper as a no-op so regeneration preserves that ownership contract.
-func isWebValueOwnedStringFree(function *clang.TypedefFunction) bool {
+// Web owns the value returned by this legacy method.
+func isWebOwnedStringFree(function *clang.TypedefFunction) bool {
 	return function != nil && function.Name == "GDExtensionSpxResFreeStr"
 }

--- a/internal/cmd/codegen/generate/gdext/godot_js_spx.cpp.tmpl
+++ b/internal/cmd/codegen/generate/gdext/godot_js_spx.cpp.tmpl
@@ -77,8 +77,7 @@ void gd{{ loadProcAddressName $f.Name }}(
 	{{- if ne 0 (len $f.Arguments) -}}, {{ end -}}{{$f.ReturnType.CStyleString }} *ret_val
 	{{- end -}}
 ) {
-	{{- if isWebValueOwnedStringFree $f }}
-	// Web strings are value-owned; there is no native pointer to release.
+	{{- if isWebOwnedStringFree $f }}
 	(void)str;
 	{{- else }}
 	{{ if ne "void" $f.ReturnType.CStyleString -}} *ret_val = {{- end }} {{ getManagerName $f.Name}}Mgr->

--- a/internal/cmd/codegen/generate/gdext/godot_js_spx.cpp.tmpl
+++ b/internal/cmd/codegen/generate/gdext/godot_js_spx.cpp.tmpl
@@ -77,6 +77,10 @@ void gd{{ loadProcAddressName $f.Name }}(
 	{{- if ne 0 (len $f.Arguments) -}}, {{ end -}}{{$f.ReturnType.CStyleString }} *ret_val
 	{{- end -}}
 ) {
+	{{- if isWebValueOwnedStringFree $f }}
+	// Web strings are value-owned; there is no native pointer to release.
+	(void)str;
+	{{- else }}
 	{{ if ne "void" $f.ReturnType.CStyleString -}} *ret_val = {{- end }} {{ getManagerName $f.Name}}Mgr->
 	{{- trimPrefix (trimPrefix (trimPrefix (loadProcAddressName $f.Name) "spx_") (getManagerName $f.Name)) "_" }}(
 	{{- range $j, $arg := $f.Arguments }}
@@ -84,6 +88,7 @@ void gd{{ loadProcAddressName $f.Name }}(
 			{{- $arg.ResolvedPtrName $j }}
 		{{- end -}}
 	);
+	{{- end }}
 }
 {{- end }}
 {{- end -}}

--- a/internal/cmd/codegen/generate/gdext/header_generator_test.go
+++ b/internal/cmd/codegen/generate/gdext/header_generator_test.go
@@ -77,7 +77,7 @@ func TestGodotJsTemplateUsesModuleRelativeIncludes(t *testing.T) {
 	require.NotContains(t, gdJsSpxCpp, `#include "modules/spx/`)
 }
 
-func TestGodotJsTemplateKeepsWebResourceStringFreeValueOwned(t *testing.T) {
+func TestGodotJsTemplateKeepsResStringOwned(t *testing.T) {
 	projectPath := t.TempDir()
 	ast := clang.CHeaderFileAST{Expr: []clang.Expr{{Function: &clang.TypedefFunction{
 		ReturnType: clang.PrimativeType{Name: "void"},

--- a/internal/cmd/codegen/generate/gdext/header_generator_test.go
+++ b/internal/cmd/codegen/generate/gdext/header_generator_test.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/goplus/spx/v3/internal/cmd/codegen/gdextensionparser/clang"
 	"github.com/goplus/spx/v3/internal/cmd/codegen/generate/common"
 	"github.com/stretchr/testify/require"
 )
@@ -74,6 +75,27 @@ func TestGodotJsTemplateUsesModuleRelativeIncludes(t *testing.T) {
 	require.Contains(t, gdJsSpxCpp, `#include "../gdextension_spx_ext.h"`)
 	require.Contains(t, gdJsSpxCpp, `#include "../spx_engine.h"`)
 	require.NotContains(t, gdJsSpxCpp, `#include "modules/spx/`)
+}
+
+func TestGodotJsTemplateKeepsWebResourceStringFreeValueOwned(t *testing.T) {
+	projectPath := t.TempDir()
+	ast := clang.CHeaderFileAST{Expr: []clang.Expr{{Function: &clang.TypedefFunction{
+		ReturnType: clang.PrimativeType{Name: "void"},
+		Name:       "GDExtensionSpxResFreeStr",
+		Arguments: []clang.Argument{{
+			Type: clang.Type{Primative: &clang.PrimativeType{Name: "GdString"}},
+			Name: "str",
+		}},
+	}}}}
+
+	require.NoError(t, os.MkdirAll(filepath.Join(projectPath, common.NativeRelDir), 0o755))
+	require.NoError(t, generateGdCppFile(projectPath, gdJsSpxCpp, ast, "godot_js_spx.cpp"))
+	generated, err := os.ReadFile(filepath.Join(projectPath, common.NativeRelDir, "godot_js_spx.cpp"))
+	require.NoError(t, err)
+	body := string(generated)
+	require.Contains(t, body, "void gdspx_res_free_str(GdString *str)")
+	require.Contains(t, body, "(void)str;")
+	require.NotContains(t, body, "resMgr->free_str(*str)")
 }
 
 func TestGenerateManagerHeaderRegistersDirectNativeArrayBridge(t *testing.T) {


### PR DESCRIPTION
Summary:
- Keep the legacy Web resource-string release wrapper as a no-op.
- Encode the ownership exception in the generator template so regeneration is stable.
- Add a focused generator regression test.

Testing:
- make generate
- go test ./...
- go test -race ./... (internal/cmd/codegen module)
- git diff --check
