### PR TITLE
fix(coroutine): drain native workers before reset

### DIFF
--- a/internal/coroutine/lifecycle.go
+++ b/internal/coroutine/lifecycle.go
@@ -114,13 +114,9 @@ func (p *Coroutines) AbortAllAndWait(timeout stime.Duration) bool {
 	return p.RunAfterAbortAll(timeout, nil)
 }
 
-// RunAfterAbortAll closes coroutine admission, aborts and drains every
-// registered thread, then runs call while admission remains closed. It must be
-// called outside a managed coroutine or its panic handler. If the timeout
-// expires, call is not run and admission stays closed until a later successful
-// RunAfterAbortAll explicitly recovers the manager.
-// The callback must not create a coroutine through this manager because the
-// admission lock remains held until it returns.
+// RunAfterAbortAll drains registered threads, then runs call with admission
+// closed. Call it outside managed code; a timeout leaves admission closed until
+// a later successful call. call must not create a coroutine.
 func (p *Coroutines) RunAfterAbortAll(timeout stime.Duration, call func()) bool {
 	if p.currentCoroutineThread() != nil || p.isFinalizingCaller() {
 		panic("coroutine: RunAfterAbortAll called from a managed coroutine or its panic handler")
@@ -136,9 +132,7 @@ func (p *Coroutines) RunAfterAbortAll(timeout stime.Duration, call func()) bool 
 	p.creationMu.Lock()
 	defer p.creationMu.Unlock()
 	if !completed || p.hasThreadsOtherThan(nil) {
-		// Fatal/reload barriers fail closed. The callback cannot safely be replayed
-		// after its caller observes a timeout, so only an explicit later barrier
-		// may recover this quarantined manager.
+		// Keep timed-out barriers closed until explicit recovery.
 		return false
 	}
 	defer p.endStoppingLocked()
@@ -153,9 +147,7 @@ func (p *Coroutines) beginStoppingLocked() {
 		p.stopping = true
 		p.abortEpoch.Add(1)
 	}
-	// A new barrier owns the admission decision until it completes. This also
-	// prevents a prior timed-out barrier's auto-reopen hook from firing while
-	// this barrier is preparing its callback.
+	// Each barrier owns recovery state until it completes.
 	p.reopenWhenDrained = false
 	p.abortAllLocked()
 }
@@ -288,9 +280,7 @@ func (p *Coroutines) unregisterThread(th Thread) {
 	p.maybeReopenAfterDrain()
 }
 
-// admitNativeTask reserves lifecycle ownership for a WaitToDo worker. The
-// reservation is made under the same read barrier as coroutine creation, so a
-// shutdown either observes the worker or rejects its admission.
+// admitNativeTask registers a WaitToDo worker under the admission barrier.
 func (p *Coroutines) admitNativeTask(me Thread) *nativeTask {
 	p.creationMu.RLock()
 	defer p.creationMu.RUnlock()

--- a/internal/coroutine/lifecycle.go
+++ b/internal/coroutine/lifecycle.go
@@ -405,7 +405,7 @@ func (p *Coroutines) finishThread(th Thread, gid uint64, recovered any) {
 	close(th.done)
 	p.removeThreadState(th)
 	p.setCurrent(nil)
-	p.unregisterThread(th)
+	defer p.unregisterThread(th)
 	p.runMu.Unlock()
 	p.goroutineThreads.Delete(gid)
 	p.handleThreadPanic(th, recovered)

--- a/internal/coroutine/lifecycle.go
+++ b/internal/coroutine/lifecycle.go
@@ -132,13 +132,16 @@ func (p *Coroutines) RunAfterAbortAll(timeout stime.Duration, call func()) bool 
 	completed := p.waitForThreadsToStop(timeout, nil)
 
 	p.creationMu.Lock()
-	defer func() {
-		p.endStoppingLocked()
-		p.creationMu.Unlock()
-	}()
+	defer p.creationMu.Unlock()
 	if !completed || p.hasThreadsOtherThan(nil) {
+		// A timeout is fail-closed: no callback/reset may run while a canceled
+		// coroutine or native worker can still touch runtime state. The last
+		// lifecycle item to unregister reopens admission once the drain is real.
+		p.reopenWhenDrained = true
+		p.maybeReopenAfterDrainLocked()
 		return false
 	}
+	defer p.endStoppingLocked()
 	if call != nil {
 		call()
 	}
@@ -146,14 +149,24 @@ func (p *Coroutines) RunAfterAbortAll(timeout stime.Duration, call func()) bool 
 }
 
 func (p *Coroutines) beginStoppingLocked() {
-	p.stopping = true
-	p.abortEpoch.Add(1)
+	if !p.stopping {
+		p.stopping = true
+		p.abortEpoch.Add(1)
+	}
+	// A new barrier owns the admission decision until it completes. This also
+	// prevents a prior timed-out barrier's auto-reopen hook from firing while
+	// this barrier is preparing its callback.
+	p.reopenWhenDrained = false
 	p.abortAllLocked()
 }
 
 func (p *Coroutines) endStoppingLocked() {
+	if !p.stopping {
+		return
+	}
 	p.abortEpoch.Add(1)
 	p.stopping = false
+	p.reopenWhenDrained = false
 }
 
 // StopIf requests cancellation of every thread accepted by filter. Filters are
@@ -267,6 +280,45 @@ func (p *Coroutines) unregisterThread(th Thread) {
 	p.threadsMu.Lock()
 	delete(p.allThreads, th)
 	p.threadsMu.Unlock()
+	p.maybeReopenAfterDrain()
+}
+
+// admitNativeTask reserves lifecycle ownership for a WaitToDo worker. The
+// reservation is made under the same read barrier as coroutine creation, so a
+// shutdown either observes the worker or rejects its admission.
+func (p *Coroutines) admitNativeTask(me Thread) *nativeTask {
+	p.creationMu.RLock()
+	defer p.creationMu.RUnlock()
+	if p.stopping || p.abortEpoch.Load()&1 != 0 || p.isThreadCanceled(me) {
+		return nil
+	}
+	task := &nativeTask{id: p.nextNativeID.Add(1)}
+	p.threadsMu.Lock()
+	p.nativeTasks[task] = struct{}{}
+	p.threadsMu.Unlock()
+	return task
+}
+
+func (p *Coroutines) finishNativeTask(task *nativeTask) {
+	if task == nil {
+		return
+	}
+	p.threadsMu.Lock()
+	delete(p.nativeTasks, task)
+	p.threadsMu.Unlock()
+	p.maybeReopenAfterDrain()
+}
+
+func (p *Coroutines) maybeReopenAfterDrain() {
+	p.creationMu.Lock()
+	p.maybeReopenAfterDrainLocked()
+	p.creationMu.Unlock()
+}
+
+func (p *Coroutines) maybeReopenAfterDrainLocked() {
+	if p.stopping && p.reopenWhenDrained && !p.hasThreadsOtherThan(nil) {
+		p.endStoppingLocked()
+	}
 }
 
 func (p *Coroutines) snapshotThreads() []Thread {
@@ -287,7 +339,7 @@ func (p *Coroutines) hasThreadsOtherThan(skip Thread) bool {
 			return true
 		}
 	}
-	return false
+	return len(p.nativeTasks) != 0
 }
 
 func (p *Coroutines) waitForThreadsToStopFromCoroutine(timeout stime.Duration, caller Thread) bool {

--- a/internal/coroutine/lifecycle.go
+++ b/internal/coroutine/lifecycle.go
@@ -116,12 +116,14 @@ func (p *Coroutines) AbortAllAndWait(timeout stime.Duration) bool {
 
 // RunAfterAbortAll closes coroutine admission, aborts and drains every
 // registered thread, then runs call while admission remains closed. It must be
-// called outside a managed coroutine. If the timeout expires, call is not run.
+// called outside a managed coroutine or its panic handler. If the timeout
+// expires, call is not run and admission stays closed until a later successful
+// RunAfterAbortAll explicitly recovers the manager.
 // The callback must not create a coroutine through this manager because the
 // admission lock remains held until it returns.
 func (p *Coroutines) RunAfterAbortAll(timeout stime.Duration, call func()) bool {
-	if p.currentCoroutineThread() != nil {
-		panic("coroutine: RunAfterAbortAll called from a managed coroutine")
+	if p.currentCoroutineThread() != nil || p.isFinalizingCaller() {
+		panic("coroutine: RunAfterAbortAll called from a managed coroutine or its panic handler")
 	}
 	p.shutdownMu.Lock()
 	defer p.shutdownMu.Unlock()
@@ -134,11 +136,9 @@ func (p *Coroutines) RunAfterAbortAll(timeout stime.Duration, call func()) bool 
 	p.creationMu.Lock()
 	defer p.creationMu.Unlock()
 	if !completed || p.hasThreadsOtherThan(nil) {
-		// A timeout is fail-closed: no callback/reset may run while a canceled
-		// coroutine or native worker can still touch runtime state. The last
-		// lifecycle item to unregister reopens admission once the drain is real.
-		p.reopenWhenDrained = true
-		p.maybeReopenAfterDrainLocked()
+		// Fatal/reload barriers fail closed. The callback cannot safely be replayed
+		// after its caller observes a timeout, so only an explicit later barrier
+		// may recover this quarantined manager.
 		return false
 	}
 	defer p.endStoppingLocked()
@@ -231,6 +231,11 @@ func (p *Coroutines) callerThread() Thread {
 		return nil
 	}
 	return value.(Thread)
+}
+
+func (p *Coroutines) isFinalizingCaller() bool {
+	_, ok := p.finalizingGoroutines.Load(gid.Get())
+	return ok
 }
 
 func (p *Coroutines) newThread(obj ThreadObj) Thread {
@@ -407,6 +412,8 @@ func (p *Coroutines) finishThread(th Thread, gid uint64, recovered any) {
 	p.setCurrent(nil)
 	defer p.unregisterThread(th)
 	p.runMu.Unlock()
+	p.finalizingGoroutines.Store(gid, struct{}{})
+	defer p.finalizingGoroutines.Delete(gid)
 	p.goroutineThreads.Delete(gid)
 	p.handleThreadPanic(th, recovered)
 }

--- a/internal/coroutine/manager.go
+++ b/internal/coroutine/manager.go
@@ -54,8 +54,8 @@ type Coroutines struct {
 	shutdownMu sync.Mutex
 	creationMu sync.RWMutex
 	stopping   bool
-	// reopenWhenDrained is set after a timed-out barrier. Admission remains
-	// closed until the final managed thread/native task unregisters.
+	// reopenWhenDrained is set only for a recoverable watchdog shutdown.
+	// Fatal/reload barrier timeouts remain quarantined until an explicit retry.
 	reopenWhenDrained bool
 
 	// threadsMu protects the thread and native-task registries.
@@ -89,6 +89,9 @@ type Coroutines struct {
 	// executes. A scheduler-wide Current value is not sufficient to identify
 	// the caller because external goroutines can observe it concurrently.
 	goroutineThreads sync.Map // map[uint64]Thread
+	// finalizingGoroutines prevents a panic callback from synchronously waiting
+	// for the thread whose teardown is invoking that callback.
+	finalizingGoroutines sync.Map // map[uint64]struct{}
 }
 
 // New creates a coroutine manager. onPanic is called when a coroutine exits

--- a/internal/coroutine/manager.go
+++ b/internal/coroutine/manager.go
@@ -48,15 +48,20 @@ type Coroutines struct {
 	current atomic.Pointer[threadImpl]
 
 	// shutdownMu serializes fatal shutdowns. creationMu protects stopping and
-	// makes thread registration atomic with respect to shutdown transitions.
+	// makes thread/native-task registration atomic with respect to shutdown
+	// transitions.
 	// Lock order is shutdownMu, runMu, then creationMu.
 	shutdownMu sync.Mutex
 	creationMu sync.RWMutex
 	stopping   bool
+	// reopenWhenDrained is set after a timed-out barrier. Admission remains
+	// closed until the final managed thread/native task unregisters.
+	reopenWhenDrained bool
 
-	// threadsMu protects the thread registry.
-	threadsMu  sync.Mutex
-	allThreads map[Thread]struct{}
+	// threadsMu protects the thread and native-task registries.
+	threadsMu   sync.Mutex
+	allThreads  map[Thread]struct{}
+	nativeTasks map[*nativeTask]struct{}
 
 	// schedulerMu protects threadStates and the condition-variable predicate.
 	// It also makes state changes and their corresponding enqueue atomic.
@@ -68,6 +73,7 @@ type Coroutines struct {
 
 	nextJobID    atomic.Int64
 	nextThreadID atomic.Int64
+	nextNativeID atomic.Uint64
 	// abortEpoch is even outside an abort registration barrier and odd while
 	// one is active. Create captures it before admission so a registration that
 	// overlaps AbortAll cannot escape the abort snapshot.
@@ -91,6 +97,7 @@ func New(onPanic func(name, stack string)) *Coroutines {
 	p := &Coroutines{
 		onPanic:           onPanic,
 		allThreads:        make(map[Thread]struct{}),
+		nativeTasks:       make(map[*nativeTask]struct{}),
 		threadStates:      make(map[Thread]threadState),
 		currentJobs:       NewQueue[*WaitJob](),
 		deferredJobs:      NewQueue[*WaitJob](),

--- a/internal/coroutine/manager.go
+++ b/internal/coroutine/manager.go
@@ -47,18 +47,15 @@ type Coroutines struct {
 	runMu   sync.Mutex
 	current atomic.Pointer[threadImpl]
 
-	// shutdownMu serializes fatal shutdowns. creationMu protects stopping and
-	// makes thread/native-task registration atomic with respect to shutdown
-	// transitions.
-	// Lock order is shutdownMu, runMu, then creationMu.
+	// shutdownMu serializes shutdowns; creationMu guards admission and lifecycle
+	// registration. Lock order is shutdownMu, runMu, then creationMu.
 	shutdownMu sync.Mutex
 	creationMu sync.RWMutex
 	stopping   bool
-	// reopenWhenDrained is set only for a recoverable watchdog shutdown.
-	// Fatal/reload barrier timeouts remain quarantined until an explicit retry.
+	// Watchdog shutdowns may reopen after drain; fatal barriers require retry.
 	reopenWhenDrained bool
 
-	// threadsMu protects the thread and native-task registries.
+	// threadsMu protects both lifecycle registries.
 	threadsMu   sync.Mutex
 	allThreads  map[Thread]struct{}
 	nativeTasks map[*nativeTask]struct{}
@@ -89,8 +86,7 @@ type Coroutines struct {
 	// executes. A scheduler-wide Current value is not sufficient to identify
 	// the caller because external goroutines can observe it concurrently.
 	goroutineThreads sync.Map // map[uint64]Thread
-	// finalizingGoroutines prevents a panic callback from synchronously waiting
-	// for the thread whose teardown is invoking that callback.
+	// Prevent reentry while a panic callback runs.
 	finalizingGoroutines sync.Map // map[uint64]struct{}
 }
 

--- a/internal/coroutine/thread_test.go
+++ b/internal/coroutine/thread_test.go
@@ -451,8 +451,7 @@ func TestRunAfterAbortAllTimeoutRequiresExplicitRecovery(t *testing.T) {
 	}
 	waitForThreadSignal(t, watchdogRejected.done, "post-watchdog quarantined creation did not finish")
 
-	// A later explicit barrier owns the recovery decision and may reopen once it
-	// proves that no lifecycle work remains.
+	// Explicit recovery reopens admission after the drain.
 	if !co.RunAfterAbortAll(time.Second, nil) {
 		t.Fatal("explicit recovery barrier did not complete after drain")
 	}

--- a/internal/coroutine/thread_test.go
+++ b/internal/coroutine/thread_test.go
@@ -22,6 +22,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/visualfc/gid"
 )
 
 type namedThreadObj struct{}
@@ -395,7 +397,7 @@ func TestAbortAllAndWaitRejectsCreationDuringBarrier(t *testing.T) {
 	}
 }
 
-func TestRunAfterAbortAllTimeoutKeepsAdmissionClosedUntilDrain(t *testing.T) {
+func TestRunAfterAbortAllTimeoutRequiresExplicitRecovery(t *testing.T) {
 	co := New(nil)
 	co.OnInited()
 	blocker := co.newThread("barrier-blocker")
@@ -430,6 +432,30 @@ func TestRunAfterAbortAllTimeoutKeepsAdmissionClosedUntilDrain(t *testing.T) {
 
 	co.removeThreadState(blocker)
 	co.unregisterThread(blocker)
+
+	stillRejected := co.CreateAndStart(true, "after-drain-before-recovery", func(Thread) int {
+		t.Fatal("creation ran while the manager remained quarantined")
+		return 0
+	})
+	if !stillRejected.Stopped() {
+		t.Fatal("creation was admitted after a timed-out barrier drained without recovery")
+	}
+	waitForThreadSignal(t, stillRejected.done, "quarantined creation did not finish")
+	co.stopRunawayThreads()
+	watchdogRejected := co.CreateAndStart(true, "after-watchdog-before-recovery", func(Thread) int {
+		t.Fatal("watchdog weakened a fatal barrier quarantine")
+		return 0
+	})
+	if !watchdogRejected.Stopped() {
+		t.Fatal("watchdog reopened admission after a fatal barrier timeout")
+	}
+	waitForThreadSignal(t, watchdogRejected.done, "post-watchdog quarantined creation did not finish")
+
+	// A later explicit barrier owns the recovery decision and may reopen once it
+	// proves that no lifecycle work remains.
+	if !co.RunAfterAbortAll(time.Second, nil) {
+		t.Fatal("explicit recovery barrier did not complete after drain")
+	}
 	var nextRan atomic.Bool
 	next := co.CreateAndStart(true, "after-timeout", func(Thread) int {
 		nextRan.Store(true)
@@ -442,6 +468,76 @@ func TestRunAfterAbortAllTimeoutKeepsAdmissionClosedUntilDrain(t *testing.T) {
 	}
 	if !nextRan.Load() {
 		t.Fatal("creation was rejected after abort barrier timed out")
+	}
+}
+
+func TestRunAfterAbortAllRejectsSynchronousPanicHandlerReentry(t *testing.T) {
+	guarded := make(chan any, 1)
+	var co *Coroutines
+	co = New(func(string, string) {
+		func() {
+			defer func() { guarded <- recover() }()
+			co.RunAfterAbortAll(time.Second, nil)
+		}()
+	})
+	co.OnInited()
+
+	worker := co.CreateAndStart(true, "panicking-worker", func(Thread) int {
+		panic("worker failure")
+	})
+	waitForThreadSignal(t, worker.done, "panicking worker did not finish")
+	select {
+	case recovered := <-guarded:
+		const want = "coroutine: RunAfterAbortAll called from a managed coroutine or its panic handler"
+		if recovered != want {
+			t.Fatalf("panic handler reentry panic = %v, want %q", recovered, want)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("panic handler did not attempt reset barrier reentry")
+	}
+	if !co.RunAfterAbortAll(time.Second, nil) {
+		t.Fatal("manager remained blocked after panic handler returned")
+	}
+}
+
+func TestFinishThreadCleansLifecycleStateWhenPanicHandlerPanics(t *testing.T) {
+	co := New(func(string, string) {
+		panic("panic handler failure")
+	})
+	worker := co.newThread("panicking-worker")
+	co.registerThread(worker)
+
+	recovered := make(chan any, 1)
+	go func() {
+		goroutineID := gid.Get()
+		co.goroutineThreads.Store(goroutineID, worker)
+		co.runMu.Lock()
+		co.setCurrent(worker)
+		defer func() { recovered <- recover() }()
+		co.finishThread(worker, goroutineID, "worker failure")
+	}()
+
+	select {
+	case got := <-recovered:
+		if got != "panic handler failure" {
+			t.Fatalf("panic handler panic = %v, want %q", got, "panic handler failure")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("panicking handler did not return control")
+	}
+	if co.hasThreadsOtherThan(nil) {
+		t.Fatal("thread remained registered after panic handler panicked")
+	}
+	finalizing := 0
+	co.finalizingGoroutines.Range(func(any, any) bool {
+		finalizing++
+		return true
+	})
+	if finalizing != 0 {
+		t.Fatalf("finalizing goroutine markers = %d, want 0", finalizing)
+	}
+	if !co.RunAfterAbortAll(time.Second, nil) {
+		t.Fatal("manager remained blocked after panic handler panicked")
 	}
 }
 

--- a/internal/coroutine/thread_test.go
+++ b/internal/coroutine/thread_test.go
@@ -394,7 +394,7 @@ func TestAbortAllAndWaitRejectsCreationDuringBarrier(t *testing.T) {
 	}
 }
 
-func TestRunAfterAbortAllTimeoutReopensAdmission(t *testing.T) {
+func TestRunAfterAbortAllTimeoutKeepsAdmissionClosedUntilDrain(t *testing.T) {
 	co := New(nil)
 	co.OnInited()
 	blocker := co.newThread("barrier-blocker")
@@ -408,6 +408,23 @@ func TestRunAfterAbortAllTimeoutReopensAdmission(t *testing.T) {
 	}
 	if callbackRan.Load() {
 		t.Fatal("abort barrier ran callback after timing out")
+	}
+
+	var rejectedRan atomic.Bool
+	rejected := co.CreateAndStart(true, "during-timeout", func(Thread) int {
+		rejectedRan.Store(true)
+		return 0
+	})
+	if !rejected.Stopped() {
+		t.Fatal("creation was admitted while a timed-out barrier still had work")
+	}
+	select {
+	case <-rejected.done:
+	case <-time.After(time.Second):
+		t.Fatal("rejected creation did not finish")
+	}
+	if rejectedRan.Load() {
+		t.Fatal("creation during a timed-out barrier ran user code")
 	}
 
 	co.removeThreadState(blocker)

--- a/internal/coroutine/thread_test.go
+++ b/internal/coroutine/thread_test.go
@@ -18,6 +18,7 @@ package coroutine
 
 import (
 	"runtime"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -441,6 +442,93 @@ func TestRunAfterAbortAllTimeoutKeepsAdmissionClosedUntilDrain(t *testing.T) {
 	}
 	if !nextRan.Load() {
 		t.Fatal("creation was rejected after abort barrier timed out")
+	}
+}
+
+func TestRunAfterAbortAllWaitsForPanicHandlerBeforeReopeningAdmission(t *testing.T) {
+	handlerStarted := make(chan struct{})
+	releaseHandler := make(chan struct{})
+	var releaseHandlerOnce sync.Once
+	co := New(func(string, string) {
+		close(handlerStarted)
+		<-releaseHandler
+	})
+	co.OnInited()
+
+	workerStarted := make(chan struct{})
+	releaseWorker := make(chan struct{})
+	var releaseWorkerOnce sync.Once
+	worker := co.CreateAndStart(true, "panicking-worker", func(Thread) int {
+		close(workerStarted)
+		<-releaseWorker
+		panic("worker failure")
+	})
+	t.Cleanup(func() {
+		releaseWorkerOnce.Do(func() { close(releaseWorker) })
+		releaseHandlerOnce.Do(func() { close(releaseHandler) })
+		if !co.AbortAllAndWait(time.Second) {
+			t.Error("panicking worker did not drain during cleanup")
+		}
+	})
+	waitForThreadSignal(t, workerStarted, "panicking worker did not start")
+
+	if co.RunAfterAbortAll(20*time.Millisecond, nil) {
+		t.Fatal("abort barrier reported success while the worker ignored cancellation")
+	}
+	releaseWorkerOnce.Do(func() { close(releaseWorker) })
+	waitForThreadSignal(t, handlerStarted, "panic handler did not start")
+
+	var rejectedRan atomic.Bool
+	rejected := co.CreateAndStart(true, "during-panic-handler", func(Thread) int {
+		rejectedRan.Store(true)
+		return 0
+	})
+	if !rejected.Stopped() {
+		t.Fatal("creation was admitted while the panic handler was running")
+	}
+	waitForThreadSignal(t, rejected.done, "rejected creation did not finish")
+	if rejectedRan.Load() {
+		t.Fatal("creation ran while the panic handler was running")
+	}
+
+	barrierStarted := make(chan struct{})
+	barrierCallback := make(chan struct{})
+	barrierResult := make(chan bool, 1)
+	go func() {
+		close(barrierStarted)
+		barrierResult <- co.RunAfterAbortAll(time.Second, func() {
+			close(barrierCallback)
+		})
+	}()
+	waitForThreadSignal(t, barrierStarted, "second abort barrier did not start")
+	select {
+	case <-barrierCallback:
+		t.Fatal("second abort barrier ran its callback while the panic handler was running")
+	case result := <-barrierResult:
+		t.Fatalf("second abort barrier returned %v while the panic handler was running", result)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	releaseHandlerOnce.Do(func() { close(releaseHandler) })
+	waitForThreadSignal(t, barrierCallback, "second abort barrier did not run its callback after the panic handler returned")
+	select {
+	case result := <-barrierResult:
+		if !result {
+			t.Fatal("second abort barrier timed out after the panic handler returned")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("second abort barrier did not return after the panic handler returned")
+	}
+	waitForThreadSignal(t, worker.done, "panicking worker did not finish")
+
+	var admittedRan atomic.Bool
+	admitted := co.CreateAndStart(true, "after-panic-handler", func(Thread) int {
+		admittedRan.Store(true)
+		return 0
+	})
+	waitForThreadSignal(t, admitted.done, "creation remained blocked after the panic handler returned")
+	if !admittedRan.Load() {
+		t.Fatal("creation was rejected after the panic handler returned")
 	}
 }
 

--- a/internal/coroutine/update.go
+++ b/internal/coroutine/update.go
@@ -39,9 +39,7 @@ const (
 	updateAwaitInitialization
 
 	updateWatchdogTimeout = stime.Second
-	// Runaway shutdown must not let an uncooperative native worker freeze the
-	// engine update loop forever. A timed-out shutdown remains fail-closed and
-	// is reopened by the final lifecycle item that drains.
+	// Bound watchdog shutdown; late workers reopen after draining.
 	runawayShutdownTimeout = updateWatchdogTimeout
 )
 
@@ -123,14 +121,10 @@ func (p *Coroutines) stopRunawayThreads() {
 
 	completed := p.waitForThreadsToStop(runawayShutdownTimeout, nil)
 
-	// Close the race between observing an empty registry and a concurrent
-	// registration. Creations during shutdown are rejected as canceled. If a
-	// native worker outlives the bounded wait, keep admission closed; its final
-	// unregister path will reopen the manager once all lifecycle work drains.
+	// Recheck admission after the bounded wait; late workers keep it closed.
 	p.creationMu.Lock()
 	if wasStopping {
-		// A watchdog must not weaken a quarantine established by a fatal/reload
-		// barrier. It also preserves an earlier watchdog's recovery policy.
+		// Preserve a fatal barrier's quarantine and any prior watchdog policy.
 		p.reopenWhenDrained = reopenWhenDrained
 		p.maybeReopenAfterDrainLocked()
 	} else if completed && !p.hasThreadsOtherThan(nil) {

--- a/internal/coroutine/update.go
+++ b/internal/coroutine/update.go
@@ -115,6 +115,8 @@ func (p *Coroutines) stopRunawayThreads() {
 
 	p.runMu.Lock()
 	p.creationMu.Lock()
+	wasStopping := p.stopping
+	reopenWhenDrained := p.reopenWhenDrained
 	p.beginStoppingLocked()
 	p.creationMu.Unlock()
 	p.runMu.Unlock()
@@ -126,7 +128,12 @@ func (p *Coroutines) stopRunawayThreads() {
 	// native worker outlives the bounded wait, keep admission closed; its final
 	// unregister path will reopen the manager once all lifecycle work drains.
 	p.creationMu.Lock()
-	if completed && !p.hasThreadsOtherThan(nil) {
+	if wasStopping {
+		// A watchdog must not weaken a quarantine established by a fatal/reload
+		// barrier. It also preserves an earlier watchdog's recovery policy.
+		p.reopenWhenDrained = reopenWhenDrained
+		p.maybeReopenAfterDrainLocked()
+	} else if completed && !p.hasThreadsOtherThan(nil) {
 		p.endStoppingLocked()
 	} else {
 		p.reopenWhenDrained = true

--- a/internal/coroutine/update.go
+++ b/internal/coroutine/update.go
@@ -39,6 +39,10 @@ const (
 	updateAwaitInitialization
 
 	updateWatchdogTimeout = stime.Second
+	// Runaway shutdown must not let an uncooperative native worker freeze the
+	// engine update loop forever. A timed-out shutdown remains fail-closed and
+	// is reopened by the final lifecycle item that drains.
+	runawayShutdownTimeout = updateWatchdogTimeout
 )
 
 // Update processes queued wait jobs and resumes eligible coroutines.
@@ -115,19 +119,20 @@ func (p *Coroutines) stopRunawayThreads() {
 	p.creationMu.Unlock()
 	p.runMu.Unlock()
 
-	for {
-		p.waitForThreadsToStop(0, nil)
+	completed := p.waitForThreadsToStop(runawayShutdownTimeout, nil)
 
-		// Close the race between observing an empty registry and a concurrent
-		// registration. Creations during shutdown are rejected as canceled.
-		p.creationMu.Lock()
-		if !p.hasThreadsOtherThan(nil) {
-			p.endStoppingLocked()
-			p.creationMu.Unlock()
-			return
-		}
-		p.creationMu.Unlock()
+	// Close the race between observing an empty registry and a concurrent
+	// registration. Creations during shutdown are rejected as canceled. If a
+	// native worker outlives the bounded wait, keep admission closed; its final
+	// unregister path will reopen the manager once all lifecycle work drains.
+	p.creationMu.Lock()
+	if completed && !p.hasThreadsOtherThan(nil) {
+		p.endStoppingLocked()
+	} else {
+		p.reopenWhenDrained = true
+		p.maybeReopenAfterDrainLocked()
 	}
+	p.creationMu.Unlock()
 }
 
 func (p *Coroutines) nextUpdateAction(stats *UpdateJobsStats) updateAction {

--- a/internal/coroutine/wait.go
+++ b/internal/coroutine/wait.go
@@ -43,8 +43,7 @@ type taskResult struct {
 	panicked   bool
 }
 
-// nativeTask is a lifecycle token for work running outside the coroutine
-// scheduler (for example, a WaitToDo/ExecuteNative worker).
+// nativeTask tracks work outside the scheduler.
 type nativeTask struct {
 	id uint64
 }
@@ -150,8 +149,7 @@ func (p *Coroutines) WaitToDo(fn func()) {
 	go func() {
 		defer p.finishNativeTask(task)
 		result := runTask(fn)
-		// Publish the result before waking the waiter. The buffered channel also
-		// lets a canceled waiter finish without leaking this worker goroutine.
+		// Publish before waking; buffering lets canceled waiters exit.
 		results <- result
 		p.markRunnableAndResume(me)
 	}()

--- a/internal/coroutine/wait.go
+++ b/internal/coroutine/wait.go
@@ -43,6 +43,12 @@ type taskResult struct {
 	panicked   bool
 }
 
+// nativeTask is a lifecycle token for work running outside the coroutine
+// scheduler (for example, a WaitToDo/ExecuteNative worker).
+type nativeTask struct {
+	id uint64
+}
+
 func runTask(fn func()) (result taskResult) {
 	result.panicked = true
 	defer func() {
@@ -135,9 +141,14 @@ func (p *Coroutines) WaitToDo(fn func()) {
 		fn()
 		return
 	}
+	task := p.admitNativeTask(me)
+	if task == nil {
+		panic(ErrAbortThread)
+	}
 	results := make(chan taskResult, 1)
 	p.setThreadState(me, threadBlocked)
 	go func() {
+		defer p.finishNativeTask(task)
 		result := runTask(fn)
 		// Publish the result before waking the waiter. The buffered channel also
 		// lets a canceled waiter finish without leaking this worker goroutine.

--- a/internal/coroutine/wait_todo_panic_test.go
+++ b/internal/coroutine/wait_todo_panic_test.go
@@ -150,22 +150,22 @@ func TestRunAfterAbortAllWaitsForWaitToDoWorker(t *testing.T) {
 		t.Fatal("canceled WaitToDo caller did not finish")
 	}
 
-	// Worker completion reopens admission after the timed-out barrier has
-	// drained. Retry briefly to account for the unregister/reopen handoff.
-	deadline := time.Now().Add(time.Second)
-	var next Thread
-	for next == nil && time.Now().Before(deadline) {
-		candidate := co.Create("after-drain", func(Thread) int { return 0 })
-		if !candidate.Stopped() {
-			next = candidate
-			break
-		}
-		<-candidate.done
-		runtime.Gosched()
+	stillRejected := co.Create("after-drain-before-recovery", func(Thread) int {
+		t.Fatal("creation ran while the manager remained quarantined")
+		return 0
+	})
+	if !stillRejected.Stopped() {
+		t.Fatal("admission reopened after a fatal barrier timed out")
 	}
-	if next == nil {
-		t.Fatal("admission did not reopen after native worker drained")
+	select {
+	case <-stillRejected.done:
+	case <-time.After(time.Second):
+		t.Fatal("quarantined creation did not finish")
 	}
+	if !co.RunAfterAbortAll(time.Second, nil) {
+		t.Fatal("explicit recovery barrier did not complete after native drain")
+	}
+	next := co.Create("after-recovery", func(Thread) int { return 0 })
 	select {
 	case <-next.done:
 	case <-time.After(time.Second):

--- a/internal/coroutine/wait_todo_panic_test.go
+++ b/internal/coroutine/wait_todo_panic_test.go
@@ -1,6 +1,9 @@
 package coroutine
 
 import (
+	"runtime"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -59,4 +62,200 @@ func TestWaitToDoPropagatesNilWorkerPanic(t *testing.T) {
 		t.Fatal("coroutine continued after a nil worker panic")
 	default:
 	}
+}
+
+func TestRunAfterAbortAllWaitsForWaitToDoWorker(t *testing.T) {
+	co := New(nil)
+	co.OnInited()
+	workerStarted := make(chan struct{})
+	workerDone := make(chan struct{})
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseWorker := func() { releaseOnce.Do(func() { close(release) }) }
+	caller := co.CreateAndStart(true, "caller", func(Thread) int {
+		co.WaitToDo(func() {
+			close(workerStarted)
+			<-release
+			close(workerDone)
+		})
+		return 0
+	})
+	defer func() {
+		releaseWorker()
+		select {
+		case <-workerDone:
+		case <-time.After(time.Second):
+			t.Error("WaitToDo worker did not finish during cleanup")
+		}
+		select {
+		case <-caller.done:
+		case <-time.After(time.Second):
+			t.Error("WaitToDo caller did not finish during cleanup")
+		}
+	}()
+
+	select {
+	case <-workerStarted:
+	case <-time.After(time.Second):
+		t.Fatal("WaitToDo worker did not start")
+	}
+
+	callbackRan := make(chan struct{}, 1)
+	completed := make(chan bool, 1)
+	go func() {
+		completed <- co.RunAfterAbortAll(20*time.Millisecond, func() {
+			callbackRan <- struct{}{}
+		})
+	}()
+	select {
+	case got := <-completed:
+		if got {
+			t.Fatal("shutdown reported success while WaitToDo worker was blocked")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("shutdown did not time out while WaitToDo worker was blocked")
+	}
+	select {
+	case <-callbackRan:
+		t.Fatal("shutdown callback ran before WaitToDo worker drained")
+	default:
+	}
+
+	var rejectedRan atomic.Bool
+	rejected := co.CreateAndStart(true, "during-timeout", func(Thread) int {
+		rejectedRan.Store(true)
+		return 0
+	})
+	if !rejected.Stopped() {
+		t.Fatal("creation was admitted while native work was still running")
+	}
+	select {
+	case <-rejected.done:
+	case <-time.After(time.Second):
+		t.Fatal("rejected creation did not finish")
+	}
+	if rejectedRan.Load() {
+		t.Fatal("creation during native drain ran user code")
+	}
+
+	releaseWorker()
+	select {
+	case <-workerDone:
+	case <-time.After(time.Second):
+		t.Fatal("WaitToDo worker did not finish after release")
+	}
+	select {
+	case <-caller.done:
+	case <-time.After(time.Second):
+		t.Fatal("canceled WaitToDo caller did not finish")
+	}
+
+	// Worker completion reopens admission after the timed-out barrier has
+	// drained. Retry briefly to account for the unregister/reopen handoff.
+	deadline := time.Now().Add(time.Second)
+	var next Thread
+	for next == nil && time.Now().Before(deadline) {
+		candidate := co.Create("after-drain", func(Thread) int { return 0 })
+		if !candidate.Stopped() {
+			next = candidate
+			break
+		}
+		<-candidate.done
+		runtime.Gosched()
+	}
+	if next == nil {
+		t.Fatal("admission did not reopen after native worker drained")
+	}
+	select {
+	case <-next.done:
+	case <-time.After(time.Second):
+		t.Fatal("post-drain coroutine did not finish")
+	}
+}
+
+func TestRunawayShutdownDoesNotBlockOnNativeWorker(t *testing.T) {
+	co := New(nil)
+	co.OnInited()
+	workerStarted := make(chan struct{})
+	release := make(chan struct{})
+	caller := co.CreateAndStart(true, "caller", func(Thread) int {
+		co.WaitToDo(func() {
+			close(workerStarted)
+			<-release
+		})
+		return 0
+	})
+
+	cleanup := func() {
+		select {
+		case <-release:
+		default:
+			close(release)
+		}
+		if !co.AbortAllAndWait(time.Second) {
+			t.Error("coroutines did not stop during cleanup")
+		}
+	}
+	defer cleanup()
+
+	select {
+	case <-workerStarted:
+	case <-time.After(time.Second):
+		t.Fatal("native worker did not start")
+	}
+
+	shutdownDone := make(chan struct{})
+	go func() {
+		co.stopRunawayThreads()
+		close(shutdownDone)
+	}()
+	select {
+	case <-shutdownDone:
+	case <-time.After(2 * runawayShutdownTimeout):
+		t.Fatal("runaway shutdown blocked on an uncooperative native worker")
+	}
+
+	var rejectedRan atomic.Bool
+	rejected := co.Create("during-native-drain", func(Thread) int {
+		rejectedRan.Store(true)
+		return 0
+	})
+	if !rejected.Stopped() {
+		t.Fatal("runaway shutdown reopened admission before native worker drained")
+	}
+	if rejectedRan.Load() {
+		t.Fatal("coroutine created during native drain ran user code")
+	}
+	select {
+	case <-rejected.done:
+	case <-time.After(time.Second):
+		t.Fatal("rejected coroutine did not finish")
+	}
+
+	close(release)
+	select {
+	case <-caller.done:
+	case <-time.After(time.Second):
+		t.Fatal("canceled WaitToDo caller did not finish after native worker release")
+	}
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		next := co.Create("after-native-drain", func(Thread) int { return 0 })
+		if !next.Stopped() {
+			select {
+			case <-next.done:
+			case <-time.After(time.Second):
+				t.Fatal("post-drain coroutine did not finish")
+			}
+			return
+		}
+		select {
+		case <-next.done:
+		case <-time.After(time.Second):
+			t.Fatal("rejected post-drain coroutine did not finish")
+		}
+		runtime.Gosched()
+	}
+	t.Fatal("admission did not reopen after native worker drained")
 }

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -277,9 +277,7 @@ func Panicf(format string, args ...any) {
 // Used on web, where the process cannot exit.
 func abortCoroutinesAndReset(exitCode int64) {
 	co := gco
-	// Panic handling has already dropped the caller identity but keeps its
-	// thread registered until the handler returns, so the drain must never run
-	// inline with the caller.
+	// Drain off-thread while the panic caller unwinds.
 	go requestResetAfterCoroutinesStop(co, 2*stime.Second, func() {
 		extMgr.RequestReset(exitCode)
 	})

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -277,18 +277,15 @@ func Panicf(format string, args ...any) {
 // Used on web, where the process cannot exit.
 func abortCoroutinesAndReset(exitCode int64) {
 	co := gco
-	requestReset := func() {
+	// Panic handling has already dropped the caller identity but keeps its
+	// thread registered until the handler returns, so the drain must never run
+	// inline with the caller.
+	go requestResetAfterCoroutinesStop(co, 2*stime.Second, func() {
 		extMgr.RequestReset(exitCode)
-	}
+	})
 	if co.IsInCoroutine() {
-		// RequestReset synchronously calls back into Game.reset on the Web main
-		// thread. Coordinate it outside the managed caller so that caller also
-		// unregisters before reset clears shared runtime state.
-		go requestResetAfterCoroutinesStop(co, 2*stime.Second, requestReset)
 		co.Abort()
-		return
 	}
-	requestResetAfterCoroutinesStop(co, 2*stime.Second, requestReset)
 }
 
 func requestResetAfterCoroutinesStop(co *coroutine.Coroutines, timeout stime.Duration, requestReset func()) bool {

--- a/internal/engine/exit_test.go
+++ b/internal/engine/exit_test.go
@@ -158,7 +158,7 @@ func TestAbortCoroutinesAndResetReturnsBeforeExternalDrain(t *testing.T) {
 func TestAbortCoroutinesAndResetAbortsManagedCaller(t *testing.T) {
 	co := coroutine.New(nil)
 	co.OnInited()
-	setupAbortCoroutinesAndResetTest(t, co)
+	recorder := setupAbortCoroutinesAndResetTest(t, co)
 
 	entered := make(chan struct{})
 	callerDone := make(chan struct{})
@@ -187,6 +187,14 @@ func TestAbortCoroutinesAndResetAbortsManagedCaller(t *testing.T) {
 	case <-caller.Context().Done():
 	case <-time.After(time.Second):
 		t.Fatal("managed reset caller context was not canceled")
+	}
+	select {
+	case exitCode := <-recorder.calls:
+		if exitCode != 9 {
+			t.Fatalf("engine reset exit code = %d, want 9", exitCode)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("engine reset was not requested after managed caller drained")
 	}
 	waitForResetAdmissionOpen(t, co)
 }

--- a/internal/engine/exit_test.go
+++ b/internal/engine/exit_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/goplus/spx/v3/internal/coroutine"
+	"github.com/goplus/spx/v3/internal/enginewrap"
 	gdx "github.com/goplus/spx/v3/pkg/spx/pkg/engine"
 )
 
@@ -31,6 +32,164 @@ type resetWorkerPlatform struct {
 }
 
 func (resetWorkerPlatform) IsMainThread() bool { return false }
+
+type resetDirectPlatform struct {
+	gdx.IPlatformMgr
+}
+
+func (resetDirectPlatform) IsMainThread() bool { return true }
+
+type resetRecordingExt struct {
+	gdx.IExtMgr
+	calls chan int64
+}
+
+func (r *resetRecordingExt) RequestReset(exitCode int64) {
+	r.calls <- exitCode
+}
+
+func setupAbortCoroutinesAndResetTest(t *testing.T, co *coroutine.Coroutines) *resetRecordingExt {
+	t.Helper()
+
+	original := gco
+	originalPlatform := gdx.PlatformMgr
+	originalExt := gdx.ExtMgr
+	recorder := &resetRecordingExt{calls: make(chan int64, 1)}
+	SetCoroutines(co)
+	gdx.PlatformMgr = resetDirectPlatform{}
+	gdx.ExtMgr = recorder
+	enginewrap.Init(WaitMainThread)
+	t.Cleanup(func() {
+		if !co.AbortAllAndWait(time.Second) {
+			t.Error("test coroutines did not stop")
+		}
+		SetCoroutines(original)
+		gdx.PlatformMgr = originalPlatform
+		gdx.ExtMgr = originalExt
+	})
+	return recorder
+}
+
+func waitForResetAdmissionClose(t *testing.T, co *coroutine.Coroutines) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		probe := co.Create("reset-close-probe", func(coroutine.Thread) int { return 0 })
+		if probe.Stopped() {
+			return
+		}
+		runtime.Gosched()
+	}
+	t.Fatal("reset barrier did not close coroutine admission")
+}
+
+func waitForResetAdmissionOpen(t *testing.T, co *coroutine.Coroutines) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		var ran atomic.Bool
+		probe := co.CreateAndStart(true, "reset-open-probe", func(coroutine.Thread) int {
+			ran.Store(true)
+			return 0
+		})
+		co.Join(probe)
+		if ran.Load() {
+			return
+		}
+		runtime.Gosched()
+	}
+	t.Fatal("reset barrier did not reopen coroutine admission")
+}
+
+func TestAbortCoroutinesAndResetReturnsBeforeExternalDrain(t *testing.T) {
+	co := coroutine.New(nil)
+	co.OnInited()
+	recorder := setupAbortCoroutinesAndResetTest(t, co)
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var released atomic.Bool
+	workerDone := make(chan struct{})
+	co.CreateAndStart(true, "blocked", func(coroutine.Thread) int {
+		defer close(workerDone)
+		close(started)
+		<-release
+		return 0
+	})
+	t.Cleanup(func() {
+		if released.CompareAndSwap(false, true) {
+			close(release)
+		}
+	})
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("blocking coroutine did not start")
+	}
+
+	returned := make(chan struct{})
+	go func() {
+		abortCoroutinesAndReset(7)
+		close(returned)
+	}()
+	select {
+	case <-returned:
+	case <-time.After(time.Second):
+		t.Fatal("external reset request waited for coroutine drain")
+	}
+	waitForResetAdmissionClose(t, co)
+	select {
+	case exitCode := <-recorder.calls:
+		t.Fatalf("engine reset %d was requested before coroutine drain", exitCode)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	if released.CompareAndSwap(false, true) {
+		close(release)
+	}
+	select {
+	case <-workerDone:
+	case <-time.After(time.Second):
+		t.Fatal("blocking coroutine did not finish after release")
+	}
+	waitForResetAdmissionOpen(t, co)
+}
+
+func TestAbortCoroutinesAndResetAbortsManagedCaller(t *testing.T) {
+	co := coroutine.New(nil)
+	co.OnInited()
+	setupAbortCoroutinesAndResetTest(t, co)
+
+	entered := make(chan struct{})
+	callerDone := make(chan struct{})
+	var returned atomic.Bool
+	caller := co.CreateAndStart(true, "caller", func(coroutine.Thread) int {
+		defer close(callerDone)
+		close(entered)
+		abortCoroutinesAndReset(9)
+		returned.Store(true)
+		return 0
+	})
+	select {
+	case <-entered:
+	case <-time.After(time.Second):
+		t.Fatal("managed caller did not start")
+	}
+	select {
+	case <-callerDone:
+	case <-time.After(time.Second):
+		t.Fatal("managed reset caller was not aborted")
+	}
+	if returned.Load() {
+		t.Fatal("managed reset caller returned normally")
+	}
+	select {
+	case <-caller.Context().Done():
+	case <-time.After(time.Second):
+		t.Fatal("managed reset caller context was not canceled")
+	}
+	waitForResetAdmissionOpen(t, co)
+}
 
 func TestRequestResetAfterCoroutinesStopWaitsForManagedCaller(t *testing.T) {
 	co := coroutine.New(nil)


### PR DESCRIPTION
## Summary
- track `WaitToDo` workers as part of coroutine lifecycle shutdown
- keep admission closed until timed-out barriers are explicitly recovered
- retain lifecycle state through panic handlers and reject reset re-entry
- coordinate Web reset requests only after managed and native work has drained
- simplify lifecycle comments and add focused concurrency coverage

## Verification
- `make generate`
- `go test ./...`
- `go test -race ./...`
- `go test -count=5 ./internal/coroutine`
- `go test -count=5 ./internal/engine`
- `go test -race -count=3 ./internal/coroutine`
- `go test -race -count=3 ./internal/engine`
- `git diff --check`

## Notes
The change bounds watchdog shutdown waits and keeps admission quarantined when work remains. Real Godot Web reset behavior remains covered by the repository workflow.