### PR TITLE
refactor(native): simplify comments and organize public methods

### DIFF
--- a/godot_modules/spx/recorder/independent_audio_recorder.cpp
+++ b/godot_modules/spx/recorder/independent_audio_recorder.cpp
@@ -38,7 +38,6 @@ Error IndependentAudioRecorder::initialize(HybridAudioDriver *p_audio_driver,
 	audio_driver = p_audio_driver;
 	config = p_config;
 
-	// Create a simple audio writer
 	audio_writer.instantiate();
 
 	Error open_result = audio_writer->open(p_audio_path, config.sample_rate, config.channels);
@@ -47,7 +46,6 @@ Error IndependentAudioRecorder::initialize(HybridAudioDriver *p_audio_driver,
 		return open_result;
 	}
 
-	// Calculate buffer size
 	buffer_size = config.sample_rate * config.channels * config.buffer_size_seconds;
 
 	// Calculate the power for the RingBuffer
@@ -57,15 +55,12 @@ Error IndependentAudioRecorder::initialize(HybridAudioDriver *p_audio_driver,
 	}
 	int actual_buffer_size = 1 << power; // Actual buffer size
 
-	// Initialize the ring buffer
 	audio_ring_buffer = RingBuffer<int32_t>(power);
 	buffer_size = actual_buffer_size; // Update to actual size
 
-	// Initialize temporary buffers
 	temp_audio_buffer.resize(config.chunk_size * config.channels);
 	chunk_buffer.resize(config.chunk_size * config.channels);
 
-	// Reset statistics
 	reset_statistics();
 
 	if (MovieDebugUtils::is_stdout_verbose()) {
@@ -92,16 +87,13 @@ Error IndependentAudioRecorder::start_recording() {
 		return ERR_UNCONFIGURED;
 	}
 
-	// Clear buffer
 	audio_ring_buffer.clear();
 	buffer_read_pos.store(0);
 	buffer_write_pos.store(0);
 
-	// Set recording status
 	recording_active.store(true);
 	recording_start_time = OS::get_singleton()->get_ticks_usec();
 
-	// Start recording thread
 	recording_thread.start(recording_thread_func, this);
 	thread_started.store(true);
 
@@ -120,18 +112,15 @@ void IndependentAudioRecorder::stop_recording() {
 		return;
 	}
 
-	// Wait for the thread to finish
 	if (thread_started.load()) {
 		recording_thread.wait_to_finish();
 		thread_started.store(false);
 	}
 
-	// Close the audio writer
 	if (audio_writer.is_valid()) {
 		audio_writer->close();
 	}
 
-	// Output final statistics
 	if (MovieDebugUtils::is_stdout_verbose()) {
 		AudioStats final_stats = get_statistics();
 		print_line(String("Audio recording completed - Total chunks: ") + String::num_int64(final_stats.total_chunks_recorded));
@@ -157,14 +146,12 @@ void IndependentAudioRecorder::recording_loop() {
 		if (current_time >= next_chunk_time) {
 			uint64_t chunk_process_start = OS::get_singleton()->get_ticks_usec();
 
-			// Process audio chunk
 			bool chunk_processed = process_audio_chunk(next_chunk_time - recording_start_time);
 
 			if (chunk_processed) {
 				chunk_count++;
 				update_statistics(chunk_process_start, config.chunk_size);
 
-				// Output debug info every 1000 chunks
 				if (MovieDebugUtils::is_stdout_verbose() && chunk_count % 1000 == 0) {
 					AudioStats current_stats = get_statistics();
 					print_line(String("Audio recording progress: ") + String::num_int64(chunk_count) + " chunks, " +
@@ -172,7 +159,6 @@ void IndependentAudioRecorder::recording_loop() {
 				}
 			}
 
-			// Calculate next chunk time
 			next_chunk_time += CHUNK_INTERVAL_USEC;
 		}
 
@@ -188,12 +174,10 @@ void IndependentAudioRecorder::recording_loop() {
 }
 
 bool IndependentAudioRecorder::process_audio_chunk(uint64_t current_recording_time) {
-	// Read audio data from the ring buffer
 	if (!read_audio_chunk(chunk_buffer, config.chunk_size * config.channels)) {
 		handle_buffer_underrun();
 		return false;
 	}
-	// Write to audio file
 	Error write_result = audio_writer->write_audio_chunk(
 			chunk_buffer.ptr(),
 			config.chunk_size);
@@ -202,7 +186,6 @@ bool IndependentAudioRecorder::process_audio_chunk(uint64_t current_recording_ti
 		ERR_PRINT("IndependentAudioRecorder: Failed to write audio chunk");
 		return false;
 	}
-	// Update statistics
 	{
 		MutexLock lock(stats_mutex);
 		stats.total_chunks_recorded++;
@@ -221,7 +204,6 @@ bool IndependentAudioRecorder::read_audio_chunk(Vector<int32_t> &output_buffer, 
 
 	MutexLock lock(buffer_mutex);
 
-	// Use RingBuffer's read method directly
 	int samples_read = audio_ring_buffer.read(output_buffer.ptrw(), requested_samples);
 
 	if (samples_read < (int)requested_samples) {
@@ -243,14 +225,12 @@ void IndependentAudioRecorder::on_audio_output(const int32_t *p_buffer, int p_fr
 
 	uint32_t samples_to_write = p_frame_count * config.channels;
 
-	// Check buffer space
 	int available_space = audio_ring_buffer.space_left();
 	if ((int)samples_to_write > available_space) {
 		handle_buffer_overrun();
 		return;
 	}
 
-	// Write data
 	audio_ring_buffer.write(p_buffer, samples_to_write);
 }
 
@@ -260,7 +240,6 @@ void IndependentAudioRecorder::update_statistics(uint64_t chunk_process_start_ti
 
 	MutexLock lock(stats_mutex);
 
-	// Update recording duration
 	stats.recording_duration_us = current_time - recording_start_time;
 
 	// Update average processing time (using moving average)
@@ -271,7 +250,6 @@ void IndependentAudioRecorder::update_statistics(uint64_t chunk_process_start_ti
 		stats.avg_chunk_process_time_us = (stats.avg_chunk_process_time_us * 9 + process_time) / 10;
 	}
 
-	// Update buffer usage
 	update_buffer_level();
 }
 

--- a/godot_modules/spx/recorder/independent_audio_recorder.cpp
+++ b/godot_modules/spx/recorder/independent_audio_recorder.cpp
@@ -131,6 +131,106 @@ void IndependentAudioRecorder::stop_recording() {
 	}
 }
 
+void IndependentAudioRecorder::on_audio_output(const int32_t *p_buffer, int p_frame_count) {
+	if (!recording_active.load() || !p_buffer || p_frame_count <= 0) {
+		return;
+	}
+
+	MutexLock lock(buffer_mutex);
+
+	uint32_t samples_to_write = p_frame_count * config.channels;
+
+	int available_space = audio_ring_buffer.space_left();
+	if ((int)samples_to_write > available_space) {
+		handle_buffer_overrun();
+		return;
+	}
+
+	audio_ring_buffer.write(p_buffer, samples_to_write);
+}
+
+uint32_t IndependentAudioRecorder::get_available_samples() const {
+	return audio_ring_buffer.data_left();
+}
+
+bool IndependentAudioRecorder::has_audio_data() const {
+	return get_available_samples() >= (config.chunk_size * config.channels);
+}
+
+float IndependentAudioRecorder::get_buffer_usage_ratio() const {
+	if (buffer_size == 0) {
+		return 0.0f;
+	}
+	return (float)get_available_samples() / (float)buffer_size;
+}
+
+IndependentAudioRecorder::AudioStats IndependentAudioRecorder::get_statistics() const {
+	MutexLock lock(stats_mutex);
+	return stats;
+}
+
+void IndependentAudioRecorder::update_config(const AudioConfig &p_config) {
+	if (is_recording()) {
+		ERR_PRINT("IndependentAudioRecorder: Cannot update configuration while recording");
+		return;
+	}
+
+	config.sample_rate = p_config.sample_rate;
+	config.channels = p_config.channels;
+	config.chunk_size = p_config.chunk_size;
+	config.buffer_size_seconds = p_config.buffer_size_seconds;
+	config.enable_audio_monitoring = p_config.enable_audio_monitoring;
+
+	// Recalculate buffer size
+	buffer_size = config.sample_rate * config.channels * config.buffer_size_seconds;
+
+	// Calculate the power for the RingBuffer
+	int power = 0;
+	while ((1 << power) < (int)buffer_size) {
+		power++;
+	}
+	int actual_buffer_size = 1 << power; // Actual buffer size
+
+	// Reinitialize the ring buffer
+	audio_ring_buffer = RingBuffer<int32_t>(power);
+	buffer_size = actual_buffer_size; // Update to actual size
+
+	temp_audio_buffer.resize(config.chunk_size * config.channels);
+	chunk_buffer.resize(config.chunk_size * config.channels);
+}
+
+void IndependentAudioRecorder::reset_statistics() {
+	MutexLock lock(stats_mutex);
+
+	stats = AudioStats();
+	buffer_read_pos.store(0);
+	buffer_write_pos.store(0);
+	recording_start_time = 0;
+}
+
+String IndependentAudioRecorder::get_debug_info() const {
+	AudioStats current_stats = get_statistics();
+
+	String info;
+	info += "=== IndependentAudioRecorder Debug Info ===\n";
+	info += String("Recording status: ") + (is_recording() ? "Running" : "Stopped") + "\n";
+	info += String("Thread status: ") + (is_thread_running() ? "Running" : "Stopped") + "\n";
+	info += String("Total audio chunks: ") + String::num_int64(current_stats.total_chunks_recorded) + "\n";
+	info += String("Total samples: ") + String::num_int64(current_stats.total_samples_recorded) + "\n";
+	info += String("Recording duration: ") + String::num_real(current_stats.recording_duration_us / 1000000.0) + " seconds\n";
+	info += String("Buffer usage: ") + String::num_int64(current_stats.current_buffer_level) + "%\n";
+	info += String("Available samples: ") + String::num_int64(get_available_samples()) + "\n";
+	info += String("Buffer overruns: ") + String::num_int64(current_stats.buffer_overruns) + "\n";
+	info += String("Buffer underruns: ") + String::num_int64(current_stats.buffer_underruns) + "\n";
+	info += String("Avg chunk process time: ") + String::num_int64(current_stats.avg_chunk_process_time_us) + " microseconds\n";
+	info += String("Config sample rate: ") + String::num_int64(config.sample_rate) + "Hz\n";
+	info += String("Config channels: ") + String::num_int64(config.channels) + "\n";
+	info += String("Config chunk size: ") + String::num_int64(config.chunk_size) + " samples\n";
+	info += "==========================================";
+
+	return info;
+}
+
 void IndependentAudioRecorder::recording_thread_func(void *p_userdata) {
 	IndependentAudioRecorder *recorder = static_cast<IndependentAudioRecorder *>(p_userdata);
 	recorder->recording_loop();
@@ -216,24 +316,6 @@ bool IndependentAudioRecorder::read_audio_chunk(Vector<int32_t> &output_buffer, 
 	return true;
 }
 
-void IndependentAudioRecorder::on_audio_output(const int32_t *p_buffer, int p_frame_count) {
-	if (!recording_active.load() || !p_buffer || p_frame_count <= 0) {
-		return;
-	}
-
-	MutexLock lock(buffer_mutex);
-
-	uint32_t samples_to_write = p_frame_count * config.channels;
-
-	int available_space = audio_ring_buffer.space_left();
-	if ((int)samples_to_write > available_space) {
-		handle_buffer_overrun();
-		return;
-	}
-
-	audio_ring_buffer.write(p_buffer, samples_to_write);
-}
-
 void IndependentAudioRecorder::update_statistics(uint64_t chunk_process_start_time, uint32_t samples_processed) {
 	uint64_t current_time = OS::get_singleton()->get_ticks_usec();
 	uint64_t process_time = current_time - chunk_process_start_time;
@@ -275,86 +357,4 @@ void IndependentAudioRecorder::handle_buffer_overrun() {
 	uint32_t read_pos = buffer_read_pos.load();
 	read_pos = (read_pos + samples_to_skip) % buffer_size;
 	buffer_read_pos.store(read_pos);
-}
-
-uint32_t IndependentAudioRecorder::get_available_samples() const {
-	return audio_ring_buffer.data_left();
-}
-
-bool IndependentAudioRecorder::has_audio_data() const {
-	return get_available_samples() >= (config.chunk_size * config.channels);
-}
-
-float IndependentAudioRecorder::get_buffer_usage_ratio() const {
-	if (buffer_size == 0) {
-		return 0.0f;
-	}
-	return (float)get_available_samples() / (float)buffer_size;
-}
-
-IndependentAudioRecorder::AudioStats IndependentAudioRecorder::get_statistics() const {
-	MutexLock lock(stats_mutex);
-	return stats;
-}
-
-void IndependentAudioRecorder::update_config(const AudioConfig &p_config) {
-	if (is_recording()) {
-		ERR_PRINT("IndependentAudioRecorder: Cannot update configuration while recording");
-		return;
-	}
-
-	config.sample_rate = p_config.sample_rate;
-	config.channels = p_config.channels;
-	config.chunk_size = p_config.chunk_size;
-	config.buffer_size_seconds = p_config.buffer_size_seconds;
-	config.enable_audio_monitoring = p_config.enable_audio_monitoring;
-
-	// Recalculate buffer size
-	buffer_size = config.sample_rate * config.channels * config.buffer_size_seconds;
-
-	// Calculate the power for the RingBuffer
-	int power = 0;
-	while ((1 << power) < (int)buffer_size) {
-		power++;
-	}
-	int actual_buffer_size = 1 << power; // Actual buffer size
-
-	// Reinitialize the ring buffer
-	audio_ring_buffer = RingBuffer<int32_t>(power);
-	buffer_size = actual_buffer_size; // Update to actual size
-
-	temp_audio_buffer.resize(config.chunk_size * config.channels);
-	chunk_buffer.resize(config.chunk_size * config.channels);
-}
-
-void IndependentAudioRecorder::reset_statistics() {
-	MutexLock lock(stats_mutex);
-
-	stats = AudioStats();
-	buffer_read_pos.store(0);
-	buffer_write_pos.store(0);
-	recording_start_time = 0;
-}
-
-String IndependentAudioRecorder::get_debug_info() const {
-	AudioStats current_stats = get_statistics();
-
-	String info;
-	info += "=== IndependentAudioRecorder Debug Info ===\n";
-	info += String("Recording status: ") + (is_recording() ? "Running" : "Stopped") + "\n";
-	info += String("Thread status: ") + (is_thread_running() ? "Running" : "Stopped") + "\n";
-	info += String("Total audio chunks: ") + String::num_int64(current_stats.total_chunks_recorded) + "\n";
-	info += String("Total samples: ") + String::num_int64(current_stats.total_samples_recorded) + "\n";
-	info += String("Recording duration: ") + String::num_real(current_stats.recording_duration_us / 1000000.0) + " seconds\n";
-	info += String("Buffer usage: ") + String::num_int64(current_stats.current_buffer_level) + "%\n";
-	info += String("Available samples: ") + String::num_int64(get_available_samples()) + "\n";
-	info += String("Buffer overruns: ") + String::num_int64(current_stats.buffer_overruns) + "\n";
-	info += String("Buffer underruns: ") + String::num_int64(current_stats.buffer_underruns) + "\n";
-	info += String("Avg chunk process time: ") + String::num_int64(current_stats.avg_chunk_process_time_us) + " microseconds\n";
-	info += String("Config sample rate: ") + String::num_int64(config.sample_rate) + "Hz\n";
-	info += String("Config channels: ") + String::num_int64(config.channels) + "\n";
-	info += String("Config chunk size: ") + String::num_int64(config.chunk_size) + " samples\n";
-	info += "==========================================";
-
-	return info;
 }

--- a/godot_modules/spx/recorder/independent_video_recorder.cpp
+++ b/godot_modules/spx/recorder/independent_video_recorder.cpp
@@ -110,6 +110,65 @@ void IndependentVideoRecorder::stop_recording() {
 	}
 }
 
+IndependentVideoRecorder::RecordingStats IndependentVideoRecorder::get_statistics() const {
+	MutexLock lock(stats_mutex);
+	return stats;
+}
+
+float IndependentVideoRecorder::get_repeat_frame_ratio() const {
+	MutexLock lock(stats_mutex);
+
+	if (stats.total_recorded_frames == 0) {
+		return 0.0f;
+	}
+
+	return (float)stats.repeated_frames_count / (float)stats.total_recorded_frames;
+}
+
+void IndependentVideoRecorder::update_config(const RecordingConfig &p_config) {
+	config.target_fps = p_config.target_fps;
+	config.video_width = p_config.video_width;
+	config.video_height = p_config.video_height;
+	config.jpeg_quality = p_config.jpeg_quality;
+	config.enable_timestamp_chunks = p_config.enable_timestamp_chunks;
+	config.enable_repeat_frame_marking = p_config.enable_repeat_frame_marking;
+
+	if (video_writer.is_valid()) {
+		video_writer->set_quality(config.jpeg_quality);
+	}
+}
+
+void IndependentVideoRecorder::reset_statistics() {
+	MutexLock lock(stats_mutex);
+
+	stats = RecordingStats();
+	last_game_frame_sequence = 0;
+	has_valid_frame = false;
+	recording_start_time = 0;
+	last_stats_update_time = 0;
+}
+
+String IndependentVideoRecorder::get_debug_info() const {
+	RecordingStats current_stats = get_statistics();
+
+	String info;
+	info += "=== IndependentVideoRecorder Debug Info ===\n";
+	info += String("Recording status: ") + (is_recording() ? "Running" : "Stopped") + "\n";
+	info += String("Thread status: ") + (is_thread_running() ? "Running" : "Stopped") + "\n";
+	info += String("Total recorded frames: ") + String::num_int64(current_stats.total_recorded_frames) + "\n";
+	info += String("New frames: ") + String::num_int64(current_stats.new_frames_count) + "\n";
+	info += String("Repeated frames: ") + String::num_int64(current_stats.repeated_frames_count) + "\n";
+	info += String("Repeated frame ratio: ") + String::num_real(get_repeat_frame_ratio() * 100.0f) + "%\n";
+	info += String("Recording duration: ") + String::num_real(current_stats.recording_duration_us / 1000000.0) + " seconds\n";
+	info += String("Avg frame process time: ") + String::num_int64(current_stats.avg_frame_process_time_us) + " microseconds\n";
+	info += String("Last game frame sequence: ") + String::num_int64(current_stats.last_game_frame_sequence) + "\n";
+	info += String("Config FPS: ") + String::num_int64(config.target_fps) + "\n";
+	info += String("Config resolution: ") + String::num_int64(config.video_width) + "x" + String::num_int64(config.video_height) + "\n";
+	info += "==========================================";
+
+	return info;
+}
+
 void IndependentVideoRecorder::recording_thread_func(void *p_userdata) {
 	IndependentVideoRecorder *recorder = static_cast<IndependentVideoRecorder *>(p_userdata);
 	recorder->recording_loop();
@@ -219,63 +278,4 @@ void IndependentVideoRecorder::update_statistics(uint64_t frame_process_start_ti
 uint8_t IndependentVideoRecorder::determine_frame_flags(const ThreadSafeFrameBuffer::FrameData &frame_data) {
 	// Simplified version, no longer uses complex frame flags
 	return 0;
-}
-
-IndependentVideoRecorder::RecordingStats IndependentVideoRecorder::get_statistics() const {
-	MutexLock lock(stats_mutex);
-	return stats;
-}
-
-float IndependentVideoRecorder::get_repeat_frame_ratio() const {
-	MutexLock lock(stats_mutex);
-
-	if (stats.total_recorded_frames == 0) {
-		return 0.0f;
-	}
-
-	return (float)stats.repeated_frames_count / (float)stats.total_recorded_frames;
-}
-
-void IndependentVideoRecorder::update_config(const RecordingConfig &p_config) {
-	config.target_fps = p_config.target_fps;
-	config.video_width = p_config.video_width;
-	config.video_height = p_config.video_height;
-	config.jpeg_quality = p_config.jpeg_quality;
-	config.enable_timestamp_chunks = p_config.enable_timestamp_chunks;
-	config.enable_repeat_frame_marking = p_config.enable_repeat_frame_marking;
-
-	if (video_writer.is_valid()) {
-		video_writer->set_quality(config.jpeg_quality);
-	}
-}
-
-void IndependentVideoRecorder::reset_statistics() {
-	MutexLock lock(stats_mutex);
-
-	stats = RecordingStats();
-	last_game_frame_sequence = 0;
-	has_valid_frame = false;
-	recording_start_time = 0;
-	last_stats_update_time = 0;
-}
-
-String IndependentVideoRecorder::get_debug_info() const {
-	RecordingStats current_stats = get_statistics();
-
-	String info;
-	info += "=== IndependentVideoRecorder Debug Info ===\n";
-	info += String("Recording status: ") + (is_recording() ? "Running" : "Stopped") + "\n";
-	info += String("Thread status: ") + (is_thread_running() ? "Running" : "Stopped") + "\n";
-	info += String("Total recorded frames: ") + String::num_int64(current_stats.total_recorded_frames) + "\n";
-	info += String("New frames: ") + String::num_int64(current_stats.new_frames_count) + "\n";
-	info += String("Repeated frames: ") + String::num_int64(current_stats.repeated_frames_count) + "\n";
-	info += String("Repeated frame ratio: ") + String::num_real(get_repeat_frame_ratio() * 100.0f) + "%\n";
-	info += String("Recording duration: ") + String::num_real(current_stats.recording_duration_us / 1000000.0) + " seconds\n";
-	info += String("Avg frame process time: ") + String::num_int64(current_stats.avg_frame_process_time_us) + " microseconds\n";
-	info += String("Last game frame sequence: ") + String::num_int64(current_stats.last_game_frame_sequence) + "\n";
-	info += String("Config FPS: ") + String::num_int64(config.target_fps) + "\n";
-	info += String("Config resolution: ") + String::num_int64(config.video_width) + "x" + String::num_int64(config.video_height) + "\n";
-	info += "==========================================";
-
-	return info;
 }

--- a/godot_modules/spx/recorder/independent_video_recorder.cpp
+++ b/godot_modules/spx/recorder/independent_video_recorder.cpp
@@ -37,7 +37,6 @@ Error IndependentVideoRecorder::initialize(ThreadSafeFrameBuffer *p_frame_buffer
 	frame_buffer = p_frame_buffer;
 	config = p_config;
 
-	// create simple video writer
 	video_writer.instantiate();
 
 	Size2i movie_size(config.video_width, config.video_height);
@@ -47,7 +46,6 @@ Error IndependentVideoRecorder::initialize(ThreadSafeFrameBuffer *p_frame_buffer
 		return open_result;
 	}
 
-	// reset statistics
 	reset_statistics();
 
 	if (MovieDebugUtils::is_stdout_verbose()) {
@@ -72,11 +70,9 @@ Error IndependentVideoRecorder::start_recording() {
 		return ERR_UNCONFIGURED;
 	}
 
-	// set recording status
 	recording_active.store(true);
 	recording_start_time = OS::get_singleton()->get_ticks_usec();
 
-	// start recording thread
 	recording_thread.start(recording_thread_func, this);
 	thread_started.store(true);
 
@@ -95,18 +91,15 @@ void IndependentVideoRecorder::stop_recording() {
 		return;
 	}
 
-	// wait for thread to finish
 	if (thread_started.load()) {
 		recording_thread.wait_to_finish();
 		thread_started.store(false);
 	}
 
-	// close video writer
 	if (video_writer.is_valid()) {
 		video_writer->close();
 	}
 
-	// output final statistics
 	if (MovieDebugUtils::is_stdout_verbose()) {
 		RecordingStats final_stats = get_statistics();
 		print_line(String("Recording completed - Total frames: ") + String::num_int64(final_stats.total_recorded_frames));
@@ -132,21 +125,18 @@ void IndependentVideoRecorder::recording_loop() {
 		if (current_time >= next_record_time) {
 			uint64_t frame_process_start = OS::get_singleton()->get_ticks_usec();
 
-			// Process frame
 			bool frame_processed = process_frame(next_record_time - recording_start_time);
 
 			if (frame_processed) {
 				frame_count++;
 				update_statistics(frame_process_start);
 
-				// Output debug information every 30 frames
 				if (MovieDebugUtils::is_stdout_verbose() && frame_count % 30 == 0) {
 					print_line(String("Recording progress: ") + String::num_int64(frame_count) + " frames, " +
 							String("Repeated frame ratio: ") + String::num_real(get_repeat_frame_ratio() * 100.0f) + "%");
 				}
 			}
 
-			// Calculate next frame time
 			next_record_time += FRAME_INTERVAL_USEC;
 		}
 
@@ -162,7 +152,6 @@ void IndependentVideoRecorder::recording_loop() {
 }
 
 bool IndependentVideoRecorder::process_frame(uint64_t current_recording_time) {
-	// Get current frame data
 	ThreadSafeFrameBuffer::FrameData frame_data = frame_buffer->get_current_frame();
 
 	ThreadSafeFrameBuffer::FrameData frame_to_write;
@@ -194,7 +183,6 @@ bool IndependentVideoRecorder::process_frame(uint64_t current_recording_time) {
 		stats.last_game_frame_sequence = frame_data.frame_sequence;
 	}
 
-	// Write to video file
 	Error write_result = video_writer->write_frame(frame_to_write.image);
 
 	if (write_result != OK) {
@@ -202,7 +190,6 @@ bool IndependentVideoRecorder::process_frame(uint64_t current_recording_time) {
 		return false;
 	}
 
-	// Update statistics
 	{
 		MutexLock lock(stats_mutex);
 		stats.total_recorded_frames++;
@@ -217,7 +204,6 @@ void IndependentVideoRecorder::update_statistics(uint64_t frame_process_start_ti
 
 	MutexLock lock(stats_mutex);
 
-	// Update recording duration
 	stats.recording_duration_us = current_time - recording_start_time;
 
 	// Update average processing time (using a moving average)

--- a/godot_modules/spx/recorder/thread_safe_frame_buffer.cpp
+++ b/godot_modules/spx/recorder/thread_safe_frame_buffer.cpp
@@ -10,7 +10,6 @@
 #include "core/os/os.h"
 
 ThreadSafeFrameBuffer::ThreadSafeFrameBuffer() {
-	// Initialize atomic variables
 	has_new_data.store(false);
 	last_sequence.store(0);
 	total_updates.store(0);
@@ -18,12 +17,10 @@ ThreadSafeFrameBuffer::ThreadSafeFrameBuffer() {
 }
 
 ThreadSafeFrameBuffer::~ThreadSafeFrameBuffer() {
-	// Clean up resources
 	reset();
 }
 
 void ThreadSafeFrameBuffer::update_frame(const Ref<Image> &new_frame, uint64_t timestamp, uint32_t sequence) {
-	// Parameter validation
 	if (new_frame.is_null()) {
 		return;
 	}
@@ -46,7 +43,6 @@ void ThreadSafeFrameBuffer::update_frame(const Ref<Image> &new_frame, uint64_t t
 		buffer_switches.fetch_add(1);
 	}
 
-	// Update status flags
 	has_new_data.store(true);
 	last_sequence.store(sequence);
 }
@@ -66,12 +62,10 @@ ThreadSafeFrameBuffer::FrameData ThreadSafeFrameBuffer::get_current_frame() cons
 void ThreadSafeFrameBuffer::reset() {
 	MutexLock lock(buffer_mutex);
 
-	// Clear buffers
 	buffer_a = FrameData();
 	buffer_b = FrameData();
 	writing_to_a = true;
 
-	// Reset status
 	has_new_data.store(false);
 	last_sequence.store(0);
 	total_updates.store(0);

--- a/godot_modules/spx/spx_audio_mgr.cpp
+++ b/godot_modules/spx/spx_audio_mgr.cpp
@@ -49,7 +49,6 @@ SpxAudio *SpxAudioMgr::_get_aid_audio(GdInt aid) {
 
 void SpxAudioMgr::on_awake() {
 	SpxBaseMgr::on_awake();
-	// Initialize SpxAudioBusPool
 	SpxAudioBusPool::init();
 	_create_root("audio_root");
 	g_audio_id = 0;
@@ -120,7 +119,6 @@ void SpxAudioMgr::stop_all() {
 void SpxAudioMgr::destroy_audio(GdObj obj) {
 	SpxAudio *audio = get_object(obj);
 	if (audio != nullptr) {
-		// Remove audio from aid_audios mapping
 		MutexLock aid_lock(aid_mutex);
 		Vector<GdInt> keys;
 		for (const auto &[aid, audio_obj] : aid_audios) {
@@ -133,7 +131,6 @@ void SpxAudioMgr::destroy_audio(GdObj obj) {
 		}
 	}
 
-	// Now destroy the object using parent class method
 	destroy_object(obj);
 }
 

--- a/godot_modules/spx/spx_audio_mgr.cpp
+++ b/godot_modules/spx/spx_audio_mgr.cpp
@@ -40,13 +40,6 @@
 #include "spx_sprite.h"
 #include "spx_sprite_mgr.h"
 
-SpxAudio *SpxAudioMgr::_get_aid_audio(GdInt aid) {
-	if (aid_audios.has(aid)) {
-		return aid_audios[aid];
-	}
-	return nullptr;
-}
-
 void SpxAudioMgr::on_awake() {
 	SpxBaseMgr::on_awake();
 	SpxAudioBusPool::init();
@@ -328,4 +321,11 @@ void SpxAudioMgr::set_timer(GdInt aid, GdFloat time) {
 		return;
 	}
 	audio->set_timer(aid, time);
+}
+
+SpxAudio *SpxAudioMgr::_get_aid_audio(GdInt aid) {
+	if (aid_audios.has(aid)) {
+		return aid_audios[aid];
+	}
+	return nullptr;
 }

--- a/godot_modules/spx/spx_base_mgr.cpp
+++ b/godot_modules/spx/spx_base_mgr.cpp
@@ -52,14 +52,6 @@ constexpr size_t SPX_MAX_ARRAY_BYTES = 256 * 1024 * 1024;
 
 } // namespace
 
-Node *SpxBaseMgr::create_owner_node() {
-	return memnew(Node2D);
-}
-
-GdInt SpxBaseMgr::get_unique_id() {
-	return SpxEngine::get_singleton()->get_unique_id();
-}
-
 void SpxBaseMgr::free_return_cstr(GdString str_ptr) {
 	free((void *)str_ptr);
 }
@@ -72,18 +64,6 @@ GdString SpxBaseMgr::to_return_cstr(const String &ret_val) {
 	}
 	strcpy(result, cstr.get_data());
 	return result;
-}
-
-Window *SpxBaseMgr::get_root() {
-	return SpxEngine::get_singleton()->get_root();
-}
-
-Node *SpxBaseMgr::get_spx_root() {
-	return SpxEngine::get_singleton()->get_spx_root();
-}
-
-SceneTree *SpxBaseMgr::get_tree() {
-	return SpxEngine::get_singleton()->get_tree();
 }
 
 void SpxBaseMgr::on_awake() {
@@ -213,6 +193,26 @@ void SpxBaseMgr::free_array(GdArray array) {
 	}
 	free(array);
 #endif
+}
+
+Node *SpxBaseMgr::create_owner_node() {
+	return memnew(Node2D);
+}
+
+GdInt SpxBaseMgr::get_unique_id() {
+	return SpxEngine::get_singleton()->get_unique_id();
+}
+
+Window *SpxBaseMgr::get_root() {
+	return SpxEngine::get_singleton()->get_root();
+}
+
+Node *SpxBaseMgr::get_spx_root() {
+	return SpxEngine::get_singleton()->get_spx_root();
+}
+
+SceneTree *SpxBaseMgr::get_tree() {
+	return SpxEngine::get_singleton()->get_tree();
 }
 
 void *SpxBaseMgr::_get_array(GdArray array, int64_t index, int type_size, int32_t expected_type) {

--- a/godot_modules/spx/spx_base_mgr.cpp
+++ b/godot_modules/spx/spx_base_mgr.cpp
@@ -118,11 +118,9 @@ void SpxBaseMgr::on_exit(int exit_code) {
 }
 
 void SpxBaseMgr::on_pause() {
-	// Default implementation - override in derived classes if needed
 }
 
 void SpxBaseMgr::on_resume() {
-	// Default implementation - override in derived classes if needed
 }
 
 GdArray SpxBaseMgr::create_array(int32_t type, int32_t size) {

--- a/godot_modules/spx/spx_layer_sorter.cpp
+++ b/godot_modules/spx/spx_layer_sorter.cpp
@@ -49,8 +49,6 @@ void SpxLayerSorter::update(const Vector<ISortableSprite *> &sortables) {
 	auto camera_mgr = SpxEngine::get_singleton()->get_camera();
 	set_screen_rect(camera_mgr->get_global_camera_rect());
 
-	// Uncomment the line below to enable screen visibility callbacks
-	//_update_visibility(sortables);
 	_collect_sprites(sortables);
 
 	if (dynamic_dirty.empty()) {
@@ -337,8 +335,6 @@ void LayerSorterDebugDrawer::_draw() {
 			draw_string(font, s.pos + Vector2(6, -2),
 					vformat("%s:%d", label_prefix, (int64_t)i),
 					HORIZONTAL_ALIGNMENT_LEFT, -1, 24, text_color);
-
-			//if (i > 0) draw_line(arr[i - 1].pos, s.pos, Color(0.4, 0.4, 0.4, 0.4), 1);
 		}
 	};
 

--- a/godot_modules/spx/spx_tilemap_types.cpp
+++ b/godot_modules/spx/spx_tilemap_types.cpp
@@ -65,10 +65,6 @@ static Array _vector2_to_array(const Vector2 &v) {
 	return arr;
 }
 
-// ============================================================================
-// SpxPhysicsLayerData
-// ============================================================================
-
 bool SpxPhysicsLayerData::from_json(const Dictionary &dict) {
 	collision_layer = dict.get("collision_layer", 1);
 	collision_mask = dict.get("collision_mask", 1);
@@ -81,10 +77,6 @@ Dictionary SpxPhysicsLayerData::to_json() const {
 	dict["collision_mask"] = collision_mask;
 	return dict;
 }
-
-// ============================================================================
-// SpxTilePhysicsData
-// ============================================================================
 
 bool SpxTilePhysicsData::from_json(const Dictionary &dict) {
 	layer = dict.get("layer", 0);
@@ -121,10 +113,6 @@ Dictionary SpxTilePhysicsData::to_json() const {
 
 	return dict;
 }
-
-// ============================================================================
-// SpxTileData
-// ============================================================================
 
 bool SpxTileData::from_json(const Dictionary &dict) {
 	if (dict.has("atlas_coords")) {
@@ -165,10 +153,6 @@ Dictionary SpxTileData::to_json() const {
 
 	return dict;
 }
-
-// ============================================================================
-// SpxTileSetSourceData
-// ============================================================================
 
 bool SpxTileSetSourceData::from_json(const Dictionary &dict) {
 	id = dict.get("id", 0);
@@ -217,10 +201,6 @@ Dictionary SpxTileSetSourceData::to_json() const {
 
 	return dict;
 }
-
-// ============================================================================
-// SpxTileSetData
-// ============================================================================
 
 bool SpxTileSetData::from_json(const Dictionary &dict) {
 	if (dict.has("tile_size")) {
@@ -273,10 +253,6 @@ Dictionary SpxTileSetData::to_json() const {
 	return dict;
 }
 
-// ============================================================================
-// SpxTileMapLayerData
-// ============================================================================
-
 bool SpxTileMapLayerData::from_json(const Dictionary &dict) {
 	name = dict.get("name", "");
 	z_index = dict.get("z_index", 0);
@@ -299,10 +275,6 @@ Dictionary SpxTileMapLayerData::to_json() const {
 	dict["tile_map_data"] = tile_map_data_base64;
 	return dict;
 }
-
-// ============================================================================
-// SpxTileMapData
-// ============================================================================
 
 bool SpxTileMapData::from_json(const Dictionary &dict) {
 	version = dict.get("version", 1);

--- a/godot_modules/spx/spx_tilemapparser_mgr.cpp
+++ b/godot_modules/spx/spx_tilemapparser_mgr.cpp
@@ -85,7 +85,6 @@ void SpxTilemapparserMgr::load_tilemap(GdString json_path) {
 		}
 	}
 
-	// Check if already loaded
 	if (tilemap_layers.has(tilemap_name)) {
 		print_line("SpxTilemapparserMgr: Tilemap already loaded: " + tilemap_name);
 		return;
@@ -101,15 +100,12 @@ void SpxTilemapparserMgr::load_tilemap(GdString json_path) {
 		return;
 	}
 
-	// Cache tileset
 	tileset_cache[tilemap_name] = tileset;
 
-	// Create TileMapLayers
 	Vector<TileMapLayer *> layers;
 	for (int i = 0; i < data.layers.size(); i++) {
 		TileMapLayer *layer = _create_tilemap_layer(data.layers[i], tileset, data.node_offset);
 		if (layer != nullptr) {
-			// Add to scene tree
 			Node *spx_root = get_spx_root();
 			if (spx_root != nullptr) {
 				spx_root->add_child(layer);
@@ -118,14 +114,12 @@ void SpxTilemapparserMgr::load_tilemap(GdString json_path) {
 		}
 	}
 
-	// Store layers in cache
 	tilemap_layers[tilemap_name] = layers;
 }
 
 void SpxTilemapparserMgr::unload_tilemap(GdString name) {
 	String tilemap_name = SpxStr(name);
 
-	// Destroy layers
 	if (tilemap_layers.has(tilemap_name)) {
 		Vector<TileMapLayer *> &layers = tilemap_layers[tilemap_name];
 		for (TileMapLayer *layer : layers) {
@@ -136,12 +130,10 @@ void SpxTilemapparserMgr::unload_tilemap(GdString name) {
 		tilemap_layers.erase(tilemap_name);
 	}
 
-	// Remove from tileset cache
 	tileset_cache.erase(tilemap_name);
 }
 
 void SpxTilemapparserMgr::destroy_all_tilemaps() {
-	// Destroy all layers
 	for (KeyValue<String, Vector<TileMapLayer *>> &kv : tilemap_layers) {
 		for (TileMapLayer *layer : kv.value) {
 			if (layer != nullptr) {
@@ -206,10 +198,8 @@ Ref<TileSet> SpxTilemapparserMgr::_create_tileset(const SpxTileSetData &data, co
 	Ref<TileSet> tileset;
 	tileset.instantiate();
 
-	// Set tile size
 	tileset->set_tile_size(data.tile_size);
 
-	// Create physics layers
 	for (int i = 0; i < data.physics_layers.size(); i++) {
 		const SpxPhysicsLayerData &layer_data = data.physics_layers[i];
 		tileset->add_physics_layer();
@@ -217,7 +207,6 @@ Ref<TileSet> SpxTilemapparserMgr::_create_tileset(const SpxTileSetData &data, co
 		tileset->set_physics_layer_collision_mask(i, layer_data.collision_mask);
 	}
 
-	// Create sources
 	for (int i = 0; i < data.sources.size(); i++) {
 		_create_atlas_source(tileset, data.sources[i], base_path);
 	}
@@ -246,7 +235,6 @@ void SpxTilemapparserMgr::_create_atlas_source(Ref<TileSet> tileset, const SpxTi
 		return;
 	}
 
-	// Create atlas source
 	Ref<TileSetAtlasSource> atlas;
 	atlas.instantiate();
 	atlas->set_texture(texture);
@@ -263,10 +251,8 @@ void SpxTilemapparserMgr::_create_atlas_source(Ref<TileSet> tileset, const SpxTi
 	for (int i = 0; i < data.tiles.size(); i++) {
 		const SpxTileData &tile_data = data.tiles[i];
 
-		// Create the tile
 		atlas->create_tile(tile_data.atlas_coords, tile_data.size_in_atlas);
 
-		// Get tile data for physics setup
 		TileData *td = atlas->get_tile_data(tile_data.atlas_coords, 0);
 		if (td != nullptr) {
 			_setup_tile_physics(td, tile_data);
@@ -279,7 +265,6 @@ void SpxTilemapparserMgr::_setup_tile_physics(TileData *tile_data, const SpxTile
 		const SpxTilePhysicsData &phys_data = data.physics[i];
 		int layer_id = phys_data.layer;
 
-		// Add collision polygons
 		for (int p = 0; p < phys_data.polygons.size(); p++) {
 			const Vector<float> &polygon_flat = phys_data.polygons[p];
 
@@ -305,19 +290,13 @@ void SpxTilemapparserMgr::_setup_tile_physics(TileData *tile_data, const SpxTile
 TileMapLayer *SpxTilemapparserMgr::_create_tilemap_layer(const SpxTileMapLayerData &data, Ref<TileSet> tileset, const Vector2 &node_offset) {
 	TileMapLayer *layer = memnew(TileMapLayer);
 
-	// Set layer name
 	layer->set_name(data.name.is_empty() ? "layer" : data.name);
-
-	// Set z_index
 	layer->set_z_index(data.z_index);
 
 	// Set offset (position) - combine layer offset with tilemap node offset for centering
 	layer->set_position(data.offset + node_offset);
 
-	// Set enabled
 	layer->set_enabled(data.enabled);
-
-	// Set tile set
 	layer->set_tile_set(tileset);
 
 	// Parse tile_map_data (Base64 encoded binary data)

--- a/godot_modules/spx/svg_mgr.cpp
+++ b/godot_modules/spx/svg_mgr.cpp
@@ -34,14 +34,6 @@ bool SvgManager::is_svg_file(const String &path) const {
 	return path.to_lower().ends_with(".svg");
 }
 
-String SvgManager::_make_image_key(const String &path, int scale) {
-	return String::num(scale) + "@" + path;
-}
-
-String SvgManager::_make_animation_key(const String &name, int scale) {
-	return String::num(scale) + "@" + name;
-}
-
 Ref<ImageTexture> SvgManager::get_svg_image(const String &image_path, int scale) {
 	ERR_FAIL_COND_V_MSG(!Thread::is_main_thread(), Ref<ImageTexture>(), "SVG image caches may only be accessed on the main thread.");
 	if (!is_svg_file(image_path)) {
@@ -77,6 +69,74 @@ bool SvgManager::is_svg_animation(const String &base_anim_key) {
 void SvgManager::mark_svg_animation(const String &base_anim_key, bool is_svg_animation) {
 	ERR_FAIL_COND_MSG(!Thread::is_main_thread(), "SVG animation caches may only be accessed on the main thread.");
 	is_svg_animation_registry[base_anim_key] = is_svg_animation;
+}
+
+void SvgManager::reset(bool p_clear_project_caches) {
+	ERR_FAIL_COND_MSG(!Thread::is_main_thread(), "SVG caches may only be reset on the main thread.");
+	if (p_clear_project_caches) {
+		svg_image_cache.clear();
+		svg_image_raw_size_cache.clear();
+		is_svg_animation_registry.clear();
+	}
+	svg_animation_cache.clear();
+}
+
+void SvgManager::update_caches(const Vector<String> &files) {
+	ERR_FAIL_COND_MSG(!Thread::is_main_thread(), "SVG caches may only be updated on the main thread.");
+	bool invalidated_svg = false;
+	for (const String &file : files) {
+		const String path = resMgr->_to_engine_path(file);
+		if (!is_svg_file(path)) {
+			continue;
+		}
+
+		Vector<String> image_keys_to_erase;
+		const String key_suffix = "@" + path;
+		for (const KeyValue<String, Ref<ImageTexture>> &E : svg_image_cache) {
+			if (E.key.ends_with(key_suffix)) {
+				image_keys_to_erase.push_back(E.key);
+			}
+		}
+		for (const String &key : image_keys_to_erase) {
+			svg_image_cache.erase(key);
+		}
+		svg_image_raw_size_cache.erase(path);
+		invalidated_svg = true;
+	}
+
+	if (invalidated_svg) {
+		// Scaled animation frames may retain textures from any image scale.
+		svg_animation_cache.clear();
+	}
+}
+
+int SvgManager::calculate_svg_scale(Vector2 required_scale) {
+	float scale = MAX(Math::abs(required_scale.x), Math::abs(required_scale.y));
+	return calculate_svg_scale(scale);
+}
+
+int SvgManager::calculate_svg_scale(float required_scale) {
+	float scale = Math::abs(required_scale);
+	if (scale <= 1.0f) {
+		return 1;
+	}
+
+	// Match Scratch's SVG MIP rule, but clamp to the largest SVG raster scale
+	// we allow to cache. Larger render scales stay pinned at this ceiling.
+	const int max_svg_scale = 1024;
+	int target_scale = 1;
+	while ((float)target_scale < scale && target_scale < max_svg_scale) {
+		target_scale <<= 1;
+	}
+	return target_scale;
+}
+
+String SvgManager::_make_image_key(const String &path, int scale) {
+	return String::num(scale) + "@" + path;
+}
+
+String SvgManager::_make_animation_key(const String &name, int scale) {
+	return String::num(scale) + "@" + name;
 }
 
 Ref<SpriteFrames> SvgManager::_load_animation(const String &anim_name, int scale) {
@@ -175,64 +235,4 @@ Ref<ImageTexture> SvgManager::_load_image(const String &path /*engine path*/, in
 	}
 
 	return Ref<ImageTexture>();
-}
-
-void SvgManager::reset(bool p_clear_project_caches) {
-	ERR_FAIL_COND_MSG(!Thread::is_main_thread(), "SVG caches may only be reset on the main thread.");
-	if (p_clear_project_caches) {
-		svg_image_cache.clear();
-		svg_image_raw_size_cache.clear();
-		is_svg_animation_registry.clear();
-	}
-	svg_animation_cache.clear();
-}
-
-void SvgManager::update_caches(const Vector<String> &files) {
-	ERR_FAIL_COND_MSG(!Thread::is_main_thread(), "SVG caches may only be updated on the main thread.");
-	bool invalidated_svg = false;
-	for (const String &file : files) {
-		const String path = resMgr->_to_engine_path(file);
-		if (!is_svg_file(path)) {
-			continue;
-		}
-
-		Vector<String> image_keys_to_erase;
-		const String key_suffix = "@" + path;
-		for (const KeyValue<String, Ref<ImageTexture>> &E : svg_image_cache) {
-			if (E.key.ends_with(key_suffix)) {
-				image_keys_to_erase.push_back(E.key);
-			}
-		}
-		for (const String &key : image_keys_to_erase) {
-			svg_image_cache.erase(key);
-		}
-		svg_image_raw_size_cache.erase(path);
-		invalidated_svg = true;
-	}
-
-	if (invalidated_svg) {
-		// Scaled animation frames may retain textures from any image scale.
-		svg_animation_cache.clear();
-	}
-}
-
-int SvgManager::calculate_svg_scale(Vector2 required_scale) {
-	float scale = MAX(Math::abs(required_scale.x), Math::abs(required_scale.y));
-	return calculate_svg_scale(scale);
-}
-
-int SvgManager::calculate_svg_scale(float required_scale) {
-	float scale = Math::abs(required_scale);
-	if (scale <= 1.0f) {
-		return 1;
-	}
-
-	// Match Scratch's SVG MIP rule, but clamp to the largest SVG raster scale
-	// we allow to cache. Larger render scales stay pinned at this ceiling.
-	const int max_svg_scale = 1024;
-	int target_scale = 1;
-	while ((float)target_scale < scale && target_scale < max_svg_scale) {
-		target_scale <<= 1;
-	}
-	return target_scale;
 }

--- a/godot_modules/spx/svg_mgr.cpp
+++ b/godot_modules/spx/svg_mgr.cpp
@@ -93,14 +93,12 @@ Ref<SpriteFrames> SvgManager::_load_animation(const String &anim_name, int scale
 		return frames;
 	}
 
-	// Get animation definition from SpxResMgr
 	auto res_mgr = SpxEngine::get_singleton()->get_res();
 	if (!res_mgr) {
 		print_error("[SvgManager] Cannot access SpxResMgr");
 		return Ref<SpriteFrames>();
 	}
 
-	// Get existing animation frame list
 	auto existing_frames = res_mgr->get_anim_frames(anim_name);
 	if (!existing_frames.is_valid()) {
 		print_error("[SvgManager] Animation not found: " + anim_name);
@@ -113,7 +111,6 @@ Ref<SpriteFrames> SvgManager::_load_animation(const String &anim_name, int scale
 		return existing_frames;
 	}
 
-	// Check if animation contains SVG frames
 	if (!existing_frames->has_animation(anim_name)) {
 		print_error("[SvgManager] Animation key not found: " + anim_name);
 		return Ref<SpriteFrames>();
@@ -124,7 +121,6 @@ Ref<SpriteFrames> SvgManager::_load_animation(const String &anim_name, int scale
 	new_frames.instantiate();
 	new_frames->add_animation(anim_name);
 
-	// Copy animation properties
 	new_frames->set_animation_loop(anim_name, existing_frames->get_animation_loop(anim_name));
 	new_frames->set_animation_speed(anim_name, existing_frames->get_animation_speed(anim_name));
 
@@ -133,19 +129,15 @@ Ref<SpriteFrames> SvgManager::_load_animation(const String &anim_name, int scale
 		auto original_texture = existing_frames->get_frame_texture(anim_name, i);
 		float duration = existing_frames->get_frame_duration(anim_name, i);
 
-		// Check if it's an SVG texture
 		String texture_path = original_texture->get_path(); // engine path
 		if (is_svg_file(texture_path)) {
-			// Load scaled version of SVG
 			Ref<ImageTexture> scaled_texture = _load_image(texture_path, scale);
 			if (scaled_texture.is_valid()) {
 				new_frames->add_frame(anim_name, scaled_texture, duration);
 			} else {
-				// If SVG loading fails, use original texture
 				new_frames->add_frame(anim_name, original_texture, duration);
 			}
 		} else {
-			// Non-SVG textures directly use original texture
 			new_frames->add_frame(anim_name, original_texture, duration);
 		}
 	}
@@ -161,7 +153,6 @@ Ref<ImageTexture> SvgManager::_load_image(const String &path /*engine path*/, in
 	if (svg_image_cache.has(key)) {
 		return svg_image_cache[key];
 	}
-	// Load SVG image
 	Ref<Image> image;
 	image.instantiate();
 	Error err = SpxImageLoaderSVG::load_image(path, image, ImageFormatLoader::FLAG_NONE, (float)scale);
@@ -172,7 +163,6 @@ Ref<ImageTexture> SvgManager::_load_image(const String &path /*engine path*/, in
 		if (!svg_image_raw_size_cache.has(path)) {
 			svg_image_raw_size_cache[path] = Vector2(image->get_width() / scale, image->get_height() / scale);
 		}
-		// Cache texture
 		svg_image_cache[key] = texture;
 		return texture;
 	}

--- a/godot_modules/spx/svg_mgr.h
+++ b/godot_modules/spx/svg_mgr.h
@@ -14,15 +14,6 @@ public:
 	SvgManager();
 	~SvgManager();
 
-private:
-	HashMap<String, Ref<ImageTexture>> svg_image_cache; // "scale@image_path" -> ImageTexture
-	HashMap<String, Ref<SpriteFrames>> svg_animation_cache; // "scale@animation_name" -> SpriteFrames
-	HashMap<String, Vector2> svg_image_raw_size_cache;
-
-	HashMap<String, bool> is_svg_animation_registry;
-	static inline SvgManager *singleton = nullptr;
-
-public:
 	bool is_svg_file(const String &path) const;
 	bool is_svg_animation(const String &base_anim_key);
 	void mark_svg_animation(const String &base_anim_key, bool is_svg_animation);
@@ -38,6 +29,13 @@ public:
 	void update_caches(const Vector<String> &files);
 
 private:
+	HashMap<String, Ref<ImageTexture>> svg_image_cache; // "scale@image_path" -> ImageTexture
+	HashMap<String, Ref<SpriteFrames>> svg_animation_cache; // "scale@animation_name" -> SpriteFrames
+	HashMap<String, Vector2> svg_image_raw_size_cache;
+
+	HashMap<String, bool> is_svg_animation_registry;
+	static inline SvgManager *singleton = nullptr;
+
 	String _make_image_key(const String &path, int scale); // "scale@path"
 	String _make_animation_key(const String &name, int scale); // "scale@name"
 

--- a/godot_modules/spx/svg_mgr.h
+++ b/godot_modules/spx/svg_mgr.h
@@ -15,7 +15,6 @@ public:
 	~SvgManager();
 
 private:
-	// New simplified data structure
 	HashMap<String, Ref<ImageTexture>> svg_image_cache; // "scale@image_path" -> ImageTexture
 	HashMap<String, Ref<SpriteFrames>> svg_animation_cache; // "scale@animation_name" -> SpriteFrames
 	HashMap<String, Vector2> svg_image_raw_size_cache;


### PR DESCRIPTION
Remove redundant comments and commented-out code in recording, audio, tilemap, sorting, and SVG modules. Place public member implementations before private helpers and group the SVG public declarations together. Validation: make generate; verified reordered function bodies remain identical; git diff --check. CI compiles the current module and runs Linux engine tests and Web compile smoke.