### PR TITLE
refactor(codegen): share manager method signature generation

### DIFF
--- a/internal/cmd/codegen/generate/common/manager_signature.go
+++ b/internal/cmd/codegen/generate/common/manager_signature.go
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2021 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package common
+
+import (
+	"strings"
+
+	"github.com/goplus/spx/v3/internal/cmd/codegen/gdextensionparser/clang"
+)
+
+// ManagerMethodSignature renders a manager method with its receiver.
+func ManagerMethodSignature(function *clang.TypedefFunction) string {
+	mgrName := GetManagerName(function.Name)
+	return "(pself *" + mgrName + "Mgr) " + managerSignature(function, mgrName)
+}
+
+// ManagerInterfaceSignature renders a manager method without its receiver.
+func ManagerInterfaceSignature(function *clang.TypedefFunction) string {
+	return managerSignature(function, GetManagerName(function.Name))
+}
+
+func managerSignature(function *clang.TypedefFunction, mgrName string) string {
+	prefix := "GDExtensionSpx"
+	sb := strings.Builder{}
+	funcName := function.Name[len(prefix)+len(mgrName):]
+	args := EffectiveArguments(function)
+	sb.WriteString(funcName)
+	sb.WriteString("(")
+	wroteArg := false
+	for _, arg := range args {
+		if ShouldSkipHighLevelArgument(function, arg) {
+			continue
+		}
+		if wroteArg {
+			sb.WriteString(", ")
+		}
+		sb.WriteString(EffectiveGoArgumentName(function, arg))
+		sb.WriteString(" ")
+		typeName := EffectiveGoArgumentType(function, arg)
+		sb.WriteString(typeName)
+		wroteArg = true
+	}
+	sb.WriteString(")")
+
+	if HasEffectiveReturn(function) {
+		typeName := EffectiveGoReturnType(function)
+		sb.WriteString(" " + typeName + " ")
+	}
+	return sb.String()
+}

--- a/internal/cmd/codegen/generate/ffi/generate.go
+++ b/internal/cmd/codegen/generate/ffi/generate.go
@@ -179,9 +179,9 @@ func GenerateManagerWrapperGoFile(projectPath string, ast clang.CHeaderFileAST) 
 		"cgoCleanUpArgument":  CgoCleanUpArgument,
 		"trimPrefix":          TrimPrefix,
 		"isManagerMethod":     IsManagerMethod,
-		"getManagerFuncName":  getManagerFuncName,
+		"getManagerFuncName":  ManagerMethodSignature,
 		"getManagerFuncBody":  getManagerFuncBody,
