### PR TITLE
perf(textures): retain CPU pixels for loaded image textures

### DIFF
--- a/godot_modules/spx/spx_draw_tiles.cpp
+++ b/godot_modules/spx/spx_draw_tiles.cpp
@@ -45,6 +45,7 @@
 #include "spx_base_mgr.h"
 #include "spx_engine.h"
 #include "spx_ext_mgr.h"
+#include "spx_image_texture.h"
 #include "spx_res_mgr.h"
 #include "spx_scene_mgr.h"
 
@@ -607,9 +608,7 @@ Ref<ImageTexture> SpxDrawTiles::_get_or_create_scaled_texture(Ref<Texture2D> tex
 	// Forced scaling will cause image rendering distortion
 	//img->resize(default_cell_size.x, default_cell_size.y, Image::INTERPOLATE_LANCZOS);
 
-	Ref<ImageTexture> scaled_tex;
-	scaled_tex.instantiate();
-	scaled_tex = scaled_tex->create_from_image(img);
+	Ref<ImageTexture> scaled_tex = SpxImageTexture::create_from_image(img);
 	texture_scaled_cache_map[texture] = scaled_tex;
 
 	if (path_cached_textures_bimap.has_value(texture)) {

--- a/godot_modules/spx/spx_image_texture.h
+++ b/godot_modules/spx/spx_image_texture.h
@@ -1,0 +1,43 @@
+#ifndef SPX_IMAGE_TEXTURE_H
+#define SPX_IMAGE_TEXTURE_H
+
+#include "core/object/callable_method_pointer.h"
+#include "scene/resources/image_texture.h"
+
+// Keep uploaded pixels on the CPU for all Texture2D consumers, including
+// collision queries, atlas extraction and tile copies. Ownership follows the
+// texture; no global cache or resource metadata is needed.
+class SpxImageTexture : public ImageTexture {
+	mutable Ref<Image> cpu_image;
+
+	void _invalidate_image() {
+		cpu_image.unref();
+	}
+
+public:
+	SpxImageTexture() {
+		connect("changed", callable_mp(this, &SpxImageTexture::_invalidate_image));
+	}
+
+	static Ref<ImageTexture> create_from_image(const Ref<Image> &p_image) {
+		ERR_FAIL_COND_V(p_image.is_null() || p_image->is_empty(), Ref<ImageTexture>());
+		Ref<SpxImageTexture> texture;
+		texture.instantiate();
+		texture->set_image(p_image);
+		texture->cpu_image = p_image->duplicate();
+		return texture;
+	}
+
+	Ref<Image> get_image() const override {
+		// Inherited set_image/update and resource reload emit changed. Read back
+		// once after such an update, then retain that new snapshot as well.
+		if (cpu_image.is_null()) {
+			cpu_image = ImageTexture::get_image();
+		}
+		// Image::duplicate shares pixel storage until a caller writes to it.
+		// Preserve get_image's independent, mutable result without copying pixels.
+		return cpu_image.is_valid() ? Ref<Image>(cpu_image->duplicate()) : Ref<Image>();
+	}
+};
+
+#endif // SPX_IMAGE_TEXTURE_H

--- a/godot_modules/spx/spx_res_mgr.cpp
+++ b/godot_modules/spx/spx_res_mgr.cpp
@@ -49,6 +49,7 @@
 #include "project_font_transaction.h"
 #include "spx_engine.h"
 #include "spx_image_loader_svg.h"
+#include "spx_image_texture.h"
 #include "spx_platform_mgr.h"
 #include "spx_svg_utils.h"
 #include "spx_theme_font.h"
@@ -293,7 +294,7 @@ Ref<Texture2D> SpxResMgr::_load_texture_direct(const String &p_path) {
 
 	_load_image(path, image);
 
-	Ref<ImageTexture> texture = ImageTexture::create_from_image(image);
+	Ref<ImageTexture> texture = SpxImageTexture::create_from_image(image);
 	cached_texture.insert(path, texture);
 	return texture;
 }

--- a/godot_modules/spx/svg_mgr.cpp
+++ b/godot_modules/spx/svg_mgr.cpp
@@ -6,6 +6,7 @@
 #include "spx.h"
 #include "spx_engine.h"
 #include "spx_image_loader_svg.h"
+#include "spx_image_texture.h"
 #include "spx_res_mgr.h"
 
 SvgManager *SvgManager::get_singleton() {
@@ -165,9 +166,7 @@ Ref<ImageTexture> SvgManager::_load_image(const String &path /*engine path*/, in
 	image.instantiate();
 	Error err = SpxImageLoaderSVG::load_image(path, image, ImageFormatLoader::FLAG_NONE, (float)scale);
 	if (err == OK) {
-		Ref<ImageTexture> texture;
-		texture.instantiate();
-		texture->set_image(image);
+		Ref<ImageTexture> texture = SpxImageTexture::create_from_image(image);
 		texture->set_path_cache(path); // cache raw path, not engine path
 
 		if (!svg_image_raw_size_cache.has(path)) {

--- a/godot_modules/spx/tests/test_spx_res_mgr.h
+++ b/godot_modules/spx/tests/test_spx_res_mgr.h
@@ -118,6 +118,12 @@ TEST_CASE("[SceneTree][SPX] Direct texture loader preserves WebP frame size and 
 
 	const Ref<Texture2D> cached = res_mgr.load_texture(frame_path, true);
 	CHECK(cached == texture);
+
+	// Pixel consumers may modify their copy without changing the texture or
+	// later collision/atlas queries sharing the same loaded resource.
+	const Color original_pixel = image->get_pixel(0, 0);
+	image->set_pixel(0, 0, Color(1, 0, 1, 1));
+	CHECK(cached->get_image()->get_pixel(0, 0) == original_pixel);
 }
 
 TEST_CASE("[SceneTree][SPX] Project theme font helper updates default and fallback fonts") {


### PR DESCRIPTION
Pixel collision queries repeatedly call `Texture2D::get_image()`, causing GPU readbacks and severe Web stalls even when the texture has not changed.

Add `SpxImageTexture` to retain CPU pixels for loaded bitmap/SVG textures and generated tile textures. Existing collision, atlas, and tile consumers benefit through the same `get_image()` API. Texture changes invalidate the snapshot; returned images use copy-on-write so callers can modify them independently. Pixel storage follows the texture lifetime, without global cache keys or resource metadata.

This retains one CPU pixel buffer per shared texture, trading memory for fewer GPU readbacks.

Validation:
- Normal Web engine build passed.
- Extended the existing WebP texture test to verify returned-image isolation; all 9 assertions passed.
- Both reported demos sustained about 30 updates/s with no GPU readbacks during steady-state collision queries. Stop/restart passed.