### PR TITLE
refactor(toolchain): share quoted fields and preserve argument round trips

### DIFF
--- a/cmd/spx/internal/command/buildlauncher_graph.go
+++ b/cmd/spx/internal/command/buildlauncher_graph.go
@@ -23,6 +23,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/goplus/spx/v3/internal/base/quoted"
 )
 
 type launcherSource struct {
@@ -177,7 +179,7 @@ func graphFlagsFromEnvironment(workDir string, env []string) ([]string, error) {
 	if strings.TrimSpace(value) == "" {
 		return nil, nil
 	}
-	fields, err := splitGOFLAGS(value)
+	fields, err := quoted.Split(value)
 	if err != nil {
 		return nil, fmt.Errorf("buildlauncher: parse GOFLAGS: %w", err)
 	}
@@ -197,41 +199,6 @@ func graphFlagsFromEnvironment(workDir string, env []string) ([]string, error) {
 		flags = append(flags, flag)
 	}
 	return flags, nil
-}
-
-// splitGOFLAGS mirrors Go's cmd/internal/quoted parser.
-func splitGOFLAGS(value string) ([]string, error) {
-	var fields []string
-	for len(value) > 0 {
-		for len(value) > 0 && isGOFLAGSFieldSpace(value[0]) {
-			value = value[1:]
-		}
-		if value == "" {
-			break
-		}
-		if value[0] == '\'' || value[0] == '"' {
-			quote := value[0]
-			value = value[1:]
-			end := strings.IndexByte(value, quote)
-			if end < 0 {
-				return nil, fmt.Errorf("unterminated %c string", quote)
-			}
-			fields = append(fields, value[:end])
-			value = value[end+1:]
-			continue
-		}
-		end := 0
-		for end < len(value) && !isGOFLAGSFieldSpace(value[end]) {
-			end++
-		}
-		fields = append(fields, value[:end])
-		value = value[end:]
-	}
-	return fields, nil
-}
-
-func isGOFLAGSFieldSpace(value byte) bool {
-	return value == ' ' || value == '\t' || value == '\n' || value == '\r'
 }
 
 func canonicalDirectory(path string) (string, error) {

--- a/cmd/spx/internal/command/buildlauncher_graph_test.go
+++ b/cmd/spx/internal/command/buildlauncher_graph_test.go
@@ -137,20 +137,6 @@ func TestLauncherGraphProtectedFilesIncludesSums(t *testing.T) {
 	}
 }
 
-func TestSplitGOFLAGSMatchesGoQuotedFields(t *testing.T) {
-	got, err := splitGOFLAGS(`-trimpath ' -modfile=module with spaces ' "-buildvcs=false"`)
-	if err != nil {
-		t.Fatal(err)
-	}
-	want := []string{"-trimpath", " -modfile=module with spaces ", "-buildvcs=false"}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("splitGOFLAGS = %#v, want %#v", got, want)
-	}
-	if _, err := splitGOFLAGS(`'-trimpath`); err == nil {
-		t.Fatal("splitGOFLAGS accepted an unterminated quote")
-	}
-}
-
 func TestLauncherGraphVerifier(t *testing.T) {
 	root := t.TempDir()
 	goMod := filepath.Join(root, "go.mod")

--- a/internal/base/quoted/quoted.go
+++ b/internal/base/quoted/quoted.go
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package quoted handles fields in Go toolchain environment variables.
+package quoted
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Split separates fields using Go's quoting rules: quotes may surround a whole
+// field; neither quotes within unquoted fields nor backslashes are interpreted.
+func Split(value string) ([]string, error) {
+	var fields []string
+	for len(value) > 0 {
+		for len(value) > 0 && isSpace(value[0]) {
+			value = value[1:]
+		}
+		if value == "" {
+			break
+		}
+		if value[0] == '\'' || value[0] == '"' {
+			quote := value[0]
+			value = value[1:]
+			end := strings.IndexByte(value, quote)
+			if end < 0 {
+				return nil, fmt.Errorf("unterminated %c string", quote)
+			}
+			fields = append(fields, value[:end])
+			value = value[end+1:]
+			continue
+		}
+		end := 0
+		for end < len(value) && !isSpace(value[end]) {
+			end++
+		}
+		fields = append(fields, value[:end])
+		value = value[end:]
+	}
+	return fields, nil
+}
+
+// Join quotes fields containing whitespace, choosing an available quote style.
+func Join(fields []string) (string, error) {
+	quoted := make([]string, len(fields))
+	for index, field := range fields {
+		hasSpace := false
+		hasSingle := strings.ContainsRune(field, '\'')
+		hasDouble := strings.ContainsRune(field, '"')
+		for offset := 0; offset < len(field); offset++ {
+			if isSpace(field[offset]) {
+				hasSpace = true
+				break
+			}
+		}
+		switch {
+		case !hasSpace:
+			quoted[index] = field
+		case !hasSingle:
+			quoted[index] = "'" + field + "'"
+		case !hasDouble:
+			quoted[index] = `"` + field + `"`
+		default:
+			return "", fmt.Errorf("field %q contains whitespace and both quote characters", field)
+		}
+	}
+	return strings.Join(quoted, " "), nil
+}
+
+func isSpace(value byte) bool {
+	return value == ' ' || value == '\t' || value == '\n' || value == '\r'
+}

--- a/internal/base/quoted/quoted.go
+++ b/internal/base/quoted/quoted.go
@@ -54,7 +54,8 @@ func Split(value string) ([]string, error) {
 	return fields, nil
 }
 
-// Join quotes fields containing whitespace, choosing an available quote style.
+// Join preserves fields for Split, quoting empty fields, whitespace, and leading
+// quotes with an available quote style.
 func Join(fields []string) (string, error) {
 	quoted := make([]string, len(fields))
 	for index, field := range fields {
@@ -68,14 +69,14 @@ func Join(fields []string) (string, error) {
 			}
 		}
 		switch {
-		case !hasSpace:
+		case field != "" && !hasSpace && field[0] != '\'' && field[0] != '"':
 			quoted[index] = field
 		case !hasSingle:
 			quoted[index] = "'" + field + "'"
 		case !hasDouble:
 			quoted[index] = `"` + field + `"`
 		default:
-			return "", fmt.Errorf("field %q contains whitespace and both quote characters", field)
+			return "", fmt.Errorf("field %q needs quoting but contains both quote characters", field)
 		}
 	}
 	return strings.Join(quoted, " "), nil

--- a/internal/base/quoted/quoted_test.go
+++ b/internal/base/quoted/quoted_test.go
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quoted
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSplit(t *testing.T) {
+	got, err := Split(`-trimpath ' -modfile=module with spaces ' "-buildvcs=false"`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"-trimpath", " -modfile=module with spaces ", "-buildvcs=false"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Split = %#v, want %#v", got, want)
+	}
+	if _, err := Split(`'-trimpath`); err == nil {
+		t.Fatal("Split accepted an unterminated quote")
+	}
+}

--- a/internal/base/quoted/quoted_test.go
+++ b/internal/base/quoted/quoted_test.go
@@ -34,3 +34,31 @@ func TestSplit(t *testing.T) {
 		t.Fatal("Split accepted an unterminated quote")
 	}
 }
