### PR TITLE
fix(runtime): verify cached asset contents before reuse

### DIFF
--- a/cmd/spx/internal/runtimeasset/runtimeasset.go
+++ b/cmd/spx/internal/runtimeasset/runtimeasset.go
@@ -17,6 +17,7 @@
 package runtimeasset
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"embed"
 	"encoding/hex"
@@ -166,17 +167,43 @@ func addAssetHash(hasher hash.Hash, name string) (err error) {
 			err = closeErr
 		}
 	}()
+	return addFileHash(hasher, name, srcFile)
+}
 
+func addFileHash(hasher hash.Hash, name string, file io.Reader) error {
 	if _, err := io.WriteString(hasher, name+"\x00"); err != nil {
-		return fmt.Errorf("hash embedded runtime asset name %s: %w", name, err)
+		return fmt.Errorf("hash runtime asset name %s: %w", name, err)
 	}
-	if _, err := io.Copy(hasher, srcFile); err != nil {
-		return fmt.Errorf("hash embedded runtime asset %s: %w", name, err)
+	if _, err := io.Copy(hasher, file); err != nil {
+		return fmt.Errorf("hash runtime asset %s: %w", name, err)
 	}
 	if _, err := io.WriteString(hasher, "\x00"); err != nil {
-		return fmt.Errorf("finalize embedded runtime asset hash %s: %w", name, err)
+		return fmt.Errorf("finalize runtime asset hash %s: %w", name, err)
 	}
 	return nil
+}
+
+func cachedAssetMatches(dstPath, name string) (matches bool, err error) {
+	file, err := os.Open(dstPath)
+	if err != nil {
+		return false, fmt.Errorf("open runtime cache asset %s: %w", dstPath, err)
+	}
+	defer func() {
+		if closeErr := file.Close(); closeErr != nil && err == nil {
+			err = closeErr
+		}
+	}()
+
+	hasher := sha256.New()
+	if err := addAssetHash(hasher, name); err != nil {
+		return false, err
+	}
+	expected := hasher.Sum(nil)
+	hasher.Reset()
+	if err := addFileHash(hasher, name, file); err != nil {
+		return false, fmt.Errorf("verify runtime cache asset %s: %w", dstPath, err)
+	}
+	return bytes.Equal(expected, hasher.Sum(nil)), nil
 }
 
 func extractAsset(cacheDir, name string) (err error) {
@@ -188,9 +215,16 @@ func extractAsset(cacheDir, name string) (err error) {
 
 	dstPath := filepath.Join(cacheDir, name)
 	mode := assetMode(name)
-	if dstInfo, err := os.Stat(dstPath); err == nil && dstInfo.Size() == info.Size() {
-		if chmodErr := os.Chmod(dstPath, mode); chmodErr == nil || runtime.GOOS == "windows" {
-			return nil
+	if dstInfo, err := os.Stat(dstPath); err == nil && dstInfo.Mode().IsRegular() && dstInfo.Size() == info.Size() {
+		// The cache key identifies the expected bundle, not the current file contents.
+		matches, err := cachedAssetMatches(dstPath, name)
+		if err != nil {
+			return err
+		}
+		if matches {
+			if chmodErr := os.Chmod(dstPath, mode); chmodErr == nil || runtime.GOOS == "windows" {
+				return nil
+			}
 		}
 	}
 

--- a/cmd/spx/internal/runtimeasset/runtimeasset_test.go
+++ b/cmd/spx/internal/runtimeasset/runtimeasset_test.go
@@ -17,11 +17,16 @@
 package runtimeasset
 
 import (
+	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
+	"sync"
 	"testing"
 	"testing/fstest"
+	"time"
 )
 
 func TestPrepareExtractsEmbeddedAssets(t *testing.T) {
@@ -172,6 +177,176 @@ func TestPrepareSeparatesCacheDirsByEmbeddedContent(t *testing.T) {
 	}
 	assertFileContent(t, filepath.Join(dirV1, "gdspx-linux-amd64.so"), "shared-one")
 	assertFileContent(t, filepath.Join(dirV2, "gdspx-linux-amd64.so"), "shared-two")
+}
+
+func TestPrepareRepairsSameSizeCorruption(t *testing.T) {
+	for _, withManifest := range []bool{false, true} {
+		name := "without manifest"
+		if withManifest {
+			name = "with manifest"
+		}
+		t.Run(name, func(t *testing.T) {
+			files := fstest.MapFS{
+				"assets/gdspxrt9.9.9": {Data: []byte("runtime")},
+			}
+			if withManifest {
+				files["assets/manifest.json"] = &fstest.MapFile{Data: []byte(`{"cache_key":"manifest-key","names":["gdspxrt9.9.9"]}`)}
+			}
+			setTestRuntimeAssets(t, files)
+			dir := prepareTestRuntime(t)
+			cachedPath := filepath.Join(dir, "gdspxrt9.9.9")
+			if err := os.WriteFile(cachedPath, []byte("corrupt"), 0o755); err != nil {
+				t.Fatal(err)
+			}
+
+			if repairedDir := prepareTestRuntime(t); repairedDir != dir {
+				t.Fatalf("cache directory changed from %s to %s", dir, repairedDir)
+			}
+			assertFileContent(t, cachedPath, "runtime")
+		})
+	}
+}
+
+func TestPrepareReusesValidCache(t *testing.T) {
+	setTestRuntimeAssets(t, fstest.MapFS{
+		"assets/gdspxrt9.9.9": {Data: []byte("runtime")},
+	})
+	dir := prepareTestRuntime(t)
+	cachedPath := filepath.Join(dir, "gdspxrt9.9.9")
+	stamp := time.Unix(1_600_000_000, 0)
+	if err := os.Chtimes(cachedPath, stamp, stamp); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(cachedPath, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.Stat(cachedPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	prepareTestRuntime(t)
+	after, err := os.Stat(cachedPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !os.SameFile(before, after) || !before.ModTime().Equal(after.ModTime()) {
+		t.Fatal("valid runtime cache was rewritten")
+	}
+	if runtime.GOOS != "windows" && after.Mode().Perm() != 0o755 {
+		t.Fatalf("runtime mode = %v, want 0755", after.Mode())
+	}
+}
+
+func TestPrepareConcurrentCacheRepair(t *testing.T) {
+	content := strings.Repeat("runtime", 1<<16)
+	setTestRuntimeAssets(t, fstest.MapFS{
+		"assets/gdspxrt9.9.9": {Data: []byte(content)},
+	})
+	dir := prepareTestRuntime(t)
+	cachedPath := filepath.Join(dir, "gdspxrt9.9.9")
+	if err := os.WriteFile(cachedPath, []byte(strings.Repeat("corrupt", 1<<16)), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Go(func() {
+			gotDir, ok, err := Prepare("9.9.9", "gdspxrt9.9.9")
+			if err != nil || !ok || gotDir != dir {
+				t.Errorf("Prepare() = (%q, %v, %v), want (%q, true, nil)", gotDir, ok, err, dir)
+				return
+			}
+			data, err := os.ReadFile(cachedPath)
+			if err != nil || string(data) != content {
+				t.Errorf("Prepare returned an incomplete or corrupt runtime: %v", err)
+			}
+		})
+	}
+	wg.Wait()
+}
+
+func TestPrepareReportsCacheRepairFailure(t *testing.T) {
+	setTestRuntimeAssets(t, fstest.MapFS{
+		"assets/gdspxrt9.9.9": {Data: []byte("runtime")},
+	})
+	dir := prepareTestRuntime(t)
+	cachedPath := filepath.Join(dir, "gdspxrt9.9.9")
+	if err := os.Remove(cachedPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(cachedPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cachedPath, "occupied"), []byte("keep"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	gotDir, ok, err := Prepare("9.9.9", "gdspxrt9.9.9")
+	if err == nil || !strings.Contains(err.Error(), cachedPath) || gotDir != "" || ok {
+		t.Fatalf("Prepare() = (%q, %v, %v), want an error identifying %s", gotDir, ok, err, cachedPath)
+	}
+	assertFileContent(t, filepath.Join(cachedPath, "occupied"), "keep")
+	leftovers, err := filepath.Glob(cachedPath + ".tmp-*")
+	if err != nil || len(leftovers) != 0 {
+		t.Fatalf("temporary cache files remain: %v, error: %v", leftovers, err)
+	}
+}
+
+func TestPrepareReportsCacheVerificationFailure(t *testing.T) {
+	setTestRuntimeAssets(t, fstest.MapFS{
+		"assets/manifest.json": {Data: []byte(`{"cache_key":"manifest-key","names":["gdspxrt9.9.9"]}`)},
+		"assets/gdspxrt9.9.9":  {Data: []byte("runtime")},
+	})
+	dir := prepareTestRuntime(t)
+	readErr := errors.New("asset read failed")
+	assetsFS = readErrorFS{FS: assetsFS, name: "assets/gdspxrt9.9.9", err: readErr}
+
+	gotDir, ok, err := Prepare("9.9.9", "gdspxrt9.9.9")
+	if !errors.Is(err, readErr) || gotDir != "" || ok {
+		t.Fatalf("Prepare() = (%q, %v, %v), want asset read error", gotDir, ok, err)
+	}
+	assertFileContent(t, filepath.Join(dir, "gdspxrt9.9.9"), "runtime")
+}
+
+type readErrorFS struct {
+	fs.FS
+	name string
+	err  error
+}
+
+func (f readErrorFS) Open(name string) (fs.File, error) {
+	file, err := f.FS.Open(name)
+	if err == nil && name == f.name {
+		return readErrorFile{File: file, err: f.err}, nil
+	}
+	return file, err
+}
+
+type readErrorFile struct {
+	fs.File
+	err error
+}
+
+func (f readErrorFile) Read([]byte) (int, error) { return 0, f.err }
+
+func setTestRuntimeAssets(t *testing.T, files fstest.MapFS) {
+	t.Helper()
+	oldFS, oldCacheBaseDirFn := assetsFS, cacheBaseDirFn
+	t.Cleanup(func() {
+		assetsFS, cacheBaseDirFn = oldFS, oldCacheBaseDirFn
+	})
+	assetsFS = files
+	cacheRoot := t.TempDir()
+	cacheBaseDirFn = func() string { return cacheRoot }
+}
+
+func prepareTestRuntime(t *testing.T) string {
+	t.Helper()
+	dir, ok, err := Prepare("9.9.9", "gdspxrt9.9.9")
+	if err != nil || !ok {
+		t.Fatalf("Prepare() = (%q, %v, %v), want an extracted runtime", dir, ok, err)
+	}
+	return dir
 }
 
 func assertFileContent(t *testing.T, path string, want string) {


### PR DESCRIPTION
Verify cached runtime assets against embedded contents before reuse, repairing same-size corruption while retaining valid files and restoring permissions. Cover manifest and non-manifest caches, concurrent repair, and verification or replacement failures. Validation: make generate; go test -race ./cmd/spx/internal/runtimeasset using the locked toolchain; git diff --check.