### PR TITLE
fix(fs/zip): bound archive expansion and metadata work

### DIFF
--- a/fs/zip/fs.go
+++ b/fs/zip/fs.go
@@ -34,19 +34,39 @@ import (
 // -------------------------------------------------------------------------------------
 
 // A FS represents a zip filesystem.
-type FS zip.ReadCloser
+type FS struct {
+	*zip.Reader
+	file *os.File
+}
 
 // Open opens a zip filesystem object.
 func Open(file string) (fs.Dir, error) {
-	zipf, err := zip.OpenReader(file)
+	source, err := os.Open(file)
 	if err != nil {
 		return nil, err
 	}
-	if err := validateZipReader(&zipf.Reader); err != nil {
-		_ = zipf.Close()
+	closeOnError := true
+	defer func() {
+		if closeOnError {
+			_ = source.Close()
+		}
+	}()
+	info, err := source.Stat()
+	if err != nil {
 		return nil, err
 	}
-	return (*FS)(zipf), nil
+	if err := preflightZipArchive(source, info.Size()); err != nil {
+		return nil, err
+	}
+	reader, err := zip.NewReader(source, info.Size())
+	if err != nil {
+		return nil, err
+	}
+	if err := validateZipReader(reader); err != nil {
+		return nil, err
+	}
+	closeOnError = false
+	return &FS{Reader: reader, file: source}, nil
 }
 
 // Open opens a zipped file object.
@@ -61,7 +81,10 @@ func (zipf *FS) Open(name string) (io.ReadCloser, error) {
 
 // Close closes the filesystem object.
 func (zipf *FS) Close() error {
-	return ((*zip.ReadCloser)(zipf)).Close()
+	if zipf == nil || zipf.file == nil {
+		return nil
+	}
+	return zipf.file.Close()
 }
 
 // OpenHttp opens hzip:<domain>/<path>

--- a/fs/zip/fs.go
+++ b/fs/zip/fs.go
@@ -42,6 +42,10 @@ func Open(file string) (fs.Dir, error) {
 	if err != nil {
 		return nil, err
 	}
+	if err := validateZipReader(&zipf.Reader); err != nil {
+		_ = zipf.Close()
+		return nil, err
+	}
 	return (*FS)(zipf), nil
 }
 
@@ -49,7 +53,7 @@ func Open(file string) (fs.Dir, error) {
 func (zipf *FS) Open(name string) (io.ReadCloser, error) {
 	for _, f := range zipf.File {
 		if f.Name == name {
-			return f.Open()
+			return openZipEntry(f)
 		}
 	}
 	return nil, fmt.Errorf("`%s` not found in zipfile: %w", name, syscall.ENOENT)

--- a/fs/zip/fs_js.go
+++ b/fs/zip/fs_js.go
@@ -78,6 +78,9 @@ func openHttpWith(remotePath, scheme string) (fs.Dir, error) {
 		return nil, err
 	}
 	r := bytes.NewReader(body)
+	if err := preflightZipArchive(r, int64(r.Len())); err != nil {
+		return nil, err
+	}
 	zipf, err := zip.NewReader(r, int64(r.Len()))
 	if err != nil {
 		return nil, err

--- a/fs/zip/fs_js.go
+++ b/fs/zip/fs_js.go
@@ -40,7 +40,7 @@ func Open(file string) (fs.Dir, error) {
 func (zipf *FS) Open(name string) (io.ReadCloser, error) {
 	for _, f := range zipf.File {
 		if f.Name == name {
-			return f.Open()
+			return openZipEntry(f)
 		}
 	}
 	return nil, fmt.Errorf("`%s` not found in zipfile: %w", name, syscall.ENOENT)
@@ -80,6 +80,9 @@ func openHttpWith(remotePath, scheme string) (fs.Dir, error) {
 	r := bytes.NewReader(body)
 	zipf, err := zip.NewReader(r, int64(r.Len()))
 	if err != nil {
+		return nil, err
+	}
+	if err := validateZipReader(zipf); err != nil {
 		return nil, err
 	}
 	return &FS{zipf}, nil

--- a/fs/zip/http_common.go
+++ b/fs/zip/http_common.go
@@ -30,8 +30,8 @@ import (
 )
 
 const (
-	// MaxRemoteZipBytes limits downloaded archive data.
-	MaxRemoteZipBytes int64 = 512 << 20
+	// MaxRemoteZipBytes is kept for compatibility.
+	MaxRemoteZipBytes int64 = MaxZipArchiveBytes
 )
 
 var (

--- a/fs/zip/limits.go
+++ b/fs/zip/limits.go
@@ -23,38 +23,29 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"sort"
 	"strings"
 	"sync/atomic"
 )
 
-// The limits protect callers that open ZIPs supplied by projects or remote
-// servers. They bound both metadata processing and the amount of data a
-// successful entry read can produce.
+// Limits bound ZIP metadata and decompression work.
 const (
-	// MaxZipArchiveBytes is the maximum compressed ZIP byte length accepted.
+	// MaxZipArchiveBytes limits compressed input.
 	MaxZipArchiveBytes int64 = 512 << 20
-	// MaxZipCentralDirectoryBytes bounds central-directory metadata parsed by
-	// archive/zip before its Reader is returned.
+	// MaxZipCentralDirectoryBytes limits central-directory metadata.
 	MaxZipCentralDirectoryBytes int64 = 64 << 20
-	// MaxZipEntries is the maximum number of central-directory entries.
+	// MaxZipEntries limits central-directory entries.
 	MaxZipEntries = 10_000
-	// MaxZipEntrySize is the maximum uncompressed size of one regular entry.
+	// MaxZipEntrySize limits one uncompressed entry.
 	MaxZipEntrySize int64 = 512 << 20
-	// MaxZipTotalSize is the maximum sum of uncompressed regular entries.
+	// MaxZipTotalSize limits total uncompressed data.
 	MaxZipTotalSize int64 = 4 << 30
-	// MaxZipCompressionRatio is the maximum declared uncompressed/compressed
-	// ratio for a non-empty regular entry.
+	// MaxZipCompressionRatio limits declared expansion.
 	MaxZipCompressionRatio uint64 = 200
 )
 
-var (
-	// ErrArchiveLimit identifies an archive rejected because it could require
-	// excessive metadata, decompression, or CPU work.
-	ErrArchiveLimit = errors.New("zip: archive limit exceeded")
-	// ErrZipArchiveLimit is an explicit package-qualified alias for callers
-	// that want to distinguish this limit from other ZIP errors.
-	ErrZipArchiveLimit = ErrArchiveLimit
-)
+// ErrArchiveLimit identifies excessive ZIP work.
+var ErrArchiveLimit = errors.New("zip: archive limit exceeded")
 
 type resolvedZipLimits struct {
 	maxArchiveBytes     int64
@@ -66,19 +57,18 @@ type resolvedZipLimits struct {
 }
 
 func defaultZipLimits() resolvedZipLimits {
-	return normalizeZipLimits(resolvedZipLimits{
+	return resolvedZipLimits{
 		maxArchiveBytes:     MaxZipArchiveBytes,
 		maxCentralDirBytes:  MaxZipCentralDirectoryBytes,
 		maxEntries:          MaxZipEntries,
 		maxEntrySize:        MaxZipEntrySize,
 		maxTotalSize:        MaxZipTotalSize,
 		maxCompressionRatio: MaxZipCompressionRatio,
-	})
+	}
 }
 
 func normalizeZipLimits(limits resolvedZipLimits) resolvedZipLimits {
-	// A test hook must not make the production path accidentally unbounded.
-	// Falling back to defaults also keeps a zero value useful in tests.
+	// Keep test overrides bounded when fields are omitted.
 	if limits.maxArchiveBytes <= 0 {
 		limits.maxArchiveBytes = MaxZipArchiveBytes
 	}
@@ -103,8 +93,7 @@ func normalizeZipLimits(limits resolvedZipLimits) resolvedZipLimits {
 	return limits
 }
 
-// The override is used only by package tests. An atomic pointer keeps tests
-// that exercise concurrent readers race-free while production uses constants.
+// Package tests override limits concurrently.
 var zipTestLimits atomic.Pointer[resolvedZipLimits]
 
 func currentZipLimits() resolvedZipLimits {
@@ -136,18 +125,14 @@ const (
 )
 
 type zipDirectoryInfo struct {
-	// endOffset is the absolute offset used by archive/zip to derive the
-	// archive base (classic EOCD or ZIP64 EOCD, respectively).
-	endOffset int64
-	// eocdOffset is always the absolute offset of the classic EOCD record.
+	endOffset  int64
 	eocdOffset int64
 	offset     uint64
 	size       uint64
 	entries    uint64
 }
 
-// preflightZipArchive bounds archive/zip's central-directory work before
-// zip.NewReader is allowed to allocate one File and its metadata per entry.
+// preflightZipArchive bounds work before zip.NewReader allocates entries.
 func preflightZipArchive(reader io.ReaderAt, size int64) error {
 	return preflightZipArchiveWithLimits(reader, size, currentZipLimits())
 }
@@ -185,28 +170,11 @@ func preflightZipArchiveWithLimits(reader io.ReaderAt, size int64, limits resolv
 		return fmt.Errorf("zip: invalid central directory offset: %w", zip.ErrFormat)
 	}
 	baseOffset := start - centralOffset
-	// Match archive/zip's compatibility handling for archives whose directory
-	// offset is absolute despite a non-zero computed base offset. The header
-	// predicate mirrors archive/zip's parser so both readers select the same
-	// physical directory.
-	if baseOffset > 0 && completeZipDirectoryHeaderAt(reader, size, centralOffset) > 0 {
-		start = centralOffset
+	// Header parsing differs across Go releases; reject an alternate base.
+	if baseOffset > 0 && hasZipDirectoryHeader(reader, size, centralOffset) {
+		return fmt.Errorf("zip: ambiguous central directory offset: %w", zip.ErrFormat)
 	}
-	centralEnd := start + centralSize
-	if centralEnd < start || centralEnd > size || centralEnd > directory.endOffset {
-		return fmt.Errorf("zip: invalid central directory bounds: %w", zip.ErrFormat)
-	}
-	if err := scanZipCentralDirectory(reader, size, start, centralEnd, directory.entries, limits); err != nil {
-		return err
-	}
-	// archive/zip reads directory headers until the first invalid signature,
-	// even when a compatibility base offset makes the declared byte range end
-	// before the end record. Reject an immediately following header so it
-	// cannot make archive/zip allocate entries that the bounded scan missed.
-	if centralEnd < directory.endOffset && completeZipDirectoryHeaderAt(reader, size, centralEnd) > 0 {
-		return fmt.Errorf("zip: central directory extends beyond its declared size: %w", zip.ErrFormat)
-	}
-	return nil
+	return scanZipCentralDirectory(reader, size, start, directory.endOffset, directory.entries, limits)
 }
 
 func readZipDirectoryInfo(reader io.ReaderAt, size int64, limits resolvedZipLimits) (zipDirectoryInfo, error) {
@@ -233,9 +201,7 @@ func readZipDirectoryInfo(reader io.ReaderAt, size int64, limits resolvedZipLimi
 		if commentEnd > size {
 			return zipDirectoryInfo{}, fmt.Errorf("zip: invalid comment length: %w", zip.ErrFormat)
 		}
-		// archive/zip selects this first non-truncated candidate. Reject the
-		// archive instead of searching for an earlier EOCD that would make the
-		// preflight and archive/zip inspect different central directories.
+		// Do not let preflight and archive/zip select different end records.
 		if commentEnd != size {
 			return zipDirectoryInfo{}, fmt.Errorf("zip: trailing data after end record: %w", zip.ErrFormat)
 		}
@@ -261,17 +227,17 @@ func readZipDirectoryInfo(reader io.ReaderAt, size int64, limits resolvedZipLimi
 		size:       uint64(directorySize),
 		entries:    uint64(entries),
 	}
-	// archive/zip treats these boundary values as a ZIP64 probe, then falls
-	// back to the classic EOCD values when no locator is present. In
-	// particular, 0xffff is a valid value for the 32-bit directory-size field.
-	mayHaveZip64 := entries == math.MaxUint16 || directorySize == math.MaxUint16 ||
-		directorySize == math.MaxUint32 || directoryOffset == math.MaxUint32
-	if mayHaveZip64 {
+	standardZip64 := entries == math.MaxUint16 || directorySize == math.MaxUint32 || directoryOffset == math.MaxUint32
+	// Go 1.25 also probes 0xffff directory sizes; later releases do not.
+	if standardZip64 || directorySize == math.MaxUint16 {
 		zip64Info, found, err := readZip64DirectoryInfo(reader, size, info, limits)
 		if err != nil {
 			return zipDirectoryInfo{}, err
 		}
 		if found {
+			if !standardZip64 {
+				return zipDirectoryInfo{}, fmt.Errorf("zip: ambiguous ZIP64 directory size: %w", zip.ErrFormat)
+			}
 			return zip64Info, nil
 		}
 	}
@@ -347,11 +313,16 @@ func readZip64EndAt(reader io.ReaderAt, size, locatorOffset int64, offset uint64
 	return recordOffset, record, true
 }
 
-func completeZipDirectoryHeaderAt(reader io.ReaderAt, size, offset int64) int64 {
-	return completeZipDirectoryHeaderWithin(reader, size, offset, size)
+func hasZipDirectoryHeader(reader io.ReaderAt, size, offset int64) bool {
+	if offset < 0 || offset > size-4 {
+		return false
+	}
+	var signature [4]byte
+	_, err := reader.ReadAt(signature[:], offset)
+	return err == nil && binary.LittleEndian.Uint32(signature[:]) == zipDirectoryHeaderSignature
 }
 
-func completeZipDirectoryHeaderWithin(reader io.ReaderAt, archiveSize, offset, end int64) int64 {
+func zipDirectoryEntryLen(reader io.ReaderAt, archiveSize, offset, end int64) int64 {
 	if offset < 0 || end < offset || end > archiveSize || offset > end-zipDirectoryHeaderLen {
 		return 0
 	}
@@ -369,57 +340,6 @@ func completeZipDirectoryHeaderWithin(reader io.ReaderAt, archiveSize, offset, e
 	if entryLen > end-offset {
 		return 0
 	}
-
-	needUncompressedSize := binary.LittleEndian.Uint32(header[24:28]) == math.MaxUint32
-	needCompressedSize := binary.LittleEndian.Uint32(header[20:24]) == math.MaxUint32
-	needHeaderOffset := binary.LittleEndian.Uint32(header[42:46]) == math.MaxUint32
-	if !needUncompressedSize && !needCompressedSize && !needHeaderOffset {
-		return entryLen
-	}
-	extra := make([]byte, int(extraLen))
-	if extraLen > 0 {
-		if _, err := reader.ReadAt(extra, offset+zipDirectoryHeaderLen+filenameLen); err != nil {
-			return 0
-		}
-	}
-	for len(extra) >= 4 {
-		tag := binary.LittleEndian.Uint16(extra[0:2])
-		fieldLen := int(binary.LittleEndian.Uint16(extra[2:4]))
-		extra = extra[4:]
-		if len(extra) < fieldLen {
-			break
-		}
-		field := extra[:fieldLen]
-		extra = extra[fieldLen:]
-		if tag != 0x0001 {
-			continue
-		}
-		if needUncompressedSize {
-			if len(field) < 8 {
-				return 0
-			}
-			field = field[8:]
-			needUncompressedSize = false
-		}
-		if needCompressedSize {
-			if len(field) < 8 {
-				return 0
-			}
-			field = field[8:]
-			needCompressedSize = false
-		}
-		if needHeaderOffset {
-			if len(field) < 8 {
-				return 0
-			}
-			needHeaderOffset = false
-		}
-	}
-	// archive/zip tolerates a missing ZIP64 uncompressed size for historical
-	// compatibility, but requires compressed size and local-header offset.
-	if needCompressedSize || needHeaderOffset {
-		return 0
-	}
 	return entryLen
 }
 
@@ -431,7 +351,7 @@ func scanZipCentralDirectory(reader io.ReaderAt, size, start, end int64, declare
 	var metadataBytes int64
 	var entries uint64
 	for offset < end {
-		entryLen := completeZipDirectoryHeaderWithin(reader, size, offset, end)
+		entryLen := zipDirectoryEntryLen(reader, size, offset, end)
 		if entryLen == 0 {
 			return fmt.Errorf("zip: invalid central directory entry: %w", zip.ErrFormat)
 		}
@@ -454,28 +374,7 @@ func scanZipCentralDirectory(reader io.ReaderAt, size, start, end int64, declare
 	return nil
 }
 
-func readZipArchiveBody(reader io.Reader, contentLength int64) ([]byte, error) {
-	if reader == nil {
-		return nil, fmt.Errorf("zip: HTTP response has no body")
-	}
-	limit := currentZipLimits().maxArchiveBytes
-	if contentLength > limit {
-		return nil, fmt.Errorf("%w: response length %d exceeds limit %d", ErrArchiveLimit, contentLength, limit)
-	}
-	body, err := io.ReadAll(io.LimitReader(reader, zipLimitWithSentinel(limit)))
-	if err != nil {
-		return nil, err
-	}
-	if int64(len(body)) > limit {
-		return nil, fmt.Errorf("%w: response exceeds limit %d", ErrArchiveLimit, limit)
-	}
-	return body, nil
-}
-
-// validateZipReader checks central-directory declarations before an archive
-// is returned to a caller. archive/zip intentionally leaves expansion limits
-// to its users, so UncompressedSize64 and the compression ratio must be
-// checked here.
+// validateZipReader bounds declared expansion work.
 func validateZipReader(reader *zip.Reader) error {
 	if reader == nil {
 		return fmt.Errorf("%w: nil ZIP reader", ErrArchiveLimit)
@@ -485,12 +384,23 @@ func validateZipReader(reader *zip.Reader) error {
 		return fmt.Errorf("%w: %d entries exceeds limit %d", ErrArchiveLimit, len(reader.File), limits.maxEntries)
 	}
 
-	var total uint64
+	paths := make([]zipPath, 0, len(reader.File))
+	var compressedTotal, total uint64
 	for _, file := range reader.File {
 		if err := validateZipFile(file, limits); err != nil {
 			return err
 		}
-		if file == nil || isZipDirectory(file) {
+		path, err := newZipPath(file)
+		if err != nil {
+			return err
+		}
+		paths = append(paths, path)
+		compressed := file.CompressedSize64
+		if compressed > uint64(limits.maxArchiveBytes) || compressedTotal > uint64(limits.maxArchiveBytes)-compressed {
+			return fmt.Errorf("%w: total compressed size exceeds limit %d", ErrArchiveLimit, limits.maxArchiveBytes)
+		}
+		compressedTotal += compressed
+		if isZipDirectory(file) {
 			continue
 		}
 		size := file.UncompressedSize64
@@ -498,6 +408,66 @@ func validateZipReader(reader *zip.Reader) error {
 			return fmt.Errorf("%w: total uncompressed size exceeds limit %d", ErrArchiveLimit, limits.maxTotalSize)
 		}
 		total += size
+	}
+	return validateZipPaths(paths)
+}
+
+type zipPath struct {
+	name      string
+	directory bool
+}
+
+func newZipPath(file *zip.File) (zipPath, error) {
+	directory := isZipDirectory(file)
+	name := file.Name
+	if directory {
+		name = strings.TrimSuffix(name, "/")
+	}
+	if !validZipPath(name) {
+		return zipPath{}, fmt.Errorf("zip: invalid entry name %q: %w", file.Name, zip.ErrFormat)
+	}
+	return zipPath{name: name, directory: directory}, nil
+}
+
+func validZipPath(name string) bool {
+	if name == "" || name[0] == '/' || name[len(name)-1] == '/' || strings.ContainsRune(name, '\\') || hasZipDrivePrefix(name) {
+		return false
+	}
+	for {
+		part := name
+		if slash := strings.IndexByte(name, '/'); slash >= 0 {
+			part, name = name[:slash], name[slash+1:]
+		} else {
+			name = ""
+		}
+		if part == "" || part == "." || part == ".." {
+			return false
+		}
+		if name == "" {
+			return true
+		}
+	}
+}
+
+func hasZipDrivePrefix(name string) bool {
+	return len(name) >= 2 && name[1] == ':' &&
+		(name[0] >= 'A' && name[0] <= 'Z' || name[0] >= 'a' && name[0] <= 'z')
+}
+
+func validateZipPaths(paths []zipPath) error {
+	sort.Slice(paths, func(i, j int) bool { return paths[i].name < paths[j].name })
+	for i, path := range paths {
+		if i > 0 && paths[i-1].name == path.name {
+			return fmt.Errorf("zip: duplicate entry %q: %w", path.name, zip.ErrFormat)
+		}
+		if path.directory {
+			continue
+		}
+		prefix := path.name + "/"
+		child := sort.Search(len(paths), func(i int) bool { return paths[i].name >= prefix })
+		if child < len(paths) && strings.HasPrefix(paths[child].name, prefix) {
+			return fmt.Errorf("zip: file entry %q is a parent path: %w", path.name, zip.ErrFormat)
+		}
 	}
 	return nil
 }
@@ -507,10 +477,7 @@ func validateZipFile(file *zip.File, limits resolvedZipLimits) error {
 		return fmt.Errorf("%w: nil ZIP entry", ErrArchiveLimit)
 	}
 	if isZipDirectory(file) {
-		// A directory has no logical payload. archive/zip permits a non-zero
-		// compressed size for some producer quirks, so do not apply a ratio to
-		// that storage data. A non-zero uncompressed declaration is still
-		// rejected because it would bypass the archive's total-size accounting.
+		// Some writers give empty directories non-zero compressed storage.
 		if file.UncompressedSize64 != 0 {
 			return fmt.Errorf("%w: directory entry %q has non-zero uncompressed size %d", ErrArchiveLimit, file.Name, file.UncompressedSize64)
 		}
@@ -536,19 +503,12 @@ func checkZipCompressionRatio(file *zip.File, maxRatio uint64) error {
 	}
 	compressed := file.CompressedSize64
 	if compressed == 0 || maxRatio == 0 || compressed > math.MaxUint64/maxRatio || file.UncompressedSize64 > compressed*maxRatio {
-		name := "<unknown>"
-		if file != nil {
-			name = file.Name
-		}
-		return fmt.Errorf("%w: entry %q compression ratio exceeds %d:1", ErrArchiveLimit, name, maxRatio)
+		return fmt.Errorf("%w: entry %q compression ratio exceeds %d:1", ErrArchiveLimit, file.Name, maxRatio)
 	}
 	return nil
 }
 
-// openZipEntry validates a single entry again at read time and caps the
-// decompressor's output with a one-byte sentinel. The sentinel ensures an
-// entry whose header understates its output cannot silently terminate at the
-// configured limit without letting archive/zip verify its checksum.
+// openZipEntry caps output at the entry's declared size plus one sentinel byte.
 func openZipEntry(file *zip.File) (io.ReadCloser, error) {
 	limits := currentZipLimits()
 	if err := validateZipFile(file, limits); err != nil {
@@ -558,10 +518,11 @@ func openZipEntry(file *zip.File) (io.ReadCloser, error) {
 	if err != nil {
 		return nil, err
 	}
+	max := int64(file.UncompressedSize64)
 	return &zipLimitedReadCloser{
 		ReadCloser: reader,
-		remaining:  zipLimitWithSentinel(limits.maxEntrySize),
-		max:        limits.maxEntrySize,
+		remaining:  zipLimitWithSentinel(max),
+		max:        max,
 		name:       file.Name,
 	}, nil
 }
@@ -603,8 +564,7 @@ func (r *zipLimitedReadCloser) Read(p []byte) (int, error) {
 	r.read += int64(n)
 	if int64(n) > allowed {
 		r.limitErr = fmt.Errorf("%w: entry %q uncompressed output exceeds limit %d", ErrArchiveLimit, r.name, r.max)
-		// The extra byte was consumed only as a sentinel. Do not expose it to
-		// callers, even though the underlying reader returned it in p.
+		// Do not expose the sentinel byte.
 		return int(allowed), r.limitErr
 	}
 	return n, err

--- a/fs/zip/limits.go
+++ b/fs/zip/limits.go
@@ -18,17 +18,24 @@ package zip
 
 import (
 	"archive/zip"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
 	"math"
 	"strings"
+	"sync/atomic"
 )
 
 // The limits protect callers that open ZIPs supplied by projects or remote
 // servers. They bound both metadata processing and the amount of data a
 // successful entry read can produce.
 const (
+	// MaxZipArchiveBytes is the maximum compressed ZIP byte length accepted.
+	MaxZipArchiveBytes int64 = 512 << 20
+	// MaxZipCentralDirectoryBytes bounds central-directory metadata parsed by
+	// archive/zip before its Reader is returned.
+	MaxZipCentralDirectoryBytes int64 = 64 << 20
 	// MaxZipEntries is the maximum number of central-directory entries.
 	MaxZipEntries = 10_000
 	// MaxZipEntrySize is the maximum uncompressed size of one regular entry.
@@ -47,30 +54,37 @@ var (
 	// ErrZipArchiveLimit is an explicit package-qualified alias for callers
 	// that want to distinguish this limit from other ZIP errors.
 	ErrZipArchiveLimit = ErrArchiveLimit
-	// These package variables are intentionally unexported so production code
-	// cannot change process-wide limits. Tests use them to exercise boundaries.
-	zipMaxEntries          = MaxZipEntries
-	zipMaxEntrySize        = MaxZipEntrySize
-	zipMaxTotalSize        = MaxZipTotalSize
-	zipMaxCompressionRatio = MaxZipCompressionRatio
 )
 
 type resolvedZipLimits struct {
+	maxArchiveBytes     int64
+	maxCentralDirBytes  int64
 	maxEntries          int
 	maxEntrySize        int64
 	maxTotalSize        int64
 	maxCompressionRatio uint64
 }
 
-func currentZipLimits() resolvedZipLimits {
-	limits := resolvedZipLimits{
-		maxEntries:          zipMaxEntries,
-		maxEntrySize:        zipMaxEntrySize,
-		maxTotalSize:        zipMaxTotalSize,
-		maxCompressionRatio: zipMaxCompressionRatio,
-	}
+func defaultZipLimits() resolvedZipLimits {
+	return normalizeZipLimits(resolvedZipLimits{
+		maxArchiveBytes:     MaxZipArchiveBytes,
+		maxCentralDirBytes:  MaxZipCentralDirectoryBytes,
+		maxEntries:          MaxZipEntries,
+		maxEntrySize:        MaxZipEntrySize,
+		maxTotalSize:        MaxZipTotalSize,
+		maxCompressionRatio: MaxZipCompressionRatio,
+	})
+}
+
+func normalizeZipLimits(limits resolvedZipLimits) resolvedZipLimits {
 	// A test hook must not make the production path accidentally unbounded.
 	// Falling back to defaults also keeps a zero value useful in tests.
+	if limits.maxArchiveBytes <= 0 {
+		limits.maxArchiveBytes = MaxZipArchiveBytes
+	}
+	if limits.maxCentralDirBytes <= 0 {
+		limits.maxCentralDirBytes = MaxZipCentralDirectoryBytes
+	}
 	if limits.maxEntries <= 0 {
 		limits.maxEntries = MaxZipEntries
 	}
@@ -87,6 +101,370 @@ func currentZipLimits() resolvedZipLimits {
 		limits.maxEntrySize = limits.maxTotalSize
 	}
 	return limits
+}
+
+// The override is used only by package tests. An atomic pointer keeps tests
+// that exercise concurrent readers race-free while production uses constants.
+var zipTestLimits atomic.Pointer[resolvedZipLimits]
+
+func currentZipLimits() resolvedZipLimits {
+	if limits := zipTestLimits.Load(); limits != nil {
+		return *limits
+	}
+	return defaultZipLimits()
+}
+
+func setZipTestLimits(limits resolvedZipLimits) {
+	limits = normalizeZipLimits(limits)
+	zipTestLimits.Store(&limits)
+}
+
+func clearZipTestLimits() {
+	zipTestLimits.Store(nil)
+}
+
+const (
+	zipDirectoryHeaderSignature = 0x02014b50
+	zipDirectoryEndSignature    = 0x06054b50
+	zipDirectory64EndSignature  = 0x06064b50
+	zipDirectory64LocSignature  = 0x07064b50
+	zipDirectoryHeaderLen       = 46
+	zipDirectoryEndLen          = 22
+	zipDirectory64EndLen        = 56
+	zipDirectory64LocLen        = 20
+	zipDirectorySearchWindow    = 65 << 10
+)
+
+type zipDirectoryInfo struct {
+	// endOffset is the absolute offset used by archive/zip to derive the
+	// archive base (classic EOCD or ZIP64 EOCD, respectively).
+	endOffset int64
+	// eocdOffset is always the absolute offset of the classic EOCD record.
+	eocdOffset int64
+	offset     uint64
+	size       uint64
+	entries    uint64
+}
+
+// preflightZipArchive bounds archive/zip's central-directory work before
+// zip.NewReader is allowed to allocate one File and its metadata per entry.
+func preflightZipArchive(reader io.ReaderAt, size int64) error {
+	return preflightZipArchiveWithLimits(reader, size, currentZipLimits())
+}
+
+func preflightZipArchiveWithLimits(reader io.ReaderAt, size int64, limits resolvedZipLimits) error {
+	if reader == nil {
+		return fmt.Errorf("%w: nil ZIP reader", ErrArchiveLimit)
+	}
+	limits = normalizeZipLimits(limits)
+	if size < 0 {
+		return fmt.Errorf("zip: negative archive size: %w", zip.ErrFormat)
+	}
+	if size > limits.maxArchiveBytes {
+		return fmt.Errorf("%w: archive size %d exceeds limit %d", ErrArchiveLimit, size, limits.maxArchiveBytes)
+	}
+
+	directory, err := readZipDirectoryInfo(reader, size, limits)
+	if err != nil {
+		return err
+	}
+	if directory.size > uint64(limits.maxCentralDirBytes) {
+		return fmt.Errorf("%w: central directory size %d exceeds limit %d", ErrArchiveLimit, directory.size, limits.maxCentralDirBytes)
+	}
+	if directory.size > uint64(size) || directory.offset > math.MaxInt64 {
+		return fmt.Errorf("zip: invalid central directory bounds: %w", zip.ErrFormat)
+	}
+	if directory.endOffset < 0 || directory.endOffset > size || directory.size > uint64(directory.endOffset) {
+		return fmt.Errorf("zip: invalid central directory offset: %w", zip.ErrFormat)
+	}
+
+	centralSize := int64(directory.size)
+	centralOffset := int64(directory.offset)
+	start := directory.endOffset - centralSize
+	if start < 0 || start > size {
+		return fmt.Errorf("zip: invalid central directory offset: %w", zip.ErrFormat)
+	}
+	baseOffset := start - centralOffset
+	// Match archive/zip's compatibility handling for archives whose directory
+	// offset is absolute despite a non-zero computed base offset. The header
+	// predicate mirrors archive/zip's parser so both readers select the same
+	// physical directory.
+	if baseOffset > 0 && completeZipDirectoryHeaderAt(reader, size, centralOffset) > 0 {
+		start = centralOffset
+	}
+	centralEnd := start + centralSize
+	if centralEnd < start || centralEnd > size || centralEnd > directory.endOffset {
+		return fmt.Errorf("zip: invalid central directory bounds: %w", zip.ErrFormat)
+	}
+	if err := scanZipCentralDirectory(reader, size, start, centralEnd, directory.entries, limits); err != nil {
+		return err
+	}
+	// archive/zip reads directory headers until the first invalid signature,
+	// even when a compatibility base offset makes the declared byte range end
+	// before the end record. Reject an immediately following header so it
+	// cannot make archive/zip allocate entries that the bounded scan missed.
+	if centralEnd < directory.endOffset && completeZipDirectoryHeaderAt(reader, size, centralEnd) > 0 {
+		return fmt.Errorf("zip: central directory extends beyond its declared size: %w", zip.ErrFormat)
+	}
+	return nil
+}
+
+func readZipDirectoryInfo(reader io.ReaderAt, size int64, limits resolvedZipLimits) (zipDirectoryInfo, error) {
+	if size < zipDirectoryEndLen {
+		return zipDirectoryInfo{}, fmt.Errorf("zip: archive too small: %w", zip.ErrFormat)
+	}
+	window := int64(zipDirectorySearchWindow)
+	if window > size {
+		window = size
+	}
+	buf := make([]byte, int(window))
+	if _, err := reader.ReadAt(buf, size-window); err != nil {
+		return zipDirectoryInfo{}, err
+	}
+
+	var endIndex = -1
+	for i := len(buf) - zipDirectoryEndLen; i >= 0; i-- {
+		if binary.LittleEndian.Uint32(buf[i:i+4]) != zipDirectoryEndSignature {
+			continue
+		}
+		commentLen := int(binary.LittleEndian.Uint16(buf[i+20 : i+22]))
+		absolute := size - window + int64(i)
+		commentEnd := absolute + zipDirectoryEndLen + int64(commentLen)
+		if commentEnd > size {
+			return zipDirectoryInfo{}, fmt.Errorf("zip: invalid comment length: %w", zip.ErrFormat)
+		}
+		// archive/zip selects this first non-truncated candidate. Reject the
+		// archive instead of searching for an earlier EOCD that would make the
+		// preflight and archive/zip inspect different central directories.
+		if commentEnd != size {
+			return zipDirectoryInfo{}, fmt.Errorf("zip: trailing data after end record: %w", zip.ErrFormat)
+		}
+		endIndex = i
+		break
+	}
+	if endIndex < 0 {
+		return zipDirectoryInfo{}, fmt.Errorf("zip: end of central directory not found: %w", zip.ErrFormat)
+	}
+
+	record := buf[endIndex : endIndex+zipDirectoryEndLen]
+	if binary.LittleEndian.Uint16(record[4:6]) != 0 || binary.LittleEndian.Uint16(record[6:8]) != 0 {
+		return zipDirectoryInfo{}, fmt.Errorf("zip: multi-disk archives are unsupported: %w", zip.ErrFormat)
+	}
+	entriesThisDisk := binary.LittleEndian.Uint16(record[8:10])
+	entries := binary.LittleEndian.Uint16(record[10:12])
+	directorySize := binary.LittleEndian.Uint32(record[12:16])
+	directoryOffset := binary.LittleEndian.Uint32(record[16:20])
+	needsZip64 := entriesThisDisk == math.MaxUint16 || entries == math.MaxUint16 ||
+		directorySize == math.MaxUint16 || directorySize == math.MaxUint32 ||
+		directoryOffset == math.MaxUint32
+	if !needsZip64 {
+		if entriesThisDisk != entries {
+			return zipDirectoryInfo{}, fmt.Errorf("zip: inconsistent central directory entry count: %w", zip.ErrFormat)
+		}
+		if int(entries) > limits.maxEntries {
+			return zipDirectoryInfo{}, fmt.Errorf("%w: %d entries exceeds limit %d", ErrArchiveLimit, entries, limits.maxEntries)
+		}
+	}
+
+	info := zipDirectoryInfo{
+		endOffset:  size - window + int64(endIndex),
+		eocdOffset: size - window + int64(endIndex),
+		offset:     uint64(directoryOffset),
+		size:       uint64(directorySize),
+		entries:    uint64(entries),
+	}
+	if !needsZip64 {
+		return info, nil
+	}
+	return readZip64DirectoryInfo(reader, size, info, limits)
+}
+
+func readZip64DirectoryInfo(reader io.ReaderAt, size int64, info zipDirectoryInfo, limits resolvedZipLimits) (zipDirectoryInfo, error) {
+	locatorOffset := info.eocdOffset - zipDirectory64LocLen
+	if locatorOffset < 0 || size < zipDirectory64EndLen {
+		return zipDirectoryInfo{}, fmt.Errorf("zip: ZIP64 locator missing: %w", zip.ErrFormat)
+	}
+	var locator [zipDirectory64LocLen]byte
+	if _, err := reader.ReadAt(locator[:], locatorOffset); err != nil {
+		return zipDirectoryInfo{}, err
+	}
+	if binary.LittleEndian.Uint32(locator[0:4]) != zipDirectory64LocSignature ||
+		binary.LittleEndian.Uint32(locator[4:8]) != 0 ||
+		binary.LittleEndian.Uint32(locator[16:20]) != 1 {
+		return zipDirectoryInfo{}, fmt.Errorf("zip: invalid ZIP64 locator: %w", zip.ErrFormat)
+	}
+	recordOffset64 := binary.LittleEndian.Uint64(locator[8:16])
+	recordOffset, record, ok := readZip64EndAt(reader, size, locatorOffset, recordOffset64)
+	if !ok {
+		return zipDirectoryInfo{}, fmt.Errorf("zip: invalid ZIP64 end record: %w", zip.ErrFormat)
+	}
+	if binary.LittleEndian.Uint32(record[16:20]) != 0 || binary.LittleEndian.Uint32(record[20:24]) != 0 {
+		return zipDirectoryInfo{}, fmt.Errorf("zip: multi-disk ZIP64 archives are unsupported: %w", zip.ErrFormat)
+	}
+	entriesThisDisk := binary.LittleEndian.Uint64(record[24:32])
+	entries := binary.LittleEndian.Uint64(record[32:40])
+	if entriesThisDisk != entries {
+		return zipDirectoryInfo{}, fmt.Errorf("zip: inconsistent ZIP64 entry count: %w", zip.ErrFormat)
+	}
+	if entries > uint64(limits.maxEntries) {
+		return zipDirectoryInfo{}, fmt.Errorf("%w: %d entries exceeds limit %d", ErrArchiveLimit, entries, limits.maxEntries)
+	}
+	info.endOffset = recordOffset
+	info.entries = entries
+	info.size = binary.LittleEndian.Uint64(record[40:48])
+	info.offset = binary.LittleEndian.Uint64(record[48:56])
+	return info, nil
+}
+
+func readZip64EndAt(reader io.ReaderAt, size, locatorOffset int64, offset uint64) (int64, [zipDirectory64EndLen]byte, bool) {
+	var record [zipDirectory64EndLen]byte
+	if offset > math.MaxInt64 {
+		return 0, record, false
+	}
+	recordOffset := int64(offset)
+	if recordOffset < 0 || recordOffset > size-zipDirectory64EndLen || recordOffset > locatorOffset-zipDirectory64EndLen {
+		return 0, record, false
+	}
+	if _, err := reader.ReadAt(record[:], recordOffset); err != nil {
+		return 0, record, false
+	}
+	if binary.LittleEndian.Uint32(record[0:4]) != zipDirectory64EndSignature {
+		return 0, record, false
+	}
+	recordSize := binary.LittleEndian.Uint64(record[4:12])
+	if recordSize < zipDirectory64EndLen-12 || recordSize > uint64(math.MaxInt64-12) {
+		return 0, record, false
+	}
+	recordTotal := int64(recordSize) + 12
+	if recordOffset > math.MaxInt64-recordTotal || recordOffset+recordTotal != locatorOffset || recordOffset+recordTotal > size {
+		return 0, record, false
+	}
+	return recordOffset, record, true
+}
+
+func completeZipDirectoryHeaderAt(reader io.ReaderAt, size, offset int64) int64 {
+	return completeZipDirectoryHeaderWithin(reader, size, offset, size)
+}
+
+func completeZipDirectoryHeaderWithin(reader io.ReaderAt, archiveSize, offset, end int64) int64 {
+	if offset < 0 || end < offset || end > archiveSize || offset > end-zipDirectoryHeaderLen {
+		return 0
+	}
+	var header [zipDirectoryHeaderLen]byte
+	if _, err := reader.ReadAt(header[:], offset); err != nil {
+		return 0
+	}
+	if binary.LittleEndian.Uint32(header[0:4]) != zipDirectoryHeaderSignature {
+		return 0
+	}
+	filenameLen := int64(binary.LittleEndian.Uint16(header[28:30]))
+	extraLen := int64(binary.LittleEndian.Uint16(header[30:32]))
+	commentLen := int64(binary.LittleEndian.Uint16(header[32:34]))
+	entryLen := int64(zipDirectoryHeaderLen) + filenameLen + extraLen + commentLen
+	if entryLen > end-offset {
+		return 0
+	}
+
+	needUncompressedSize := binary.LittleEndian.Uint32(header[24:28]) == math.MaxUint32
+	needCompressedSize := binary.LittleEndian.Uint32(header[20:24]) == math.MaxUint32
+	needHeaderOffset := binary.LittleEndian.Uint32(header[42:46]) == math.MaxUint32
+	if !needUncompressedSize && !needCompressedSize && !needHeaderOffset {
+		return entryLen
+	}
+	extra := make([]byte, int(extraLen))
+	if extraLen > 0 {
+		if _, err := reader.ReadAt(extra, offset+zipDirectoryHeaderLen+filenameLen); err != nil {
+			return 0
+		}
+	}
+	for len(extra) >= 4 {
+		tag := binary.LittleEndian.Uint16(extra[0:2])
+		fieldLen := int(binary.LittleEndian.Uint16(extra[2:4]))
+		extra = extra[4:]
+		if len(extra) < fieldLen {
+			break
+		}
+		field := extra[:fieldLen]
+		extra = extra[fieldLen:]
+		if tag != 0x0001 {
+			continue
+		}
+		if needUncompressedSize {
+			if len(field) < 8 {
+				return 0
+			}
+			field = field[8:]
+			needUncompressedSize = false
+		}
+		if needCompressedSize {
+			if len(field) < 8 {
+				return 0
+			}
+			field = field[8:]
+			needCompressedSize = false
+		}
+		if needHeaderOffset {
+			if len(field) < 8 {
+				return 0
+			}
+			needHeaderOffset = false
+		}
+	}
+	// archive/zip tolerates a missing ZIP64 uncompressed size for historical
+	// compatibility, but requires compressed size and local-header offset.
+	if needCompressedSize || needHeaderOffset {
+		return 0
+	}
+	return entryLen
+}
+
+func scanZipCentralDirectory(reader io.ReaderAt, size, start, end int64, declaredEntries uint64, limits resolvedZipLimits) error {
+	if start < 0 || end < start || end > size {
+		return fmt.Errorf("zip: invalid central directory bounds: %w", zip.ErrFormat)
+	}
+	offset := start
+	var metadataBytes int64
+	var entries uint64
+	for offset < end {
+		entryLen := completeZipDirectoryHeaderWithin(reader, size, offset, end)
+		if entryLen == 0 {
+			return fmt.Errorf("zip: invalid central directory entry: %w", zip.ErrFormat)
+		}
+		if entryLen > limits.maxCentralDirBytes-metadataBytes {
+			return fmt.Errorf("%w: central directory metadata exceeds limit %d", ErrArchiveLimit, limits.maxCentralDirBytes)
+		}
+		metadataBytes += entryLen
+		entries++
+		if entries > uint64(limits.maxEntries) {
+			return fmt.Errorf("%w: central directory contains more than %d entries", ErrArchiveLimit, limits.maxEntries)
+		}
+		offset += entryLen
+	}
+	if offset != end {
+		return fmt.Errorf("zip: central directory scan did not reach its declared end: %w", zip.ErrFormat)
+	}
+	if entries != declaredEntries {
+		return fmt.Errorf("zip: central directory declares %d entries but contains %d: %w", declaredEntries, entries, zip.ErrFormat)
+	}
+	return nil
+}
+
+func readZipArchiveBody(reader io.Reader, contentLength int64) ([]byte, error) {
+	if reader == nil {
+		return nil, fmt.Errorf("zip: HTTP response has no body")
+	}
+	limit := currentZipLimits().maxArchiveBytes
+	if contentLength > limit {
+		return nil, fmt.Errorf("%w: response length %d exceeds limit %d", ErrArchiveLimit, contentLength, limit)
+	}
+	body, err := io.ReadAll(io.LimitReader(reader, zipLimitWithSentinel(limit)))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(body)) > limit {
+		return nil, fmt.Errorf("%w: response exceeds limit %d", ErrArchiveLimit, limit)
+	}
+	return body, nil
 }
 
 // validateZipReader checks central-directory declarations before an archive

--- a/fs/zip/limits.go
+++ b/fs/zip/limits.go
@@ -254,18 +254,6 @@ func readZipDirectoryInfo(reader io.ReaderAt, size int64, limits resolvedZipLimi
 	entries := binary.LittleEndian.Uint16(record[10:12])
 	directorySize := binary.LittleEndian.Uint32(record[12:16])
 	directoryOffset := binary.LittleEndian.Uint32(record[16:20])
-	needsZip64 := entriesThisDisk == math.MaxUint16 || entries == math.MaxUint16 ||
-		directorySize == math.MaxUint16 || directorySize == math.MaxUint32 ||
-		directoryOffset == math.MaxUint32
-	if !needsZip64 {
-		if entriesThisDisk != entries {
-			return zipDirectoryInfo{}, fmt.Errorf("zip: inconsistent central directory entry count: %w", zip.ErrFormat)
-		}
-		if int(entries) > limits.maxEntries {
-			return zipDirectoryInfo{}, fmt.Errorf("%w: %d entries exceeds limit %d", ErrArchiveLimit, entries, limits.maxEntries)
-		}
-	}
-
 	info := zipDirectoryInfo{
 		endOffset:  size - window + int64(endIndex),
 		eocdOffset: size - window + int64(endIndex),
@@ -273,47 +261,64 @@ func readZipDirectoryInfo(reader io.ReaderAt, size int64, limits resolvedZipLimi
 		size:       uint64(directorySize),
 		entries:    uint64(entries),
 	}
-	if !needsZip64 {
-		return info, nil
+	// archive/zip treats these boundary values as a ZIP64 probe, then falls
+	// back to the classic EOCD values when no locator is present. In
+	// particular, 0xffff is a valid value for the 32-bit directory-size field.
+	mayHaveZip64 := entries == math.MaxUint16 || directorySize == math.MaxUint16 ||
+		directorySize == math.MaxUint32 || directoryOffset == math.MaxUint32
+	if mayHaveZip64 {
+		zip64Info, found, err := readZip64DirectoryInfo(reader, size, info, limits)
+		if err != nil {
+			return zipDirectoryInfo{}, err
+		}
+		if found {
+			return zip64Info, nil
+		}
 	}
-	return readZip64DirectoryInfo(reader, size, info, limits)
+	if entriesThisDisk != entries {
+		return zipDirectoryInfo{}, fmt.Errorf("zip: inconsistent central directory entry count: %w", zip.ErrFormat)
+	}
+	if int(entries) > limits.maxEntries {
+		return zipDirectoryInfo{}, fmt.Errorf("%w: %d entries exceeds limit %d", ErrArchiveLimit, entries, limits.maxEntries)
+	}
+	return info, nil
 }
 
-func readZip64DirectoryInfo(reader io.ReaderAt, size int64, info zipDirectoryInfo, limits resolvedZipLimits) (zipDirectoryInfo, error) {
+func readZip64DirectoryInfo(reader io.ReaderAt, size int64, info zipDirectoryInfo, limits resolvedZipLimits) (zipDirectoryInfo, bool, error) {
 	locatorOffset := info.eocdOffset - zipDirectory64LocLen
 	if locatorOffset < 0 || size < zipDirectory64EndLen {
-		return zipDirectoryInfo{}, fmt.Errorf("zip: ZIP64 locator missing: %w", zip.ErrFormat)
+		return zipDirectoryInfo{}, false, nil
 	}
 	var locator [zipDirectory64LocLen]byte
 	if _, err := reader.ReadAt(locator[:], locatorOffset); err != nil {
-		return zipDirectoryInfo{}, err
+		return zipDirectoryInfo{}, false, err
 	}
 	if binary.LittleEndian.Uint32(locator[0:4]) != zipDirectory64LocSignature ||
 		binary.LittleEndian.Uint32(locator[4:8]) != 0 ||
 		binary.LittleEndian.Uint32(locator[16:20]) != 1 {
-		return zipDirectoryInfo{}, fmt.Errorf("zip: invalid ZIP64 locator: %w", zip.ErrFormat)
+		return zipDirectoryInfo{}, false, nil
 	}
 	recordOffset64 := binary.LittleEndian.Uint64(locator[8:16])
 	recordOffset, record, ok := readZip64EndAt(reader, size, locatorOffset, recordOffset64)
 	if !ok {
-		return zipDirectoryInfo{}, fmt.Errorf("zip: invalid ZIP64 end record: %w", zip.ErrFormat)
+		return zipDirectoryInfo{}, true, fmt.Errorf("zip: invalid ZIP64 end record: %w", zip.ErrFormat)
 	}
 	if binary.LittleEndian.Uint32(record[16:20]) != 0 || binary.LittleEndian.Uint32(record[20:24]) != 0 {
-		return zipDirectoryInfo{}, fmt.Errorf("zip: multi-disk ZIP64 archives are unsupported: %w", zip.ErrFormat)
+		return zipDirectoryInfo{}, true, fmt.Errorf("zip: multi-disk ZIP64 archives are unsupported: %w", zip.ErrFormat)
 	}
 	entriesThisDisk := binary.LittleEndian.Uint64(record[24:32])
 	entries := binary.LittleEndian.Uint64(record[32:40])
 	if entriesThisDisk != entries {
-		return zipDirectoryInfo{}, fmt.Errorf("zip: inconsistent ZIP64 entry count: %w", zip.ErrFormat)
+		return zipDirectoryInfo{}, true, fmt.Errorf("zip: inconsistent ZIP64 entry count: %w", zip.ErrFormat)
 	}
 	if entries > uint64(limits.maxEntries) {
-		return zipDirectoryInfo{}, fmt.Errorf("%w: %d entries exceeds limit %d", ErrArchiveLimit, entries, limits.maxEntries)
+		return zipDirectoryInfo{}, true, fmt.Errorf("%w: %d entries exceeds limit %d", ErrArchiveLimit, entries, limits.maxEntries)
 	}
 	info.endOffset = recordOffset
 	info.entries = entries
 	info.size = binary.LittleEndian.Uint64(record[40:48])
 	info.offset = binary.LittleEndian.Uint64(record[48:56])
-	return info, nil
+	return info, true, nil
 }
 
 func readZip64EndAt(reader io.ReaderAt, size, locatorOffset int64, offset uint64) (int64, [zipDirectory64EndLen]byte, bool) {

--- a/fs/zip/limits.go
+++ b/fs/zip/limits.go
@@ -1,0 +1,228 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zip
+
+import (
+	"archive/zip"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"strings"
+)
+
+// The limits protect callers that open ZIPs supplied by projects or remote
+// servers. They bound both metadata processing and the amount of data a
+// successful entry read can produce.
+const (
+	// MaxZipEntries is the maximum number of central-directory entries.
+	MaxZipEntries = 10_000
+	// MaxZipEntrySize is the maximum uncompressed size of one regular entry.
+	MaxZipEntrySize int64 = 512 << 20
+	// MaxZipTotalSize is the maximum sum of uncompressed regular entries.
+	MaxZipTotalSize int64 = 4 << 30
+	// MaxZipCompressionRatio is the maximum declared uncompressed/compressed
+	// ratio for a non-empty regular entry.
+	MaxZipCompressionRatio uint64 = 200
+)
+
+var (
+	// ErrArchiveLimit identifies an archive rejected because it could require
+	// excessive metadata, decompression, or CPU work.
+	ErrArchiveLimit = errors.New("zip: archive limit exceeded")
+	// ErrZipArchiveLimit is an explicit package-qualified alias for callers
+	// that want to distinguish this limit from other ZIP errors.
+	ErrZipArchiveLimit = ErrArchiveLimit
+	// These package variables are intentionally unexported so production code
+	// cannot change process-wide limits. Tests use them to exercise boundaries.
+	zipMaxEntries          = MaxZipEntries
+	zipMaxEntrySize        = MaxZipEntrySize
+	zipMaxTotalSize        = MaxZipTotalSize
+	zipMaxCompressionRatio = MaxZipCompressionRatio
+)
+
+type resolvedZipLimits struct {
+	maxEntries          int
+	maxEntrySize        int64
+	maxTotalSize        int64
+	maxCompressionRatio uint64
+}
+
+func currentZipLimits() resolvedZipLimits {
+	limits := resolvedZipLimits{
+		maxEntries:          zipMaxEntries,
+		maxEntrySize:        zipMaxEntrySize,
+		maxTotalSize:        zipMaxTotalSize,
+		maxCompressionRatio: zipMaxCompressionRatio,
+	}
+	// A test hook must not make the production path accidentally unbounded.
+	// Falling back to defaults also keeps a zero value useful in tests.
+	if limits.maxEntries <= 0 {
+		limits.maxEntries = MaxZipEntries
+	}
+	if limits.maxEntrySize <= 0 {
+		limits.maxEntrySize = MaxZipEntrySize
+	}
+	if limits.maxTotalSize <= 0 {
+		limits.maxTotalSize = MaxZipTotalSize
+	}
+	if limits.maxCompressionRatio == 0 {
+		limits.maxCompressionRatio = MaxZipCompressionRatio
+	}
+	if limits.maxEntrySize > limits.maxTotalSize {
+		limits.maxEntrySize = limits.maxTotalSize
+	}
+	return limits
+}
+
+// validateZipReader checks central-directory declarations before an archive
+// is returned to a caller. archive/zip intentionally leaves expansion limits
+// to its users, so UncompressedSize64 and the compression ratio must be
+// checked here.
+func validateZipReader(reader *zip.Reader) error {
+	if reader == nil {
+		return fmt.Errorf("%w: nil ZIP reader", ErrArchiveLimit)
+	}
+	limits := currentZipLimits()
+	if len(reader.File) > limits.maxEntries {
+		return fmt.Errorf("%w: %d entries exceeds limit %d", ErrArchiveLimit, len(reader.File), limits.maxEntries)
+	}
+
+	var total uint64
+	for _, file := range reader.File {
+		if err := validateZipFile(file, limits); err != nil {
+			return err
+		}
+		if file == nil || isZipDirectory(file) {
+			continue
+		}
+		size := file.UncompressedSize64
+		if size > uint64(limits.maxTotalSize) || total > uint64(limits.maxTotalSize)-size {
+			return fmt.Errorf("%w: total uncompressed size exceeds limit %d", ErrArchiveLimit, limits.maxTotalSize)
+		}
+		total += size
+	}
+	return nil
+}
+
+func validateZipFile(file *zip.File, limits resolvedZipLimits) error {
+	if file == nil {
+		return fmt.Errorf("%w: nil ZIP entry", ErrArchiveLimit)
+	}
+	if isZipDirectory(file) {
+		// A directory has no logical payload. archive/zip permits a non-zero
+		// compressed size for some producer quirks, so do not apply a ratio to
+		// that storage data. A non-zero uncompressed declaration is still
+		// rejected because it would bypass the archive's total-size accounting.
+		if file.UncompressedSize64 != 0 {
+			return fmt.Errorf("%w: directory entry %q has non-zero uncompressed size %d", ErrArchiveLimit, file.Name, file.UncompressedSize64)
+		}
+		return nil
+	}
+	uncompressed := file.UncompressedSize64
+	if uncompressed > uint64(limits.maxEntrySize) {
+		return fmt.Errorf("%w: entry %q uncompressed size %d exceeds limit %d", ErrArchiveLimit, file.Name, uncompressed, limits.maxEntrySize)
+	}
+	if err := checkZipCompressionRatio(file, limits.maxCompressionRatio); err != nil {
+		return err
+	}
+	return nil
+}
+
+func isZipDirectory(file *zip.File) bool {
+	return file != nil && strings.HasSuffix(file.Name, "/")
+}
+
+func checkZipCompressionRatio(file *zip.File, maxRatio uint64) error {
+	if file == nil || file.UncompressedSize64 == 0 {
+		return nil
+	}
+	compressed := file.CompressedSize64
+	if compressed == 0 || maxRatio == 0 || compressed > math.MaxUint64/maxRatio || file.UncompressedSize64 > compressed*maxRatio {
+		name := "<unknown>"
+		if file != nil {
+			name = file.Name
+		}
+		return fmt.Errorf("%w: entry %q compression ratio exceeds %d:1", ErrArchiveLimit, name, maxRatio)
+	}
+	return nil
+}
+
+// openZipEntry validates a single entry again at read time and caps the
+// decompressor's output with a one-byte sentinel. The sentinel ensures an
+// entry whose header understates its output cannot silently terminate at the
+// configured limit without letting archive/zip verify its checksum.
+func openZipEntry(file *zip.File) (io.ReadCloser, error) {
+	limits := currentZipLimits()
+	if err := validateZipFile(file, limits); err != nil {
+		return nil, err
+	}
+	reader, err := file.Open()
+	if err != nil {
+		return nil, err
+	}
+	return &zipLimitedReadCloser{
+		ReadCloser: reader,
+		remaining:  zipLimitWithSentinel(limits.maxEntrySize),
+		max:        limits.maxEntrySize,
+		name:       file.Name,
+	}, nil
+}
+
+func zipLimitWithSentinel(max int64) int64 {
+	if max >= math.MaxInt64 {
+		return math.MaxInt64
+	}
+	return max + 1
+}
+
+type zipLimitedReadCloser struct {
+	io.ReadCloser
+	remaining int64
+	max       int64
+	read      int64
+	name      string
+	limitErr  error
+}
+
+func (r *zipLimitedReadCloser) Read(p []byte) (int, error) {
+	if r.limitErr != nil {
+		return 0, r.limitErr
+	}
+	if r.remaining == 0 {
+		r.limitErr = fmt.Errorf("%w: entry %q uncompressed output exceeds limit %d", ErrArchiveLimit, r.name, r.max)
+		return 0, r.limitErr
+	}
+	if int64(len(p)) > r.remaining {
+		p = p[:r.remaining]
+	}
+	n, err := r.ReadCloser.Read(p)
+	if n < 0 || n > len(p) {
+		r.limitErr = fmt.Errorf("%w: entry %q returned invalid read count %d", ErrArchiveLimit, r.name, n)
+		return 0, r.limitErr
+	}
+	allowed := r.max - r.read
+	r.remaining -= int64(n)
+	r.read += int64(n)
+	if int64(n) > allowed {
+		r.limitErr = fmt.Errorf("%w: entry %q uncompressed output exceeds limit %d", ErrArchiveLimit, r.name, r.max)
+		// The extra byte was consumed only as a sentinel. Do not expose it to
+		// callers, even though the underlying reader returned it in p.
+		return int(allowed), r.limitErr
+	}
+	return n, err
+}

--- a/fs/zip/limits_test.go
+++ b/fs/zip/limits_test.go
@@ -1,0 +1,214 @@
+//go:build !js
+
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zip
+
+import (
+	archivezip "archive/zip"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+type limitZipEntry struct {
+	name   string
+	data   string
+	method uint16
+}
+
+func TestOpenRejectsTooManyZipEntries(t *testing.T) {
+	path := makeLimitZip(t, limitZipEntry{name: "one", data: "1", method: archivezip.Store}, limitZipEntry{name: "two", data: "2", method: archivezip.Store})
+	old := zipMaxEntries
+	zipMaxEntries = 1
+	t.Cleanup(func() { zipMaxEntries = old })
+
+	_, err := Open(path)
+	if !errors.Is(err, ErrArchiveLimit) {
+		t.Fatalf("Open error = %v, want ErrArchiveLimit", err)
+	}
+}
+
+func TestOpenRejectsOversizedZipEntry(t *testing.T) {
+	path := makeLimitZip(t, limitZipEntry{name: "large", data: "12345", method: archivezip.Store})
+	oldSize := zipMaxEntrySize
+	zipMaxEntrySize = 4
+	t.Cleanup(func() { zipMaxEntrySize = oldSize })
+
+	_, err := Open(path)
+	if !errors.Is(err, ErrArchiveLimit) {
+		t.Fatalf("Open error = %v, want ErrArchiveLimit", err)
+	}
+	if !strings.Contains(err.Error(), "large") {
+		t.Fatalf("Open error = %v, want entry name", err)
+	}
+}
+
+func TestOpenRejectsExcessiveTotalZipSize(t *testing.T) {
+	path := makeLimitZip(t,
+		limitZipEntry{name: "one", data: "123", method: archivezip.Store},
+		limitZipEntry{name: "two", data: "456", method: archivezip.Store},
+	)
+	oldTotal := zipMaxTotalSize
+	zipMaxTotalSize = 5
+	t.Cleanup(func() { zipMaxTotalSize = oldTotal })
+
+	_, err := Open(path)
+	if !errors.Is(err, ErrArchiveLimit) {
+		t.Fatalf("Open error = %v, want ErrArchiveLimit", err)
+	}
+	if !strings.Contains(err.Error(), "total") {
+		t.Fatalf("Open error = %v, want total-size detail", err)
+	}
+}
+
+func TestOpenRejectsExcessiveZipCompressionRatio(t *testing.T) {
+	path := makeLimitZip(t, limitZipEntry{
+		name:   "repetitive",
+		data:   strings.Repeat("a", 4096),
+		method: archivezip.Deflate,
+	})
+	oldRatio := zipMaxCompressionRatio
+	zipMaxCompressionRatio = 2
+	t.Cleanup(func() { zipMaxCompressionRatio = oldRatio })
+
+	_, err := Open(path)
+	if !errors.Is(err, ErrArchiveLimit) {
+		t.Fatalf("Open error = %v, want ErrArchiveLimit", err)
+	}
+	if !strings.Contains(err.Error(), "compression ratio") {
+		t.Fatalf("Open error = %v, want compression-ratio detail", err)
+	}
+}
+
+func TestOpenRejectsNonEmptyDirectoryDeclaration(t *testing.T) {
+	path := makeLimitZip(t, limitZipEntry{name: "dir/", data: "", method: archivezip.Store})
+	reader, err := archivezip.OpenReader(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reader.Close()
+	reader.File[0].UncompressedSize64 = 1
+	// The changed declaration models a malformed central-directory entry.
+	if err := validateZipReader(&reader.Reader); !errors.Is(err, ErrArchiveLimit) {
+		t.Fatalf("validateZipReader error = %v, want ErrArchiveLimit", err)
+	}
+}
+
+func TestOpenAndReadZipAtLimits(t *testing.T) {
+	path := makeLimitZip(t, limitZipEntry{name: "exact", data: "1234", method: archivezip.Store})
+	oldSize, oldTotal, oldRatio := zipMaxEntrySize, zipMaxTotalSize, zipMaxCompressionRatio
+	zipMaxEntrySize = 4
+	zipMaxTotalSize = 4
+	zipMaxCompressionRatio = 1
+	t.Cleanup(func() {
+		zipMaxEntrySize, zipMaxTotalSize, zipMaxCompressionRatio = oldSize, oldTotal, oldRatio
+	})
+
+	dir, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dir.Close()
+	file, err := dir.Open("exact")
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := io.ReadAll(file)
+	closeErr := file.Close()
+	if err != nil || closeErr != nil {
+		t.Fatalf("read exact entry: data=%q err=%v close=%v", data, err, closeErr)
+	}
+	if string(data) != "1234" {
+		t.Fatalf("entry = %q, want 1234", data)
+	}
+}
+
+func TestOpenReadRejectsEntryThatGrowsPastLimit(t *testing.T) {
+	path := makeLimitZip(t, limitZipEntry{name: "grow", data: "123456", method: archivezip.Store})
+	reader, err := archivezip.OpenReader(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reader.Close()
+	// Mutating the exported header simulates an archive whose declaration was
+	// tampered with after parsing. The wrapper must still fail closed.
+	reader.File[0].UncompressedSize64 = 4
+	oldSize := zipMaxEntrySize
+	zipMaxEntrySize = 4
+	t.Cleanup(func() { zipMaxEntrySize = oldSize })
+	zipFS := (*FS)(reader)
+	entry, err := zipFS.Open("grow")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, readErr := io.ReadAll(entry)
+	_ = entry.Close()
+	if readErr == nil {
+		t.Fatal("reading tampered entry succeeded, want error")
+	}
+}
+
+func TestZipLimitedReaderDoesNotExposeSentinelByte(t *testing.T) {
+	reader := &zipLimitedReadCloser{
+		ReadCloser: io.NopCloser(strings.NewReader("12345")),
+		remaining:  5,
+		max:        4,
+		name:       "sentinel",
+	}
+	data, err := io.ReadAll(reader)
+	_ = reader.Close()
+	if !errors.Is(err, ErrArchiveLimit) {
+		t.Fatalf("ReadAll error = %v, want ErrArchiveLimit", err)
+	}
+	if string(data) != "1234" {
+		t.Fatalf("ReadAll data = %q, want 1234", data)
+	}
+}
+
+func makeLimitZip(t *testing.T, entries ...limitZipEntry) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "archive.zip")
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writer := archivezip.NewWriter(file)
+	for _, item := range entries {
+		header := &archivezip.FileHeader{Name: item.name, Method: item.method}
+		entry, err := writer.CreateHeader(header)
+		if err != nil {
+			file.Close()
+			t.Fatal(err)
+		}
+		if _, err := io.WriteString(entry, item.data); err != nil {
+			file.Close()
+			t.Fatal(err)
+		}
+	}
+	if err := writer.Close(); err != nil {
+		file.Close()
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}

--- a/fs/zip/limits_test.go
+++ b/fs/zip/limits_test.go
@@ -92,6 +92,17 @@ func TestOpenRejectsExcessiveTotalZipSize(t *testing.T) {
 	}
 }
 
+func TestValidateRejectsRepeatedCompressedWork(t *testing.T) {
+	useZipTestLimits(t, func(limits *resolvedZipLimits) { limits.maxArchiveBytes = 7 })
+	reader := &archivezip.Reader{File: []*archivezip.File{
+		{FileHeader: archivezip.FileHeader{Name: "one", CompressedSize64: 4}},
+		{FileHeader: archivezip.FileHeader{Name: "two", CompressedSize64: 4}},
+	}}
+	if err := validateZipReader(reader); !errors.Is(err, ErrArchiveLimit) {
+		t.Fatalf("validateZipReader error = %v, want ErrArchiveLimit", err)
+	}
+}
+
 func TestOpenRejectsExcessiveZipCompressionRatio(t *testing.T) {
 	path := makeLimitZip(t, limitZipEntry{
 		name:   "repetitive",
@@ -123,6 +134,62 @@ func TestOpenRejectsNonEmptyDirectoryDeclaration(t *testing.T) {
 	}
 }
 
+func TestOpenRejectsAmbiguousZipPaths(t *testing.T) {
+	tests := []struct {
+		name    string
+		entries []limitZipEntry
+	}{
+		{"duplicate", []limitZipEntry{{name: "a"}, {name: "a"}}},
+		{"duplicate directory", []limitZipEntry{{name: "a/"}, {name: "a/"}}},
+		{"file then directory", []limitZipEntry{{name: "a"}, {name: "a/"}}},
+		{"directory then file", []limitZipEntry{{name: "a/"}, {name: "a"}}},
+		{"file before child", []limitZipEntry{{name: "a"}, {name: "a-b"}, {name: "a/b"}}},
+		{"file after child", []limitZipEntry{{name: "a/b/c"}, {name: "a/b"}}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := Open(makeLimitZip(t, test.entries...))
+			if !errors.Is(err, archivezip.ErrFormat) {
+				t.Fatalf("Open error = %v, want archive/zip format error", err)
+			}
+		})
+	}
+}
+
+func TestOpenRejectsInvalidZipPaths(t *testing.T) {
+	for _, name := range []string{"", "/a", `a\b`, "a//b", "a/./b", "a/../b", "../a", "C:/a", ".", "a//"} {
+		t.Run(name, func(t *testing.T) {
+			_, err := Open(makeLimitZip(t, limitZipEntry{name: name}))
+			if !errors.Is(err, archivezip.ErrFormat) && !errors.Is(err, archivezip.ErrInsecurePath) {
+				t.Fatalf("Open error = %v, want invalid path error", err)
+			}
+		})
+	}
+}
+
+func TestOpenAcceptsUnambiguousZipPaths(t *testing.T) {
+	tests := []struct {
+		name    string
+		entries []limitZipEntry
+	}{
+		{"directory before child", []limitZipEntry{{name: "a/"}, {name: "a/b", data: "b"}}},
+		{"directory after child", []limitZipEntry{{name: "a/b", data: "b"}, {name: "a/"}}},
+		{"adjacent prefix", []limitZipEntry{{name: "a"}, {name: "ab/c"}}},
+		{"deep path", []limitZipEntry{{name: strings.Repeat("a/", 32_000) + "z"}}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dir, err := Open(makeLimitZip(t, test.entries...))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := dir.Close(); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
 func TestOpenAndReadZipAtLimits(t *testing.T) {
 	path := makeLimitZip(t, limitZipEntry{name: "exact", data: "1234", method: archivezip.Store})
 	useZipTestLimits(t, func(limits *resolvedZipLimits) {
@@ -150,7 +217,7 @@ func TestOpenAndReadZipAtLimits(t *testing.T) {
 	}
 }
 
-func TestOpenReadRejectsEntryThatGrowsPastLimit(t *testing.T) {
+func TestOpenReadRejectsEntryThatExceedsDeclaration(t *testing.T) {
 	path := makeLimitZip(t, limitZipEntry{name: "grow", data: "123456", method: archivezip.Store})
 	reader, err := archivezip.OpenReader(path)
 	if err != nil {
@@ -160,16 +227,19 @@ func TestOpenReadRejectsEntryThatGrowsPastLimit(t *testing.T) {
 	// Mutating the exported header simulates an archive whose declaration was
 	// tampered with after parsing. The wrapper must still fail closed.
 	reader.File[0].UncompressedSize64 = 4
-	useZipTestLimits(t, func(limits *resolvedZipLimits) { limits.maxEntrySize = 4 })
+	useZipTestLimits(t, func(limits *resolvedZipLimits) { limits.maxEntrySize = 10 })
 	zipFS := &FS{Reader: &reader.Reader}
 	entry, err := zipFS.Open("grow")
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, readErr := io.ReadAll(entry)
+	data, readErr := io.ReadAll(entry)
 	_ = entry.Close()
 	if readErr == nil {
-		t.Fatal("reading tampered entry succeeded, want error")
+		t.Fatal("reading tampered entry succeeded")
+	}
+	if len(data) > 4 {
+		t.Fatalf("read %d bytes, want at most declared size", len(data))
 	}
 }
 
@@ -224,7 +294,7 @@ func TestPreflightAcceptsZip64OffsetsWithSmallEntryCount(t *testing.T) {
 	}
 }
 
-func TestPreflightAcceptsZip64DirectorySizeSentinel(t *testing.T) {
+func TestPreflightRejectsAmbiguousZip64DirectorySize(t *testing.T) {
 	data := makeLimitZip64Offsets(t, makeLimitZipBytes(t, limitZipEntry{name: "one", data: "1", method: archivezip.Store}))
 	eocd := findLimitZipEnd(t, data)
 	locator := eocd - zipDirectory64LocLen
@@ -236,11 +306,21 @@ func TestPreflightAcceptsZip64DirectorySizeSentinel(t *testing.T) {
 	binary.LittleEndian.PutUint32(data[eocd+12:eocd+16], math.MaxUint16)
 	binary.LittleEndian.PutUint32(data[eocd+16:eocd+20], uint32(centralOffset))
 
+	if err := preflightZipArchive(bytes.NewReader(data), int64(len(data))); !errors.Is(err, archivezip.ErrFormat) {
+		t.Fatalf("ambiguous directory-size error = %v, want archive/zip format error", err)
+	}
+}
+
+func TestPreflightAcceptsStandardZip64WithFFFFDirectorySize(t *testing.T) {
+	data := makeLimitZip64Offsets(t, makeLimitZipBytes(t, limitZipEntry{name: "one", data: "1", method: archivezip.Store}))
+	eocd := findLimitZipEnd(t, data)
+	binary.LittleEndian.PutUint32(data[eocd+12:eocd+16], math.MaxUint16)
+
 	if err := preflightZipArchive(bytes.NewReader(data), int64(len(data))); err != nil {
-		t.Fatalf("ZIP64 directory-size sentinel rejected: %v", err)
+		t.Fatalf("standard ZIP64 probe rejected: %v", err)
 	}
 	if _, err := archivezip.NewReader(bytes.NewReader(data), int64(len(data))); err != nil {
-		t.Fatalf("archive/zip rejected ZIP64 directory-size sentinel: %v", err)
+		t.Fatalf("archive/zip rejected standard ZIP64 probe: %v", err)
 	}
 }
 
@@ -273,17 +353,6 @@ func TestPreflightAcceptsClassicDirectorySizeFFFF(t *testing.T) {
 	}
 	if _, err := archivezip.NewReader(bytes.NewReader(data), int64(len(data))); err != nil {
 		t.Fatalf("archive/zip rejected classic directory size 0xffff: %v", err)
-	}
-}
-
-func TestReadZipArchiveBodyRejectsOversize(t *testing.T) {
-	useZipTestLimits(t, func(limits *resolvedZipLimits) { limits.maxArchiveBytes = 4 })
-
-	if _, err := readZipArchiveBody(strings.NewReader("12345"), -1); !errors.Is(err, ErrArchiveLimit) {
-		t.Fatalf("streamed body error = %v, want ErrArchiveLimit", err)
-	}
-	if _, err := readZipArchiveBody(strings.NewReader(""), 5); !errors.Is(err, ErrArchiveLimit) {
-		t.Fatalf("declared body error = %v, want ErrArchiveLimit", err)
 	}
 }
 
@@ -382,7 +451,7 @@ func TestPreflightRejectsGapBeforeZip64Locator(t *testing.T) {
 	}
 }
 
-func TestPreflightMatchesArchiveZipBaseOffsetProbe(t *testing.T) {
+func TestPreflightRejectsAmbiguousBaseOffset(t *testing.T) {
 	data := makeLimitZipBytes(t,
 		limitZipEntry{name: "one", data: "1", method: archivezip.Store},
 		limitZipEntry{name: "two", data: "2", method: archivezip.Store},
@@ -400,13 +469,8 @@ func TestPreflightMatchesArchiveZipBaseOffsetProbe(t *testing.T) {
 	end = findLimitZipEnd(t, data)
 	binary.LittleEndian.PutUint16(data[end+8:end+10], 1)
 	binary.LittleEndian.PutUint16(data[end+10:end+12], 1)
-	useZipTestLimits(t, func(limits *resolvedZipLimits) { limits.maxEntries = 2 })
-
-	if completeZipDirectoryHeaderAt(bytes.NewReader(data), int64(len(data)), int64(centralOffset)) != 0 {
-		t.Fatal("invalid ZIP64 decoy accepted as a complete directory header")
-	}
-	if err := preflightZipArchive(bytes.NewReader(data), int64(len(data))); !errors.Is(err, ErrArchiveLimit) {
-		t.Fatalf("base-offset decoy error = %v, want ErrArchiveLimit", err)
+	if err := preflightZipArchive(bytes.NewReader(data), int64(len(data))); !errors.Is(err, archivezip.ErrFormat) {
+		t.Fatalf("base-offset decoy error = %v, want archive/zip format error", err)
 	}
 }
 
@@ -437,7 +501,7 @@ func TestScanCentralDirectoryHonorsDeclaredEnd(t *testing.T) {
 	centralOffset := int(binary.LittleEndian.Uint32(data[end+16 : end+20]))
 	centralSize := int(binary.LittleEndian.Uint32(data[end+12 : end+16]))
 	central := data[centralOffset : centralOffset+centralSize]
-	firstLen := completeZipDirectoryHeaderAt(bytes.NewReader(central), int64(len(central)), 0)
+	firstLen := zipDirectoryEntryLen(bytes.NewReader(central), int64(len(central)), 0, int64(len(central)))
 	if firstLen == 0 {
 		t.Fatal("first central-directory header missing")
 	}

--- a/fs/zip/limits_test.go
+++ b/fs/zip/limits_test.go
@@ -244,6 +244,38 @@ func TestPreflightAcceptsZip64DirectorySizeSentinel(t *testing.T) {
 	}
 }
 
+func TestPreflightAcceptsClassicDirectorySizeFFFF(t *testing.T) {
+	var output bytes.Buffer
+	writer := archivezip.NewWriter(&output)
+	header := &archivezip.FileHeader{
+		Name:    "x",
+		Method:  archivezip.Store,
+		Comment: strings.Repeat("c", math.MaxUint16-zipDirectoryHeaderLen-len("x")),
+	}
+	entry, err := writer.CreateHeader(header)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := entry.Write([]byte("x")); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	data := output.Bytes()
+	end := findLimitZipEnd(t, data)
+	if got := binary.LittleEndian.Uint32(data[end+12 : end+16]); got != math.MaxUint16 {
+		t.Fatalf("central directory size = %d, want %d", got, uint32(math.MaxUint16))
+	}
+
+	if err := preflightZipArchive(bytes.NewReader(data), int64(len(data))); err != nil {
+		t.Fatalf("classic directory size 0xffff rejected: %v", err)
+	}
+	if _, err := archivezip.NewReader(bytes.NewReader(data), int64(len(data))); err != nil {
+		t.Fatalf("archive/zip rejected classic directory size 0xffff: %v", err)
+	}
+}
+
 func TestReadZipArchiveBodyRejectsOversize(t *testing.T) {
 	useZipTestLimits(t, func(limits *resolvedZipLimits) { limits.maxArchiveBytes = 4 })
 

--- a/fs/zip/limits_test.go
+++ b/fs/zip/limits_test.go
@@ -20,11 +20,15 @@ package zip
 
 import (
 	archivezip "archive/zip"
+	"bytes"
+	"encoding/binary"
 	"errors"
 	"io"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -34,11 +38,24 @@ type limitZipEntry struct {
 	method uint16
 }
 
+func useZipTestLimits(t *testing.T, update func(*resolvedZipLimits)) {
+	t.Helper()
+	previous := zipTestLimits.Load()
+	limits := defaultZipLimits()
+	update(&limits)
+	setZipTestLimits(limits)
+	t.Cleanup(func() {
+		if previous == nil {
+			clearZipTestLimits()
+			return
+		}
+		setZipTestLimits(*previous)
+	})
+}
+
 func TestOpenRejectsTooManyZipEntries(t *testing.T) {
 	path := makeLimitZip(t, limitZipEntry{name: "one", data: "1", method: archivezip.Store}, limitZipEntry{name: "two", data: "2", method: archivezip.Store})
-	old := zipMaxEntries
-	zipMaxEntries = 1
-	t.Cleanup(func() { zipMaxEntries = old })
+	useZipTestLimits(t, func(limits *resolvedZipLimits) { limits.maxEntries = 1 })
 
 	_, err := Open(path)
 	if !errors.Is(err, ErrArchiveLimit) {
@@ -48,9 +65,7 @@ func TestOpenRejectsTooManyZipEntries(t *testing.T) {
 
 func TestOpenRejectsOversizedZipEntry(t *testing.T) {
 	path := makeLimitZip(t, limitZipEntry{name: "large", data: "12345", method: archivezip.Store})
-	oldSize := zipMaxEntrySize
-	zipMaxEntrySize = 4
-	t.Cleanup(func() { zipMaxEntrySize = oldSize })
+	useZipTestLimits(t, func(limits *resolvedZipLimits) { limits.maxEntrySize = 4 })
 
 	_, err := Open(path)
 	if !errors.Is(err, ErrArchiveLimit) {
@@ -66,9 +81,7 @@ func TestOpenRejectsExcessiveTotalZipSize(t *testing.T) {
 		limitZipEntry{name: "one", data: "123", method: archivezip.Store},
 		limitZipEntry{name: "two", data: "456", method: archivezip.Store},
 	)
-	oldTotal := zipMaxTotalSize
-	zipMaxTotalSize = 5
-	t.Cleanup(func() { zipMaxTotalSize = oldTotal })
+	useZipTestLimits(t, func(limits *resolvedZipLimits) { limits.maxTotalSize = 5 })
 
 	_, err := Open(path)
 	if !errors.Is(err, ErrArchiveLimit) {
@@ -85,9 +98,7 @@ func TestOpenRejectsExcessiveZipCompressionRatio(t *testing.T) {
 		data:   strings.Repeat("a", 4096),
 		method: archivezip.Deflate,
 	})
-	oldRatio := zipMaxCompressionRatio
-	zipMaxCompressionRatio = 2
-	t.Cleanup(func() { zipMaxCompressionRatio = oldRatio })
+	useZipTestLimits(t, func(limits *resolvedZipLimits) { limits.maxCompressionRatio = 2 })
 
 	_, err := Open(path)
 	if !errors.Is(err, ErrArchiveLimit) {
@@ -114,12 +125,10 @@ func TestOpenRejectsNonEmptyDirectoryDeclaration(t *testing.T) {
 
 func TestOpenAndReadZipAtLimits(t *testing.T) {
 	path := makeLimitZip(t, limitZipEntry{name: "exact", data: "1234", method: archivezip.Store})
-	oldSize, oldTotal, oldRatio := zipMaxEntrySize, zipMaxTotalSize, zipMaxCompressionRatio
-	zipMaxEntrySize = 4
-	zipMaxTotalSize = 4
-	zipMaxCompressionRatio = 1
-	t.Cleanup(func() {
-		zipMaxEntrySize, zipMaxTotalSize, zipMaxCompressionRatio = oldSize, oldTotal, oldRatio
+	useZipTestLimits(t, func(limits *resolvedZipLimits) {
+		limits.maxEntrySize = 4
+		limits.maxTotalSize = 4
+		limits.maxCompressionRatio = 1
 	})
 
 	dir, err := Open(path)
@@ -151,10 +160,8 @@ func TestOpenReadRejectsEntryThatGrowsPastLimit(t *testing.T) {
 	// Mutating the exported header simulates an archive whose declaration was
 	// tampered with after parsing. The wrapper must still fail closed.
 	reader.File[0].UncompressedSize64 = 4
-	oldSize := zipMaxEntrySize
-	zipMaxEntrySize = 4
-	t.Cleanup(func() { zipMaxEntrySize = oldSize })
-	zipFS := (*FS)(reader)
+	useZipTestLimits(t, func(limits *resolvedZipLimits) { limits.maxEntrySize = 4 })
+	zipFS := &FS{Reader: &reader.Reader}
 	entry, err := zipFS.Open("grow")
 	if err != nil {
 		t.Fatal(err)
@@ -164,6 +171,293 @@ func TestOpenReadRejectsEntryThatGrowsPastLimit(t *testing.T) {
 	if readErr == nil {
 		t.Fatal("reading tampered entry succeeded, want error")
 	}
+}
+
+func TestPreflightRejectsForgedSmallEntryCount(t *testing.T) {
+	data := makeLimitZipBytes(t,
+		limitZipEntry{name: "one", data: "1", method: archivezip.Store},
+		limitZipEntry{name: "two", data: "2", method: archivezip.Store},
+		limitZipEntry{name: "three", data: "3", method: archivezip.Store},
+	)
+	end := findLimitZipEnd(t, data)
+	binary.LittleEndian.PutUint16(data[end+8:end+10], 1)
+	binary.LittleEndian.PutUint16(data[end+10:end+12], 1)
+	useZipTestLimits(t, func(limits *resolvedZipLimits) { limits.maxEntries = 2 })
+
+	if err := preflightZipArchive(bytes.NewReader(data), int64(len(data))); !errors.Is(err, ErrArchiveLimit) {
+		t.Fatalf("preflightZipArchive error = %v, want ErrArchiveLimit", err)
+	}
+}
+
+func TestOpenRejectsOversizedArchiveBeforeParsing(t *testing.T) {
+	path := makeLimitZip(t, limitZipEntry{name: "one", data: "1", method: archivezip.Store})
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	useZipTestLimits(t, func(limits *resolvedZipLimits) { limits.maxArchiveBytes = info.Size() - 1 })
+
+	_, err = Open(path)
+	if !errors.Is(err, ErrArchiveLimit) {
+		t.Fatalf("Open error = %v, want ErrArchiveLimit", err)
+	}
+}
+
+func TestPreflightRejectsOversizedCentralDirectory(t *testing.T) {
+	data := makeLimitZipBytes(t, limitZipEntry{name: "metadata", data: "1", method: archivezip.Store})
+	useZipTestLimits(t, func(limits *resolvedZipLimits) { limits.maxCentralDirBytes = zipDirectoryHeaderLen - 1 })
+
+	if err := preflightZipArchive(bytes.NewReader(data), int64(len(data))); !errors.Is(err, ErrArchiveLimit) {
+		t.Fatalf("preflightZipArchive error = %v, want ErrArchiveLimit", err)
+	}
+}
+
+func TestPreflightAcceptsZip64OffsetsWithSmallEntryCount(t *testing.T) {
+	data := makeLimitZipBytes(t, limitZipEntry{name: "one", data: "1", method: archivezip.Store})
+	data = makeLimitZip64Offsets(t, data)
+	reader := bytes.NewReader(data)
+	if err := preflightZipArchive(reader, int64(len(data))); err != nil {
+		t.Fatalf("preflightZipArchive error = %v", err)
+	}
+	if _, err := archivezip.NewReader(reader, int64(len(data))); err != nil {
+		t.Fatalf("archive/zip rejected ZIP64 fixture: %v", err)
+	}
+}
+
+func TestPreflightAcceptsZip64DirectorySizeSentinel(t *testing.T) {
+	data := makeLimitZip64Offsets(t, makeLimitZipBytes(t, limitZipEntry{name: "one", data: "1", method: archivezip.Store}))
+	eocd := findLimitZipEnd(t, data)
+	locator := eocd - zipDirectory64LocLen
+	recordOffset := int(binary.LittleEndian.Uint64(data[locator+8 : locator+16]))
+	records := binary.LittleEndian.Uint64(data[recordOffset+32 : recordOffset+40])
+	centralOffset := binary.LittleEndian.Uint64(data[recordOffset+48 : recordOffset+56])
+	binary.LittleEndian.PutUint16(data[eocd+8:eocd+10], uint16(records))
+	binary.LittleEndian.PutUint16(data[eocd+10:eocd+12], uint16(records))
+	binary.LittleEndian.PutUint32(data[eocd+12:eocd+16], math.MaxUint16)
+	binary.LittleEndian.PutUint32(data[eocd+16:eocd+20], uint32(centralOffset))
+
+	if err := preflightZipArchive(bytes.NewReader(data), int64(len(data))); err != nil {
+		t.Fatalf("ZIP64 directory-size sentinel rejected: %v", err)
+	}
+	if _, err := archivezip.NewReader(bytes.NewReader(data), int64(len(data))); err != nil {
+		t.Fatalf("archive/zip rejected ZIP64 directory-size sentinel: %v", err)
+	}
+}
+
+func TestReadZipArchiveBodyRejectsOversize(t *testing.T) {
+	useZipTestLimits(t, func(limits *resolvedZipLimits) { limits.maxArchiveBytes = 4 })
+
+	if _, err := readZipArchiveBody(strings.NewReader("12345"), -1); !errors.Is(err, ErrArchiveLimit) {
+		t.Fatalf("streamed body error = %v, want ErrArchiveLimit", err)
+	}
+	if _, err := readZipArchiveBody(strings.NewReader(""), 5); !errors.Is(err, ErrArchiveLimit) {
+		t.Fatalf("declared body error = %v, want ErrArchiveLimit", err)
+	}
+}
+
+func TestPreflightRequiresEOCDCommentToReachEOF(t *testing.T) {
+	data := makeLimitZipBytesWithComment(t, "zip comment", limitZipEntry{name: "one", data: "1", method: archivezip.Store})
+	if err := preflightZipArchive(bytes.NewReader(data), int64(len(data))); err != nil {
+		t.Fatalf("valid comment archive rejected: %v", err)
+	}
+	trailing := append(append([]byte(nil), data...), 0x7f)
+	if err := preflightZipArchive(bytes.NewReader(trailing), int64(len(trailing))); !errors.Is(err, archivezip.ErrFormat) {
+		t.Fatalf("trailing bytes error = %v, want archive/zip format error", err)
+	}
+}
+
+func TestPreflightRejectsLaterEOCDWithTrailingData(t *testing.T) {
+	data := makeLimitZipBytes(t, limitZipEntry{name: "one", data: "1", method: archivezip.Store})
+	firstEnd := findLimitZipEnd(t, data)
+	trailing := make([]byte, zipDirectoryEndLen+1)
+	binary.LittleEndian.PutUint32(trailing[0:4], zipDirectoryEndSignature)
+	data = append(data, trailing...)
+	binary.LittleEndian.PutUint16(data[firstEnd+20:firstEnd+22], uint16(len(trailing)))
+
+	if _, err := archivezip.NewReader(bytes.NewReader(data), int64(len(data))); err != nil {
+		t.Fatalf("archive/zip did not select the later EOCD fixture: %v", err)
+	}
+	if err := preflightZipArchive(bytes.NewReader(data), int64(len(data))); !errors.Is(err, archivezip.ErrFormat) {
+		t.Fatalf("later EOCD with trailing data error = %v, want archive/zip format error", err)
+	}
+}
+
+func TestPreflightAcceptsEmptyZip(t *testing.T) {
+	data := makeLimitZipBytes(t)
+	if err := preflightZipArchive(bytes.NewReader(data), int64(len(data))); err != nil {
+		t.Fatalf("empty ZIP rejected: %v", err)
+	}
+	if _, err := archivezip.NewReader(bytes.NewReader(data), int64(len(data))); err != nil {
+		t.Fatalf("archive/zip rejected empty ZIP: %v", err)
+	}
+}
+
+func TestPreflightAcceptsSelfExtractingPrefix(t *testing.T) {
+	data := makeLimitZipBytes(t, limitZipEntry{name: "one", data: "1", method: archivezip.Store})
+	prefix := []byte("#!/bin/sh\necho prefix\n")
+	data = append(append([]byte(nil), prefix...), data...)
+	if err := preflightZipArchive(bytes.NewReader(data), int64(len(data))); err != nil {
+		t.Fatalf("self-extracting ZIP rejected: %v", err)
+	}
+	reader, err := archivezip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		t.Fatalf("archive/zip rejected self-extracting ZIP: %v", err)
+	}
+	if len(reader.File) != 1 || reader.File[0].Name != "one" {
+		t.Fatalf("self-extracting ZIP files = %#v", reader.File)
+	}
+}
+
+func TestPreflightRejectsZip64RelativeLocatorWithPrefix(t *testing.T) {
+	data := makeLimitZip64Offsets(t, makeLimitZipBytes(t, limitZipEntry{name: "one", data: "1", method: archivezip.Store}))
+	prefix := []byte("self extracting prefix\x00")
+	data = append(append([]byte(nil), prefix...), data...)
+	if err := preflightZipArchive(bytes.NewReader(data), int64(len(data))); !errors.Is(err, archivezip.ErrFormat) {
+		t.Fatalf("relative ZIP64 locator error = %v, want archive/zip format error", err)
+	}
+	if _, err := archivezip.NewReader(bytes.NewReader(data), int64(len(data))); !errors.Is(err, archivezip.ErrFormat) {
+		t.Fatalf("archive/zip relative ZIP64 locator error = %v, want format error", err)
+	}
+}
+
+func TestPreflightAcceptsZip64AbsoluteLocatorWithPrefix(t *testing.T) {
+	data := makeLimitZip64Offsets(t, makeLimitZipBytes(t, limitZipEntry{name: "one", data: "1", method: archivezip.Store}))
+	prefix := []byte("self extracting prefix\x00")
+	data = append(append([]byte(nil), prefix...), data...)
+	eocd := findLimitZipEnd(t, data)
+	locator := eocd - zipDirectory64LocLen
+	offset := binary.LittleEndian.Uint64(data[locator+8 : locator+16])
+	binary.LittleEndian.PutUint64(data[locator+8:locator+16], offset+uint64(len(prefix)))
+	if err := preflightZipArchive(bytes.NewReader(data), int64(len(data))); err != nil {
+		t.Fatalf("self-extracting ZIP64 with absolute locator rejected: %v", err)
+	}
+	if _, err := archivezip.NewReader(bytes.NewReader(data), int64(len(data))); err != nil {
+		t.Fatalf("archive/zip rejected self-extracting ZIP64: %v", err)
+	}
+}
+
+func TestPreflightRejectsGapBeforeZip64Locator(t *testing.T) {
+	data := makeLimitZip64Offsets(t, makeLimitZipBytes(t, limitZipEntry{name: "one", data: "1", method: archivezip.Store}))
+	eocd := findLimitZipEnd(t, data)
+	locator := eocd - zipDirectory64LocLen
+	withGap := make([]byte, 0, len(data)+1)
+	withGap = append(withGap, data[:locator]...)
+	withGap = append(withGap, 0)
+	withGap = append(withGap, data[locator:]...)
+
+	if err := preflightZipArchive(bytes.NewReader(withGap), int64(len(withGap))); !errors.Is(err, archivezip.ErrFormat) {
+		t.Fatalf("ZIP64 locator gap error = %v, want archive/zip format error", err)
+	}
+}
+
+func TestPreflightMatchesArchiveZipBaseOffsetProbe(t *testing.T) {
+	data := makeLimitZipBytes(t,
+		limitZipEntry{name: "one", data: "1", method: archivezip.Store},
+		limitZipEntry{name: "two", data: "2", method: archivezip.Store},
+		limitZipEntry{name: "three", data: "3", method: archivezip.Store},
+	)
+	end := findLimitZipEnd(t, data)
+	centralOffset := int(binary.LittleEndian.Uint32(data[end+16 : end+20]))
+	centralSize := int(binary.LittleEndian.Uint32(data[end+12 : end+16]))
+	prefix := make([]byte, centralOffset+centralSize+16)
+	decoy := prefix[centralOffset : centralOffset+centralSize]
+	binary.LittleEndian.PutUint32(decoy[0:4], zipDirectoryHeaderSignature)
+	binary.LittleEndian.PutUint32(decoy[20:24], math.MaxUint32)
+	binary.LittleEndian.PutUint16(decoy[32:34], uint16(centralSize-zipDirectoryHeaderLen))
+	data = append(prefix, data...)
+	end = findLimitZipEnd(t, data)
+	binary.LittleEndian.PutUint16(data[end+8:end+10], 1)
+	binary.LittleEndian.PutUint16(data[end+10:end+12], 1)
+	useZipTestLimits(t, func(limits *resolvedZipLimits) { limits.maxEntries = 2 })
+
+	if completeZipDirectoryHeaderAt(bytes.NewReader(data), int64(len(data)), int64(centralOffset)) != 0 {
+		t.Fatal("invalid ZIP64 decoy accepted as a complete directory header")
+	}
+	if err := preflightZipArchive(bytes.NewReader(data), int64(len(data))); !errors.Is(err, ErrArchiveLimit) {
+		t.Fatalf("base-offset decoy error = %v, want ErrArchiveLimit", err)
+	}
+}
+
+func TestPreflightRejectsHeaderPastDeclaredDirectorySize(t *testing.T) {
+	data := makeLimitZipBytes(t, limitZipEntry{name: "one", data: "1", method: archivezip.Store})
+	end := findLimitZipEnd(t, data)
+	centralOffset := int(binary.LittleEndian.Uint32(data[end+16 : end+20]))
+	central := append([]byte(nil), data[centralOffset:end]...)
+	withExtraHeader := make([]byte, 0, len(data)+len(central))
+	withExtraHeader = append(withExtraHeader, data[:end]...)
+	withExtraHeader = append(withExtraHeader, central...)
+	withExtraHeader = append(withExtraHeader, data[end:]...)
+
+	if err := preflightZipArchive(bytes.NewReader(withExtraHeader), int64(len(withExtraHeader))); !errors.Is(err, archivezip.ErrFormat) {
+		t.Fatalf("extra directory header error = %v, want archive/zip format error", err)
+	}
+	if _, err := archivezip.NewReader(bytes.NewReader(withExtraHeader), int64(len(withExtraHeader))); err == nil {
+		t.Fatal("archive/zip accepted a directory header past the declared size")
+	}
+}
+
+func TestScanCentralDirectoryHonorsDeclaredEnd(t *testing.T) {
+	data := makeLimitZipBytes(t,
+		limitZipEntry{name: "one", data: "1", method: archivezip.Store},
+		limitZipEntry{name: "two", data: "2", method: archivezip.Store},
+	)
+	end := findLimitZipEnd(t, data)
+	centralOffset := int(binary.LittleEndian.Uint32(data[end+16 : end+20]))
+	centralSize := int(binary.LittleEndian.Uint32(data[end+12 : end+16]))
+	central := data[centralOffset : centralOffset+centralSize]
+	firstLen := completeZipDirectoryHeaderAt(bytes.NewReader(central), int64(len(central)), 0)
+	if firstLen == 0 {
+		t.Fatal("first central-directory header missing")
+	}
+	if err := scanZipCentralDirectory(bytes.NewReader(central), int64(len(central)), 0, firstLen, 1, defaultZipLimits()); err != nil {
+		t.Fatalf("bounded central-directory scan failed: %v", err)
+	}
+}
+
+func TestPreflightRejectsCentralDirectorySizePastEOCD(t *testing.T) {
+	data := makeLimitZipBytes(t, limitZipEntry{name: "one", data: "1", method: archivezip.Store})
+	end := findLimitZipEnd(t, data)
+	size := binary.LittleEndian.Uint32(data[end+12 : end+16])
+	binary.LittleEndian.PutUint32(data[end+12:end+16], size+uint32(zipDirectoryHeaderLen))
+	if err := preflightZipArchive(bytes.NewReader(data), int64(len(data))); !errors.Is(err, archivezip.ErrFormat) {
+		t.Fatalf("oversized central directory error = %v, want archive/zip format error", err)
+	}
+}
+
+func TestFSNilCloseIsSafe(t *testing.T) {
+	var nilFS *FS
+	if err := nilFS.Close(); err != nil {
+		t.Fatalf("nil FS Close error = %v", err)
+	}
+	if err := (&FS{}).Close(); err != nil {
+		t.Fatalf("empty FS Close error = %v", err)
+	}
+}
+
+func TestZipLimitHookConcurrent(t *testing.T) {
+	previous := zipTestLimits.Load()
+	t.Cleanup(func() {
+		if previous == nil {
+			clearZipTestLimits()
+		} else {
+			setZipTestLimits(*previous)
+		}
+	})
+	var group sync.WaitGroup
+	for i := 0; i < 32; i++ {
+		group.Add(2)
+		go func(i int) {
+			defer group.Done()
+			limits := defaultZipLimits()
+			limits.maxEntries = i + 1
+			setZipTestLimits(limits)
+		}(i)
+		go func() {
+			defer group.Done()
+			_ = currentZipLimits()
+		}()
+	}
+	group.Wait()
 }
 
 func TestZipLimitedReaderDoesNotExposeSentinelByte(t *testing.T) {
@@ -211,4 +505,90 @@ func makeLimitZip(t *testing.T, entries ...limitZipEntry) string {
 		t.Fatal(err)
 	}
 	return path
+}
+
+func makeLimitZipBytes(t *testing.T, entries ...limitZipEntry) []byte {
+	t.Helper()
+	var output bytes.Buffer
+	writer := archivezip.NewWriter(&output)
+	for _, item := range entries {
+		header := &archivezip.FileHeader{Name: item.name, Method: item.method}
+		entry, err := writer.CreateHeader(header)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := io.WriteString(entry, item.data); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return output.Bytes()
+}
+
+func makeLimitZipBytesWithComment(t *testing.T, comment string, entries ...limitZipEntry) []byte {
+	t.Helper()
+	var output bytes.Buffer
+	writer := archivezip.NewWriter(&output)
+	for _, item := range entries {
+		header := &archivezip.FileHeader{Name: item.name, Method: item.method}
+		entry, err := writer.CreateHeader(header)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := io.WriteString(entry, item.data); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := writer.SetComment(comment); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return output.Bytes()
+}
+
+func findLimitZipEnd(t *testing.T, data []byte) int {
+	t.Helper()
+	signature := []byte{'P', 'K', 0x05, 0x06}
+	offset := bytes.LastIndex(data, signature)
+	if offset < 0 || len(data)-offset < zipDirectoryEndLen {
+		t.Fatal("ZIP end record not found")
+	}
+	return offset
+}
+
+func makeLimitZip64Offsets(t *testing.T, data []byte) []byte {
+	t.Helper()
+	end := findLimitZipEnd(t, data)
+	records := binary.LittleEndian.Uint16(data[end+10 : end+12])
+	centralSize := binary.LittleEndian.Uint32(data[end+12 : end+16])
+	centralOffset := binary.LittleEndian.Uint32(data[end+16 : end+20])
+
+	zip64 := make([]byte, zipDirectory64EndLen+zipDirectory64LocLen)
+	binary.LittleEndian.PutUint32(zip64[0:4], zipDirectory64EndSignature)
+	binary.LittleEndian.PutUint64(zip64[4:12], zipDirectory64EndLen-12)
+	binary.LittleEndian.PutUint16(zip64[12:14], 45)
+	binary.LittleEndian.PutUint16(zip64[14:16], 45)
+	binary.LittleEndian.PutUint64(zip64[24:32], uint64(records))
+	binary.LittleEndian.PutUint64(zip64[32:40], uint64(records))
+	binary.LittleEndian.PutUint64(zip64[40:48], uint64(centralSize))
+	binary.LittleEndian.PutUint64(zip64[48:56], uint64(centralOffset))
+	locator := zip64[zipDirectory64EndLen:]
+	binary.LittleEndian.PutUint32(locator[0:4], zipDirectory64LocSignature)
+	binary.LittleEndian.PutUint64(locator[8:16], uint64(end))
+	binary.LittleEndian.PutUint32(locator[16:20], 1)
+
+	result := make([]byte, 0, len(data)+len(zip64))
+	result = append(result, data[:end]...)
+	result = append(result, zip64...)
+	result = append(result, data[end:]...)
+	newEnd := end + len(zip64)
+	binary.LittleEndian.PutUint16(result[newEnd+8:newEnd+10], math.MaxUint16)
+	binary.LittleEndian.PutUint16(result[newEnd+10:newEnd+12], math.MaxUint16)
+	binary.LittleEndian.PutUint32(result[newEnd+12:newEnd+16], math.MaxUint32)
+	binary.LittleEndian.PutUint32(result[newEnd+16:newEnd+20], math.MaxUint32)
+	return result
 }


### PR DESCRIPTION
## Summary

- bound archive bytes, central-directory metadata, entry counts, expansion sizes, compression ratios, and cumulative compressed work
- preflight classic and ZIP64 metadata before archive/zip allocates entries, rejecting cross-version offset ambiguity
- reject non-canonical, duplicate, and file-parent paths and cap reads at each entry declared size
- apply the checks to native, Web, remote, and cached ZIP paths

## Validation

- `make generate` twice with no generated diff
- `go vet ./...`
- `go test ./...`
- `go test -race ./...`
- Go 1.25.8 and Go 1.27.1 ZIP tests, including strict `zipinsecurepath`
- Go 1.25.8 and Go 1.27.1 WebAssembly compile checks