+
+func TestJoinPreservesFields(t *testing.T) {
+	for _, fields := range [][]string{
+		{""},
+		{"-trimpath", "", "-buildvcs=false"},
+		{"'leading", `"leading`},
+		{"two words", "tab\tfield", "line\nfield"},
+		{`-DNAME="value"`, `-DNAME='value'`, `both'"quotes`},
+		{`C:\Program Files\SDK`, "中文路径"},
+	} {
+		joined, err := Join(fields)
+		if err != nil {
+			t.Fatalf("Join(%q): %v", fields, err)
+		}
+		got, err := Split(joined)
+		if err != nil || !reflect.DeepEqual(got, fields) {
+			t.Errorf("Split(Join(%q)) = %q, %v", fields, got, err)
+		}
+	}
+}
+
+func TestJoinRejectsUnrepresentableFields(t *testing.T) {
+	for _, field := range []string{`both ' and " quotes`, `'both"`, `"both'`} {
+		if _, err := Join([]string{field}); err == nil {
+			t.Errorf("Join(%q) accepted a field requiring both quote styles", field)
+		}
+	}
+}

--- a/internal/cmd/buildctl/shared/macos_go_toolchain.go
+++ b/internal/cmd/buildctl/shared/macos_go_toolchain.go
@@ -23,6 +23,8 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+
+	"github.com/goplus/spx/v3/internal/base/quoted"
 )
 
 var macOSCGOFlagVariables = []string{
@@ -145,7 +147,7 @@ func resolveMacOSXcrunPath(xcrun macOSXcrunResolver, valid macOSPathPredicate, d
 }
 
 func macOSCommandIsUsable(value string, env map[string]string, isExecutable macOSPathPredicate) bool {
-	fields, err := splitQuotedFields(value)
+	fields, err := quoted.Split(value)
 	if err != nil || len(fields) == 0 {
 		return false
 	}
@@ -165,7 +167,7 @@ func macOSCommandIsUsable(value string, env map[string]string, isExecutable macO
 }
 
 func normalizeMacOSCGOFlags(value, sdkRoot string, isDirectory macOSPathPredicate) (string, error) {
-	fields, err := splitQuotedFields(value)
+	fields, err := quoted.Split(value)
 	if err != nil {
 		return "", err
 	}
@@ -203,7 +205,7 @@ func normalizeMacOSCGOFlags(value, sdkRoot string, isDirectory macOSPathPredicat
 	if !changed {
 		return value, nil
 	}
-	return joinQuotedFields(normalized)
+	return quoted.Join(normalized)
 }
 
 func normalizeAttachedSysroot(field, sdkRoot string, isDirectory macOSPathPredicate) (string, bool) {
@@ -253,73 +255,6 @@ func replaceMissingSDKPaths(field, sdkRoot string, isDirectory macOSPathPredicat
 		}
 		searchFrom = end
 	}
-}
-
-// splitQuotedFields and joinQuotedFields match the quoting rules used by Go
-// for CGO_* environment variables: quotes may surround a whole field and are
-// not shell-evaluated or unescaped.
-func splitQuotedFields(value string) ([]string, error) {
-	var fields []string
-	for len(value) > 0 {
-		for len(value) > 0 && isQuotedFieldSpace(value[0]) {
-			value = value[1:]
-		}
-		if value == "" {
-			break
-		}
-		if value[0] == '\'' || value[0] == '"' {
-			quote := value[0]
-			value = value[1:]
-			end := strings.IndexByte(value, quote)
-			if end < 0 {
-				return nil, fmt.Errorf("unterminated %c string", quote)
-			}
-			fields = append(fields, value[:end])
-			value = value[end+1:]
-			continue
-		}
-		end := 0
-		for end < len(value) && !isQuotedFieldSpace(value[end]) {
-			end++
-		}
-		if end == len(value) {
-			fields = append(fields, value)
-			break
-		}
-		fields = append(fields, value[:end])
-		value = value[end:]
-	}
-	return fields, nil
-}
-
-func joinQuotedFields(fields []string) (string, error) {
-	quoted := make([]string, len(fields))
-	for index, field := range fields {
-		hasSpace := false
-		hasSingle := strings.ContainsRune(field, '\'')
-		hasDouble := strings.ContainsRune(field, '"')
-		for offset := 0; offset < len(field); offset++ {
-			if isQuotedFieldSpace(field[offset]) {
-				hasSpace = true
-				break
-			}
-		}
-		switch {
-		case !hasSpace:
-			quoted[index] = field
-		case !hasSingle:
-			quoted[index] = "'" + field + "'"
-		case !hasDouble:
-			quoted[index] = `"` + field + `"`
-		default:
-			return "", fmt.Errorf("field %q contains whitespace and both quote characters", field)
-		}
-	}
-	return strings.Join(quoted, " "), nil
-}
-
-func isQuotedFieldSpace(value byte) bool {
-	return value == ' ' || value == '\t' || value == '\n' || value == '\r'
 }
 
 func cloneStringMap(input map[string]string) map[string]string {

--- a/internal/cmd/buildctl/shared/macos_go_toolchain_test.go
+++ b/internal/cmd/buildctl/shared/macos_go_toolchain_test.go
@@ -25,6 +25,8 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/goplus/spx/v3/internal/base/quoted"
 )
 
 type fakeMacOSPaths struct {
@@ -540,7 +542,7 @@ printf 'CGO_CFLAGS=%s\n' "$CGO_CFLAGS" >> "$OUTPUT_PATH"
 
 func assertQuotedFields(t *testing.T, value string, want []string) {
 	t.Helper()
-	got, err := splitQuotedFields(value)
+	got, err := quoted.Split(value)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cmd/buildctl/shared/macos_go_toolchain_test.go
+++ b/internal/cmd/buildctl/shared/macos_go_toolchain_test.go
@@ -34,14 +34,6 @@ type fakeMacOSPaths struct {
 	executables map[string]bool
 }
 
-func (p fakeMacOSPaths) isDirectory(path string) bool {
-	return p.directories[path]
-}
-
-func (p fakeMacOSPaths) isExecutable(path string) bool {
-	return p.executables[path]
-}
-
 func TestConfigureMacOSGoToolchainEnvRepairsStaleInputs(t *testing.T) {
 	t.Parallel()
 
@@ -538,6 +530,14 @@ printf 'CGO_CFLAGS=%s\n' "$CGO_CFLAGS" >> "$OUTPUT_PATH"
 			t.Errorf("child %s = %q, want %q", key, got, want)
 		}
 	}
+}
+
+func (p fakeMacOSPaths) isDirectory(path string) bool {
+	return p.directories[path]
+}
+
+func (p fakeMacOSPaths) isExecutable(path string) bool {
+	return p.executables[path]
 }
 
 func assertQuotedFields(t *testing.T, value string, want []string) {

--- a/internal/release/runtime_pack_source.go
+++ b/internal/release/runtime_pack_source.go
@@ -88,6 +88,7 @@ var runtimeBuildRecipeFiles = map[string]struct{}{
 var runtimeBuildRecipePrefixes = []string{
 	".github/actions/setup-buildctl/",
 	"internal/base/fileutil/",
+	"internal/base/quoted/",
 }
 
 var runtimePackSourceFiles = map[string]struct{}{

--- a/internal/release/runtime_pack_source.go
+++ b/internal/release/runtime_pack_source.go
@@ -27,41 +27,6 @@ import (
 	"strings"
 )
 
-// RuntimePackSourceSHA256 returns a stable digest of the tracked SPX inputs
-// that can affect spx-runtime-assets.zip at revision. It deliberately excludes
-// godot_modules/spx: the module tree is an independent Godot-engine input and
-// is recorded separately in RuntimeProvenance.ModuleTree. Go constraints use
-// the fixed Linux/amd64 CGO pack target.
-//
-// Git tree entries are used instead of worktree contents so untracked build
-// outputs cannot contaminate release provenance.
-func RuntimePackSourceSHA256(repoRoot, revision string) (string, error) {
-	tree, err := trackedTree(repoRoot, revision, "runtime pack source")
-	if err != nil {
-		return "", err
-	}
-	paths, projections, err := runtimePackSourcePaths(repoRoot, tree)
-	if err != nil {
-		return "", err
-	}
-	return selectedRuntimePackSourceSHA256(tree, paths, projections)
-}
-
-func runtimePackSourcePathTreeSHA256(tree []byte) (string, error) {
-	return selectedTreeSHA256(tree, "runtime pack source", isRuntimePackSourcePath)
-}
-
-// RuntimeBuildRecipeSHA256 returns a stable digest of the implementation that
-// can change runtime-pack bytes. CI transport details such as workflow layout
-// and external Action versions are deliberately excluded.
-func RuntimeBuildRecipeSHA256(repoRoot, revision string) (string, error) {
-	return trackedTreeSHA256(repoRoot, revision, "runtime build recipe", isRuntimeBuildRecipePath)
-}
-
-func runtimeBuildRecipeTreeSHA256(tree []byte) (string, error) {
-	return selectedTreeSHA256(tree, "runtime build recipe", isRuntimeBuildRecipePath)
-}
-
 var runtimeBuildRecipeFiles = map[string]struct{}{
 	".github/scripts/runtime/build_pack.sh":               {},
 	".github/scripts/runtime_build_contract.py":           {},
@@ -154,6 +119,41 @@ var runtimePackSourceDirectories = map[string]struct{}{
 }
 
 var runtimePackSourcePrefixes = []string{"cmd/spx/template/project/engine/"}
+
+// RuntimePackSourceSHA256 returns a stable digest of the tracked SPX inputs
+// that can affect spx-runtime-assets.zip at revision. It deliberately excludes
+// godot_modules/spx: the module tree is an independent Godot-engine input and
+// is recorded separately in RuntimeProvenance.ModuleTree. Go constraints use
+// the fixed Linux/amd64 CGO pack target.
+//
+// Git tree entries are used instead of worktree contents so untracked build
+// outputs cannot contaminate release provenance.
+func RuntimePackSourceSHA256(repoRoot, revision string) (string, error) {
+	tree, err := trackedTree(repoRoot, revision, "runtime pack source")
+	if err != nil {
+		return "", err
+	}
+	paths, projections, err := runtimePackSourcePaths(repoRoot, tree)
+	if err != nil {
+		return "", err
+	}
+	return selectedRuntimePackSourceSHA256(tree, paths, projections)
+}
+
+// RuntimeBuildRecipeSHA256 returns a stable digest of the implementation that
+// can change runtime-pack bytes. CI transport details such as workflow layout
+// and external Action versions are deliberately excluded.
+func RuntimeBuildRecipeSHA256(repoRoot, revision string) (string, error) {
+	return trackedTreeSHA256(repoRoot, revision, "runtime build recipe", isRuntimeBuildRecipePath)
+}
+
+func runtimePackSourcePathTreeSHA256(tree []byte) (string, error) {
+	return selectedTreeSHA256(tree, "runtime pack source", isRuntimePackSourcePath)
+}
+
+func runtimeBuildRecipeTreeSHA256(tree []byte) (string, error) {
+	return selectedTreeSHA256(tree, "runtime build recipe", isRuntimeBuildRecipePath)
+}
 
 func trackedTreeSHA256(repoRoot, revision, label string, include func(string) bool) (string, error) {
 	tree, err := trackedTree(repoRoot, revision, label)

--- a/internal/release/runtime_pack_source_test.go
+++ b/internal/release/runtime_pack_source_test.go
@@ -162,6 +162,8 @@ func TestRuntimeBuildRecipePathSeparatesRecipeFromSources(t *testing.T) {
 		{".github/scripts/runtime_lock_snapshot.py", false},
 		{"cmd/internal/macos_go_toolchain.sh", true},
 		{"internal/cmd/buildctl/shared/macos_go_toolchain.go", true},
+		{"internal/base/quoted/quoted.go", true},
+		{"internal/base/quoted/quoted_test.go", false},
 		{".github/scripts/release/assemble.sh", false},
 		{".github/scripts/runtime/manifest.go", false},
 		{".github/scripts/runtime/digest.go", false},


### PR DESCRIPTION
Share quoted-field parsing between launcher GOFLAGS and macOS CGO setup, including the helper in runtime build-recipe hashing. Fix Join dropping empty arguments or misparsing fields starting with a quote; reject fields that cannot be represented. Keep public APIs before helpers. Validation: new regression tests reproduced the bugs before the fix; make generate; quoted, buildctl/shared, command, and release tests; git diff --check.