### PR TITLE
refactor(codegen): prepare immutable generation metadata

### DIFF
--- a/internal/cmd/codegen/gdextensionparser/clang/manager_names.go
+++ b/internal/cmd/codegen/gdextensionparser/clang/manager_names.go
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2021 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package clang
+
+import (
+	"sort"
+	"strings"
+	"unicode"
+)
+
+// ManagerNames resolves the longest known prefix without sorting during lookup.
+// Its zero value uses the legacy two-byte-prefix fallback.
+type ManagerNames struct{ longestFirst []string }
+
+func NewManagerNames(names []string) ManagerNames {
+	result := ManagerNames{longestFirst: append([]string(nil), names...)}
+	for i, name := range result.longestFirst {
+		result.longestFirst[i] = strings.ToLower(name)
+	}
+	sort.Slice(result.longestFirst, func(i, j int) bool {
+		return len(result.longestFirst[i]) > len(result.longestFirst[j])
+	})
+	return result
+}
+
+func (m ManagerNames) Resolve(name string) string {
+	return m.resolve(name, unicode.IsUpper)
+}
+
+// resolveASCII retains the parser's ASCII fallback. Parsed C identifiers are ASCII;
+// the template helpers historically also accept manually constructed Unicode names.
+func (m ManagerNames) resolveASCII(name string) string {
+	return m.resolve(name, func(r rune) bool { return r >= 'A' && r <= 'Z' })
+}
+
+func (m ManagerNames) resolve(name string, isUpper func(rune) bool) string {
+	suffix := name[len("GDExtensionSpx"):]
+	lower := strings.ToLower(suffix)
+	for _, manager := range m.longestFirst {
+		if strings.HasPrefix(lower, manager) {
+			return manager
+		}
+	}
+	chars := []rune{rune(suffix[0]), rune(suffix[1])}
+	for _, r := range suffix[2:] {
+		if isUpper(r) {
+			break
+		}
+		chars = append(chars, r)
+	}
+	return strings.ToLower(string(chars))
+}

--- a/internal/cmd/codegen/gdextensionparser/clang/manager_names_test.go
+++ b/internal/cmd/codegen/gdextensionparser/clang/manager_names_test.go
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2021 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package clang
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestManagerNamesLongestPrefixAndFallback(t *testing.T) {
+	names := []string{"foo", "foobar", "ui"}
+	matcher := NewManagerNames(names)
+	names[1] = "changed"
+	for _, tt := range []struct{ name, want string }{
+		{"GDExtensionSpxFooBarShow", "foobar"},
+		{"GDExtensionSpxFooShow", "foo"},
+		{"GDExtensionSpxUiBindNode", "ui"},
+		{"GDExtensionSpxCameraGetPosition", "camera"},
+	} {
+		require.Equal(t, tt.want, matcher.Resolve(tt.name))
+		require.Equal(t, tt.want, matcher.resolveASCII(tt.name))
+	}
+	// Preserve the two historical fallbacks for manually constructed identifiers.
+	require.Equal(t, "ab", (ManagerNames{}).Resolve("GDExtensionSpxAbÉShow"))
+	require.Equal(t, "abé", (ManagerNames{}).resolveASCII("GDExtensionSpxAbÉShow"))
+}
+
+func TestCollectManagerFunctionsUsesExactLongestMatch(t *testing.T) {
+	ast, err := ParseCString(`typedef void (*GDExtensionSpxFooShow)();
+ typedef void (*GDExtensionSpxFoobarShow)();`)
+	require.NoError(t, err)
+	names := NewManagerNames([]string{"foo", "foobar"})
+	functions := ast.CollectGDExtensionManagerFunctions("foo", names)
+	require.Len(t, functions, 1)
+	require.Equal(t, "GDExtensionSpxFooShow", functions[0].Name)
+}

--- a/internal/cmd/codegen/gdextensionparser/clang/parser.go
+++ b/internal/cmd/codegen/gdextensionparser/clang/parser.go
@@ -18,7 +18,6 @@ package clang
 
 import (
 	"fmt"
-	"sort"
 	"strings"
 
 	"github.com/alecthomas/participle/v2"
@@ -154,7 +153,7 @@ func (a CHeaderFileAST) CollectFunctionsOfClass(className string) []TypedefFunct
 	return fns
 }
 
