### PR TITLE
fix(web): avoid watchdog-triggered WASM crashes

### DIFF
--- a/internal/coroutine/lifecycle.go
+++ b/internal/coroutine/lifecycle.go
@@ -147,8 +147,6 @@ func (p *Coroutines) beginStoppingLocked() {
 		p.stopping = true
 		p.abortEpoch.Add(1)
 	}
-	// Each barrier owns recovery state until it completes.
-	p.reopenWhenDrained = false
 	p.abortAllLocked()
 }
 
@@ -158,7 +156,6 @@ func (p *Coroutines) endStoppingLocked() {
 	}
 	p.abortEpoch.Add(1)
 	p.stopping = false
-	p.reopenWhenDrained = false
 }
 
 // StopIf requests cancellation of every thread accepted by filter. Filters are
@@ -277,7 +274,6 @@ func (p *Coroutines) unregisterThread(th Thread) {
 	p.threadsMu.Lock()
 	delete(p.allThreads, th)
 	p.threadsMu.Unlock()
-	p.maybeReopenAfterDrain()
 }
 
 // admitNativeTask registers a WaitToDo worker under the admission barrier.
@@ -301,19 +297,6 @@ func (p *Coroutines) finishNativeTask(task *nativeTask) {
 	p.threadsMu.Lock()
 	delete(p.nativeTasks, task)
 	p.threadsMu.Unlock()
-	p.maybeReopenAfterDrain()
-}
-
-func (p *Coroutines) maybeReopenAfterDrain() {
-	p.creationMu.Lock()
-	p.maybeReopenAfterDrainLocked()
-	p.creationMu.Unlock()
-}
-
-func (p *Coroutines) maybeReopenAfterDrainLocked() {
-	if p.stopping && p.reopenWhenDrained && !p.hasThreadsOtherThan(nil) {
-		p.endStoppingLocked()
-	}
 }
 
 func (p *Coroutines) snapshotThreads() []Thread {

--- a/internal/coroutine/manager.go
+++ b/internal/coroutine/manager.go
@@ -52,8 +52,6 @@ type Coroutines struct {
 	shutdownMu sync.Mutex
 	creationMu sync.RWMutex
 	stopping   bool
-	// Watchdog shutdowns may reopen after drain; fatal barriers require retry.
-	reopenWhenDrained bool
 
 	// threadsMu protects both lifecycle registries.
 	threadsMu   sync.Mutex

--- a/internal/coroutine/scheduler_test.go
+++ b/internal/coroutine/scheduler_test.go
@@ -458,20 +458,70 @@ func TestUpdateWatchdogDeadlineResetsWhileAwaitingInitialization(t *testing.T) {
 	}
 }
 
-func TestUpdateWatchdogStopsRecursiveSpawnChainOnRetry(t *testing.T) {
+func TestUpdateWatchdogPreservesScriptsAndQueuedWork(t *testing.T) {
+	co := New(nil)
+	co.OnInited()
+	t.Cleanup(func() {
+		if !co.AbortAllAndWait(time.Second) {
+			t.Error("coroutines did not stop during cleanup")
+		}
+	})
+
+	resumed := make(chan struct{})
+	thread := co.CreateAndStart(true, "slow-frame", func(me Thread) int {
+		co.WaitYield(me)
+		close(resumed)
+		return 0
+	})
+	waitForThreadSignal(t, thread.yieldedOrDone, "script did not reach its yield")
+
+	queuedRan, deferredRan := false, false
+	co.enqueueJob(&WaitJob{Type: waitTypeMainThread, Call: func() { queuedRan = true }})
+	co.deferredJobs.PushBack(&WaitJob{Type: waitTypeYield, Call: func() { deferredRan = true }})
+
+	now := time.Now()
+	co.updateWatchdogNow = func() time.Time { return now }
+	co.enqueuePriorityJob(&WaitJob{Type: waitTypeMainThread, Call: func() {
+		now = now.Add(updateWatchdogTimeout)
+	}})
+	co.Update()
+
+	if thread.Stopped() {
+		t.Fatal("watchdog canceled a script after a slow frame")
+	}
+	select {
+	case <-resumed:
+		t.Fatal("script resumed after the frame budget was exhausted")
+	default:
+	}
+	if queuedRan || deferredRan {
+		t.Fatal("Update processed remaining work after the frame budget was exhausted")
+	}
+
+	created := co.Create("after-slow-frame", func(Thread) int { return 0 })
+	if created.Stopped() {
+		t.Fatal("watchdog rejected a new script")
+	}
+	co.Update()
+	waitForThreadSignal(t, resumed, "script did not resume on the next Update")
+	if !queuedRan || !deferredRan {
+		t.Fatal("queued or deferred work was lost after a slow frame")
+	}
+}
+
+func TestUpdateWatchdogReturnsOnRecursiveSpawnRetry(t *testing.T) {
 	previousProcs := runtime.GOMAXPROCS(1)
 	t.Cleanup(func() { runtime.GOMAXPROCS(previousProcs) })
 
 	co := New(nil)
 	co.OnInited()
-
 	clockStart := time.Now()
 	var clockCalls atomic.Int64
 	co.updateWatchdogNow = func() time.Time {
 		if clockCalls.Add(1) == 1 {
 			return clockStart
 		}
-		return clockStart.Add(updateWatchdogTimeout + time.Nanosecond)
+		return clockStart.Add(updateWatchdogTimeout)
 	}
 
 	var keepSpawning atomic.Bool
@@ -500,194 +550,16 @@ func TestUpdateWatchdogStopsRecursiveSpawnChainOnRetry(t *testing.T) {
 		co.Update()
 		close(updateDone)
 	}()
-
-	select {
-	case <-updateDone:
-	case <-time.After(time.Second):
-		keepSpawning.Store(false)
-		if !co.AbortAllAndWait(time.Second) {
-			t.Fatal("recursive spawn chain did not stop after the watchdog test timed out")
-		}
-		select {
-		case <-updateDone:
-		case <-time.After(time.Second):
-			t.Fatal("Update remained blocked after recursive spawn chain cleanup")
-		}
-		t.Fatal("Update did not stop a recursive spawn chain after the watchdog expired")
-	}
-
-	if got := clockCalls.Load(); got < 2 {
-		t.Fatalf("watchdog clock was called %d times, want a deadline check after a wait retry", got)
-	}
-	if got := spawned.Load(); got == 0 {
-		t.Fatal("recursive spawn chain never started")
-	}
-	stats := co.GetLastUpdateStats()
-	if stats.TaskCounts != 0 {
-		t.Fatalf("processed %d wait jobs, want a retry-only spawn chain", stats.TaskCounts)
-	}
-	if !co.waitForThreadsToStop(time.Second, nil) {
-		t.Fatal("managed threads did not drain after watchdog cancellation")
-	}
+	waitForThreadSignal(t, updateDone, "Update did not return after a retry exhausted the frame budget")
 	keepSpawning.Store(false)
-
-	co.updateWatchdogNow = time.Now
-	resumed := make(chan struct{})
-	thread := co.Create("after-watchdog", func(me Thread) int {
-		co.WaitYield(me)
-		close(resumed)
-		return 0
-	})
-	deadline := time.Now().Add(time.Second)
-	for !thread.suspended.Load() {
-		if time.Now().After(deadline) {
-			t.Fatal("post-watchdog coroutine did not reach its yield")
-		}
-		runtime.Gosched()
-	}
-
-	recoveryDone := make(chan struct{})
-	go func() {
-		co.Update()
-		close(recoveryDone)
-	}()
-	select {
-	case <-recoveryDone:
-	case <-time.After(time.Second):
-		if !co.AbortAllAndWait(time.Second) {
-			t.Fatal("post-watchdog coroutine did not stop during recovery cleanup")
-		}
-		select {
-		case <-recoveryDone:
-		case <-time.After(time.Second):
-			t.Fatal("recovery Update remained blocked after cleanup")
-		}
-		t.Fatal("scheduler did not complete an Update after watchdog recovery")
-	}
-	select {
-	case <-resumed:
-	default:
-		t.Fatal("scheduler did not resume a coroutine after watchdog recovery")
-	}
-}
-
-func TestRunawayShutdownReturnsBeforeDrainAndRejectsThreadCreation(t *testing.T) {
-	co := New(nil)
-	blocker := co.newThread("shutdown-blocker")
-	co.registerThread(blocker)
-	removeBlocker := func() {
-		co.removeThreadState(blocker)
-		co.unregisterThread(blocker)
-	}
-	t.Cleanup(func() {
-		removeBlocker()
-		if !co.AbortAllAndWait(time.Second) {
-			t.Error("coroutines did not stop during cleanup")
-		}
-	})
-
-	shutdownDone := make(chan struct{})
-	go func() {
-		co.stopRunawayThreads()
-		close(shutdownDone)
-	}()
-
-	select {
-	case <-shutdownDone:
-	case <-time.After(time.Second):
-		t.Fatal("runaway shutdown waited for the canceled thread to exit")
-	}
-	if !blocker.Stopped() {
-		t.Fatal("runaway shutdown did not cancel the registered thread")
-	}
-
-	var ran atomic.Bool
-	created := make(chan Thread, 1)
-	go func() {
-		created <- co.Create("after-shutdown", func(Thread) int {
-			ran.Store(true)
-			return 0
-		})
-	}()
-
-	var rejected Thread
-	select {
-	case rejected = <-created:
-	case <-time.After(time.Second):
-		t.Fatal("thread creation remained blocked during runaway shutdown")
-	}
-	if !rejected.Stopped() {
-		t.Fatal("thread created during runaway shutdown was not canceled")
-	}
-
-	removeBlocker()
-	if ran.Load() {
-		t.Fatal("thread created during runaway shutdown ran user code")
-	}
-
-	afterShutdown := make(chan struct{})
-	co.Create("after-shutdown", func(Thread) int {
-		close(afterShutdown)
-		return 0
-	})
-	select {
-	case <-afterShutdown:
-	case <-time.After(time.Second):
-		t.Fatal("thread created after runaway shutdown did not run")
-	}
 	if !co.waitForThreadsToStop(time.Second, nil) {
-		t.Fatal("post-shutdown thread did not complete")
+		t.Fatal("recursive spawn chain did not finish")
 	}
-}
-
-func TestRunawayShutdownAllowsCanceledCleanupToCreate(t *testing.T) {
-	co := New(nil)
-	co.OnInited()
-	t.Cleanup(func() {
-		if !co.AbortAllAndWait(time.Second) {
-			t.Error("coroutines did not stop during cleanup")
-		}
-	})
-
-	var cleanupChildRan atomic.Bool
-	cleanupCreated := make(chan struct{})
-	thread := co.Create("worker", func(me Thread) int {
-		defer func() {
-			co.Create("cleanup-child", func(Thread) int {
-				cleanupChildRan.Store(true)
-				return 0
-			})
-			close(cleanupCreated)
-		}()
-		co.WaitYield(me)
-		return 0
-	})
-
-	deadline := time.Now().Add(time.Second)
-	for !thread.suspended.Load() {
-		if time.Now().After(deadline) {
-			t.Fatal("worker did not reach its yield")
-		}
-		runtime.Gosched()
+	if clockCalls.Load() < 2 || spawned.Load() == 0 {
+		t.Fatal("test did not exercise the watchdog on a recursive spawn retry")
 	}
-
-	shutdownDone := make(chan struct{})
-	go func() {
-		co.stopRunawayThreads()
-		close(shutdownDone)
-	}()
-	select {
-	case <-shutdownDone:
-	case <-time.After(time.Second):
-		t.Fatal("runaway shutdown deadlocked with coroutine cleanup")
-	}
-	select {
-	case <-cleanupCreated:
-	case <-time.After(time.Second):
-		t.Fatal("canceled coroutine cleanup did not finish creating its child")
-	}
-	if cleanupChildRan.Load() {
-		t.Fatal("child created by canceled cleanup ran during shutdown")
+	if stats := co.GetLastUpdateStats(); stats.TaskCounts != 0 {
+		t.Fatalf("processed %d wait jobs, want a retry-only spawn chain", stats.TaskCounts)
 	}
 }
 

--- a/internal/coroutine/scheduler_test.go
+++ b/internal/coroutine/scheduler_test.go
@@ -526,8 +526,8 @@ func TestUpdateWatchdogStopsRecursiveSpawnChainOnRetry(t *testing.T) {
 	if stats.TaskCounts != 0 {
 		t.Fatalf("processed %d wait jobs, want a retry-only spawn chain", stats.TaskCounts)
 	}
-	if remaining := len(co.snapshotThreads()); remaining != 0 {
-		t.Fatalf("%d managed threads remained after watchdog shutdown", remaining)
+	if !co.waitForThreadsToStop(time.Second, nil) {
+		t.Fatal("managed threads did not drain after watchdog cancellation")
 	}
 	keepSpawning.Store(false)
 
@@ -571,7 +571,7 @@ func TestUpdateWatchdogStopsRecursiveSpawnChainOnRetry(t *testing.T) {
 	}
 }
 
-func TestRunawayShutdownRejectsThreadCreation(t *testing.T) {
+func TestRunawayShutdownReturnsBeforeDrainAndRejectsThreadCreation(t *testing.T) {
 	co := New(nil)
 	blocker := co.newThread("shutdown-blocker")
 	co.registerThread(blocker)
@@ -592,12 +592,13 @@ func TestRunawayShutdownRejectsThreadCreation(t *testing.T) {
 		close(shutdownDone)
 	}()
 
-	deadline := time.Now().Add(time.Second)
-	for !blocker.Stopped() {
-		if time.Now().After(deadline) {
-			t.Fatal("runaway shutdown did not reach its abort snapshot")
-		}
-		runtime.Gosched()
+	select {
+	case <-shutdownDone:
+	case <-time.After(time.Second):
+		t.Fatal("runaway shutdown waited for the canceled thread to exit")
+	}
+	if !blocker.Stopped() {
+		t.Fatal("runaway shutdown did not cancel the registered thread")
 	}
 
 	var ran atomic.Bool
@@ -620,11 +621,6 @@ func TestRunawayShutdownRejectsThreadCreation(t *testing.T) {
 	}
 
 	removeBlocker()
-	select {
-	case <-shutdownDone:
-	case <-time.After(time.Second):
-		t.Fatal("runaway shutdown did not finish")
-	}
 	if ran.Load() {
 		t.Fatal("thread created during runaway shutdown ran user code")
 	}
@@ -687,7 +683,7 @@ func TestRunawayShutdownAllowsCanceledCleanupToCreate(t *testing.T) {
 	}
 	select {
 	case <-cleanupCreated:
-	default:
+	case <-time.After(time.Second):
 		t.Fatal("canceled coroutine cleanup did not finish creating its child")
 	}
 	if cleanupChildRan.Load() {

--- a/internal/coroutine/thread_test.go
+++ b/internal/coroutine/thread_test.go
@@ -368,6 +368,13 @@ func TestAbortAllAndWaitRejectsCreationDuringBarrier(t *testing.T) {
 		runtime.Gosched()
 	}
 
+	co.stopRunawayThreads()
+	select {
+	case <-abortDone:
+		t.Fatal("watchdog waited for the active abort barrier to time out")
+	default:
+	}
+
 	var childRan atomic.Bool
 	child := co.Create("during-barrier", func(Thread) int {
 		childRan.Store(true)

--- a/internal/coroutine/thread_test.go
+++ b/internal/coroutine/thread_test.go
@@ -368,13 +368,6 @@ func TestAbortAllAndWaitRejectsCreationDuringBarrier(t *testing.T) {
 		runtime.Gosched()
 	}
 
-	co.stopRunawayThreads()
-	select {
-	case <-abortDone:
-		t.Fatal("watchdog waited for the active abort barrier to time out")
-	default:
-	}
-
 	var childRan atomic.Bool
 	child := co.Create("during-barrier", func(Thread) int {
 		childRan.Store(true)
@@ -448,15 +441,6 @@ func TestRunAfterAbortAllTimeoutRequiresExplicitRecovery(t *testing.T) {
 		t.Fatal("creation was admitted after a timed-out barrier drained without recovery")
 	}
 	waitForThreadSignal(t, stillRejected.done, "quarantined creation did not finish")
-	co.stopRunawayThreads()
-	watchdogRejected := co.CreateAndStart(true, "after-watchdog-before-recovery", func(Thread) int {
-		t.Fatal("watchdog weakened a fatal barrier quarantine")
-		return 0
-	})
-	if !watchdogRejected.Stopped() {
-		t.Fatal("watchdog reopened admission after a fatal barrier timeout")
-	}
-	waitForThreadSignal(t, watchdogRejected.done, "post-watchdog quarantined creation did not finish")
 
 	// Explicit recovery reopens admission after the drain.
 	if !co.RunAfterAbortAll(time.Second, nil) {

--- a/internal/coroutine/update.go
+++ b/internal/coroutine/update.go
@@ -39,8 +39,6 @@ const (
 	updateAwaitInitialization
 
 	updateWatchdogTimeout = stime.Second
-	// Bound watchdog shutdown; late workers reopen after draining.
-	runawayShutdownTimeout = updateWatchdogTimeout
 )
 
 // Update processes queued wait jobs and resumes eligible coroutines.
@@ -108,32 +106,25 @@ updateLoop:
 
 func (p *Coroutines) stopRunawayThreads() {
 	// This remains cooperative: an active thread must release runMu first.
-	p.shutdownMu.Lock()
+	// Another shutdown already owns cancellation and recovery. Waiting for its
+	// drain here would block the engine callback just like waiting for our own.
+	if !p.shutdownMu.TryLock() {
+		return
+	}
 	defer p.shutdownMu.Unlock()
 
 	p.runMu.Lock()
 	p.creationMu.Lock()
-	wasStopping := p.stopping
-	reopenWhenDrained := p.reopenWhenDrained
+	// Preserve an existing fatal barrier's quarantine. Otherwise the last
+	// exiting thread or native worker will reopen admission.
+	reopenWhenDrained := !p.stopping || p.reopenWhenDrained
 	p.beginStoppingLocked()
+	p.reopenWhenDrained = reopenWhenDrained
+	p.maybeReopenAfterDrainLocked()
 	p.creationMu.Unlock()
 	p.runMu.Unlock()
-
-	completed := p.waitForThreadsToStop(runawayShutdownTimeout, nil)
-
-	// Recheck admission after the bounded wait; late workers keep it closed.
-	p.creationMu.Lock()
-	if wasStopping {
-		// Preserve a fatal barrier's quarantine and any prior watchdog policy.
-		p.reopenWhenDrained = reopenWhenDrained
-		p.maybeReopenAfterDrainLocked()
-	} else if completed && !p.hasThreadsOtherThan(nil) {
-		p.endStoppingLocked()
-	} else {
-		p.reopenWhenDrained = true
-		p.maybeReopenAfterDrainLocked()
-	}
-	p.creationMu.Unlock()
+	// Do not wait for cleanup here. A timed wait can suspend the Go runtime
+	// inside a direct WASM export, returning to JS before Update has finished.
 }
 
 func (p *Coroutines) nextUpdateAction(stats *UpdateJobsStats) updateAction {

--- a/internal/coroutine/update.go
+++ b/internal/coroutine/update.go
@@ -93,8 +93,9 @@ updateLoop:
 		}
 
 		if !p.updateWatchdogNow().Before(state.watchdogDeadline) {
-			log.Warn("engine update exceeded 1 second - stopping runaway scripts (waitMainCount=%d)", stats.WaitMainCount)
-			p.stopRunawayThreads()
+			// A slow frame is not necessarily a runaway script. Leave queued work
+			// for the next Update without canceling scripts or waiting for cleanup.
+			log.Warn("engine update exceeded 1 second - deferring remaining work to next frame (waitMainCount=%d)", stats.WaitMainCount)
 			break updateLoop
 		}
 	}
@@ -102,29 +103,6 @@ updateLoop:
 	stats.LoopTime = elapsedMillis(start)
 	stats.LoopIterations = iterations
 	p.promoteDeferredJobs(stats)
-}
-
-func (p *Coroutines) stopRunawayThreads() {
-	// This remains cooperative: an active thread must release runMu first.
-	// Another shutdown already owns cancellation and recovery. Waiting for its
-	// drain here would block the engine callback just like waiting for our own.
-	if !p.shutdownMu.TryLock() {
-		return
-	}
-	defer p.shutdownMu.Unlock()
-
-	p.runMu.Lock()
-	p.creationMu.Lock()
-	// Preserve an existing fatal barrier's quarantine. Otherwise the last
-	// exiting thread or native worker will reopen admission.
-	reopenWhenDrained := !p.stopping || p.reopenWhenDrained
-	p.beginStoppingLocked()
-	p.reopenWhenDrained = reopenWhenDrained
-	p.maybeReopenAfterDrainLocked()
-	p.creationMu.Unlock()
-	p.runMu.Unlock()
-	// Do not wait for cleanup here. A timed wait can suspend the Go runtime
-	// inside a direct WASM export, returning to JS before Update has finished.
 }
 
 func (p *Coroutines) nextUpdateAction(stats *UpdateJobsStats) updateAction {

--- a/internal/coroutine/wait_todo_panic_test.go
+++ b/internal/coroutine/wait_todo_panic_test.go
@@ -1,7 +1,6 @@
 package coroutine
 
 import (
-	"runtime"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -171,91 +170,4 @@ func TestRunAfterAbortAllWaitsForWaitToDoWorker(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("post-drain coroutine did not finish")
 	}
-}
-
-func TestRunawayShutdownDoesNotBlockOnNativeWorker(t *testing.T) {
-	co := New(nil)
-	co.OnInited()
-	workerStarted := make(chan struct{})
-	release := make(chan struct{})
-	caller := co.CreateAndStart(true, "caller", func(Thread) int {
-		co.WaitToDo(func() {
-			close(workerStarted)
-			<-release
-		})
-		return 0
-	})
-
-	cleanup := func() {
-		select {
-		case <-release:
-		default:
-			close(release)
-		}
-		if !co.AbortAllAndWait(time.Second) {
-			t.Error("coroutines did not stop during cleanup")
-		}
-	}
-	defer cleanup()
-
-	select {
-	case <-workerStarted:
-	case <-time.After(time.Second):
-		t.Fatal("native worker did not start")
-	}
-
-	shutdownDone := make(chan struct{})
-	go func() {
-		co.stopRunawayThreads()
-		close(shutdownDone)
-	}()
-	select {
-	case <-shutdownDone:
-	case <-time.After(time.Second):
-		t.Fatal("runaway shutdown blocked on an uncooperative native worker")
-	}
-
-	var rejectedRan atomic.Bool
-	rejected := co.Create("during-native-drain", func(Thread) int {
-		rejectedRan.Store(true)
-		return 0
-	})
-	if !rejected.Stopped() {
-		t.Fatal("runaway shutdown reopened admission before native worker drained")
-	}
-	if rejectedRan.Load() {
-		t.Fatal("coroutine created during native drain ran user code")
-	}
-	select {
-	case <-rejected.done:
-	case <-time.After(time.Second):
-		t.Fatal("rejected coroutine did not finish")
-	}
-
-	close(release)
-	select {
-	case <-caller.done:
-	case <-time.After(time.Second):
-		t.Fatal("canceled WaitToDo caller did not finish after native worker release")
-	}
-
-	deadline := time.Now().Add(time.Second)
-	for time.Now().Before(deadline) {
-		next := co.Create("after-native-drain", func(Thread) int { return 0 })
-		if !next.Stopped() {
-			select {
-			case <-next.done:
-			case <-time.After(time.Second):
-				t.Fatal("post-drain coroutine did not finish")
-			}
-			return
-		}
-		select {
-		case <-next.done:
-		case <-time.After(time.Second):
-			t.Fatal("rejected post-drain coroutine did not finish")
-		}
-		runtime.Gosched()
-	}
-	t.Fatal("admission did not reopen after native worker drained")
 }

--- a/internal/coroutine/wait_todo_panic_test.go
+++ b/internal/coroutine/wait_todo_panic_test.go
@@ -211,7 +211,7 @@ func TestRunawayShutdownDoesNotBlockOnNativeWorker(t *testing.T) {
 	}()
 	select {
 	case <-shutdownDone:
-	case <-time.After(2 * runawayShutdownTimeout):
+	case <-time.After(time.Second):
 		t.Fatal("runaway shutdown blocked on an uncooperative native worker")
 	}
 


### PR DESCRIPTION
When an update exceeds one second, the watchdog cancels scripts and synchronously waits for cleanup inside the direct Go WASM callback. This wait can trigger `fatal error: traceback did not unwind completely`, turning slow frames into crashes.

Change the watchdog to log a warning and finish the current update, preserving scripts and queued work for the next frame. Remove the obsolete watchdog shutdown/recovery code and replace its tests with coverage for script continuation, queue preservation, and retry-path timeouts.

Keep the direct WASM callbacks, scheduler retry checks, and explicit stop/error cleanup behavior.

## Validation

- `GOTOOLCHAIN=go1.25.8 go test -race ./internal/coroutine ./internal/engine .`
- `make build-wasm`
- Direct WASM reproducer: baseline crashes; fixed build completes subsequent stack growth/GC and resumes the script.
- Both reported demos exercised under slow frames in normal Web mode without the reproduced fatal error.

## Limitations

The budget remains cooperative: expensive tasks or infinite loops can still cause stalls. This change addresses the watchdog crash; performance improvements are handled separately.