### PR TITLE
fix(coroutine): preserve panic values and fault stacks

### DIFF
--- a/docs/en/dev/engine/architecture.md
+++ b/docs/en/dev/engine/architecture.md
@@ -6,6 +6,8 @@ SPX consists of the XGo game runtime, platform bindings, and the SPX fork of God
 
 The Go-to-engine boundary differs by platform. Native platforms use GDExtension/native bindings. Web builds combine Go WASM with an Emscripten-built Godot runtime and JavaScript bridge code.
 
+Unhandled coroutine panics reach the engine as `coroutine.PanicReport`, preserving the original value, thread name, and stack at the fault. The engine includes this context in its log and `OnRuntimePanic` callback; an optional creation stack is labeled separately. `ErrAbortThread` and `ErrStopThisScript` remain normal control flow and are not reported. Shutdown barriers wait for panic reporting to finish, and lifecycle cleanup still runs if the reporter panics.
+
 ### 1. PC platforms
 
 Desktop builds support two primary workflows:

--- a/docs/zh/dev/engine/architecture.md
+++ b/docs/zh/dev/engine/architecture.md
@@ -8,6 +8,8 @@
 5. 用户逻辑使用 xgo 进行实现，在运行时会先编译成 Go，再按目标平台编译为动态库或 WebAssembly，或者解释执行
 6. 坐标空间和 Go/Godot 转换边界详见 [coordinate_system.md](./coordinate_system.md)
 
+协程未处理的 panic 通过 `coroutine.PanicReport` 传递到引擎，保留原始值、线程名和故障位置的栈。引擎日志和 `OnRuntimePanic` 回调包含这些信息，可选的创建栈单独标注。`ErrAbortThread` 和 `ErrStopThisScript` 仍作为正常控制流，不报告为错误。关闭屏障会等待 panic 报告结束；即使报告处理器发生 panic，生命周期清理也仍会执行。
+
 ### 1. PC 平台
 0. 依赖的是 cgo
 1. 通过 `make generate-bindings` 自动生成 Go wrapper 代码，用于在 Go 中调用 C++ 接口

--- a/internal/coroutine/lifecycle.go
+++ b/internal/coroutine/lifecycle.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"reflect"
 	"runtime"
+	sdebug "runtime/debug"
 	"sync"
 	stime "time"
 
@@ -396,7 +397,12 @@ func (p *Coroutines) handleThreadPanic(th Thread, recovered any) {
 		return
 	}
 	if p.onPanic != nil {
-		p.onPanic(th.name, th.stack)
+		p.onPanic(PanicReport{
+			Value:         recovered,
+			Name:          th.name,
+			Stack:         string(sdebug.Stack()),
+			CreationStack: th.stack,
+		})
 		return
 	}
 	panic(recovered)

--- a/internal/coroutine/manager.go
+++ b/internal/coroutine/manager.go
@@ -36,9 +36,17 @@ var (
 	ErrStopThisScript = errors.New("stop this script")
 )
 