-		"getManagerInterface": getManagerInterface,
+		"getManagerInterface": ManagerInterfaceSignature,
 	}
 
 	return GenerateFile(funcs, "manager_native.gen.go", managerNativeText, ManagerData{Ast: ast, Mangers: GetManagers(ast)},
@@ -203,9 +203,9 @@ func GenerateManagerInterfaceGoFile(projectPath string, ast clang.CHeaderFileAST
 		"cgoCleanUpArgument":  CgoCleanUpArgument,
 		"trimPrefix":          TrimPrefix,
 		"isManagerMethod":     IsManagerMethod,
-		"getManagerFuncName":  getManagerFuncName,
+		"getManagerFuncName":  ManagerMethodSignature,
 		"getManagerFuncBody":  getManagerFuncBody,
-		"getManagerInterface": getManagerInterface,
+		"getManagerInterface": ManagerInterfaceSignature,
 	}
 
 	return GenerateFile(funcs, "interface.gen.go", interfaceGoFileText, ManagerData{Ast: ast, Mangers: GetManagers(ast)},
@@ -288,40 +288,6 @@ func GenerateManagerImplPureGoFile(projectPath string, ast clang.CHeaderFileAST,
 	genFile := strings.ToLower(clsName) + "_pure.gen.go"
 	return GenerateFile(funcs, genFile, implPureGoFileText, data,
 		filepath.Join(projectPath, EnginePkgRelDir, genFile))
-}
-
-func getManagerFuncName(function *clang.TypedefFunction) string {
-	prefix := "GDExtensionSpx"
-	sb := strings.Builder{}
-	mgrName := GetManagerName(function.Name)
-	funcName := function.Name[len(prefix)+len(mgrName):]
-	args := EffectiveArguments(function)
-	sb.WriteString("(")
-	sb.WriteString("pself *" + mgrName)
-	sb.WriteString("Mgr) ")
-	sb.WriteString(funcName)
-	sb.WriteString("(")
-	wroteArg := false
-	for _, arg := range args {
-		if ShouldSkipHighLevelArgument(function, arg) {
-			continue
-		}
-		if wroteArg {
-			sb.WriteString(", ")
-		}
-		sb.WriteString(EffectiveGoArgumentName(function, arg))
-		sb.WriteString(" ")
-		typeName := EffectiveGoArgumentType(function, arg)
-		sb.WriteString(typeName)
-		wroteArg = true
-	}
-	sb.WriteString(")")
-
-	if HasEffectiveReturn(function) {
-		typeName := EffectiveGoReturnType(function)
-		sb.WriteString(" " + typeName + " ")
-	}
-	return sb.String()
 }
 
 func getManagerFuncBody(function *clang.TypedefFunction) string {
@@ -434,37 +400,6 @@ func getManagerFuncBody(function *clang.TypedefFunction) string {
 	}
 	if dispatchToMainThread {
 		sb.WriteString("\n\t})")
-	}
-	return sb.String()
-}
-
-func getManagerInterface(function *clang.TypedefFunction) string {
-	prefix := "GDExtensionSpx"
-	sb := strings.Builder{}
-	mgrName := GetManagerName(function.Name)
-	funcName := function.Name[len(prefix)+len(mgrName):]
-	args := EffectiveArguments(function)
-	sb.WriteString(funcName)
-	sb.WriteString("(")
-	wroteArg := false
-	for _, arg := range args {
-		if ShouldSkipHighLevelArgument(function, arg) {
-			continue
-		}
-		if wroteArg {
-			sb.WriteString(", ")
-		}
-		sb.WriteString(EffectiveGoArgumentName(function, arg))
-		sb.WriteString(" ")
-		typeName := EffectiveGoArgumentType(function, arg)
-		sb.WriteString(typeName)
-		wroteArg = true
-	}
-	sb.WriteString(")")
-
-	if HasEffectiveReturn(function) {
-		typeName := EffectiveGoReturnType(function)
-		sb.WriteString(" " + typeName + " ")
 	}
 	return sb.String()
 }

--- a/internal/cmd/codegen/generate/ffi/generate.go
+++ b/internal/cmd/codegen/generate/ffi/generate.go
@@ -63,6 +63,14 @@ var (
 	syncPureApiText string
 )
 
+type ImplData struct {
+	Ast     clang.CHeaderFileAST
+	Methods []clang.TypedefFunction
+	ClsName string
+}
+
+type ByName []clang.TypedefFunction
+
 func Generate(projectPath string, ast clang.CHeaderFileAST) error {
 	generators := []struct {
 		name string
@@ -258,12 +266,6 @@ func GenerateSyncPureGoFile(projectPath string, ast clang.CHeaderFileAST) error 
 		filepath.Join(projectPath, EnginewrapRelDir, "sync_pure.gen.go"))
 }
 
-type ImplData struct {
-	Ast     clang.CHeaderFileAST
-	Methods []clang.TypedefFunction
-	ClsName string
-}
-
 func GenerateManagerImplGoFile(projectPath string, ast clang.CHeaderFileAST, clsName string) error {
 	funcs := template.FuncMap{
 		"getManagerImpl": getManagerImpl,
@@ -277,6 +279,7 @@ func GenerateManagerImplGoFile(projectPath string, ast clang.CHeaderFileAST, cls
 	return GenerateFile(funcs, genFile, implGoFileText, data,
 		filepath.Join(projectPath, EnginePkgRelDir, genFile))
 }
+
 func GenerateManagerImplPureGoFile(projectPath string, ast clang.CHeaderFileAST, clsName string) error {
 	funcs := template.FuncMap{
 		"getManagerImplPure": getManagerImplPure,
@@ -288,6 +291,25 @@ func GenerateManagerImplPureGoFile(projectPath string, ast clang.CHeaderFileAST,
 	genFile := strings.ToLower(clsName) + "_pure.gen.go"
 	return GenerateFile(funcs, genFile, implPureGoFileText, data,
 		filepath.Join(projectPath, EnginePkgRelDir, genFile))
+}
+
+func MustGdxReturnType(function *clang.TypedefFunction) string {
+	typeName := EffectiveGoReturnType(function)
+	if typeName == "Object" {
+		return "gdx.Object"
+	}
+	if typeName == "Array" {
+		return "gdx.Array"
+	}
+	return typeName
+}
+
+func (arr ByName) Len() int { return len(arr) }
+
+func (arr ByName) Swap(i, j int) { arr[i], arr[j] = arr[j], arr[i] }
+
+func (arr ByName) Less(i, j int) bool {
+	return arr[i].Name < arr[j].Name
 }
 
 func getManagerFuncBody(function *clang.TypedefFunction) string {
@@ -419,17 +441,6 @@ func goZeroValue(typeName string) string {
 	}
 }
 
-func MustGdxReturnType(function *clang.TypedefFunction) string {
-	typeName := EffectiveGoReturnType(function)
-	if typeName == "Object" {
-		return "gdx.Object"
-	}
-	if typeName == "Array" {
-		return "gdx.Array"
-	}
-	return typeName
-}
-
 func genSyncPureApiWrapFunction(function *clang.TypedefFunction) string {
 	prefix := "GDExtensionSpx"
 	sb := strings.Builder{}
@@ -558,16 +569,6 @@ func genSyncManagerWrapFunction(function *clang.TypedefFunction) string {
 	return ""
 }
 
-type ByName []clang.TypedefFunction
-
-func (arr ByName) Len() int { return len(arr) }
-
-func (arr ByName) Swap(i, j int) { arr[i], arr[j] = arr[j], arr[i] }
-
-func (arr ByName) Less(i, j int) bool {
-	return arr[i].Name < arr[j].Name
-}
-
 func getManagerImplPure(function *clang.TypedefFunction, clsName string) string {
 	prefix := "GDExtensionSpx"
 	sb := strings.Builder{}
@@ -605,6 +606,7 @@ func getManagerImplPure(function *clang.TypedefFunction, clsName string) string 
 	sb.WriteString("}\n")
 	return sb.String()
 }
+
 func getManagerImpl(function *clang.TypedefFunction, clsName string) string {
 	prefix := "GDExtensionSpx"
 	sb := strings.Builder{}

--- a/internal/cmd/codegen/generate/webffi/generate.go
+++ b/internal/cmd/codegen/generate/webffi/generate.go
@@ -56,6 +56,59 @@ var (
 	workerWrapJsFileText string
 )
 
+type managerFuncBodySpec struct {
+	call      string
+	fallback  []string
+	boolAsInt bool
+}
+
+var inputCacheManagerFuncBodies = map[string]managerFuncBodySpec{
+	"GDExtensionSpxInputGetGlobalMousePos": {
+		call: "WebInputMousePos(func() Vec2",
+		fallback: []string{
+			"_retValue := API.SpxInputGetGlobalMousePos.Invoke()",
+			"return JsToGdVec2(_retValue)",
+		},
+	},
+	"GDExtensionSpxInputGetKey": {
+		call: "WebInputKeyState(key, func() bool",
+		fallback: []string{
+			"arg0Low, arg0High := JsSplitGdInt(key)",
+			"_retValue := API.SpxInputGetKey.Invoke(arg0Low, arg0High)",
+			"return JsToGdBool(_retValue)",
+		},
+	},
+	"GDExtensionSpxInputGetMouseState": {
+		call: "WebInputMouseState(mouse_id, func() bool",
+		fallback: []string{
+			"arg0Low, arg0High := JsSplitGdInt(mouse_id)",
+			"_retValue := API.SpxInputGetMouseState.Invoke(arg0Low, arg0High)",
+			"return JsToGdBool(_retValue)",
+		},
+	},
+	"GDExtensionSpxInputGetKeyState": {
+		call: "WebInputKeyState(key, func() bool",
+		fallback: []string{
+			"arg0Low, arg0High := JsSplitGdInt(key)",
+			"_retValue := API.SpxInputGetKeyState.Invoke(arg0Low, arg0High)",
+			"return JsToGdInt(_retValue) != 0",
+		},
+		boolAsInt: true,
+	},
+	"GDExtensionSpxInputGetAxis": {
+		call: "CachedActionAxis(neg_action, pos_action, func() float64",
+		fallback: []string{
+			"arg0 := JsFromGdString(neg_action)",
+			"arg1 := JsFromGdString(pos_action)",
+			"_retValue := API.SpxInputGetAxis.Invoke(arg0, arg1)",
+			"return JsToGdFloat(_retValue)",
+		},
+	},
+	"GDExtensionSpxInputIsActionPressed":      actionBoolManagerFuncBody("pressed", "API.SpxInputIsActionPressed"),
+	"GDExtensionSpxInputIsActionJustPressed":  actionBoolManagerFuncBody("just_pressed", "API.SpxInputIsActionJustPressed"),
+	"GDExtensionSpxInputIsActionJustReleased": actionBoolManagerFuncBody("just_released", "API.SpxInputIsActionJustReleased"),
+}
+
 func Generate(projectPath, spxModulePath string, ast clang.CHeaderFileAST) error {
 	generators := []struct {
 		name string
@@ -290,59 +343,6 @@ func getManagerFuncBody(function *clang.TypedefFunction) string {
 		sb.WriteString("JsTo" + name + "(_retValue)")
 	}
 	return sb.String()
-}
-
-type managerFuncBodySpec struct {
-	call      string
-	fallback  []string
-	boolAsInt bool
-}
-
-var inputCacheManagerFuncBodies = map[string]managerFuncBodySpec{
-	"GDExtensionSpxInputGetGlobalMousePos": {
-		call: "WebInputMousePos(func() Vec2",
-		fallback: []string{
-			"_retValue := API.SpxInputGetGlobalMousePos.Invoke()",
-			"return JsToGdVec2(_retValue)",
-		},
-	},
-	"GDExtensionSpxInputGetKey": {
-		call: "WebInputKeyState(key, func() bool",
-		fallback: []string{
-			"arg0Low, arg0High := JsSplitGdInt(key)",
-			"_retValue := API.SpxInputGetKey.Invoke(arg0Low, arg0High)",
-			"return JsToGdBool(_retValue)",
-		},
-	},
-	"GDExtensionSpxInputGetMouseState": {
-		call: "WebInputMouseState(mouse_id, func() bool",
-		fallback: []string{
-			"arg0Low, arg0High := JsSplitGdInt(mouse_id)",
-			"_retValue := API.SpxInputGetMouseState.Invoke(arg0Low, arg0High)",
-			"return JsToGdBool(_retValue)",
-		},
-	},
-	"GDExtensionSpxInputGetKeyState": {
-		call: "WebInputKeyState(key, func() bool",
-		fallback: []string{
-			"arg0Low, arg0High := JsSplitGdInt(key)",
-			"_retValue := API.SpxInputGetKeyState.Invoke(arg0Low, arg0High)",
-			"return JsToGdInt(_retValue) != 0",
-		},
-		boolAsInt: true,
-	},
-	"GDExtensionSpxInputGetAxis": {
-		call: "CachedActionAxis(neg_action, pos_action, func() float64",
-		fallback: []string{
-			"arg0 := JsFromGdString(neg_action)",
-			"arg1 := JsFromGdString(pos_action)",
-			"_retValue := API.SpxInputGetAxis.Invoke(arg0, arg1)",
-			"return JsToGdFloat(_retValue)",
-		},
-	},
-	"GDExtensionSpxInputIsActionPressed":      actionBoolManagerFuncBody("pressed", "API.SpxInputIsActionPressed"),
-	"GDExtensionSpxInputIsActionJustPressed":  actionBoolManagerFuncBody("just_pressed", "API.SpxInputIsActionJustPressed"),
-	"GDExtensionSpxInputIsActionJustReleased": actionBoolManagerFuncBody("just_released", "API.SpxInputIsActionJustReleased"),
 }
 
 func getInputCacheManagerFuncBody(name string) (string, bool) {

--- a/internal/cmd/codegen/generate/webffi/generate.go
+++ b/internal/cmd/codegen/generate/webffi/generate.go
@@ -150,9 +150,9 @@ func GenerateManagerWrapperGoFile(projectPath string, ast clang.CHeaderFileAST) 
 		"cgoCleanUpArgument":  CgoCleanUpArgument,
 		"trimPrefix":          TrimPrefix,
 		"isManagerMethod":     IsManagerMethod,
-		"getManagerFuncName":  getManagerFuncName,
+		"getManagerFuncName":  ManagerMethodSignature,
 		"getManagerFuncBody":  getManagerFuncBody,
-		"getManagerInterface": getManagerInterface,
+		"getManagerInterface": ManagerInterfaceSignature,
 	}
 
 	return GenerateFile(funcs, "manager_web.gen.go", managerWebText, ManagerData{Ast: ast, Mangers: GetManagers(ast)},
@@ -213,40 +213,6 @@ func trimTrailingWhitespace(src []byte) []byte {
 		lines[i] = bytes.TrimRight(line, " \t")
 	}
 	return bytes.Join(lines, []byte("\n"))
-}
-
-func getManagerFuncName(function *clang.TypedefFunction) string {
-	prefix := "GDExtensionSpx"
-	sb := strings.Builder{}
-	mgrName := GetManagerName(function.Name)
-	funcName := function.Name[len(prefix)+len(mgrName):]
-	args := EffectiveArguments(function)
-	sb.WriteString("(")
-	sb.WriteString("pself *" + mgrName)
-	sb.WriteString("Mgr) ")
-	sb.WriteString(funcName)
-	sb.WriteString("(")
-	wroteArg := false
-	for _, arg := range args {
-		if ShouldSkipHighLevelArgument(function, arg) {
-			continue
-		}
-		if wroteArg {
-			sb.WriteString(", ")
-		}
-		sb.WriteString(EffectiveGoArgumentName(function, arg))
-		sb.WriteString(" ")
-		typeName := EffectiveGoArgumentType(function, arg)
-		sb.WriteString(typeName)
-		wroteArg = true
-	}
-	sb.WriteString(")")
-
-	if HasEffectiveReturn(function) {
-		typeName := EffectiveGoReturnType(function)
-		sb.WriteString(" " + typeName + " ")
-	}
-	return sb.String()
 }
 
 func getManagerFuncBody(function *clang.TypedefFunction) string {
@@ -425,37 +391,6 @@ func appendIndented(lines []string, indent string, values ...string) []string {
 		lines = append(lines, indent+value)
 	}
 	return lines
-}
-
-func getManagerInterface(function *clang.TypedefFunction) string {
-	prefix := "GDExtensionSpx"
-	sb := strings.Builder{}
-	mgrName := GetManagerName(function.Name)
-	funcName := function.Name[len(prefix)+len(mgrName):]
-	args := EffectiveArguments(function)
-	sb.WriteString(funcName)
-	sb.WriteString("(")
-	wroteArg := false
-	for _, arg := range args {
-		if ShouldSkipHighLevelArgument(function, arg) {
-			continue
-		}
-		if wroteArg {
-			sb.WriteString(", ")
-		}
-		sb.WriteString(EffectiveGoArgumentName(function, arg))
-		sb.WriteString(" ")
-		typeName := EffectiveGoArgumentType(function, arg)
-		sb.WriteString(typeName)
-		wroteArg = true
-	}
-	sb.WriteString(")")
-
-	if HasEffectiveReturn(function) {
-		typeName := EffectiveGoReturnType(function)
-		sb.WriteString(" " + typeName + " ")
-	}
-	return sb.String()
 }
 
 func getJsFuncArgs(function *clang.TypedefFunction) []string {


### PR DESCRIPTION
Use one shared method-signature renderer for native and Web bindings, removing duplicate receiver and interface rendering logic. Group declarations and public generator entry points before private helpers. Validation: make generate produces unchanged generated artifacts; all tests in the codegen Go module pass; git diff --check.