### PR TITLE
refactor(input): avoid redundant replay snapshot copies

### DIFF
--- a/internal/input/replay_controller.go
+++ b/internal/input/replay_controller.go
@@ -88,7 +88,7 @@ func (c *InputReplayController) StartReplay(replay InputReplay) error {
 	}
 	c.mode = InputSessionModeReplaying
 	c.replay = cloneInputReplay(replay)
-	c.last = InputReplayFrame{Frame: -1, State: cloneInputReplayState(replay.Initial)}
+	c.last = InputReplayFrame{Frame: -1, State: c.replay.Initial}
 	return nil
 }
 
@@ -162,7 +162,7 @@ func (c *InputReplayController) ResolveWithMouseEvents(
 	}
 	c.record.Frames = append(c.record.Frames, cloneInputReplayFrame(effective))
 	c.next++
-	return cloneInputReplayFrame(effective), firstTick, nil
+	return effective, firstTick, nil
 }
 
 func (c *InputReplayController) modeValue() InputSessionMode {
@@ -185,9 +185,10 @@ func (c *InputReplayController) resolveReplay() (InputReplayFrame, bool, error) 
 
 	firstTick := c.cursor == 0
 	frame := cloneInputReplayFrame(c.replay.Frames[c.cursor])
+	// The replay is controller-owned and immutable; only caller snapshots need copies.
+	c.last = c.replay.Frames[c.cursor]
 	c.cursor++
 	c.next = int64(c.cursor)
-	c.last = cloneInputReplayFrame(frame)
 	c.exhausted = c.cursor == len(c.replay.Frames)
 	c.resolved = true
 	return frame, firstTick, nil

--- a/internal/input/replay_test.go
+++ b/internal/input/replay_test.go
@@ -24,43 +24,6 @@ import (
 	"testing"
 )
 
-func validInputReplay() InputReplay {
-	return InputReplay{
-		Format:        InputReplayFormat,
-		Version:       InputReplayVersion,
-		FixedTimestep: 1.0 / 30.0,
-		Initial: InputReplayState{
-			Mouse:    InputReplayMouse{X: 1, Y: 2},
-			Buttons:  0,
-			KeysDown: []int64{10},
-		},
-		Frames: []InputReplayFrame{
-			{
-				Frame: 0,
-				Time:  0,
-				State: InputReplayState{
-					Mouse:    InputReplayMouse{X: 3, Y: 4},
-					Buttons:  1,
-					KeysDown: []int64{10, 20},
-				},
-				MouseEvents: []InputReplayMouseEvent{{Button: 1, Pressed: true}},
-				KeyEvents:   []InputReplayKeyEvent{{Key: 20, Pressed: true}},
-			},
-			{
-				Frame: 1,
-				Time:  0.25,
-				State: InputReplayState{
-					Mouse:    InputReplayMouse{X: 5, Y: 6},
-					Buttons:  0,
-					KeysDown: []int64{20},
-				},
-				MouseEvents: []InputReplayMouseEvent{{Button: 1, Pressed: false}},
-				KeyEvents:   []InputReplayKeyEvent{{Key: 10, Pressed: false}},
-			},
-		},
-	}
-}
-
 func TestInputReplayValidateAcceptsCanonicalReplay(t *testing.T) {
 	if err := validInputReplay().Validate(); err != nil {
 		t.Fatalf("Validate() error: %v", err)
@@ -421,5 +384,42 @@ func TestInputReplayControllerIdleResolveReturnsIsolatedLiveFrame(t *testing.T) 
 	events[0].Key = 2
 	if frame.State.KeysDown[0] != 1 || frame.KeyEvents[0].Key != 1 {
 		t.Fatalf("idle Resolve aliased live input: %+v", frame)
+	}
+}
+
+func validInputReplay() InputReplay {
+	return InputReplay{
+		Format:        InputReplayFormat,
+		Version:       InputReplayVersion,
+		FixedTimestep: 1.0 / 30.0,
+		Initial: InputReplayState{
+			Mouse:    InputReplayMouse{X: 1, Y: 2},
+			Buttons:  0,
+			KeysDown: []int64{10},
+		},
+		Frames: []InputReplayFrame{
+			{
+				Frame: 0,
+				Time:  0,
+				State: InputReplayState{
+					Mouse:    InputReplayMouse{X: 3, Y: 4},
+					Buttons:  1,
+					KeysDown: []int64{10, 20},
+				},
+				MouseEvents: []InputReplayMouseEvent{{Button: 1, Pressed: true}},
+				KeyEvents:   []InputReplayKeyEvent{{Key: 20, Pressed: true}},
+			},
+			{
+				Frame: 1,
+				Time:  0.25,
+				State: InputReplayState{
+					Mouse:    InputReplayMouse{X: 5, Y: 6},
+					Buttons:  0,
+					KeysDown: []int64{20},
+				},
+				MouseEvents: []InputReplayMouseEvent{{Button: 1, Pressed: false}},
+				KeyEvents:   []InputReplayKeyEvent{{Key: 10, Pressed: false}},
+			},
+		},
 	}
 }

--- a/internal/input/replay_test.go
+++ b/internal/input/replay_test.go
@@ -201,6 +201,17 @@ func TestInputReplayControllerRecordsTicksAndDeepCopies(t *testing.T) {
 	if recorded.Frames[0].State.KeysDown[0] != 1 || recorded.Frames[0].MouseEvents[0].Button != 1 || recorded.Frames[0].KeyEvents[0].Key != 2 {
 		t.Fatalf("recording aliased caller or result: %+v", recorded.Frames[0])
 	}
+	recorded.Initial.KeysDown[0] = 666
+	recorded.Frames[0].State.KeysDown[0] = 666
+	recorded.Frames[0].MouseEvents[0].Button = 3
+	recorded.Frames[0].KeyEvents[0].Key = 666
+	snapshot, err := controller.Recording()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if snapshot.Initial.KeysDown[0] != 1 || snapshot.Frames[0].State.KeysDown[0] != 1 || snapshot.Frames[0].MouseEvents[0].Button != 1 || snapshot.Frames[0].KeyEvents[0].Key != 2 {
+		t.Fatalf("recording snapshots share mutable data: %+v", snapshot)
+	}
 	controller.Reset()
 	if status := controller.Status(); status.Mode != InputSessionModeIdle {
 		t.Fatalf("status after Reset = %+v", status)
@@ -240,6 +251,11 @@ func TestInputReplayControllerReplaysAndFreezesLastState(t *testing.T) {
 	if !status.Exhausted || status.NextFrame != 2 || status.FrameCount != 2 {
 		t.Fatalf("finished status = %+v", status)
 	}
+	wantFrozenState := validInputReplay().Frames[1].State
+	frame1.State.KeysDown[0] = 999
+	frame1.State.Mouse.X = 999
+	frame1.MouseEvents[0].Button = 3
+	frame1.KeyEvents[0].Key = 999
 
 	frozen, first, err := controller.Resolve(
 		InputReplayState{Mouse: InputReplayMouse{X: 999, Y: 999}, KeysDown: []int64{999}},
@@ -249,14 +265,22 @@ func TestInputReplayControllerReplaysAndFreezesLastState(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if first || !reflect.DeepEqual(frozen.State, frame1.State) {
-		t.Fatalf("frozen frame = (%+v, %v), want state %+v", frozen, first, frame1.State)
+	if first || !reflect.DeepEqual(frozen.State, wantFrozenState) {
+		t.Fatalf("frozen frame = (%+v, %v), want state %+v", frozen, first, wantFrozenState)
 	}
 	if len(frozen.KeyEvents) != 0 {
 		t.Fatalf("frozen frame repeated key events: %+v", frozen.KeyEvents)
 	}
 	if len(frozen.MouseEvents) != 0 {
 		t.Fatalf("frozen frame repeated mouse events: %+v", frozen.MouseEvents)
+	}
+	frozen.State.KeysDown[0] = 888
+	frozenAgain, _, err := controller.Resolve(InputReplayState{}, nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(frozenAgain.State, wantFrozenState) {
+		t.Fatalf("frozen frames share mutable data: %+v", frozenAgain.State)
 	}
 	controller.Reset()
 }
@@ -307,6 +331,7 @@ func TestInputReplayControllerEmptyReplayFreezesInitialState(t *testing.T) {
 	if err := controller.StartReplay(replay); err != nil {
 		t.Fatal(err)
 	}
+	replay.Initial.KeysDown[0] = 999
 	if controller.Status().Exhausted {
 		t.Fatal("empty replay exhausted before its first effective tick")
 	}
@@ -320,12 +345,16 @@ func TestInputReplayControllerEmptyReplayFreezesInitialState(t *testing.T) {
 	if !controller.Status().Exhausted {
 		t.Fatal("empty replay did not exhaust after its first effective tick")
 	}
-	_, first, err = controller.Resolve(InputReplayState{KeysDown: []int64{9}}, nil, 1)
+	frame.State.KeysDown[0] = 888
+	frame, first, err = controller.Resolve(InputReplayState{KeysDown: []int64{9}}, nil, 1)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if first {
 		t.Fatal("empty replay reported first tick more than once")
+	}
+	if !reflect.DeepEqual(frame.State.KeysDown, []int64{1}) {
+		t.Fatalf("empty replay snapshots share mutable data: %+v", frame.State)
 	}
 }
 


### PR DESCRIPTION
Reuse immutable controller-owned replay state and avoid recopying an already isolated recording result. Keep snapshots returned to callers independent, with regression coverage for recording, frozen frames, and empty replays. Public controller methods precede helpers; test fixtures follow tests. Validation: make generate; input and root package tests; git diff --check.