### PR TITLE
refactor(buildctl): share environment and command helpers

### DIFF
--- a/internal/cmd/buildctl/shared/command_helpers.go
+++ b/internal/cmd/buildctl/shared/command_helpers.go
@@ -21,10 +21,6 @@ import (
 	"os/exec"
 )
 
-func runCommandOutput(name string, args ...string) ([]byte, error) {
-	return RunCommandOutputWithEnv("", os.Environ(), name, args...)
-}
-
 // RunCommandOutputWithEnv returns combined output using the given environment
 // and working directory. An empty workdir inherits the current directory.
 func RunCommandOutputWithEnv(workdir string, env []string, name string, args ...string) ([]byte, error) {
@@ -34,6 +30,10 @@ func RunCommandOutputWithEnv(workdir string, env []string, name string, args ...
 		cmd.Dir = workdir
 	}
 	return cmd.CombinedOutput()
+}
+
+func runCommandOutput(name string, args ...string) ([]byte, error) {
+	return RunCommandOutputWithEnv("", os.Environ(), name, args...)
 }
 
 func runStreamingCommand(workdir, name string, args ...string) error {

--- a/internal/cmd/buildctl/shared/command_helpers.go
+++ b/internal/cmd/buildctl/shared/command_helpers.go
@@ -22,10 +22,12 @@ import (
 )
 
 func runCommandOutput(name string, args ...string) ([]byte, error) {
-	return runCommandOutputWithEnv("", os.Environ(), name, args...)
+	return RunCommandOutputWithEnv("", os.Environ(), name, args...)
 }
 
-func runCommandOutputWithEnv(workdir string, env []string, name string, args ...string) ([]byte, error) {
+// RunCommandOutputWithEnv returns combined output using the given environment
+// and working directory. An empty workdir inherits the current directory.
+func RunCommandOutputWithEnv(workdir string, env []string, name string, args ...string) ([]byte, error) {
 	cmd := exec.Command(name, args...)
 	cmd.Env = env
 	if workdir != "" {

--- a/internal/cmd/buildctl/shared/command_runner.go
+++ b/internal/cmd/buildctl/shared/command_runner.go
@@ -65,13 +65,13 @@ func buildctlCommandEnv() (map[string]string, error) {
 	if goRoot := runtime.GOROOT(); goRoot != "" {
 		pathDirs = append(pathDirs, filepath.Join(goRoot, "bin"))
 	}
-	setPathEnv(env, prependToPath(pathEnvValue(env), pathDirs...))
+	setPathEnv(env, PrependToPath(pathEnvValue(env), pathDirs...))
 	env["GOTOOLCHAIN"] = "go" + release.DefaultRuntimeLock().Toolchain.Go
 	return env, nil
 }
 
 func currentBuildEnv() (map[string]string, error) {
-	env := currentEnvMap()
+	env := CurrentEnvMap()
 	if err := configureCurrentMacOSGoToolchainEnv(env); err != nil {
 		return nil, fmt.Errorf("configure macOS Go toolchain: %w", err)
 	}
@@ -168,7 +168,8 @@ func setPathEnv(env map[string]string, value string) {
 	env["PATH"] = value
 }
 
-func currentEnvMap() map[string]string {
+// CurrentEnvMap returns a copy of the process environment keyed by name.
+func CurrentEnvMap() map[string]string {
 	env := map[string]string{}
 	for _, item := range os.Environ() {
 		parts := strings.SplitN(item, "=", 2)
@@ -193,7 +194,8 @@ func envMapToSlice(env map[string]string) []string {
 	return out
 }
 
-func prependToPath(pathValue string, dirs ...string) string {
+// PrependToPath puts dirs before pathValue, omitting empty and duplicate entries.
+func PrependToPath(pathValue string, dirs ...string) string {
 	result := []string{}
 	seen := map[string]bool{}
 	appendDir := func(dir string) {

--- a/internal/cmd/buildctl/shared/command_runner.go
+++ b/internal/cmd/buildctl/shared/command_runner.go
@@ -52,6 +52,39 @@ func (r CommandRunner) RunCommand(workdir string, name string, args ...string) e
 	return cmd.Run()
 }
 
+// CurrentEnvMap returns a copy of the process environment keyed by name.
+func CurrentEnvMap() map[string]string {
+	env := map[string]string{}
+	for _, item := range os.Environ() {
+		parts := strings.SplitN(item, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		env[parts[0]] = parts[1]
+	}
+	return env
+}
+
+// PrependToPath puts dirs before pathValue, omitting empty and duplicate entries.
+func PrependToPath(pathValue string, dirs ...string) string {
+	result := []string{}
+	seen := map[string]bool{}
+	appendDir := func(dir string) {
+		if dir == "" || seen[dir] {
+			return
+		}
+		seen[dir] = true
+		result = append(result, dir)
+	}
+	for _, dir := range dirs {
+		appendDir(dir)
+	}
+	for _, dir := range filepath.SplitList(pathValue) {
+		appendDir(dir)
+	}
+	return strings.Join(result, string(os.PathListSeparator))
+}
+
 func buildctlCommandEnv() (map[string]string, error) {
 	env, err := currentBuildEnv()
 	if err != nil {
@@ -168,19 +201,6 @@ func setPathEnv(env map[string]string, value string) {
 	env["PATH"] = value
 }
 
-// CurrentEnvMap returns a copy of the process environment keyed by name.
-func CurrentEnvMap() map[string]string {
-	env := map[string]string{}
-	for _, item := range os.Environ() {
-		parts := strings.SplitN(item, "=", 2)
-		if len(parts) != 2 {
-			continue
-		}
-		env[parts[0]] = parts[1]
-	}
-	return env
-}
-
 func envMapToSlice(env map[string]string) []string {
 	keys := make([]string, 0, len(env))
 	for key := range env {
@@ -192,24 +212,4 @@ func envMapToSlice(env map[string]string) []string {
 		out = append(out, key+"="+env[key])
 	}
 	return out
-}
-
-// PrependToPath puts dirs before pathValue, omitting empty and duplicate entries.
-func PrependToPath(pathValue string, dirs ...string) string {
-	result := []string{}
-	seen := map[string]bool{}
-	appendDir := func(dir string) {
-		if dir == "" || seen[dir] {
-			return
-		}
-		seen[dir] = true
-		result = append(result, dir)
-	}
-	for _, dir := range dirs {
-		appendDir(dir)
-	}
-	for _, dir := range filepath.SplitList(pathValue) {
-		appendDir(dir)
-	}
-	return strings.Join(result, string(os.PathListSeparator))
 }

--- a/internal/cmd/buildctl/shared/runner_test.go
+++ b/internal/cmd/buildctl/shared/runner_test.go
@@ -176,3 +176,11 @@ func TestCommandRunnerRunCommandReturnsResolvePathError(t *testing.T) {
 		t.Fatalf("runCommand error = %v, want command path resolution context", err)
 	}
 }
+
+func TestPrependToPathDedupes(t *testing.T) {
+	got := PrependToPath(strings.Join([]string{"/usr/bin", "/bin"}, string(filepath.ListSeparator)), "/custom/bin", "/usr/bin")
+	want := strings.Join([]string{"/custom/bin", "/usr/bin", "/bin"}, string(filepath.ListSeparator))
+	if got != want {
+		t.Fatalf("PrependToPath = %q, want %q", got, want)
+	}
+}

--- a/internal/cmd/buildctl/tool/setup_env.go
+++ b/internal/cmd/buildctl/tool/setup_env.go
@@ -24,7 +24,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
-	"slices"
 	"strconv"
 	"strings"
 
@@ -39,7 +38,7 @@ type emsdkEnvironment struct {
 var (
 	buildEnvLookPath           = exec.LookPath
 	buildEnvRunStreaming       = shared.RunStreamingCommand
-	buildEnvRunOutputWithDir   = runCommandOutputWithEnv
+	buildEnvRunOutputWithDir   = shared.RunCommandOutputWithEnv
 	resolveEMSDKShellExportsFn = ResolveEMSDKShellExports
 )
 
@@ -199,7 +198,7 @@ func verifyEMSDK(env emsdkEnvironment) error {
 	if err != nil {
 		return err
 	}
-	output, err := buildEnvRunOutputWithDir("", envMapToSlice(verifyEnv), emppPath, "--version")
+	output, err := buildEnvRunOutputWithDir("", shared.EnvMapToSlice(verifyEnv), emppPath, "--version")
 	if err != nil {
 		return fmt.Errorf("failed to set up emsdk. Please check the installation: %w", err)
 	}
@@ -214,7 +213,7 @@ func resolveEMSDKVerificationEnvironment(env emsdkEnvironment) (map[string]strin
 		return nil, "", err
 	}
 
-	merged := currentEnvMap()
+	merged := shared.CurrentEnvMap()
 	for key, value := range exports {
 		merged[key] = value
 	}
@@ -254,17 +253,17 @@ func detectPythonCommand() (string, error) {
 }
 
 func resolveJDKShellEnvironment() (map[string]string, error) {
-	env := currentEnvMap()
+	env := shared.CurrentEnvMap()
 	for _, binDir := range candidateJDKBinDirs() {
-		if dirExists(binDir) {
-			env["PATH"] = prependToPath(env["PATH"], binDir)
+		if shared.DirExists(binDir) {
+			env["PATH"] = shared.PrependToPath(env["PATH"], binDir)
 			break
 		}
 	}
 
 	if javaHome, err := resolveJavaHome(env); err == nil && javaHome != "" {
 		env["JAVA_HOME"] = javaHome
-		env["PATH"] = prependToPath(env["PATH"], filepath.Join(javaHome, "bin"))
+		env["PATH"] = shared.PrependToPath(env["PATH"], filepath.Join(javaHome, "bin"))
 	}
 	return env, nil
 }
@@ -275,15 +274,15 @@ func resolveJavaHome(env map[string]string) (string, error) {
 	}
 	if runtime.GOOS == "darwin" {
 		for _, binDir := range candidateJDKBinDirs() {
-			if dirExists(binDir) {
+			if shared.DirExists(binDir) {
 				prefix := filepath.Dir(binDir)
 				home := filepath.Join(prefix, "libexec", "openjdk.jdk", "Contents", "Home")
-				if dirExists(home) {
+				if shared.DirExists(home) {
 					return home, nil
 				}
 			}
 		}
-		output, err := runCommandOutputWithEnv("", envMapToSlice(env), "/usr/libexec/java_home", "-v", strconv.Itoa(requiredJDKMajor))
+		output, err := shared.RunCommandOutputWithEnv("", shared.EnvMapToSlice(env), "/usr/libexec/java_home", "-v", strconv.Itoa(requiredJDKMajor))
 		if err == nil {
 			return strings.TrimSpace(string(output)), nil
 		}
@@ -302,7 +301,7 @@ func candidateJDKBinDirs() []string {
 }
 
 func detectJavaMajorVersion(env map[string]string) (int, bool) {
-	output, err := runCommandOutputWithEnv("", envMapToSlice(env), "java", "-version")
+	output, err := shared.RunCommandOutputWithEnv("", shared.EnvMapToSlice(env), "java", "-version")
 	if err != nil {
 		return 0, false
 	}
@@ -392,7 +391,7 @@ func ResolveEMSDKShellExports() (map[string]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	before := currentEnvMap()
+	before := shared.CurrentEnvMap()
 	output, err := runEMSDKShellOutput(env.repoDir, "source ./emsdk_env.sh >/dev/null 2>&1; env -0")
 	if err != nil {
 		return nil, err
@@ -402,7 +401,7 @@ func ResolveEMSDKShellExports() (map[string]string, error) {
 }
 
 func runEMSDKShellOutput(workdir, script string) ([]byte, error) {
-	return runCommandOutputWithEnv(workdir, os.Environ(), "bash", "-lc", script)
+	return shared.RunCommandOutputWithEnv(workdir, os.Environ(), "bash", "-lc", script)
 }
 
 func parseNullEnvOutput(data []byte) map[string]string {
@@ -431,62 +430,4 @@ func selectEMSDKExports(before, after map[string]string) map[string]string {
 		}
 	}
 	return exports
-}
-
-func prependToPath(pathValue string, dirs ...string) string {
-	result := []string{}
-	seen := map[string]bool{}
-	appendDir := func(dir string) {
-		if dir == "" || seen[dir] {
-			return
-		}
-		seen[dir] = true
-		result = append(result, dir)
-	}
-	for _, dir := range dirs {
-		appendDir(dir)
-	}
-	for _, dir := range filepath.SplitList(pathValue) {
-		appendDir(dir)
-	}
-	return strings.Join(result, string(os.PathListSeparator))
-}
-
-func currentEnvMap() map[string]string {
-	env := map[string]string{}
-	for _, item := range os.Environ() {
-		parts := strings.SplitN(item, "=", 2)
-		if len(parts) != 2 {
-			continue
-		}
-		env[parts[0]] = parts[1]
-	}
-	return env
-}
-
-func envMapToSlice(env map[string]string) []string {
-	keys := make([]string, 0, len(env))
-	for key := range env {
-		keys = append(keys, key)
-	}
-	slices.Sort(keys)
-	out := make([]string, 0, len(keys))
-	for _, key := range keys {
-		out = append(out, key+"="+env[key])
-	}
-	return out
-}
-
-func runCommandOutputWithEnv(workdir string, env []string, name string, args ...string) ([]byte, error) {
-	cmd := exec.Command(name, args...)
-	cmd.Env = env
-	if workdir != "" {
-		cmd.Dir = workdir
-	}
-	return cmd.CombinedOutput()
-}
-
-func dirExists(path string) bool {
-	info, err := os.Stat(path)
-	return err == nil && info.IsDir()
 }

--- a/internal/cmd/buildctl/tool/setup_env.go
+++ b/internal/cmd/buildctl/tool/setup_env.go
@@ -42,11 +42,6 @@ var (
 	resolveEMSDKShellExportsFn = ResolveEMSDKShellExports
 )
 
-func setupSCons() error {
-	_, err := EnsureSCons()
-	return err
-}
-
 func EnsureSCons() (string, error) {
 	python, err := detectPythonCommand()
 	if err != nil {
@@ -85,13 +80,6 @@ func EnsureSCons() (string, error) {
 		return "", err
 	}
 	return sconsCommand, nil
-}
-
-func sconsEnvironmentCommands(venvDir string) (pythonCommand, sconsCommand string) {
-	if runtime.GOOS == "windows" {
-		return filepath.Join(venvDir, "Scripts", "python.exe"), filepath.Join(venvDir, "Scripts", "scons.exe")
-	}
-	return filepath.Join(venvDir, "bin", "python"), filepath.Join(venvDir, "bin", "scons")
 }
 
 func SetupJDK() error {
@@ -191,6 +179,45 @@ func SetupEMSDK() error {
 		return err
 	}
 	return verifyEMSDK(env)
+}
+
+func ResolveJDKShellExports() (map[string]string, error) {
+	env, err := resolveJDKShellEnvironment()
+	if err != nil {
+		return nil, err
+	}
+	exports := map[string]string{}
+	if javaHome := strings.TrimSpace(env["JAVA_HOME"]); javaHome != "" {
+		exports["JAVA_HOME"] = javaHome
+		exports["PATH"] = env["PATH"]
+	}
+	return exports, nil
+}
+
+func ResolveEMSDKShellExports() (map[string]string, error) {
+	env, err := resolveEMSDKEnvironment()
+	if err != nil {
+		return nil, err
+	}
+	before := shared.CurrentEnvMap()
+	output, err := runEMSDKShellOutput(env.repoDir, "source ./emsdk_env.sh >/dev/null 2>&1; env -0")
+	if err != nil {
+		return nil, err
+	}
+	after := parseNullEnvOutput(output)
+	return selectEMSDKExports(before, after), nil
+}
+
+func setupSCons() error {
+	_, err := EnsureSCons()
+	return err
+}
+
+func sconsEnvironmentCommands(venvDir string) (pythonCommand, sconsCommand string) {
+	if runtime.GOOS == "windows" {
+		return filepath.Join(venvDir, "Scripts", "python.exe"), filepath.Join(venvDir, "Scripts", "scons.exe")
+	}
+	return filepath.Join(venvDir, "bin", "python"), filepath.Join(venvDir, "bin", "scons")
 }
 
 func verifyEMSDK(env emsdkEnvironment) error {
@@ -337,19 +364,6 @@ func parseJavaMajorVersion(output string) (int, bool) {
 	return 0, false
 }
 
-func ResolveJDKShellExports() (map[string]string, error) {
-	env, err := resolveJDKShellEnvironment()
-	if err != nil {
-		return nil, err
-	}
-	exports := map[string]string{}
-	if javaHome := strings.TrimSpace(env["JAVA_HOME"]); javaHome != "" {
-		exports["JAVA_HOME"] = javaHome
-		exports["PATH"] = env["PATH"]
-	}
-	return exports, nil
-}
-
 func resolveEMSDKEnvironment() (emsdkEnvironment, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
@@ -384,20 +398,6 @@ func detectEMSDKVersion(env emsdkEnvironment) (string, bool) {
 		return "", false
 	}
 	return fields[2], true
-}
-
-func ResolveEMSDKShellExports() (map[string]string, error) {
-	env, err := resolveEMSDKEnvironment()
-	if err != nil {
-		return nil, err
-	}
-	before := shared.CurrentEnvMap()
-	output, err := runEMSDKShellOutput(env.repoDir, "source ./emsdk_env.sh >/dev/null 2>&1; env -0")
-	if err != nil {
-		return nil, err
-	}
-	after := parseNullEnvOutput(output)
-	return selectEMSDKExports(before, after), nil
 }
 
 func runEMSDKShellOutput(workdir, script string) ([]byte, error) {

--- a/internal/cmd/buildctl/tool/setup_env_test.go
+++ b/internal/cmd/buildctl/tool/setup_env_test.go
@@ -22,6 +22,8 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/goplus/spx/v3/internal/cmd/buildctl/shared"
 )
 
 func TestSConsEnvironmentCommands(t *testing.T) {
@@ -54,14 +56,6 @@ func TestParseJavaMajorVersion(t *testing.T) {
 		if got != tc.want || ok != tc.ok {
 			t.Fatalf("parseJavaMajorVersion(%q) = (%d,%v), want (%d,%v)", tc.output, got, ok, tc.want, tc.ok)
 		}
-	}
-}
-
-func TestPrependToPathDedupes(t *testing.T) {
-	got := prependToPath("/usr/bin:/bin", "/custom/bin", "/usr/bin")
-	want := strings.Join([]string{"/custom/bin", "/usr/bin", "/bin"}, string(filepath.ListSeparator))
-	if got != want {
-		t.Fatalf("prependToPath = %q, want %q", got, want)
 	}
 }
 
@@ -151,7 +145,7 @@ func TestResolveEMSDKVerificationEnvironmentAddsConfigAndCache(t *testing.T) {
 	if env["EM_CACHE"] != filepath.Join(repoDir, "upstream", "emscripten", "cache") {
 		t.Fatalf("unexpected EM_CACHE: %q", env["EM_CACHE"])
 	}
-	if !dirExists(env["EM_CACHE"]) {
+	if !shared.DirExists(env["EM_CACHE"]) {
 		t.Fatalf("expected EM_CACHE directory to exist: %s", env["EM_CACHE"])
 	}
 }


### PR DESCRIPTION
Reuse shared environment, PATH, directory, and command-output helpers in buildctl setup, removing duplicate implementations. Place public functions before private helpers in the affected implementation files. Validation: make generate; tests for buildctl/shared and buildctl/tool; git diff --check.