### PR TITLE
fix(cli): propagate special command failures

### DIFF
--- a/cmd/spx/internal/command/cmd.go
+++ b/cmd/spx/internal/command/cmd.go
@@ -134,8 +134,8 @@ func (cmd *CmdTool) RunCmd(projectName, fileSuffix, version string, fs embed.FS,
 		return err
 	}
 
-	if cmd.handleSpecialCommands() {
-		return nil
+	if handled, err := cmd.handleSpecialCommands(); handled {
+		return err
 	}
 	if isRuntimeModeCommand(cmd.Args.CmdName) {
 		cmd.RuntimeMode = true
@@ -177,28 +177,31 @@ func (cmd *CmdTool) setupInterpretedPaths(dstRelDir string) error {
 }
 
 // handleSpecialCommands handles commands without setup.
-func (cmd *CmdTool) handleSpecialCommands() bool {
+func (cmd *CmdTool) handleSpecialCommands() (handled bool, err error) {
 	switch cmd.Args.CmdName {
 	case "help", "version":
 		cmd.ShowHelpInfo()
-		return true
+		return true, nil
 	case "clear":
-		if err := cmd.Clear(); err != nil {
+		err = cmd.Clear()
+		if err != nil {
 			logErrorf("Clearing project: %v", err)
 		}
-		return true
+		return true, err
 	case "clearbuild":
-		if err := cmd.ClearBuild(); err != nil {
+		err = cmd.ClearBuild()
+		if err != nil {
 			logErrorf("Clearing build artifacts: %v", err)
 		}
-		return true
+		return true, err
 	case "stopweb":
-		if err := cmd.StopWeb(); err != nil {
+		err = cmd.StopWeb()
+		if err != nil {
 			logErrorf("Stopping web server: %v", err)
 		}
-		return true
+		return true, err
 	}
-	return false
+	return false, nil
 }
 
 // executeCommand runs the main command flow.

--- a/cmd/spx/internal/command/cmd_test.go
+++ b/cmd/spx/internal/command/cmd_test.go
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2021 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package command
+
+import (
+	"embed"
+	"errors"
+	"flag"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunCmdPropagatesSpecialCommandErrors(t *testing.T) {
+	for _, name := range []string{"clear", "clearbuild", "stopweb"} {
+		t.Run(name, func(t *testing.T) {
+			root := t.TempDir()
+			t.Chdir(root)
+			projectDir := "project"
+			if name == "stopweb" {
+				cmd := &CmdTool{TargetAbsDir: root}
+				if err := os.Mkdir(cmd.webServerPIDPath(), 0o755); err != nil {
+					t.Fatal(err)
+				}
+			} else {
+				// Removal must fail for an overlong path component on all hosts.
+				if err := os.Mkdir(projectDir, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				projectDir = filepath.Join(projectDir, strings.Repeat("x", 300))
+			}
+			oldFlags, oldArgs := flag.CommandLine, os.Args
+			flag.CommandLine = flag.NewFlagSet("spx", flag.ContinueOnError)
+			flag.CommandLine.SetOutput(io.Discard)
+			os.Args = []string{"spx", name, "--path", root}
+			t.Cleanup(func() { flag.CommandLine, os.Args = oldFlags, oldArgs })
+
+			cmd := &CmdTool{}
+			err := cmd.RunCmd("spx", ".spx", "test", embed.FS{}, "", projectDir)
+			var pathErr *os.PathError
+			if !errors.As(err, &pathErr) {
+				t.Fatalf("RunCmd(%s) error = %v, want filesystem error", name, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Return errors from clear, clearbuild, and stopweb so failed special commands produce a failing CLI exit status. Add filesystem-failure regression coverage. Validation: make generate; go test ./cmd/spx/internal/command using the locked Go toolchain; git diff --check.