### PR TITLE
refactor(web): share integer and object ID decoding

### DIFF
--- a/godot_modules/spx/web/js/engine/gdspx.util.js
+++ b/godot_modules/spx/web/js/engine/gdspx.util.js
@@ -165,13 +165,7 @@ function ToGdObj(value) {
 }
 
 function ToJsObj(ptr) {
-    const dataView = GetHeapDataView();
-    const low = dataView.getUint32(ptr, true);
-    const high = dataView.getUint32(ptr + 4, true);
-    return {
-        'low': low,
-        'high': high
-    };
+    return ToJsInt(ptr);
 }
 
 function ToJsBigObj(ptr) {


### PR DESCRIPTION
Delegate object ID decoding to the existing two-lane integer decoder, removing duplicated DataView reads while preserving low/high values and heap refresh behavior. The file already exposes these conversion functions together. Validation: make generate; Node checks for zero, high-bit and maximum lanes, ordinary values, and heap replacement; git diff --check.