+// PanicReport preserves an unhandled coroutine panic and its diagnostic context.
+type PanicReport struct {
+	Value         any
+	Name          string
+	Stack         string // Stack at the panic site, captured during recovery.
+	CreationStack string // Optional stack captured when the coroutine was created.
+}
+
 // Coroutines coordinates thread lifecycle and cooperative scheduling.
 type Coroutines struct {
-	onPanic   func(name, stack string)
+	onPanic   func(PanicReport)
 	hasInited atomic.Bool
 	debug     bool
 
@@ -91,8 +99,8 @@ type Coroutines struct {
 }
 
 // New creates a coroutine manager. onPanic is called when a coroutine exits
-// with an unhandled panic other than ErrAbortThread.
-func New(onPanic func(name, stack string)) *Coroutines {
+// with an unhandled panic other than ErrAbortThread or ErrStopThisScript.
+func New(onPanic func(PanicReport)) *Coroutines {
 	p := &Coroutines{
 		onPanic:           onPanic,
 		allThreads:        make(map[Thread]struct{}),

--- a/internal/coroutine/panic_test.go
+++ b/internal/coroutine/panic_test.go
@@ -1,0 +1,105 @@
+package coroutine
+
+import (
+	"errors"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestPanicReportPreservesValueAndFaultStack(t *testing.T) {
+	errorValue := errors.New("original error")
+	for _, value := range []any{"sentinel", errorValue, []string{"uncomparable", "value"}} {
+		t.Run(reflect.TypeOf(value).String(), func(t *testing.T) {
+			reports := make(chan PanicReport, 1)
+			co := New(func(report PanicReport) { reports <- report })
+			worker := co.Create("panic-worker", func(Thread) int {
+				panicWithValue(value)
+				return 0
+			})
+			waitForThreadSignal(t, worker.done, "panicking coroutine did not finish")
+			if !co.AbortAllAndWait(time.Second) {
+				t.Fatal("panic handler did not finish")
+			}
+			select {
+			case report := <-reports:
+				if !reflect.DeepEqual(report.Value, value) {
+					t.Errorf("reported panic = %#v, want %#v", report.Value, value)
+				}
+				if value == errorValue && report.Value != errorValue {
+					t.Error("panic report replaced the original error")
+				}
+				if report.Name != "panic-worker" {
+					t.Errorf("reported name = %q, want panic-worker", report.Name)
+				}
+				if !strings.Contains(report.Stack, "panicWithValue") {
+					t.Errorf("report does not include the fault site: %q", report.Stack)
+				}
+				if report.CreationStack != "" {
+					t.Error("creation stack captured when debug is disabled")
+				}
+			default:
+				t.Fatal("panic was not reported")
+			}
+		})
+	}
+}
+
+func panicWithValue(value any) { panic(value) }
+
+func TestPanicReportPreservesRuntimePanicAndCreationStack(t *testing.T) {
+	reports := make(chan PanicReport, 1)
+	co := New(func(report PanicReport) { reports <- report })
+	co.debug = true
+	worker := co.Create("runtime-panic-worker", panicWithNilDereference)
+	waitForThreadSignal(t, worker.done, "panicking coroutine did not finish")
+	if !co.AbortAllAndWait(time.Second) {
+		t.Fatal("panic handler did not finish")
+	}
+	select {
+	case report := <-reports:
+		if _, ok := report.Value.(runtime.Error); !ok {
+			t.Errorf("runtime panic type = %T, want runtime.Error", report.Value)
+		}
+		if !strings.Contains(report.Stack, "panicWithNilDereference") {
+			t.Errorf("report does not include the fault site: %q", report.Stack)
+		}
+		if !strings.Contains(report.CreationStack, "TestPanicReportPreservesRuntimePanicAndCreationStack") {
+			t.Errorf("report does not include the creation site: %q", report.CreationStack)
+		}
+		if strings.Contains(report.CreationStack, "panicWithNilDereference") {
+			t.Error("creation stack was replaced with the fault stack")
+		}
+	default:
+		t.Fatal("runtime panic was not reported")
+	}
+}
+
+func panicWithNilDereference(Thread) int {
+	var pointer *int
+	return *pointer
+}
+
+func TestPanicReportIgnoresNormalCompletionAndStopSentinels(t *testing.T) {
+	for _, value := range []any{nil, ErrAbortThread, ErrStopThisScript} {
+		reports := make(chan PanicReport, 1)
+		co := New(func(report PanicReport) { reports <- report })
+		worker := co.Create("stopped-worker", func(Thread) int {
+			if value != nil {
+				panic(value)
+			}
+			return 0
+		})
+		waitForThreadSignal(t, worker.done, "coroutine did not finish")
+		if !co.AbortAllAndWait(time.Second) {
+			t.Fatal("coroutine did not drain")
+		}
+		select {
+		case report := <-reports:
+			t.Errorf("normal termination %v reported as panic: %+v", value, report)
+		default:
+		}
+	}
+}

--- a/internal/coroutine/thread_test.go
+++ b/internal/coroutine/thread_test.go
@@ -464,7 +464,7 @@ func TestRunAfterAbortAllTimeoutRequiresExplicitRecovery(t *testing.T) {
 func TestRunAfterAbortAllRejectsSynchronousPanicHandlerReentry(t *testing.T) {
 	guarded := make(chan any, 1)
 	var co *Coroutines
-	co = New(func(string, string) {
+	co = New(func(PanicReport) {
 		func() {
 			defer func() { guarded <- recover() }()
 			co.RunAfterAbortAll(time.Second, nil)
@@ -491,7 +491,7 @@ func TestRunAfterAbortAllRejectsSynchronousPanicHandlerReentry(t *testing.T) {
 }
 
 func TestFinishThreadCleansLifecycleStateWhenPanicHandlerPanics(t *testing.T) {
-	co := New(func(string, string) {
+	co := New(func(PanicReport) {
 		panic("panic handler failure")
 	})
 	worker := co.newThread("panicking-worker")
@@ -535,7 +535,7 @@ func TestRunAfterAbortAllWaitsForPanicHandlerBeforeReopeningAdmission(t *testing
 	handlerStarted := make(chan struct{})
 	releaseHandler := make(chan struct{})
 	var releaseHandlerOnce sync.Once
-	co := New(func(string, string) {
+	co := New(func(PanicReport) {
 		close(handlerStarted)
 		<-releaseHandler
 	})

--- a/internal/coroutine/wait_todo_panic_test.go
+++ b/internal/coroutine/wait_todo_panic_test.go
@@ -20,7 +20,7 @@ func TestRunTaskTracksNilPanic(t *testing.T) {
 
 func TestWaitToDoPropagatesWorkerPanic(t *testing.T) {
 	panicReported := make(chan any, 1)
-	co := New(func(name, stack string) { panicReported <- "worker failure" })
+	co := New(func(report PanicReport) { panicReported <- report.Value })
 	co.OnInited()
 	co.CreateAndStart(true, "caller", func(me Thread) int {
 		co.WaitToDo(func() { panic("worker failure") })
@@ -42,7 +42,7 @@ func TestWaitToDoPropagatesWorkerPanic(t *testing.T) {
 
 func TestWaitToDoPropagatesNilWorkerPanic(t *testing.T) {
 	t.Setenv("GODEBUG", "panicnil=1")
-	co := New(func(string, string) {})
+	co := New(func(PanicReport) {})
 	co.OnInited()
 	continued := make(chan struct{}, 1)
 	thread := co.CreateAndStart(true, "caller", func(Thread) int {

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -230,9 +230,13 @@ func CheckPanic() {
 	}
 }
 
-// OnPanic reports a panic with an optional name and stack.
-func OnPanic(name, stack string) {
-	handlePanic(name, stack, nil, true)
+// OnPanic reports a coroutine's original panic and its fault and creation stacks.
+func OnPanic(report coroutine.PanicReport) {
+	stack := report.Stack
+	if report.CreationStack != "" {
+		stack += "\ncreated at:\n" + report.CreationStack
+	}
+	handlePanic(report.Name, stack, report.Value, true)
 }
 
 // handlePanic reports a panic and optionally exits.
@@ -266,13 +270,13 @@ func handlePanic(name, stack string, err any, exitOnPanic bool) {
 // Panic reports a panic message through the engine.
 func Panic(args ...any) {
 	msg := fmt.Sprint(args...)
-	OnPanic(msg, "")
+	handlePanic(msg, "", nil, true)
 }
 
 // Panicf reports a formatted panic message through the engine.
 func Panicf(format string, args ...any) {
 	msg := fmt.Sprintf(format, args...)
-	OnPanic(msg, "")
+	handlePanic(msg, "", nil, true)
 }
 
 // abortCoroutinesAndReset aborts coroutines and resets the engine.

--- a/internal/engine/panic_test.go
+++ b/internal/engine/panic_test.go
@@ -1,0 +1,63 @@
+//go:build !js && !pure_engine
+
+package engine
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/goplus/spx/v3/internal/coroutine"
+	"github.com/goplus/spx/v3/internal/enginewrap"
+	gdx "github.com/goplus/spx/v3/pkg/spx/pkg/engine"
+)
+
+type panicRecordingExt struct {
+	gdx.IExtMgr
+	messages chan string
+	exits    chan int64
+}
+
+func (r *panicRecordingExt) OnRuntimePanic(message string) { r.messages <- message }
+func (r *panicRecordingExt) RequestExit(code int64)        { r.exits <- code }
+
+func TestCoroutinePanicReachesRuntimeWithCauseAndFaultStack(t *testing.T) {
+	co := coroutine.New(OnPanic)
+	originalCo, originalPlatform, originalExt := gco, gdx.PlatformMgr, gdx.ExtMgr
+	recorder := &panicRecordingExt{messages: make(chan string, 1), exits: make(chan int64, 1)}
+	SetCoroutines(co)
+	gdx.PlatformMgr = resetDirectPlatform{}
+	gdx.ExtMgr = recorder
+	enginewrap.Init(WaitMainThread)
+	t.Cleanup(func() {
+		if !co.AbortAllAndWait(time.Second) {
+			t.Error("panicking coroutine did not finish")
+		}
+		SetCoroutines(originalCo)
+		gdx.PlatformMgr, gdx.ExtMgr = originalPlatform, originalExt
+	})
+
+	co.Create("panic-worker", panicWithSentinelCause)
+	select {
+	case message := <-recorder.messages:
+		for _, want := range []string{"panic-worker: panic: sentinel cause", "stack:", "panicWithSentinelCause"} {
+			if !strings.Contains(message, want) {
+				t.Errorf("runtime panic message %q does not contain %q", message, want)
+			}
+		}
+	case <-time.After(time.Second):
+		t.Fatal("coroutine panic did not reach runtime")
+	}
+	select {
+	case code := <-recorder.exits:
+		if code != 1 {
+			t.Errorf("panic exit code = %d, want 1", code)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("coroutine panic did not request exit")
+	}
+}
+
+func panicWithSentinelCause(coroutine.Thread) int {
+	panic("sentinel cause")
+}

--- a/runtime_stop_test.go
+++ b/runtime_stop_test.go
@@ -94,7 +94,7 @@ func TestProcedureScopesStopThisScriptAcrossRepeat(t *testing.T) {
 
 func TestStopThisScriptAtEventBoundaryEndsThread(t *testing.T) {
 	panicReported := make(chan struct{}, 1)
-	co := coroutine.New(func(name, stack string) {
+	co := coroutine.New(func(coroutine.PanicReport) {
 		panicReported <- struct{}{}
 	})
 	original := gco


### PR DESCRIPTION
Carry the original panic value, coroutine name, fault stack, and optional creation stack through the engine runtime panic callback. Preserve stop sentinels and lifecycle cleanup behavior. Add regression coverage for values, runtime faults, stack origins, and runtime reporting. Validation: make generate; tests for ./internal/coroutine, ./internal/engine, and the root package; coroutine race tests; git diff --check.