-func (a CHeaderFileAST) CollectGDExtensionManagerFunctions(managerName string, knownManagers []string) []TypedefFunction {
+func (a CHeaderFileAST) CollectGDExtensionManagerFunctions(managerName string, managerNames ManagerNames) []TypedefFunction {
 	allFns := a.CollectFunctions()
 
 	fns := make([]TypedefFunction, 0, len(allFns))
@@ -163,8 +162,7 @@ func (a CHeaderFileAST) CollectGDExtensionManagerFunctions(managerName string, k
 		if strings.HasPrefix(fn.Name, "GDExtensionSpx") &&
 			!strings.HasPrefix(fn.Name, "GDExtensionSpxCallback") &&
 			!slices.Contains(legacyGDExtentionInterfaceFunctionNames, fn.Name) {
-			// Exact match: use getManagerNameForFunc to determine which manager the function belongs to
-			actualManager := getManagerNameForFunc(fn.Name, knownManagers)
+			actualManager := managerNames.resolveASCII(fn.Name)
 			if actualManager == managerName {
 				fns = append(fns, fn)
 			}
@@ -415,40 +413,6 @@ func ParseCString(s string) (CHeaderFileAST, error) {
 	}
 
 	return *ast, nil
-}
-
-// getManagerNameForFunc extracts the manager name from the function name.
-func getManagerNameForFunc(funcName string, knownManagers []string) string {
-	prefix := "GDExtensionSpx"
-	str := funcName[len(prefix):]
-	lowerStr := strings.ToLower(str)
-
-	// Prefer matching against known manager names (sorted by length descending, prioritizing longer names)
-	if len(knownManagers) > 0 {
-		// Create a copy sorted by length in descending order
-		sortedNames := make([]string, len(knownManagers))
-		copy(sortedNames, knownManagers)
-		sort.Slice(sortedNames, func(i, j int) bool {
-			return len(sortedNames[i]) > len(sortedNames[j])
-		})
-
-		for _, mgr := range sortedNames {
-			if strings.HasPrefix(lowerStr, mgr) {
-				return mgr
-			}
-		}
-	}
-
-	// Fall back to the original logic (stop at uppercase letter)
-	chs := []rune{}
-	chs = append(chs, rune(str[0]), rune(str[1]))
-	for _, ch := range str[2:] {
-		if ch >= 'A' && ch <= 'Z' {
-			break
-		}
-		chs = append(chs, ch)
-	}
-	return strings.ToLower(string(chs))
 }
 
 func joinCTypeAndName(typeName, name string) string {

--- a/internal/cmd/codegen/generate/common/context.go
+++ b/internal/cmd/codegen/generate/common/context.go
@@ -17,32 +17,42 @@
 package common
 
 import (
+	"slices"
 	"sort"
-	"strings"
-	"unicode"
 
 	"github.com/goplus/spx/v3/internal/cmd/codegen/gdextensionparser/clang"
 )
 
-// GenerationContext owns the metadata for one generation task.
-// Create a fresh context for each independent input; no state is shared across tasks.
+// GenerationMetadata is collected from headers before binding templates run.
+type GenerationMetadata struct {
+	ManagerNames          []string
+	NativeArrayBridges    map[string]NativeArrayBridgeSpec
+	ArrayTransformBridges map[string]ArrayTransformBridgeSpec
+}
+
+// GenerationContext snapshots metadata and manager membership for one AST.
+// Rendering only reads this context; independent outputs can share it.
 type GenerationContext struct {
+	ast                   clang.CHeaderFileAST
 	managerSet            map[string]bool
+	managers              []string
+	managerNames          clang.ManagerNames
 	cppType2Go            map[string]string
-	KnownManagerNames     []string
 	nativeArrayBridges    map[string]NativeArrayBridgeSpec
 	arrayTransformBridges map[string]ArrayTransformBridgeSpec
 }
 
 type ManagerData struct {
-	Ast               clang.CHeaderFileAST
-	Managers          []string
-	KnownManagerNames []string
+	Ast          clang.CHeaderFileAST
+	Managers     []string
+	ManagerNames clang.ManagerNames
 }
 
-func NewGenerationContext() *GenerationContext {
-	return &GenerationContext{
+func NewGenerationContext(ast clang.CHeaderFileAST, metadata GenerationMetadata) *GenerationContext {
+	c := &GenerationContext{
+		ast:                   ast,
 		managerSet:            make(map[string]bool),
+		managerNames:          clang.NewManagerNames(metadata.ManagerNames),
 		nativeArrayBridges:    make(map[string]NativeArrayBridgeSpec),
 		arrayTransformBridges: make(map[string]ArrayTransformBridgeSpec),
 		cppType2Go: map[string]string{
@@ -52,47 +62,33 @@ func NewGenerationContext() *GenerationContext {
 			"GdColor": "Color", "GdArray": "Array",
 		},
 	}
-}
-
-// PrepareAST replaces the manager membership used by template predicates.
-func (c *GenerationContext) PrepareAST(ast clang.CHeaderFileAST) {
-	c.managerSet = make(map[string]bool)
-	for _, name := range c.GetManagers(ast) {
+	for name, spec := range metadata.NativeArrayBridges {
+		c.nativeArrayBridges[name] = spec
+	}
+	for name, spec := range metadata.ArrayTransformBridges {
+		spec.Params = slices.Clone(spec.Params)
+		c.arrayTransformBridges[name] = spec
+	}
+	c.managers = c.GetManagers(ast)
+	for _, name := range c.managers {
 		c.managerSet[name] = true
 	}
+	return c
 }
 
-// RegisterManagerName registers a known manager name (obtained from header parsing).
-func (c *GenerationContext) RegisterManagerName(name string) {
-	name = strings.ToLower(name)
-	// Avoid duplicate entries
-	for _, n := range c.KnownManagerNames {
-		if n == name {
-			return
-		}
-	}
-	c.KnownManagerNames = append(c.KnownManagerNames, name)
+// AST returns the input used to prepare this context. Treat it as read-only.
+func (c *GenerationContext) AST() clang.CHeaderFileAST { return c.ast }
+
+func (c *GenerationContext) ManagerData() ManagerData {
+	return ManagerData{Ast: c.ast, Managers: slices.Clone(c.managers), ManagerNames: c.managerNames}
 }
 
-// ClearKnownManagerNames clears the list of known manager names.
-func (c *GenerationContext) ClearKnownManagerNames() {
-	c.KnownManagerNames = []string{}
+func (c *GenerationContext) GetManagerName(name string) string {
+	return c.managerNames.Resolve(name)
 }
 
-func (c *GenerationContext) ClearNativeArrayBridgeSpecs() {
-	c.nativeArrayBridges = map[string]NativeArrayBridgeSpec{}
-}
-
-func (c *GenerationContext) ClearArrayTransformBridgeSpecs() {
-	c.arrayTransformBridges = map[string]ArrayTransformBridgeSpec{}
-}
-
-func (c *GenerationContext) RegisterNativeArrayBridgeSpec(spec NativeArrayBridgeSpec) {
-	c.nativeArrayBridges[spec.BaseFunctionName] = spec
-}
-
-func (c *GenerationContext) RegisterArrayTransformBridgeSpec(spec ArrayTransformBridgeSpec) {
-	c.arrayTransformBridges[spec.FunctionName] = spec
+func (c *GenerationContext) IsManagerMethod(function *clang.TypedefFunction) bool {
+	return c.managerSet[c.GetManagerName(function.Name)]
 }
 
 func (c *GenerationContext) HasArrayTransformBridgeSpec(function *clang.TypedefFunction) bool {
@@ -110,12 +106,14 @@ func (c *GenerationContext) GetNativeArrayBridgeSpec(functionName string) (Nativ
 
 func (c *GenerationContext) GetArrayTransformBridgeSpec(functionName string) (ArrayTransformBridgeSpec, bool) {
 	spec, ok := c.arrayTransformBridges[functionName]
+	spec.Params = slices.Clone(spec.Params)
 	return spec, ok
 }
 
 func (c *GenerationContext) ListArrayTransformBridgeSpecs() []ArrayTransformBridgeSpec {
 	specs := make([]ArrayTransformBridgeSpec, 0, len(c.arrayTransformBridges))
 	for _, spec := range c.arrayTransformBridges {
+		spec.Params = slices.Clone(spec.Params)
 		specs = append(specs, spec)
 	}
 	sort.Slice(specs, func(i, j int) bool {
@@ -132,50 +130,11 @@ func (c *GenerationContext) HasNativeArrayBridgeSpec(function *clang.TypedefFunc
 	return ok
 }
 
-func (c *GenerationContext) GetManagerName(str string) string {
-	prefix := "GDExtensionSpx"
-	str = str[len(prefix):]
-	lowerStr := strings.ToLower(str)
-
-	// Match the longest known name without reordering KnownManagerNames.
-	if len(c.KnownManagerNames) > 0 {
-		sortedNames := make([]string, len(c.KnownManagerNames))
-		copy(sortedNames, c.KnownManagerNames)
-		sort.Slice(sortedNames, func(i, j int) bool {
-			return len(sortedNames[i]) > len(sortedNames[j])
-		})
-
-		for _, mgr := range sortedNames {
-			if strings.HasPrefix(lowerStr, mgr) {
-				return mgr
-			}
-		}
-	}
-
-	// Otherwise, keep the first two bytes and stop at the next uppercase rune.
-	chs := []rune{rune(str[0]), rune(str[1])}
-	for _, ch := range str[2:] {
-		if unicode.IsUpper(ch) {
-			break
-		}
-		chs = append(chs, ch)
-	}
-	return strings.ToLower(string(chs))
-}
-
-func (c *GenerationContext) IsManagerMethod(function *clang.TypedefFunction) bool {
-	return c.managerSet[c.GetManagerName(function.Name)]
-}
-
 func (c *GenerationContext) GetManagers(ast clang.CHeaderFileAST) []string {
-	items := []string{}
-	for _, item := range ast.CollectGDExtensionInterfaceFunctions() {
-		items = append(items, item.Name)
-	}
 	managerSet := make(map[string]bool)
 	managers := []string{}
-	for _, str := range items {
-		managerSet[c.GetManagerName(str)] = true
+	for _, fn := range ast.CollectGDExtensionInterfaceFunctions() {
+		managerSet[c.GetManagerName(fn.Name)] = true
 	}
 	delete(managerSet, "")
 	delete(managerSet, "string")

--- a/internal/cmd/codegen/generate/common/context_test.go
+++ b/internal/cmd/codegen/generate/common/context_test.go
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2021 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package common
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"text/template"
+
+	"github.com/goplus/spx/v3/internal/cmd/codegen/gdextensionparser/clang"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerationContextSnapshotsMetadata(t *testing.T) {
+	ast, err := clang.ParseCString("typedef void (*GDExtensionSpxSpriteShow)();")
+	require.NoError(t, err)
+	metadata := GenerationMetadata{
+		ManagerNames:          []string{"sprite"},
+		NativeArrayBridges:    map[string]NativeArrayBridgeSpec{"first": {GoArgType: "[]float32"}},
+		ArrayTransformBridges: map[string]ArrayTransformBridgeSpec{"first": {FunctionName: "first", Params: []RawExportParam{{Name: "input"}}}},
+	}
+	first := NewGenerationContext(ast, metadata)
+	metadata.ManagerNames[0] = "camera"
+	metadata.NativeArrayBridges["first"] = NativeArrayBridgeSpec{GoArgType: "changed"}
+	metadata.ArrayTransformBridges["first"].Params[0].Name = "changed"
+	second := NewGenerationContext(clang.CHeaderFileAST{}, metadata)
+	require.Equal(t, "sprite", first.GetManagerName("GDExtensionSpxSpriteShow"))
+	require.True(t, first.IsManagerMethod(&clang.TypedefFunction{Name: "GDExtensionSpxSpriteShow"}))
+	require.False(t, second.IsManagerMethod(&clang.TypedefFunction{Name: "GDExtensionSpxSpriteShow"}))
+	spec, ok := first.GetNativeArrayBridgeSpec("first")
+	require.True(t, ok)
+	require.Equal(t, "[]float32", spec.GoArgType)
+	transform, ok := first.GetArrayTransformBridgeSpec("first")
+	require.True(t, ok)
+	require.Equal(t, "input", transform.Params[0].Name)
+	transform.Params[0].Name = "caller mutation"
+	first.ListArrayTransformBridgeSpecs()[0].Params[0].Name = "another mutation"
+	again, _ := first.GetArrayTransformBridgeSpec("first")
+	require.Equal(t, "input", again.Params[0].Name)
+	require.Equal(t, "int64", first.MustGoTypeForCType("GdInt", "test"))
+}
+
+func TestGetManagersDoesNotChangePreparedAST(t *testing.T) {
+	first, err := clang.ParseCString("typedef void (*GDExtensionSpxSpriteShow)();")
+	require.NoError(t, err)
+	second, err := clang.ParseCString("typedef void (*GDExtensionSpxCameraShow)();")
+	require.NoError(t, err)
+	generation := NewGenerationContext(first, GenerationMetadata{ManagerNames: []string{"sprite", "camera"}})
+	require.Equal(t, []string{"camera"}, generation.GetManagers(second))
+	require.True(t, generation.IsManagerMethod(&clang.TypedefFunction{Name: "GDExtensionSpxSpriteShow"}))
+	require.False(t, generation.IsManagerMethod(&clang.TypedefFunction{Name: "GDExtensionSpxCameraShow"}))
+}
+
+func TestGenerationContextsRenderIndependently(t *testing.T) {
+	for _, manager := range []string{"foo", "foobar"} {
+		generation := NewGenerationContext(clang.CHeaderFileAST{}, GenerationMetadata{ManagerNames: []string{manager}})
+		// Render concurrent outputs using the same prepared context as well as distinct contexts.
+		for _, output := range []string{"native", "web"} {
+			t.Run(manager+"/"+output, func(t *testing.T) {
+				t.Parallel()
+				dst := filepath.Join(t.TempDir(), "manager.go")
+				err := GenerateFile(template.FuncMap{"manager": generation.GetManagerName}, "manager.go",
+					`package generated
+const Manager = "{{manager .}}"
+`, "GDExtensionSpxFooBar", dst)
+				require.NoError(t, err)
+				data, err := os.ReadFile(dst)
+				require.NoError(t, err)
+				require.Contains(t, string(data), `const Manager = "`+manager+`"`)
+			})
+		}
+	}
+}

--- a/internal/cmd/codegen/generate/common/funcs_test.go
+++ b/internal/cmd/codegen/generate/common/funcs_test.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"text/template"
 
 	"github.com/goplus/spx/v3/internal/cmd/codegen/gdextensionparser/clang"
 	"github.com/stretchr/testify/require"
@@ -141,7 +140,7 @@ func TestMustPrimitiveTypeNamePanicsOnFunctionPointer(t *testing.T) {
 }
 
 func TestEffectiveGoReturnTypePanicsOnMissingTypeMapping(t *testing.T) {
-	generation := NewGenerationContext()
+	generation := NewGenerationContext(clang.CHeaderFileAST{}, GenerationMetadata{})
 
 	function := &clang.TypedefFunction{
 		Name: "GDExtensionSpxTestUnknownReturn",
@@ -168,7 +167,7 @@ func TestEffectiveGoReturnTypePanicsOnMissingTypeMapping(t *testing.T) {
 }
 
 func TestMustGoTypeForCTypePanicsOnMissingMapping(t *testing.T) {
-	generation := NewGenerationContext()
+	generation := NewGenerationContext(clang.CHeaderFileAST{}, GenerationMetadata{})
 
 	require.PanicsWithValue(
 		t,
@@ -180,9 +179,9 @@ func TestMustGoTypeForCTypePanicsOnMissingMapping(t *testing.T) {
 }
 
 func TestEffectiveGoArgumentTypeUsesNativeArrayBridgeSpec(t *testing.T) {
-	generation := NewGenerationContext()
+	metadata := GenerationMetadata{}
 
-	generation.RegisterNativeArrayBridgeSpec(NativeArrayBridgeSpec{
+	metadata.NativeArrayBridges = map[string]NativeArrayBridgeSpec{"GDExtensionSpxSpriteBatchUpdateTransforms": {
 		BaseFunctionName: "GDExtensionSpxSpriteBatchUpdateTransforms",
 		BaseArgName:      "buffer",
 		DataArgName:      "buffer_data",
@@ -191,7 +190,8 @@ func TestEffectiveGoArgumentTypeUsesNativeArrayBridgeSpec(t *testing.T) {
 		LenArgName:       "len",
 		LenArgGoType:     "int32",
 		GoArgType:        "[]float32",
-	})
+	}}
+	generation := NewGenerationContext(clang.CHeaderFileAST{}, metadata)
 
 	function := &clang.TypedefFunction{
 		Name: "GDExtensionSpxSpriteBatchUpdateTransforms",
@@ -215,54 +215,4 @@ func TestEffectiveGoArgumentTypeUsesNativeArrayBridgeSpec(t *testing.T) {
 	require.Equal(t, "[]float32", generation.EffectiveGdxArgumentType(function, function.Arguments[0]))
 	require.Equal(t, "buffer", generation.EffectiveGoArgumentName(function, function.Arguments[0]))
 	require.True(t, generation.ShouldSkipHighLevelArgument(function, function.Arguments[1]))
-}
-
-func TestGenerationContextsAreIndependent(t *testing.T) {
-	first, second := NewGenerationContext(), NewGenerationContext()
-	first.RegisterManagerName("sprite")
-	first.RegisterNativeArrayBridgeSpec(NativeArrayBridgeSpec{BaseFunctionName: "first", GoArgType: "[]float32"})
-	first.RegisterArrayTransformBridgeSpec(ArrayTransformBridgeSpec{FunctionName: "first"})
-	second.RegisterManagerName("camera")
-	require.Equal(t, []string{"sprite"}, first.KnownManagerNames)
-	require.Equal(t, []string{"camera"}, second.KnownManagerNames)
-	_, exists := second.GetNativeArrayBridgeSpec("first")
-	require.False(t, exists)
-	require.Empty(t, second.ListArrayTransformBridgeSpecs())
-	second.ClearKnownManagerNames()
-	require.Equal(t, []string{"sprite"}, first.KnownManagerNames)
-	require.Equal(t, "int64", first.MustGoTypeForCType("GdInt", "test"))
-	require.Equal(t, "int64", second.MustGoTypeForCType("GdInt", "test"))
-}
-
-func TestGetManagersDoesNotChangePreparedAST(t *testing.T) {
-	generation := NewGenerationContext()
-	generation.RegisterManagerName("sprite")
-	generation.RegisterManagerName("camera")
-	first, err := clang.ParseCString("typedef void (*GDExtensionSpxSpriteShow)();")
-	require.NoError(t, err)
-	second, err := clang.ParseCString("typedef void (*GDExtensionSpxCameraShow)();")
-	require.NoError(t, err)
-	generation.PrepareAST(first)
-	require.Equal(t, []string{"camera"}, generation.GetManagers(second))
-	require.True(t, generation.IsManagerMethod(&clang.TypedefFunction{Name: "GDExtensionSpxSpriteShow"}))
-	require.False(t, generation.IsManagerMethod(&clang.TypedefFunction{Name: "GDExtensionSpxCameraShow"}))
-}
-
-func TestGenerationContextsRenderIndependently(t *testing.T) {
-	for _, manager := range []string{"foo", "foobar"} {
-		t.Run(manager, func(t *testing.T) {
-			t.Parallel()
-			generation := NewGenerationContext()
-			generation.RegisterManagerName(manager)
-			dst := filepath.Join(t.TempDir(), "manager.go")
-			err := GenerateFile(template.FuncMap{"manager": generation.GetManagerName}, "manager.go",
-				`package generated
-const Manager = "{{manager .}}"
-`, "GDExtensionSpxFooBar", dst)
-			require.NoError(t, err)
-			data, err := os.ReadFile(dst)
-			require.NoError(t, err)
-			require.Contains(t, string(data), `const Manager = "`+manager+`"`)
-		})
-	}
 }

--- a/internal/cmd/codegen/generate/ffi/generate.go
+++ b/internal/cmd/codegen/generate/ffi/generate.go
@@ -84,31 +84,32 @@ func (arr ByName) Less(i, j int) bool {
 	return arr[i].Name < arr[j].Name
 }
 
-func (g *Generator) Generate(projectPath string, ast clang.CHeaderFileAST) error {
+func (g *Generator) Generate(projectPath string) error {
+	ast := g.AST()
 	generators := []struct {
 		name string
-		fn   func(string, clang.CHeaderFileAST) error
+		fn   func() error
 	}{
-		{"GDExtension wrapper header", GenerateGDExtensionWrapperHeaderFile},
-		{"GDExtension wrapper Go source", GenerateGDExtensionWrapperGoFile},
-		{"GDExtension interface", GenerateGDExtensionInterfaceGoFile},
-		{"manager wrapper", g.GenerateManagerWrapperGoFile},
-		{"manager interface", g.GenerateManagerInterfaceGoFile},
-		{"synchronized API", g.GenerateSyncApiGoFile},
-		{"pure synchronized API", g.GenerateSyncPureGoFile},
+		{"GDExtension wrapper header", func() error { return GenerateGDExtensionWrapperHeaderFile(projectPath, ast) }},
+		{"GDExtension wrapper Go source", func() error { return GenerateGDExtensionWrapperGoFile(projectPath, ast) }},
+		{"GDExtension interface", func() error { return GenerateGDExtensionInterfaceGoFile(projectPath, ast) }},
+		{"manager wrapper", func() error { return g.GenerateManagerWrapperGoFile(projectPath) }},
+		{"manager interface", func() error { return g.GenerateManagerInterfaceGoFile(projectPath) }},
+		{"synchronized API", func() error { return g.GenerateSyncApiGoFile(projectPath) }},
+		{"pure synchronized API", func() error { return g.GenerateSyncPureGoFile(projectPath) }},
 	}
 	for _, generator := range generators {
-		if err := generator.fn(projectPath, ast); err != nil {
+		if err := generator.fn(); err != nil {
 			return fmt.Errorf("generate %s: %w", generator.name, err)
 		}
 	}
 
-	clsNames := []string{"Sprite"} // add other classes if needed, Audio, Camera, Input, etc
+	clsNames := []string{"Sprite"}
 	for _, clsName := range clsNames {
-		if err := g.GenerateManagerImplGoFile(projectPath, ast, clsName); err != nil {
+		if err := g.GenerateManagerImplGoFile(projectPath, clsName); err != nil {
 			return fmt.Errorf("generate %s manager implementation: %w", clsName, err)
 		}
-		if err := g.GenerateManagerImplPureGoFile(projectPath, ast, clsName); err != nil {
+		if err := g.GenerateManagerImplPureGoFile(projectPath, clsName); err != nil {
 			return fmt.Errorf("generate pure %s manager implementation: %w", clsName, err)
 		}
 	}
@@ -186,8 +187,7 @@ func GenerateGDExtensionInterfaceGoFile(projectPath string, ast clang.CHeaderFil
 		filepath.Join(projectPath, NativeRelDir, "ffi.gen.go"))
 }
 
-func (g *Generator) GenerateManagerWrapperGoFile(projectPath string, ast clang.CHeaderFileAST) error {
-	g.PrepareAST(ast)
+func (g *Generator) GenerateManagerWrapperGoFile(projectPath string) error {
 	funcs := template.FuncMap{
 		"gdiVariableName":     GdiVariableName,
 		"snakeCase":           strcase.ToSnake,
@@ -206,13 +206,12 @@ func (g *Generator) GenerateManagerWrapperGoFile(projectPath string, ast clang.C
 		"getManagerInterface": g.ManagerInterfaceSignature,
 	}
 
-	return GenerateFile(funcs, "manager_native.gen.go", managerNativeText, ManagerData{Ast: ast, Managers: g.GetManagers(ast), KnownManagerNames: g.KnownManagerNames},
+	return GenerateFile(funcs, "manager_native.gen.go", managerNativeText, g.ManagerData(),
 		filepath.Join(projectPath, GdengineImplRelDir, "manager_native.gen.go"))
 
 }
 
-func (g *Generator) GenerateManagerInterfaceGoFile(projectPath string, ast clang.CHeaderFileAST) error {
-	g.PrepareAST(ast)
+func (g *Generator) GenerateManagerInterfaceGoFile(projectPath string) error {
 	funcs := template.FuncMap{
 		"gdiVariableName":     GdiVariableName,
 		"snakeCase":           strcase.ToSnake,
@@ -231,12 +230,11 @@ func (g *Generator) GenerateManagerInterfaceGoFile(projectPath string, ast clang
 		"getManagerInterface": g.ManagerInterfaceSignature,
 	}
 
-	return GenerateFile(funcs, "interface.gen.go", interfaceGoFileText, ManagerData{Ast: ast, Managers: g.GetManagers(ast), KnownManagerNames: g.KnownManagerNames},
+	return GenerateFile(funcs, "interface.gen.go", interfaceGoFileText, g.ManagerData(),
 		filepath.Join(projectPath, EnginePkgRelDir, "interface.gen.go"))
 }
 
-func (g *Generator) GenerateSyncApiGoFile(projectPath string, ast clang.CHeaderFileAST) error {
-	g.PrepareAST(ast)
+func (g *Generator) GenerateSyncApiGoFile(projectPath string) error {
 	funcs := template.FuncMap{
 		"gdiVariableName":            GdiVariableName,
 		"snakeCase":                  strcase.ToSnake,
@@ -255,12 +253,11 @@ func (g *Generator) GenerateSyncApiGoFile(projectPath string, ast clang.CHeaderF
 		"genSyncManagerWrapFunction": genSyncManagerWrapFunction,
 	}
 
-	return GenerateFile(funcs, "sync.gen.go", syncApiText, ManagerData{Ast: ast, Managers: g.GetManagers(ast), KnownManagerNames: g.KnownManagerNames},
+	return GenerateFile(funcs, "sync.gen.go", syncApiText, g.ManagerData(),
 		filepath.Join(projectPath, EnginewrapRelDir, "sync.gen.go"))
 }
 
-func (g *Generator) GenerateSyncPureGoFile(projectPath string, ast clang.CHeaderFileAST) error {
-	g.PrepareAST(ast)
+func (g *Generator) GenerateSyncPureGoFile(projectPath string) error {
 	funcs := template.FuncMap{
 		"gdiVariableName":            GdiVariableName,
 		"snakeCase":                  strcase.ToSnake,
@@ -279,11 +276,12 @@ func (g *Generator) GenerateSyncPureGoFile(projectPath string, ast clang.CHeader
 		"genSyncManagerWrapFunction": genSyncManagerWrapFunction,
 	}
 
-	return GenerateFile(funcs, "sync_pure.gen.go", syncPureApiText, ManagerData{Ast: ast, Managers: g.GetManagers(ast), KnownManagerNames: g.KnownManagerNames},
+	return GenerateFile(funcs, "sync_pure.gen.go", syncPureApiText, g.ManagerData(),
 		filepath.Join(projectPath, EnginewrapRelDir, "sync_pure.gen.go"))
 }
 
-func (g *Generator) GenerateManagerImplGoFile(projectPath string, ast clang.CHeaderFileAST, clsName string) error {
+func (g *Generator) GenerateManagerImplGoFile(projectPath string, clsName string) error {
+	ast := g.AST()
 	funcs := template.FuncMap{
 		"getManagerImpl": g.getManagerImpl,
 	}
@@ -297,7 +295,8 @@ func (g *Generator) GenerateManagerImplGoFile(projectPath string, ast clang.CHea
 		filepath.Join(projectPath, EnginePkgRelDir, genFile))
 }
 
-func (g *Generator) GenerateManagerImplPureGoFile(projectPath string, ast clang.CHeaderFileAST, clsName string) error {
+func (g *Generator) GenerateManagerImplPureGoFile(projectPath string, clsName string) error {
+	ast := g.AST()
 	funcs := template.FuncMap{
 		"getManagerImplPure": g.getManagerImplPure,
 	}

--- a/internal/cmd/codegen/generate/ffi/generate_test.go
+++ b/internal/cmd/codegen/generate/ffi/generate_test.go
@@ -30,10 +30,10 @@ import (
 )
 
 func TestGenerateManagerWrapperRunsNativeCallsOnMainThread(t *testing.T) {
-	generation := &Generator{GenerationContext: common.NewGenerationContext()}
+	metadata := common.GenerationMetadata{}
 
-	generation.RegisterManagerName("sprite")
-	generation.RegisterManagerName("platform")
+	metadata.ManagerNames = append(metadata.ManagerNames, "sprite")
+	metadata.ManagerNames = append(metadata.ManagerNames, "platform")
 
 	ast := clang.CHeaderFileAST{Expr: []clang.Expr{
 		{Function: managerFunction(
@@ -54,7 +54,8 @@ func TestGenerateManagerWrapperRunsNativeCallsOnMainThread(t *testing.T) {
 	}}
 
 	projectPath := filepath.Join(t.TempDir(), "internal", "cmd", "codegen")
-	require.NoError(t, generation.GenerateManagerWrapperGoFile(projectPath, ast))
+	generation := &Generator{GenerationContext: common.NewGenerationContext(ast, metadata)}
+	require.NoError(t, generation.GenerateManagerWrapperGoFile(projectPath))
 	generatedPath := filepath.Join(projectPath, common.GdengineImplRelDir, "manager_native.gen.go")
 	generated, err := os.ReadFile(generatedPath)
 	require.NoError(t, err)

--- a/internal/cmd/codegen/generate/ffi/interface.go.tmpl
+++ b/internal/cmd/codegen/generate/ffi/interface.go.tmpl
@@ -23,7 +23,7 @@ var (
 
 {{ range $i, $name := $view.Managers -}}
 type I{{camelCase $name}}Mgr interface {
-{{- range $i, $f := $view.Ast.CollectGDExtensionManagerFunctions $name $view.KnownManagerNames }}
+{{- range $i, $f := $view.Ast.CollectGDExtensionManagerFunctions $name $view.ManagerNames }}
 	{{ getManagerInterface $f }}
 {{- end }} 
 }

--- a/internal/cmd/codegen/generate/ffi/sync.gen.go.tmpl
+++ b/internal/cmd/codegen/generate/ffi/sync.gen.go.tmpl
@@ -45,7 +45,7 @@ type {{camelCase $name}}MgrImpl struct {
 
 {{ range $i, $name := $view.Managers -}}
 // I{{camelCase $name}}Mgr
-{{- range $i, $f := $view.Ast.CollectGDExtensionManagerFunctions $name $view.KnownManagerNames }}
+{{- range $i, $f := $view.Ast.CollectGDExtensionManagerFunctions $name $view.ManagerNames }}
 {{ genSyncApiWrapFunction $f }}
 {{- end }} 
 

--- a/internal/cmd/codegen/generate/ffi/sync_pure.gen.go.tmpl
+++ b/internal/cmd/codegen/generate/ffi/sync_pure.gen.go.tmpl
@@ -45,7 +45,7 @@ type {{camelCase $name}}MgrImpl struct {
 
 {{ range $i, $name := $view.Managers -}}
 // I{{camelCase $name}}Mgr
-{{- range $i, $f := $view.Ast.CollectGDExtensionManagerFunctions $name $view.KnownManagerNames }}
+{{- range $i, $f := $view.Ast.CollectGDExtensionManagerFunctions $name $view.ManagerNames }}
 {{ genSyncPureApiWrapFunction $f }}
 {{- end }} 
 

--- a/internal/cmd/codegen/generate/gdext/generate.go
+++ b/internal/cmd/codegen/generate/gdext/generate.go
@@ -50,13 +50,8 @@ type Generator struct {
 	*GenerationContext
 }
 
-func (g *Generator) GenerateHeader(projectPath, spxModulePath string) error {
-	outputFile := filepath.Join(projectPath, NativeRelDir, "gdextension_spx_ext.h")
-	return g.generateSpxExtHeader(spxModulePath, outputFile, true)
-}
-
-func (g *Generator) Generate(projectPath, spxModulePath string, ast clang.CHeaderFileAST) error {
-	if err := g.generateGdCppFile(projectPath, gdSpxExtCpp, ast, "gdextension_spx_ext.cpp"); err != nil {
+func (g *Generator) Generate(projectPath, spxModulePath string, headers Headers) error {
+	if err := g.generateGdCppFile(projectPath, gdSpxExtCpp, "gdextension_spx_ext.cpp"); err != nil {
 		return err
 	}
 	outputFile := filepath.Join(projectPath, NativeRelDir, "gdextension_spx_ext.cpp")
@@ -69,14 +64,14 @@ func (g *Generator) Generate(projectPath, spxModulePath string, ast clang.CHeade
 
 	// use the new format header
 	outputFile = filepath.Join(projectPath, NativeRelDir, "gdextension_spx_ext.h")
-	if err := g.generateSpxExtHeader(spxModulePath, outputFile, false); err != nil {
+	if err := os.WriteFile(outputFile, []byte(headers.Standard), 0o644); err != nil {
 		return err
 	}
 	if err := fileCopy(outputFile, filepath.Join(spxModulePath, "gdextension_spx_ext.h")); err != nil {
 		return fmt.Errorf("copy gdextension_spx_ext.h: %w", err)
 	}
 
-	if err := g.generateGdCppFile(projectPath, gdJsSpxCpp, ast, "godot_js_spx.cpp"); err != nil {
+	if err := g.generateGdCppFile(projectPath, gdJsSpxCpp, "godot_js_spx.cpp"); err != nil {
 		return err
 	}
 	outputFile = filepath.Join(projectPath, NativeRelDir, "godot_js_spx.cpp")
@@ -110,8 +105,7 @@ func fileCopy(src, dst string) error {
 	return dstFile.Sync()
 }
 
-func (g *Generator) generateGdCppFile(projectPath string, templateStr string, ast clang.CHeaderFileAST, outputFileName string) error {
-	g.PrepareAST(ast)
+func (g *Generator) generateGdCppFile(projectPath string, templateStr string, outputFileName string) error {
 	funcs := template.FuncMap{
 		"gdiVariableName":             GdiVariableName,
 		"snakeCase":                   strcase.ToSnake,
@@ -190,7 +184,7 @@ func (g *Generator) generateGdCppFile(projectPath string, templateStr string, as
 	}
 
 	var b bytes.Buffer
-	err = tmpl.Execute(&b, ManagerData{Ast: ast, Managers: g.GetManagers(ast), KnownManagerNames: g.KnownManagerNames})
+	err = tmpl.Execute(&b, g.ManagerData())
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/codegen/generate/gdext/header_generator.go
+++ b/internal/cmd/codegen/generate/gdext/header_generator.go
@@ -23,6 +23,8 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
+	"sort"
 	"strings"
 
 	"github.com/goplus/spx/v3/internal/cmd/codegen/generate/common"
@@ -30,17 +32,14 @@ import (
 	"github.com/iancoleman/strcase"
 )
 
-// Pre-compiled regular expressions for better performance
 var (
-	// For normalizeParams function
 	reSpaceComma = regexp.MustCompile(`\s+,`)
 	reSpaceParen = regexp.MustCompile(`\s+\)`)
 	reCommaSpace = regexp.MustCompile(`,\s*`)
 
-	// For mergeManagerHeader function
 	reClassDefinition = regexp.MustCompile(`class\s+(\w+)\s*:\s*(?:public\s+)?(?:SpxBaseMgr|SpxObjectMgr<\w+>)(?:\s*,\s*[^\{]+)?\s*\{`)
 
-	// For generateManagerHeader function. Only methods explicitly marked with
+	// Only methods explicitly marked with
 	// SPX_API or SPX_BIND become part of the cross-language ABI.
 	reMethodVoid           = regexp.MustCompile(`\s*(?:SPX_API|SPX_BIND)\s+void\s+(\w+)\((.*)\);`)
 	reMethodReturn         = regexp.MustCompile(`\s*(?:SPX_API|SPX_BIND)\s+(\w+)\s+(\w+)\((.*)\);`)
@@ -77,17 +76,29 @@ func shouldSkipGeneratedMethod(methodName string) bool {
 	return strings.HasSuffix(methodName, "_raw") || isArrayTransformBridgeMethod(methodName)
 }
 
-func (g *Generator) generateSpxExtHeader(dir, outputFile string, isRawFormat bool) error {
-	mergedStr, err := mergeManagerHeader(dir)
+// Headers holds both ABI spellings and the metadata collected from one input.
+type Headers struct {
+	Raw      string
+	Standard string
+	Metadata common.GenerationMetadata
+}
+
+type headerCollector struct {
+	metadata common.GenerationMetadata
+	methods  []classMethodDecl
+}
+
+func PrepareHeaders(dir string) (Headers, error) {
+	merged, err := mergeManagerHeader(dir)
 	if err != nil {
-		return err
+		return Headers{}, err
 	}
-	mergedHeaderFuncStr := g.generateManagerHeader(mergedStr, isRawFormat)
-	finalHeader := strings.Replace(gdSpxExtH, "###MANAGER_FUNC_DEFINE", mergedHeaderFuncStr, -1)
-	if err := os.WriteFile(outputFile, []byte(finalHeader), 0o644); err != nil {
-		return fmt.Errorf("write generated SPX extension header: %w", err)
-	}
-	return nil
+	h := parseManagerHeader(merged)
+	return Headers{
+		Raw:      strings.ReplaceAll(gdSpxExtH, "###MANAGER_FUNC_DEFINE", h.render(true)),
+		Standard: strings.ReplaceAll(gdSpxExtH, "###MANAGER_FUNC_DEFINE", h.render(false)),
+		Metadata: h.metadata,
+	}, nil
 }
 
 func mergeManagerHeader(dir string) (string, error) {
@@ -178,20 +189,16 @@ func normalizeParams(params string) string {
 	params = reSpaceParen.ReplaceAllString(params, ")")
 	// Ensure single space after commas
 	params = reCommaSpace.ReplaceAllString(params, ", ")
-	// Trim any leading/trailing whitespace
 	return strings.TrimSpace(params)
 }
 
-func (g *Generator) generateManagerHeader(input string, rawFormat bool) string {
+func parseManagerHeader(input string) *headerCollector {
+	g := &headerCollector{metadata: common.GenerationMetadata{
+		NativeArrayBridges:    make(map[string]common.NativeArrayBridgeSpec),
+		ArrayTransformBridges: make(map[string]common.ArrayTransformBridgeSpec),
+	}}
 	scanner := bufio.NewScanner(strings.NewReader(input))
 	var currentClassName string
-
-	var builder strings.Builder
-
-	// Clear the previous list of manager names
-	g.ClearKnownManagerNames()
-	g.ClearNativeArrayBridgeSpecs()
-	g.ClearArrayTransformBridgeSpecs()
 
 	baseMethods := map[string]classMethodDecl{}
 	rawMethods := map[string]classMethodDecl{}
@@ -202,12 +209,13 @@ func (g *Generator) generateManagerHeader(input string, rawFormat bool) string {
 			parts := strings.Fields(line)
 			currentClassName = parts[1]
 			currentClassName = currentClassName[:len(currentClassName)-3]
-			// Register manager name (remove "Spx" prefix)
 			if strings.HasPrefix(currentClassName, "Spx") {
-				managerName := currentClassName[3:] // Remove "Spx" prefix
-				g.RegisterManagerName(managerName)
+				managerName := strings.ToLower(currentClassName[3:])
+				if !slices.Contains(g.metadata.ManagerNames, managerName) {
+					g.metadata.ManagerNames = append(g.metadata.ManagerNames, managerName)
+				}
 			}
-			builder.WriteString("// " + currentClassName + "\n")
+			g.methods = append(g.methods, classMethodDecl{ClassName: currentClassName})
 			continue
 		}
 		if reMethodVoid.MatchString(line) {
@@ -224,8 +232,7 @@ func (g *Generator) generateManagerHeader(input string, rawFormat bool) string {
 				continue
 			}
 			baseMethods[currentClassName+"::"+matches[1]] = methodDecl
-			methodName := strcase.ToCamel(matches[1])
-			builder.WriteString(fmt.Sprintf("typedef void (*GDExtension%s%s)(%s);\n", currentClassName, methodName, params))
+			g.methods = append(g.methods, methodDecl)
 		} else if reMethodReturn.MatchString(line) {
 			matches := reMethodReturn.FindStringSubmatch(line)
 			params := normalizeParams(matches[3])
@@ -240,16 +247,7 @@ func (g *Generator) generateManagerHeader(input string, rawFormat bool) string {
 				continue
 			}
 			baseMethods[currentClassName+"::"+matches[2]] = methodDecl
-			returnType := matches[1]
-			methodName := strcase.ToCamel(matches[2])
-			if rawFormat {
-				builder.WriteString(fmt.Sprintf("typedef %s (*GDExtension%s%s)(%s);\n", returnType, currentClassName, methodName, params))
-			} else {
-				if len(params) > 0 {
-					returnType = ", " + returnType
-				}
-				builder.WriteString(fmt.Sprintf("typedef void (*GDExtension%s%s)(%s%s *ret_value);\n", currentClassName, methodName, params, returnType))
-			}
+			g.methods = append(g.methods, methodDecl)
 		}
 	}
 
@@ -259,12 +257,34 @@ func (g *Generator) generateManagerHeader(input string, rawFormat bool) string {
 
 	g.registerNativeArrayBridgeSpecs(baseMethods, rawMethods)
 	g.registerArrayTransformBridgeSpecs(baseMethods, rawMethods)
-	g.appendSyntheticArrayTransformTypedefs(&builder, rawFormat, baseMethods)
+	return g
+}
 
+func (g *headerCollector) render(rawFormat bool) string {
+	var builder strings.Builder
+	baseMethods := make(map[string]classMethodDecl)
+	for _, method := range g.methods {
+		if method.MethodName == "" {
+			builder.WriteString("// " + method.ClassName + "\n")
+			continue
+		}
+		baseMethods[method.ClassName+"::"+method.MethodName] = method
+		returnType, params := method.ReturnType, method.Params
+		name := strcase.ToCamel(method.MethodName)
+		if returnType == "void" || rawFormat {
+			fmt.Fprintf(&builder, "typedef %s (*GDExtension%s%s)(%s);\n", returnType, method.ClassName, name, params)
+		} else {
+			if len(params) > 0 {
+				returnType = ", " + returnType
+			}
+			fmt.Fprintf(&builder, "typedef void (*GDExtension%s%s)(%s%s *ret_value);\n", method.ClassName, name, params, returnType)
+		}
+	}
+	g.appendSyntheticArrayTransformTypedefs(&builder, rawFormat, baseMethods)
 	return builder.String()
 }
 
-func (g *Generator) registerNativeArrayBridgeSpecs(baseMethods map[string]classMethodDecl, rawMethods map[string]classMethodDecl) {
+func (g *headerCollector) registerNativeArrayBridgeSpecs(baseMethods map[string]classMethodDecl, rawMethods map[string]classMethodDecl) {
 	for _, baseMethod := range baseMethods {
 		dataType, dataArgName, lenType, lenArgName, goArgType, ptrType, lenGoType, fastArrayType, ok := parseRawNativeArrayParams(baseMethod.Params)
 		if !ok {
@@ -272,7 +292,7 @@ func (g *Generator) registerNativeArrayBridgeSpecs(baseMethods map[string]classM
 		}
 
 		baseFunctionName := "GDExtension" + baseMethod.ClassName + strcase.ToCamel(baseMethod.MethodName)
-		g.RegisterNativeArrayBridgeSpec(common.NativeArrayBridgeSpec{
+		g.metadata.NativeArrayBridges[baseFunctionName] = common.NativeArrayBridgeSpec{
 			BaseFunctionName: baseFunctionName,
 			BaseArgName:      highLevelArrayArgName(dataArgName),
 			DataArgName:      dataArgName,
@@ -288,7 +308,7 @@ func (g *Generator) registerNativeArrayBridgeSpecs(baseMethods map[string]classM
 			RawLenArgName:    lenArgName,
 			RawLenCType:      lenType,
 			FastArrayType:    fastArrayType,
-		})
+		}
 	}
 
 	for key, rawMethod := range rawMethods {
@@ -310,7 +330,7 @@ func (g *Generator) registerNativeArrayBridgeSpecs(baseMethods map[string]classM
 		baseFunctionName := "GDExtension" + rawMethod.ClassName + strcase.ToCamel(baseMethod.MethodName)
 		rawFunctionName := "GDExtension" + rawMethod.ClassName + strcase.ToCamel(rawMethod.MethodName)
 
-		g.RegisterNativeArrayBridgeSpec(common.NativeArrayBridgeSpec{
+		g.metadata.NativeArrayBridges[baseFunctionName] = common.NativeArrayBridgeSpec{
 			BaseFunctionName: baseFunctionName,
 			BaseArgName:      baseArgName,
 			DataArgName:      baseArgName,
@@ -326,7 +346,7 @@ func (g *Generator) registerNativeArrayBridgeSpecs(baseMethods map[string]classM
 			RawLenArgName:    rawLenArgName,
 			RawLenCType:      rawLenType,
 			FastArrayType:    fastArrayType,
-		})
+		}
 	}
 }
 
@@ -335,7 +355,7 @@ func isArrayTransformBridgeMethod(methodName string) bool {
 	return ok
 }
 
-func (g *Generator) registerArrayTransformBridgeSpecs(baseMethods map[string]classMethodDecl, rawMethods map[string]classMethodDecl) {
+func (g *headerCollector) registerArrayTransformBridgeSpecs(baseMethods map[string]classMethodDecl, rawMethods map[string]classMethodDecl) {
 	for key, rawMethod := range rawMethods {
 		baseMethod, hasBaseMethod := baseMethods[key]
 		baseMethodName := strings.TrimSuffix(rawMethod.MethodName, "_raw")
@@ -379,7 +399,7 @@ func (g *Generator) registerArrayTransformBridgeSpecs(baseMethods map[string]cla
 		}
 
 		baseFunctionName := "GDExtension" + rawMethod.ClassName + strcase.ToCamel(baseMethodName)
-		g.RegisterArrayTransformBridgeSpec(common.ArrayTransformBridgeSpec{
+		spec := common.ArrayTransformBridgeSpec{
 			FunctionName:     baseFunctionName,
 			ArrayArgName:     baseArgName,
 			MethodName:       rawMethod.MethodName,
@@ -387,18 +407,24 @@ func (g *Generator) registerArrayTransformBridgeSpecs(baseMethods map[string]cla
 			InputArrayType:   inputType,
 			OutputArrayType:  outputType,
 			OutputCountScale: override.OutputCountScale,
-		})
+		}
+		g.metadata.ArrayTransformBridges[spec.FunctionName] = spec
 	}
 }
 
-func (g *Generator) appendSyntheticArrayTransformTypedefs(builder *strings.Builder, rawFormat bool, baseMethods map[string]classMethodDecl) {
+func (g *headerCollector) appendSyntheticArrayTransformTypedefs(builder *strings.Builder, rawFormat bool, baseMethods map[string]classMethodDecl) {
 	existingFunctions := make(map[string]struct{}, len(baseMethods))
 	for _, baseMethod := range baseMethods {
 		functionName := "GDExtension" + baseMethod.ClassName + strcase.ToCamel(baseMethod.MethodName)
 		existingFunctions[functionName] = struct{}{}
 	}
 
-	for _, spec := range g.ListArrayTransformBridgeSpecs() {
+	specs := make([]common.ArrayTransformBridgeSpec, 0, len(g.metadata.ArrayTransformBridges))
+	for _, spec := range g.metadata.ArrayTransformBridges {
+		specs = append(specs, spec)
+	}
+	sort.Slice(specs, func(i, j int) bool { return specs[i].FunctionName < specs[j].FunctionName })
+	for _, spec := range specs {
 		if _, ok := existingFunctions[spec.FunctionName]; ok {
 			continue
 		}

--- a/internal/cmd/codegen/generate/gdext/header_generator_test.go
+++ b/internal/cmd/codegen/generate/gdext/header_generator_test.go
@@ -28,7 +28,6 @@ import (
 )
 
 func TestMergeManagerHeaderSupportsAdditionalBaseClasses(t *testing.T) {
-	generation := &Generator{GenerationContext: common.NewGenerationContext()}
 
 	dir := t.TempDir()
 	header := strings.TrimSpace(`
@@ -42,11 +41,10 @@ public:
 	merged, err := mergeManagerHeader(dir)
 	require.NoError(t, err)
 	require.Contains(t, merged, "class SpxUiMgr")
-	require.Contains(t, generation.generateManagerHeader(merged, false), "GDExtensionSpxUiBindNode")
+	require.Contains(t, parseManagerHeader(merged).render(false), "GDExtensionSpxUiBindNode")
 }
 
 func TestGenerateManagerHeaderSkipsRawMethods(t *testing.T) {
-	generation := &Generator{GenerationContext: common.NewGenerationContext()}
 
 	input := strings.TrimSpace(`
 class SpxSpriteMgr {
@@ -59,7 +57,9 @@ public:
 };
 `)
 
-	output := generation.generateManagerHeader(input, false)
+	header := parseManagerHeader(input)
+	output := header.render(false)
+	generation := common.NewGenerationContext(clang.CHeaderFileAST{}, header.metadata)
 
 	require.Contains(t, output, "GDExtensionSpxSpriteBatchUpdateTransforms")
 	require.Contains(t, output, "GDExtensionSpxSpriteDestroySprite")
@@ -83,7 +83,6 @@ func TestGodotJsTemplateUsesModuleRelativeIncludes(t *testing.T) {
 }
 
 func TestGodotJsTemplateKeepsResStringOwned(t *testing.T) {
-	generation := &Generator{GenerationContext: common.NewGenerationContext()}
 
 	projectPath := t.TempDir()
 	ast := clang.CHeaderFileAST{Expr: []clang.Expr{{Function: &clang.TypedefFunction{
@@ -96,7 +95,8 @@ func TestGodotJsTemplateKeepsResStringOwned(t *testing.T) {
 	}}}}
 
 	require.NoError(t, os.MkdirAll(filepath.Join(projectPath, common.NativeRelDir), 0o755))
-	require.NoError(t, generation.generateGdCppFile(projectPath, gdJsSpxCpp, ast, "godot_js_spx.cpp"))
+	generation := &Generator{GenerationContext: common.NewGenerationContext(ast, common.GenerationMetadata{})}
+	require.NoError(t, generation.generateGdCppFile(projectPath, gdJsSpxCpp, "godot_js_spx.cpp"))
 	generated, err := os.ReadFile(filepath.Join(projectPath, common.NativeRelDir, "godot_js_spx.cpp"))
 	require.NoError(t, err)
 	body := string(generated)
@@ -107,7 +107,6 @@ func TestGodotJsTemplateKeepsResStringOwned(t *testing.T) {
 }
 
 func TestGodotJsTemplateValidatesAndBindsGdStrings(t *testing.T) {
-	generation := &Generator{GenerationContext: common.NewGenerationContext()}
 
 	projectPath := t.TempDir()
 	ast := clang.CHeaderFileAST{Expr: []clang.Expr{{Function: &clang.TypedefFunction{
@@ -120,7 +119,8 @@ func TestGodotJsTemplateValidatesAndBindsGdStrings(t *testing.T) {
 	}}}}
 
 	require.NoError(t, os.MkdirAll(filepath.Join(projectPath, common.NativeRelDir), 0o755))
-	require.NoError(t, generation.generateGdCppFile(projectPath, gdJsSpxCpp, ast, "godot_js_spx.cpp"))
+	generation := &Generator{GenerationContext: common.NewGenerationContext(ast, common.GenerationMetadata{})}
+	require.NoError(t, generation.generateGdCppFile(projectPath, gdJsSpxCpp, "godot_js_spx.cpp"))
 	generated, err := os.ReadFile(filepath.Join(projectPath, common.NativeRelDir, "godot_js_spx.cpp"))
 	require.NoError(t, err)
 	body := string(generated)
@@ -133,7 +133,6 @@ func TestGodotJsTemplateValidatesAndBindsGdStrings(t *testing.T) {
 }
 
 func TestGodotJsTemplateValidatesAndBindsGdArrays(t *testing.T) {
-	generation := &Generator{GenerationContext: common.NewGenerationContext()}
 
 	projectPath := t.TempDir()
 	ast := clang.CHeaderFileAST{Expr: []clang.Expr{{Function: &clang.TypedefFunction{
@@ -146,7 +145,8 @@ func TestGodotJsTemplateValidatesAndBindsGdArrays(t *testing.T) {
 	}}}}
 
 	require.NoError(t, os.MkdirAll(filepath.Join(projectPath, common.NativeRelDir), 0o755))
-	require.NoError(t, generation.generateGdCppFile(projectPath, gdJsSpxCpp, ast, "godot_js_spx.cpp"))
+	generation := &Generator{GenerationContext: common.NewGenerationContext(ast, common.GenerationMetadata{})}
+	require.NoError(t, generation.generateGdCppFile(projectPath, gdJsSpxCpp, "godot_js_spx.cpp"))
 	generated, err := os.ReadFile(filepath.Join(projectPath, common.NativeRelDir, "godot_js_spx.cpp"))
 	require.NoError(t, err)
 	body := string(generated)
@@ -158,7 +158,6 @@ func TestGodotJsTemplateValidatesAndBindsGdArrays(t *testing.T) {
 }
 
 func TestGenerateManagerHeaderRegistersDirectNativeArrayBridge(t *testing.T) {
-	generation := &Generator{GenerationContext: common.NewGenerationContext()}
 
 	input := strings.TrimSpace(`
 class SpxSpriteMgr {
@@ -167,7 +166,9 @@ public:
 };
 `)
 
-	output := generation.generateManagerHeader(input, false)
+	header := parseManagerHeader(input)
+	output := header.render(false)
+	generation := common.NewGenerationContext(clang.CHeaderFileAST{}, header.metadata)
 
 	require.Contains(t, output, "GDExtensionSpxSpriteBatchUpdateTransforms")
 	spec, ok := generation.GetNativeArrayBridgeSpec("GDExtensionSpxSpriteBatchUpdateTransforms")
@@ -181,7 +182,6 @@ public:
 }
 
 func TestGenerateManagerHeaderRegistersArrayTransformBridge(t *testing.T) {
-	generation := &Generator{GenerationContext: common.NewGenerationContext()}
 
 	input := strings.TrimSpace(`
 class SpxSpriteMgr {
@@ -190,7 +190,9 @@ public:
 };
 `)
 
-	output := generation.generateManagerHeader(input, false)
+	header := parseManagerHeader(input)
+	output := header.render(false)
+	generation := common.NewGenerationContext(clang.CHeaderFileAST{}, header.metadata)
 
 	require.Contains(t, output, "GDExtensionSpxSpriteBatchRetrievePositions")
 	require.NotContains(t, output, "GDExtensionSpxSpriteBatchRetrievePositionsRaw")
@@ -211,7 +213,6 @@ public:
 }
 
 func TestGenerateManagerHeaderSynthesizesFastReturnTypedefForRawFormat(t *testing.T) {
-	generation := &Generator{GenerationContext: common.NewGenerationContext()}
 
 	input := strings.TrimSpace(`
 class SpxSpriteMgr {
@@ -220,8 +221,24 @@ public:
 };
 `)
 
-	output := generation.generateManagerHeader(input, true)
+	output := parseManagerHeader(input).render(true)
 
 	require.Contains(t, output, "typedef GdArray (*GDExtensionSpxSpriteBatchRetrievePositions)(GdArray objs);")
 	require.NotContains(t, output, "GDExtensionSpxSpriteBatchRetrievePositionsRaw")
+}
+
+func TestHeaderRenderingDoesNotChangeMetadata(t *testing.T) {
+	input := `class SpxSpriteMgr {
+ SPX_API GdBool destroy_sprite(GdObj obj);
+ SPX_API void batch_retrieve_positions(const GdObj *ids, int count, float *out, int out_len);
+ };`
+	header := parseManagerHeader(input)
+	before := common.NewGenerationContext(clang.CHeaderFileAST{}, header.metadata)
+	standard, raw := header.render(false), header.render(true)
+	require.Equal(t, standard, header.render(false))
+	require.Equal(t, raw, header.render(true))
+	require.Contains(t, raw, "typedef GdBool (*GDExtensionSpxSpriteDestroySprite)(GdObj obj);")
+	require.Contains(t, standard, "typedef void (*GDExtensionSpxSpriteDestroySprite)(GdObj obj, GdBool *ret_value);")
+	after := common.NewGenerationContext(clang.CHeaderFileAST{}, header.metadata)
+	require.Equal(t, before.ListArrayTransformBridgeSpecs(), after.ListArrayTransformBridgeSpecs())
 }

--- a/internal/cmd/codegen/generate/webffi/generate.go
+++ b/internal/cmd/codegen/generate/webffi/generate.go
@@ -38,6 +38,7 @@ import (
 var (
 	WebRelDir = "../../gdengine/binding/web"
 )
+
 var (
 
 	//go:embed callbacks.go.tmpl
@@ -114,15 +115,16 @@ type Generator struct {
 	*GenerationContext
 }
 
-func (g *Generator) Generate(projectPath, spxModulePath string, ast clang.CHeaderFileAST) error {
+func (g *Generator) Generate(projectPath, spxModulePath string) error {
+	ast := g.AST()
 	generators := []struct {
 		name string
 		fn   func() error
 	}{
 		{"callback Go source", func() error { return GenerateCallbackGoFile(projectPath, ast) }},
 		{"GDExtension interface", func() error { return GenerateGDExtensionInterfaceGoFile(projectPath, ast) }},
-		{"manager wrapper", func() error { return g.GenerateManagerWrapperGoFile(projectPath, ast) }},
-		{"JavaScript engine bridge", func() error { return g.GenerateJsEngineJsFile(projectPath, spxModulePath, ast) }},
+		{"manager wrapper", func() error { return g.GenerateManagerWrapperGoFile(projectPath) }},
+		{"JavaScript engine bridge", func() error { return g.GenerateJsEngineJsFile(projectPath, spxModulePath) }},
 		{"Web worker wrapper", func() error { return GenerateWorkerWrapJsFile(projectPath, ast) }},
 	}
 	for _, generator := range generators {
@@ -194,8 +196,7 @@ func GenerateGDExtensionInterfaceGoFile(projectPath string, ast clang.CHeaderFil
 		filepath.Join(projectPath, WebRelDir, "ffi.gen.go"))
 }
 
-func (g *Generator) GenerateManagerWrapperGoFile(projectPath string, ast clang.CHeaderFileAST) error {
-	g.PrepareAST(ast)
+func (g *Generator) GenerateManagerWrapperGoFile(projectPath string) error {
 	funcs := template.FuncMap{
 		"gdiVariableName":     GdiVariableName,
 		"snakeCase":           strcase.ToSnake,
@@ -214,11 +215,11 @@ func (g *Generator) GenerateManagerWrapperGoFile(projectPath string, ast clang.C
 		"getManagerInterface": g.ManagerInterfaceSignature,
 	}
 
-	return GenerateFile(funcs, "manager_web.gen.go", managerWebText, ManagerData{Ast: ast, Managers: g.GetManagers(ast), KnownManagerNames: g.KnownManagerNames},
+	return GenerateFile(funcs, "manager_web.gen.go", managerWebText, g.ManagerData(),
 		filepath.Join(projectPath, GdengineImplRelDir, "manager_web.gen.go"))
 }
 
-func (g *Generator) GenerateJsEngineJsFile(projectPath, spxModulePath string, ast clang.CHeaderFileAST) error {
+func (g *Generator) GenerateJsEngineJsFile(projectPath, spxModulePath string) error {
 	funcs := template.FuncMap{
 		"gdiVariableName":     GdiVariableName,
 		"snakeCase":           strcase.ToSnake,
@@ -245,7 +246,7 @@ func (g *Generator) GenerateJsEngineJsFile(projectPath, spxModulePath string, as
 	}
 
 	var b bytes.Buffer
-	err = tmpl.Execute(&b, ast)
+	err = tmpl.Execute(&b, g.AST())
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/codegen/generate/webffi/generate_test.go
+++ b/internal/cmd/codegen/generate/webffi/generate_test.go
@@ -28,7 +28,6 @@ import (
 )
 
 func TestGenerateJsEngineJsFileTrimsTrailingWhitespace(t *testing.T) {
-	generation := &Generator{GenerationContext: common.NewGenerationContext()}
 
 	function := &clang.TypedefFunction{
 		Name:       "GDExtensionSpxTestDoThing",
@@ -39,7 +38,8 @@ func TestGenerateJsEngineJsFileTrimsTrailingWhitespace(t *testing.T) {
 	}
 	spxModulePath := filepath.Join(t.TempDir(), "spx")
 
-	require.NoError(t, generation.GenerateJsEngineJsFile("", spxModulePath, ast))
+	generation := &Generator{GenerationContext: common.NewGenerationContext(ast, common.GenerationMetadata{})}
+	require.NoError(t, generation.GenerateJsEngineJsFile("", spxModulePath))
 	body, err := os.ReadFile(filepath.Join(spxModulePath, "web", "js", "engine", "gdspx.js"))
 	require.NoError(t, err)
 	for _, line := range strings.Split(string(body), "\n") {
@@ -52,7 +52,7 @@ func TestGenerateJsEngineJsFileTrimsTrailingWhitespace(t *testing.T) {
 }
 
 func TestGetJsFuncArgsFlattensGdObj(t *testing.T) {
-	generation := &Generator{GenerationContext: common.NewGenerationContext()}
+	generation := &Generator{GenerationContext: common.NewGenerationContext(clang.CHeaderFileAST{}, common.GenerationMetadata{})}
 
 	function := &clang.TypedefFunction{
 		Name: "GDExtensionSpxPhysicsCheckTouchedStageBoundaries",
@@ -79,9 +79,9 @@ func TestGetJsFuncArgsFlattensGdObj(t *testing.T) {
 }
 
 func TestGetJsFuncArgsSkipsNativeArrayLenArg(t *testing.T) {
-	generation := &Generator{GenerationContext: common.NewGenerationContext()}
+	metadata := common.GenerationMetadata{}
 
-	generation.RegisterNativeArrayBridgeSpec(common.NativeArrayBridgeSpec{
+	metadata.NativeArrayBridges = map[string]common.NativeArrayBridgeSpec{"GDExtensionSpxSpriteBatchUpdateTransforms": {
 		BaseFunctionName: "GDExtensionSpxSpriteBatchUpdateTransforms",
 		BaseArgName:      "buffer",
 		DataArgName:      "buffer_data",
@@ -90,7 +90,8 @@ func TestGetJsFuncArgsSkipsNativeArrayLenArg(t *testing.T) {
 		LenArgName:       "len",
 		LenArgGoType:     "int32",
 		GoArgType:        "[]float32",
-	})
+	}}
+	generation := &Generator{GenerationContext: common.NewGenerationContext(clang.CHeaderFileAST{}, metadata)}
 
 	function := &clang.TypedefFunction{
 		Name: "GDExtensionSpxSpriteBatchUpdateTransforms",
@@ -114,7 +115,7 @@ func TestGetJsFuncArgsSkipsNativeArrayLenArg(t *testing.T) {
 }
 
 func TestGetJsFuncBodyUsesHighLowCtorOrderForFlatGdIntArgs(t *testing.T) {
-	generation := &Generator{GenerationContext: common.NewGenerationContext()}
+	generation := &Generator{GenerationContext: common.NewGenerationContext(clang.CHeaderFileAST{}, common.GenerationMetadata{})}
 
 	function := &clang.TypedefFunction{
 		Name: "GDExtensionSpxPhysicsCheckTouchedStageBoundaries",
@@ -142,7 +143,7 @@ func TestGetJsFuncBodyUsesHighLowCtorOrderForFlatGdIntArgs(t *testing.T) {
 }
 
 func TestGetJsFuncBodyUsesFixedScratchAccessorForFlatReturn(t *testing.T) {
-	generation := &Generator{GenerationContext: common.NewGenerationContext()}
+	generation := &Generator{GenerationContext: common.NewGenerationContext(clang.CHeaderFileAST{}, common.GenerationMetadata{})}
 
 	function := &clang.TypedefFunction{
 		Name: "GDExtensionSpxPhysicsCheckTouchedStageBoundaries",
@@ -171,15 +172,16 @@ func TestGetJsFuncBodyUsesFixedScratchAccessorForFlatReturn(t *testing.T) {
 }
 
 func TestGetJsFuncBodyUsesArrayTransformBridgeSpec(t *testing.T) {
-	generation := &Generator{GenerationContext: common.NewGenerationContext()}
+	metadata := common.GenerationMetadata{}
 
-	generation.RegisterArrayTransformBridgeSpec(common.ArrayTransformBridgeSpec{
+	metadata.ArrayTransformBridges = map[string]common.ArrayTransformBridgeSpec{"GDExtensionSpxSpriteBatchRetrievePositions": {
 		FunctionName:     "GDExtensionSpxSpriteBatchRetrievePositions",
 		ArrayArgName:     "objs",
 		InputArrayType:   6,
 		OutputArrayType:  2,
 		OutputCountScale: 2,
-	})
+	}}
+	generation := &Generator{GenerationContext: common.NewGenerationContext(clang.CHeaderFileAST{}, metadata)}
 
 	function := &clang.TypedefFunction{
 		Name: "GDExtensionSpxSpriteBatchRetrievePositions",
@@ -191,7 +193,7 @@ func TestGetJsFuncBodyUsesArrayTransformBridgeSpec(t *testing.T) {
 }
 
 func TestGetJsFuncBodyRequiresWasmArrayForInputSnapshot(t *testing.T) {
-	generation := &Generator{GenerationContext: common.NewGenerationContext()}
+	generation := &Generator{GenerationContext: common.NewGenerationContext(clang.CHeaderFileAST{}, common.GenerationMetadata{})}
 
 	function := &clang.TypedefFunction{
 		Name: "GDExtensionSpxInputWriteSnapshot",
@@ -204,7 +206,7 @@ func TestGetJsFuncBodyRequiresWasmArrayForInputSnapshot(t *testing.T) {
 }
 
 func TestGetJsFuncBodyTreatsWebFreeStrAsValueOperation(t *testing.T) {
-	generation := &Generator{GenerationContext: common.NewGenerationContext()}
+	generation := &Generator{GenerationContext: common.NewGenerationContext(clang.CHeaderFileAST{}, common.GenerationMetadata{})}
 
 	body := generation.getJsFuncBody(&clang.TypedefFunction{Name: "GDExtensionSpxResFreeStr"})
 	require.Contains(t, body, "Web strings are value-owned")
@@ -213,13 +215,14 @@ func TestGetJsFuncBodyTreatsWebFreeStrAsValueOperation(t *testing.T) {
 }
 
 func TestGetJsFuncBodyValidatesNativeFastArray(t *testing.T) {
-	generation := &Generator{GenerationContext: common.NewGenerationContext()}
+	metadata := common.GenerationMetadata{}
 
-	generation.RegisterNativeArrayBridgeSpec(common.NativeArrayBridgeSpec{
+	metadata.NativeArrayBridges = map[string]common.NativeArrayBridgeSpec{"GDExtensionSpxSpriteBatchUpdateTransforms": {
 		BaseFunctionName: "GDExtensionSpxSpriteBatchUpdateTransforms",
 		BaseArgName:      "buffer",
 		FastArrayType:    2,
-	})
+	}}
+	generation := &Generator{GenerationContext: common.NewGenerationContext(clang.CHeaderFileAST{}, metadata)}
 
 	body := generation.getJsFuncBody(&clang.TypedefFunction{
 		Name: "GDExtensionSpxSpriteBatchUpdateTransforms",
@@ -249,7 +252,7 @@ func TestJsTemplateDeclaresInstanceScratchForMousePos(t *testing.T) {
 }
 
 func TestGetJsFuncBodyUsesInstanceScratchForMousePos(t *testing.T) {
-	generation := &Generator{GenerationContext: common.NewGenerationContext()}
+	generation := &Generator{GenerationContext: common.NewGenerationContext(clang.CHeaderFileAST{}, common.GenerationMetadata{})}
 
 	function := &clang.TypedefFunction{
 		Name: "GDExtensionSpxInputGetGlobalMousePos",
@@ -264,7 +267,7 @@ func TestGetJsFuncBodyUsesInstanceScratchForMousePos(t *testing.T) {
 }
 
 func TestGetManagerFuncBodyUsesInputCacheOverride(t *testing.T) {
-	generation := &Generator{GenerationContext: common.NewGenerationContext()}
+	generation := &Generator{GenerationContext: common.NewGenerationContext(clang.CHeaderFileAST{}, common.GenerationMetadata{})}
 
 	function := &clang.TypedefFunction{
 		Name: "GDExtensionSpxInputIsActionPressed",
@@ -277,7 +280,7 @@ func TestGetManagerFuncBodyUsesInputCacheOverride(t *testing.T) {
 }
 
 func TestGetManagerFuncBodyUsesActionAxisOverride(t *testing.T) {
-	generation := &Generator{GenerationContext: common.NewGenerationContext()}
+	generation := &Generator{GenerationContext: common.NewGenerationContext(clang.CHeaderFileAST{}, common.GenerationMetadata{})}
 
 	function := &clang.TypedefFunction{
 		Name: "GDExtensionSpxInputGetAxis",

--- a/internal/cmd/codegen/main.go
+++ b/internal/cmd/codegen/main.go
@@ -24,7 +24,6 @@ import (
 	"strings"
 
 	"github.com/goplus/spx/v3/internal/cmd/codegen/gdextensionparser"
-	"github.com/goplus/spx/v3/internal/cmd/codegen/gdextensionparser/clang"
 	"github.com/goplus/spx/v3/internal/cmd/codegen/generate/common"
 	"github.com/goplus/spx/v3/internal/cmd/codegen/generate/ffi"
 	"github.com/goplus/spx/v3/internal/cmd/codegen/generate/gdext"
@@ -107,51 +106,45 @@ func validateCodegenInputs(spxModuleSource string) error {
 }
 
 func generateCode() error {
-	generation := common.NewGenerationContext()
-	nativeGenerator := ffi.Generator{GenerationContext: generation}
-	webGenerator := webffi.Generator{GenerationContext: generation}
-	extensionGenerator := gdext.Generator{GenerationContext: generation}
 	// Validate every external input before generators can create or replace files.
 	if err := validateCodegenInputs(spxModulePath); err != nil {
 		return err
 	}
 
-	var (
-		ast clang.CHeaderFileAST
-		err error
-	)
 	if verbose {
 		spxlog.Info(`build configuration "%s" selected`, buildConfig)
 		spxlog.Info(`SPX module source "%s" selected`, spxModulePath)
 	}
-	// generte c++ ext header file
+	// Prepare both header spellings and metadata before rendering bindings.
 	if genClangAPI {
 		if verbose {
 			spxlog.Info("Generating gdextension godot ext functions...")
 		}
-		if err := extensionGenerator.GenerateHeader(packagePath, spxModulePath); err != nil {
+		headers, err := gdext.PrepareHeaders(spxModulePath)
+		if err != nil {
+			return fmt.Errorf("prepare GDExtension headers: %w", err)
+		}
+		if err := os.WriteFile(filepath.Join(packagePath, common.NativeRelDir, "gdextension_spx_ext.h"), []byte(headers.Raw), 0o644); err != nil {
 			return fmt.Errorf("generate GDExtension header: %w", err)
 		}
-	}
-
-	// generate go wrap code
-	if genClangAPI {
-		ast, err = gdextensionparser.GenerateGDExtensionInterfaceAST(packagePath, parsedASTPath)
+		ast, err := gdextensionparser.GenerateGDExtensionInterfaceAST(packagePath, parsedASTPath)
 		if err != nil {
 			return fmt.Errorf("parse GDExtension interface: %w", err)
 		}
-	}
-	if genClangAPI {
 		if verbose {
 			spxlog.Info("Generating gdextension C wrapper functions...")
 		}
-		if err := nativeGenerator.Generate(packagePath, ast); err != nil {
+		generation := common.NewGenerationContext(ast, headers.Metadata)
+		nativeGenerator := ffi.Generator{GenerationContext: generation}
+		webGenerator := webffi.Generator{GenerationContext: generation}
+		extensionGenerator := gdext.Generator{GenerationContext: generation}
+		if err := nativeGenerator.Generate(packagePath); err != nil {
 			return fmt.Errorf("generate native bindings: %w", err)
 		}
-		if err := webGenerator.Generate(packagePath, spxModulePath, ast); err != nil {
+		if err := webGenerator.Generate(packagePath, spxModulePath); err != nil {
 			return fmt.Errorf("generate Web bindings: %w", err)
 		}
-		if err := extensionGenerator.Generate(packagePath, spxModulePath, ast); err != nil {
+		if err := extensionGenerator.Generate(packagePath, spxModulePath, headers); err != nil {
 			return fmt.Errorf("generate GDExtension sources: %w", err)
 		}
 	}


### PR DESCRIPTION
Prepare both GDExtension header spellings and bridge metadata from one header scan, then bind each generator to a read-only context for its input AST. Rendering no longer clears registries, prepares manager membership repeatedly, or accepts an AST that can disagree with its metadata.

Share longest-prefix manager-name matching between parsing and templates, with the existing ASCII/Unicode fallback distinction preserved. Snapshot metadata, including nested parameter slices, so collection and rendering cannot modify each other's state.

Validation: generator tests and race detection passed; `make generate` preserves generated binding contents. Tests cover overlapping manager names, snapshot isolation, concurrent rendering, and both header spellings.
