### PR TITLE
fix(web): preserve callback identity across registrations

### DIFF
--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -47,6 +47,14 @@ jobs:
           bash -n .github/scripts/npm/prepare_package.sh
           bash -n .github/scripts/release/assemble.sh
 
+      - name: Set up Node.js for Web bridge tests
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
+
+      - name: Test Web callback routing
+        run: node --test cmd/ispx/tests/*.test.cjs
+
       - name: Test Go code
         shell: bash
         run: |

--- a/cmd/ispx/tests/worker.message.manager.test.cjs
+++ b/cmd/ispx/tests/worker.message.manager.test.cjs
@@ -1,0 +1,131 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+
+const sourcePath = path.join(__dirname, '../web/worker.message.manager.js');
+const source = fs.readFileSync(sourcePath, 'utf8');
+
+function loadManager() {
+    const window = {};
+    const errors = [];
+    const context = vm.createContext({
+        window,
+        Date: { now: () => 1788776630000 },
+        console: { error: (...args) => errors.push(args), warn: () => {} },
+    });
+    vm.runInContext(source, context, { filename: sourcePath });
+    const manager = new context.WorkerMessageManager();
+    const messages = [];
+    manager.setPThreads({
+        runningWorkers: [{ postMessage: (message) => messages.push(message) }],
+    });
+    const game = { rtenv: {} };
+    manager.bindMainThreadCallbacks(game);
+    return { context, window, manager, messages, errors, call: game.rtenv._spxOnMainCall };
+}
+
+const settleCallbacks = () => new Promise(setImmediate);
+
+test('consecutive calls with a frozen clock keep distinct callback routes', async () => {
+    const { manager, window, messages, call } = loadManager();
+    const received = [];
+    manager.callWorkerFunction('subscribe', 'first', (value) => received.push(['first', value]), 42);
+    manager.callWorkerFunction('subscribe', 'second', (value) => received.push(['second', value]), null);
+
+    const first = messages[0].data.args;
+    const second = messages[1].data.args;
+    assert.deepEqual(Array.from(first), ['first', '_SPX_CALLBACK_FUNC_', first[2], 42]);
+    assert.deepEqual(Array.from(second), ['second', '_SPX_CALLBACK_FUNC_', second[2], null]);
+    assert.notEqual(first[2], second[2]);
+    assert.equal(Object.keys(window._spxMainCalls).length, 2);
+
+    call(second[2], 'request-b', 'B');
+    call(first[2], 'request-a', 'A');
+    await settleCallbacks();
+    assert.deepEqual(received, [['second', 'B'], ['first', 'A']]);
+    assert.deepEqual(messages.slice(2).map((message) => message.responseId), ['request-b', 'request-a']);
+});
+
+test('async callbacks respond to their own requests when they finish out of order', async () => {
+    const { manager, messages, call } = loadManager();
+    let resolveFirst;
+    let resolveSecond;
+    const first = manager.processArguments(() => new Promise((resolve) => { resolveFirst = resolve; }))[1];
+    const second = manager.processArguments(() => new Promise((resolve) => { resolveSecond = resolve; }))[1];
+    call(first, 'request-a');
+    call(second, 'request-b');
+
+    resolveSecond('result-b');
+    await settleCallbacks();
+    resolveFirst('result-a');
+    await settleCallbacks();
+    assert.deepEqual(messages.map(({ responseId, result, error }) => ({ responseId, result, error })), [
+        { responseId: 'request-b', result: 'result-b', error: null },
+        { responseId: 'request-a', result: 'result-a', error: null },
+    ]);
+});
+
+test('subscriptions remain callable until the callback registry is cleared', async () => {
+    const { manager, window, messages, call } = loadManager();
+    const received = [];
+    const callbackName = manager.processArguments((value) => received.push(value))[1];
+    call(callbackName, 'first', 1);
+    call(callbackName, 'second', 2);
+    await settleCallbacks();
+    assert.deepEqual(received, [1, 2]);
+    assert.equal(typeof window._spxMainCalls[callbackName], 'function');
+
+    manager.bindMainCallHandler();
+    assert.equal(Object.keys(window._spxMainCalls).length, 0);
+    const nextCallback = manager.processArguments((value) => received.push(value))[1];
+    assert.notEqual(nextCallback, callbackName);
+    call(callbackName, 'stale', 3);
+    call(nextCallback, 'current', 4);
+    await settleCallbacks();
+    assert.deepEqual(received, [1, 2, 4]);
+    assert.deepEqual(messages.map((message) => message.responseId), ['first', 'second', 'current']);
+});
+
+test('a replacement manager does not reuse cleared callback identifiers', async () => {
+    const { context, manager, window, call } = loadManager();
+    const oldCallback = manager.processArguments(() => assert.fail('cleared callback ran'))[1];
+    const replacement = new context.WorkerMessageManager();
+    let calls = 0;
+    const newCallback = replacement.processArguments(() => { calls++; })[1];
+    assert.notEqual(oldCallback, newCallback);
+    assert.equal(window._spxMainCalls[oldCallback], undefined);
+
+    call(oldCallback, 'stale');
+    window._spxOnMainCall(newCallback, 'current');
+    await settleCallbacks();
+    assert.equal(calls, 1);
+});
+
+test('clearing the registry discards pending responses without disabling new callbacks', async () => {
+    const { manager, messages, window, call } = loadManager();
+    let resolveOld;
+    const oldCallback = manager.processArguments(() => new Promise((resolve) => { resolveOld = resolve; }))[1];
+    call(oldCallback, 'old-request');
+
+    manager.bindMainCallHandler();
+    const currentCallback = manager.processArguments(() => 'current-result')[1];
+    window._spxOnMainCall(currentCallback, 'current-request');
+    resolveOld('old-result');
+    await settleCallbacks();
+    assert.deepEqual(messages.map(({ responseId, result }) => ({ responseId, result })), [
+        { responseId: 'current-request', result: 'current-result' },
+    ]);
+});
+
+test('callback errors preserve their request identity', async () => {
+    const { manager, messages, errors, call } = loadManager();
+    const callbackName = manager.processArguments(() => { throw new Error('sentinel'); })[1];
+    call(callbackName, 'failed-request');
+    await settleCallbacks();
+    assert.equal(messages.length, 1);
+    assert.equal(messages[0].responseId, 'failed-request');
+    assert.equal(messages[0].error, 'sentinel');
+    assert.equal(errors.length, 1);
+});

--- a/cmd/ispx/web/worker.message.manager.js
+++ b/cmd/ispx/web/worker.message.manager.js
@@ -1,3 +1,5 @@
+// Keep callback IDs unique across calls and manager replacements in this window.
+let nextWorkerCallbackId = 0;
 
 // PThread Worker 消息管理器类
 class WorkerMessageManager {
@@ -66,12 +68,10 @@ class WorkerMessageManager {
     processArguments(...args) {
 
         const processedArgs = [];
-        let callbackCounter = 0;
-
         for (let arg of args) {
             if (typeof arg === 'function') {
                 // generate unique callback name
-                const callbackName = `_onSpxCall_${Date.now()}_${callbackCounter++}`;
+                const callbackName = `_onSpxCall_${nextWorkerCallbackId++}`;
 
                 // register callback function
                 this.registerWorkerCallback(callbackName, arg);
@@ -88,8 +88,9 @@ class WorkerMessageManager {
 
     // register worker callback function
     registerWorkerCallback(callbackName, userFunction) {
+        const callbacks = window._spxMainCalls;
         // create callback handler function
-        window._spxMainCalls[callbackName] = async function (requestId, ...args) {
+        callbacks[callbackName] = async function (requestId, ...args) {
             let errorMsg = null;
             let result = null;
 
@@ -106,6 +107,11 @@ class WorkerMessageManager {
             } catch (error) {
                 console.error(`Error in ${callbackName}:`, error);
                 errorMsg = error.message;
+            }
+
+            // Rebinding clears subscriptions, including their pending responses.
+            if (window._spxMainCalls !== callbacks) {
+                return;
             }
 
             // send response to worker


### PR DESCRIPTION
Use distinct callback identifiers across calls and manager replacements, and discard pending responses after the callback registry is reset. Add Node regression tests for same-tick registrations, out-of-order responses, subscriptions, manager replacement, reset, and errors; run them in CI. Validation: make generate; all six Node 24 tests pass; git diff --check.