### PR TITLE
refactor(cli): simplify build and packaging helpers

### DIFF
--- a/cmd/spx/internal/command/build.go
+++ b/cmd/spx/internal/command/build.go
@@ -92,9 +92,7 @@ func (cmd *CmdTool) BuildTinyGoLib() error {
 }
 
 func (cmd *CmdTool) BuildDll() error {
-	if err := cmd.hideIOSFiles(); err != nil {
-		return err
-	}
+	cmd.hideIOSFiles()
 
 	targetArchs, err := cmd.determineTargetArchs()
 	if err != nil {
@@ -135,12 +133,12 @@ func (cmd *CmdTool) withGoDir(f func() error) error {
 }
 
 // hideIOSFiles renames ios* files to .txt files.
-func (cmd *CmdTool) hideIOSFiles() error {
+func (cmd *CmdTool) hideIOSFiles() {
 	searchPattern := filepath.Join(cmd.ProjectDir, "go", "ios*")
 	files, err := filepath.Glob(searchPattern)
 	if err != nil {
 		logWarnf("Glob failed for pattern %s: %v", searchPattern, err)
-		return nil
+		return
 	}
 
 	for _, file := range files {
@@ -151,7 +149,6 @@ func (cmd *CmdTool) hideIOSFiles() error {
 			}
 		}
 	}
-	return nil
 }
 
 // determineTargetArchs resolves target architectures.
@@ -169,8 +166,6 @@ func (cmd *CmdTool) determineTargetArchs() ([]string, error) {
 	switch runtime.GOOS {
 	case "windows":
 		validArchs = []string{"amd64", "386"}
-	case "darwin":
-		validArchs = []string{"amd64", "arm64"}
 	case "linux":
 		validArchs = []string{"amd64", "arm", "arm64", "386"}
 	default:

--- a/cmd/spx/internal/command/export_web.go
+++ b/cmd/spx/internal/command/export_web.go
@@ -151,10 +151,10 @@ func (cmd *CmdTool) prepareMinigameEngineAssets(paths minigamePaths, buildMode s
 	ispxWasm := filepath.Join(paths.rawWebDir, "ispx.wasm")
 
 	if buildMode == "fast" {
-		if err := cmd.moveFile(godotEditorWasm, filepath.Join(paths.engineDir, "engine.wasm")); err != nil {
+		if err := os.Rename(godotEditorWasm, filepath.Join(paths.engineDir, "engine.wasm")); err != nil {
 			return fmt.Errorf("failed to move %s: %w", godotEditorWasm, err)
 		}
-		if err := cmd.moveFile(ispxWasm, filepath.Join(paths.engineDir, "ispx.wasm")); err != nil {
+		if err := os.Rename(ispxWasm, filepath.Join(paths.engineDir, "ispx.wasm")); err != nil {
 			return fmt.Errorf("failed to move %s: %w", ispxWasm, err)
 		}
 	} else {
@@ -321,11 +321,6 @@ func (cmd *CmdTool) writeWebLogicAssets() error {
 func (cmd *CmdTool) compressBrotli(filePath string) error {
 	execCmd := exec.Command("brotli", "-f", "-q", "11", filePath)
 	return execCmd.Run()
-}
-
-// moveFile moves one file.
-func (cmd *CmdTool) moveFile(srcFile, dstFile string) error {
-	return os.Rename(srcFile, dstFile)
 }
 
 // moveFilesByPattern moves matching files.

--- a/cmd/spx/internal/pack/pack.go
+++ b/cmd/spx/internal/pack/pack.go
@@ -118,14 +118,7 @@ func packZip(zipWriter *zip.Writer, baseFolder string, paths []dirInfo) error {
 	baseFolder = strings.ReplaceAll(baseFolder, "\\", "/")
 	seenNames := make(map[string]struct{}, len(paths))
 	slices.SortFunc(paths, func(a, b dirInfo) int {
-		nameA := zipEntryName(baseFolder, a)
-		nameB := zipEntryName(baseFolder, b)
-		if nameA < nameB {
-			return -1
-		} else if nameA > nameB {
-			return 1
-		}
-		return 0
+		return strings.Compare(zipEntryName(baseFolder, a), zipEntryName(baseFolder, b))
 	})
 	for _, dirInfo := range paths {
 		filePath := dirInfo.path

--- a/internal/cmd/buildctl/engine/download_web.go
+++ b/internal/cmd/buildctl/engine/download_web.go
@@ -57,9 +57,6 @@ func downloadWebAssets(env engineDownloadEnv, mode string) error {
 }
 
 func webModeReleaseTemplateName(mode string) (string, error) {
-	if err := shared.ValidateWebMode(mode); err != nil {
-		return "", err
-	}
 	switch mode {
 	case "normal":
 		return "web.zip", nil

--- a/internal/cmd/buildctl/runtimecmd/assets.go
+++ b/internal/cmd/buildctl/runtimecmd/assets.go
@@ -25,33 +25,6 @@ import (
 	toolpkg "github.com/goplus/spx/v3/internal/cmd/buildctl/tool"
 )
 
-func exportWebRuntime(cfg runtimeExportWebConfig, runner shared.ScriptRunner) error {
-	if err := toolpkg.InstallTools(toolpkg.InstallConfig{Web: true, NoEmbedRuntime: true}, runner); err != nil {
-		return err
-	}
-
-	spxCommand, err := webModeSPXCommand(cfg.mode)
-	if err != nil {
-		return err
-	}
-	outputZip, err := webModeOutputZip(cfg.mode)
-	if err != nil {
-		return err
-	}
-
-	workspace, cleanup, err := prepareRuntimeWorkspace(runner.RepoRootDir(), false)
-	if err != nil {
-		return err
-	}
-	defer cleanup()
-
-	if err := runRepoSPXCommand(runner, workspace.workDir, spxCommand); err != nil {
-		return err
-	}
-
-	return shared.ZipDirectory(filepath.Join(workspace.workDir, "project", ".builds", "web"), filepath.Join(workspace.repoRoot, outputZip))
-}
-
 func ExportWebTemplateRuntime(mode string, runner shared.ScriptRunner) error {
 	if err := shared.ValidateWebMode(mode); err != nil {
 		return err
@@ -92,6 +65,33 @@ func ExportWebTemplateRuntime(mode string, runner shared.ScriptRunner) error {
 	}
 	prefix := fmt.Sprintf("var EnginePackMode = '%s';\n", mode)
 	return os.WriteFile(engineJS, append([]byte(prefix), content...), 0o644)
+}
+
+func exportWebRuntime(cfg runtimeExportWebConfig, runner shared.ScriptRunner) error {
+	if err := toolpkg.InstallTools(toolpkg.InstallConfig{Web: true, NoEmbedRuntime: true}, runner); err != nil {
+		return err
+	}
+
+	spxCommand, err := webModeSPXCommand(cfg.mode)
+	if err != nil {
+		return err
+	}
+	outputZip, err := webModeOutputZip(cfg.mode)
+	if err != nil {
+		return err
+	}
+
+	workspace, cleanup, err := prepareRuntimeWorkspace(runner.RepoRootDir(), false)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	if err := runRepoSPXCommand(runner, workspace.workDir, spxCommand); err != nil {
+		return err
+	}
+
+	return shared.ZipDirectory(filepath.Join(workspace.workDir, "project", ".builds", "web"), filepath.Join(workspace.repoRoot, outputZip))
 }
 
 func webModeOutputZip(mode string) (string, error) {

--- a/internal/cmd/buildctl/runtimecmd/assets.go
+++ b/internal/cmd/buildctl/runtimecmd/assets.go
@@ -95,9 +95,6 @@ func ExportWebTemplateRuntime(mode string, runner shared.ScriptRunner) error {
 }
 
 func webModeOutputZip(mode string) (string, error) {
-	if err := shared.ValidateWebMode(mode); err != nil {
-		return "", err
-	}
 	switch mode {
 	case "normal":
 		return "spx_web.zip", nil
@@ -113,9 +110,6 @@ func webModeOutputZip(mode string) (string, error) {
 }
 
 func webModeSPXCommand(mode string) (string, error) {
-	if err := shared.ValidateWebMode(mode); err != nil {
-		return "", err
-	}
 	switch mode {
 	case "normal":
 		return "exportweb", nil

--- a/internal/launchpack/project.go
+++ b/internal/launchpack/project.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 
@@ -58,14 +59,7 @@ func collectProjectAllowlist(cfg Config) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	foundProject := false
-	for _, name := range projectFiles {
-		if name == projectBase {
-			foundProject = true
-			break
-		}
-	}
-	if !foundProject {
+	if !slices.Contains(projectFiles, projectBase) {
 		return nil, fmt.Errorf("launchpack: project file %q is not in the source allowlist", projectBase)
 	}
 


### PR DESCRIPTION
Remove redundant wrappers and branches in CLI build, packaging, launcher allowlist checks, and Web mode selection. Keep existing error behavior and place public runtime asset APIs before helpers. Validation: make generate; tests for command, pack, buildctl/engine, buildctl/runtimecmd, and launchpack; git diff --check.