### PR TITLE
refactor(codegen): simplify template and string output

### DIFF
--- a/internal/cmd/codegen/gdextensionparser/parse.go
+++ b/internal/cmd/codegen/gdextensionparser/parse.go
@@ -57,7 +57,8 @@ func ReadFiles(dir, fileName string) (string, error) {
 		if strings.Contains(line, "/*******") {
 			continue
 		}
-		sb.WriteString(line + "\n")
+		sb.WriteString(line)
+		sb.WriteByte('\n')
 	}
 	finalStr := sb.String()
 	finalStr = strings.ReplaceAll(finalStr, "\r", "")

--- a/internal/cmd/codegen/generate/common/funcs.go
+++ b/internal/cmd/codegen/generate/common/funcs.go
@@ -593,36 +593,41 @@ func MustPrimitiveTypeName(arg clang.Argument, functionName string) string {
 	panic(fmt.Sprintf("unsupported function-pointer argument %q in %s: %s", arg.Name, functionName, arg.Type.CStyleString()))
 }
 
-func GenerateFile(funcs template.FuncMap, name string, text string, data any, dstPath string) error {
-	tmpl, err := template.New(name).
-		Funcs(funcs).
-		Parse(text)
+// RenderTemplate completes template execution before any output file is opened.
+func RenderTemplate(funcs template.FuncMap, name, text string, data any) ([]byte, error) {
+	tmpl, err := template.New(name).Funcs(funcs).Parse(text)
 	if err != nil {
-		return err
+		return nil, err
 	}
-
 	var b bytes.Buffer
-	err = tmpl.Execute(&b, data)
+	if err := tmpl.Execute(&b, data); err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
+}
+
+func WriteGeneratedFile(dstPath string, output []byte, mode os.FileMode) error {
+	if err := os.WriteFile(dstPath, output, mode); err != nil {
+		return fmt.Errorf("write generated file %q: %w", dstPath, err)
+	}
+	spxlog.Info("Generated file: %s", dstPath)
+	return nil
+}
+
+func GenerateFile(funcs template.FuncMap, name string, text string, data any, dstPath string) error {
+	output, err := RenderTemplate(funcs, name, text, data)
 	if err != nil {
 		return err
 	}
-	output := b.Bytes()
-	isGoFile := filepath.Ext(dstPath) == ".go"
-	if isGoFile {
+	if filepath.Ext(dstPath) == ".go" {
 		output = licenseheader.AddToGoSource(output)
 		output, err = format.Source(output)
 		if err != nil {
 			return fmt.Errorf("format generated Go file %q: %w", dstPath, err)
 		}
 	}
-
-	dir := filepath.Dir(dstPath)
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		return fmt.Errorf("create generated file directory %q: %w", dir, err)
+	if err := os.MkdirAll(filepath.Dir(dstPath), 0o755); err != nil {
+		return fmt.Errorf("create generated file directory %q: %w", filepath.Dir(dstPath), err)
 	}
-	if err := os.WriteFile(dstPath, output, 0o644); err != nil {
-		return fmt.Errorf("write generated file %q: %w", dstPath, err)
-	}
-	spxlog.Info("Generated file: %s", dstPath)
-	return nil
+	return WriteGeneratedFile(dstPath, output, 0o644)
 }

--- a/internal/cmd/codegen/generate/common/manager_signature.go
+++ b/internal/cmd/codegen/generate/common/manager_signature.go
@@ -58,7 +58,9 @@ func (c *GenerationContext) managerSignature(function *clang.TypedefFunction, mg
 
 	if HasEffectiveReturn(function) {
 		typeName := c.EffectiveGoReturnType(function)
-		sb.WriteString(" " + typeName + " ")
+		sb.WriteByte(' ')
+		sb.WriteString(typeName)
+		sb.WriteByte(' ')
 	}
 	return sb.String()
 }

--- a/internal/cmd/codegen/generate/ffi/generate.go
+++ b/internal/cmd/codegen/generate/ffi/generate.go
@@ -14,16 +14,12 @@
  * limitations under the License.
  */
 
-// Package gdextensionwrapper generates C code to wrap all of the gdextension
-// methods to call functions on the gdextension_api_structs to work
-// around the Cgo C function pointer limitation.
+// Package ffi generates native Go bindings and C function-pointer wrappers.
 package ffi
 
 import (
-	"bytes"
 	_ "embed"
 	"fmt"
-	"os"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -117,33 +113,11 @@ func (g *Generator) Generate(projectPath string) error {
 }
 
 func GenerateGDExtensionWrapperHeaderFile(projectPath string, ast clang.CHeaderFileAST) error {
-	tmpl, err := template.New("ffi_wrapper.gen.h").
-		Funcs(template.FuncMap{
-			"snakeCase": strcase.ToSnake,
-		}).
-		Parse(ffiWrapperHeaderFileText)
+	output, err := RenderTemplate(template.FuncMap{"snakeCase": strcase.ToSnake}, "ffi_wrapper.gen.h", ffiWrapperHeaderFileText, ast)
 	if err != nil {
 		return err
 	}
-
-	var b bytes.Buffer
-	err = tmpl.Execute(&b, ast)
-	if err != nil {
-		return err
-	}
-
-	filename := filepath.Join(projectPath, NativeRelDir, "ffi_wrapper.gen.h")
-	f, err := os.Create(filename)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-
-	_, err = f.Write(b.Bytes())
-	if err != nil {
-		return err
-	}
-	return nil
+	return WriteGeneratedFile(filepath.Join(projectPath, NativeRelDir, "ffi_wrapper.gen.h"), output, 0o666)
 }
 
 func GenerateGDExtensionWrapperGoFile(projectPath string, ast clang.CHeaderFileAST) error {
@@ -329,7 +303,7 @@ func (g *Generator) getManagerFuncBody(function *clang.TypedefFunction) string {
 	dispatchToMainThread := function.Name != "GDExtensionSpxPlatformIsMainThread"
 	if dispatchToMainThread {
 		if HasEffectiveReturn(function) {
-			sb.WriteString("\treturn enginewrap.CallInMainThreadValue(func() " + g.EffectiveGoReturnType(function) + " {\n")
+			fmt.Fprintf(&sb, "\treturn enginewrap.CallInMainThreadValue(func() %s {\n", g.EffectiveGoReturnType(function))
 		} else {
 			sb.WriteString("\tenginewrap.CallInMainThread(func() {\n")
 		}
@@ -346,46 +320,56 @@ func (g *Generator) getManagerFuncBody(function *clang.TypedefFunction) string {
 		if g.IsNativeArrayDataArg(function, arg) {
 			spec, _ := g.GetNativeArrayBridgeSpec(function.Name)
 			goArgName := g.EffectiveGoArgumentName(function, arg)
-			sb.WriteString("var " + argName + " " + spec.DataArgPtrType + "\n")
+			fmt.Fprintf(&sb, "var %s %s\n", argName, spec.DataArgPtrType)
 			sb.WriteString(prefixTab)
-			sb.WriteString("if len(" + goArgName + ") > 0 {\n")
-			sb.WriteString(prefixTab + "\t" + argName + " = &" + goArgName + "[0]\n")
-			sb.WriteString(prefixTab + "}\n")
+			fmt.Fprintf(&sb, "if len(%s) > 0 {\n", goArgName)
+			fmt.Fprintf(&sb, "%s\t%s = &%s[0]\n", prefixTab, argName, goArgName)
+			sb.WriteString(prefixTab)
+			sb.WriteString("}\n")
 			lenArgName := "arg" + strconv.Itoa(i+1)
 			sb.WriteString(prefixTab)
-			sb.WriteString(lenArgName + " := " + g.NativeArrayLenExpr(function, goArgName))
+			fmt.Fprintf(&sb, "%s := %s", lenArgName, g.NativeArrayLenExpr(function, goArgName))
 			params = append(params, argName, lenArgName)
 			sb.WriteString("\n")
 			continue
 		}
 		switch typeName {
 		case "GdString":
-			sb.WriteString(argName + "Str := ")
+			sb.WriteString(argName)
+			sb.WriteString("Str := ")
 			sb.WriteString("C.CString(")
 			sb.WriteString(arg.Name)
 			sb.WriteString(")")
-			sb.WriteString("\n" + prefixTab)
-			sb.WriteString(argName + " := " + "(GdString)(" + argName + "Str) \n")
-			sb.WriteString(prefixTab + "defer " + "C.free(unsafe.Pointer(" + argName + "Str))")
+			sb.WriteByte('\n')
+			sb.WriteString(prefixTab)
+			fmt.Fprintf(&sb, "%s := (GdString)(%sStr) \n", argName, argName)
+			fmt.Fprintf(&sb, "%sdefer C.free(unsafe.Pointer(%sStr))", prefixTab, argName)
 		case "GdArray":
-			sb.WriteString(argName + "Info := ")
+			sb.WriteString(argName)
+			sb.WriteString("Info := ")
 			sb.WriteString("ToGdArrayInfo(")
 			sb.WriteString(arg.Name)
 			sb.WriteString(")")
-			sb.WriteString("\n" + prefixTab)
-			sb.WriteString("if " + argName + "Info != nil {\n")
-			sb.WriteString(prefixTab + "\tdefer " + argName + "Info.Free()\n")
-			sb.WriteString(prefixTab + "}\n")
+			sb.WriteByte('\n')
 			sb.WriteString(prefixTab)
-			sb.WriteString(argName + " := GdArray(nil)\n")
+			fmt.Fprintf(&sb, "if %sInfo != nil {\n", argName)
+			fmt.Fprintf(&sb, "%s\tdefer %sInfo.Free()\n", prefixTab, argName)
 			sb.WriteString(prefixTab)
-			sb.WriteString("if " + argName + "Info != nil {\n")
-			sb.WriteString(prefixTab + "\t" + argName + " = " + argName + "Info.Raw()\n")
-			sb.WriteString(prefixTab + "}")
+			sb.WriteString("}\n")
+			sb.WriteString(prefixTab)
+			sb.WriteString(argName)
+			sb.WriteString(" := GdArray(nil)\n")
+			sb.WriteString(prefixTab)
+			fmt.Fprintf(&sb, "if %sInfo != nil {\n", argName)
+			fmt.Fprintf(&sb, "%s\t%s = %sInfo.Raw()\n", prefixTab, argName, argName)
+			sb.WriteString(prefixTab)
+			sb.WriteByte('}')
 
 		default:
-			sb.WriteString(argName + " := ")
-			sb.WriteString("To" + typeName)
+			sb.WriteString(argName)
+			sb.WriteString(" := ")
+			sb.WriteString("To")
+			sb.WriteString(typeName)
 			sb.WriteString("(")
 			sb.WriteString(arg.Name)
 			sb.WriteString(")")
@@ -399,7 +383,7 @@ func (g *Generator) getManagerFuncBody(function *clang.TypedefFunction) string {
 	if hasSyntheticReturn {
 		rawType := EffectiveRawReturnType(function)
 		sb.WriteString(prefixTab)
-		sb.WriteString("var retValue " + rawType + "\n")
+		fmt.Fprintf(&sb, "var retValue %s\n", rawType)
 	}
 
 	sb.WriteString(prefixTab)
@@ -423,10 +407,11 @@ func (g *Generator) getManagerFuncBody(function *clang.TypedefFunction) string {
 	sb.WriteString(")")
 
 	if HasEffectiveReturn(function) {
-		sb.WriteString("\n" + prefixTab)
+		sb.WriteByte('\n')
+		sb.WriteString(prefixTab)
 		sb.WriteString("return ")
 		typeName := g.EffectiveGoReturnType(function)
-		sb.WriteString("To" + strcase.ToCamel(typeName) + "(retValue)")
+		fmt.Fprintf(&sb, "To%s(retValue)", strcase.ToCamel(typeName))
 	}
 	if dispatchToMainThread {
 		sb.WriteString("\n\t})")
@@ -458,7 +443,7 @@ func (g *Generator) genSyncPureApiWrapFunction(function *clang.TypedefFunction) 
 	args := EffectiveArguments(function)
 	retType := g.EffectiveGoReturnType(function)
 
-	sb.WriteString(fmt.Sprintf("func (*%s) ", mgrTypeName+"Impl"))
+	fmt.Fprintf(&sb, "func (*%sImpl) ", mgrTypeName)
 	sb.WriteString(pureFuncName)
 	sb.WriteString("(")
 	wroteArg := false
@@ -478,13 +463,14 @@ func (g *Generator) genSyncPureApiWrapFunction(function *clang.TypedefFunction) 
 	sb.WriteString(")")
 
 	if retType != "" {
-		sb.WriteString(" " + g.MustGdxReturnType(function))
+		sb.WriteByte(' ')
+		sb.WriteString(g.MustGdxReturnType(function))
 	}
 	sb.WriteString(" {")
 	prefixStr := "\t"
 	// body
 	if retType != "" {
-		sb.WriteString("\n" + prefixStr + "return " + goZeroValue(g.MustGdxReturnType(function)) + "\n")
+		fmt.Fprintf(&sb, "\n%sreturn %s\n", prefixStr, goZeroValue(g.MustGdxReturnType(function)))
 	}
 	sb.WriteString("}")
 	return sb.String()
@@ -511,7 +497,7 @@ func (g *Generator) genSyncApiWrapFunction(function *clang.TypedefFunction) stri
 	args := EffectiveArguments(function)
 	retType := g.EffectiveGoReturnType(function)
 
-	sb.WriteString(fmt.Sprintf("func (*%s) ", mgrTypeName+"Impl"))
+	fmt.Fprintf(&sb, "func (*%sImpl) ", mgrTypeName)
 	sb.WriteString(pureFuncName)
 	sb.WriteString("(")
 	wroteArg := false
@@ -531,24 +517,27 @@ func (g *Generator) genSyncApiWrapFunction(function *clang.TypedefFunction) stri
 	sb.WriteString(")")
 
 	if retType != "" {
-		sb.WriteString(" " + g.MustGdxReturnType(function))
+		sb.WriteByte(' ')
+		sb.WriteString(g.MustGdxReturnType(function))
 	}
 	sb.WriteString(" {")
 	prefixStr := "\t"
 	// body
 	if retType != "" {
-		sb.WriteString("\n" + prefixStr + "var _ret1 " + g.MustGdxReturnType(function) + "")
+		fmt.Fprintf(&sb, "\n%svar _ret1 %s", prefixStr, g.MustGdxReturnType(function))
 	}
 
 	sb.WriteString(`	
 	callInMainThread(func() {
 `)
 	if retType != "" {
-		sb.WriteString(prefixStr + "\t_ret1 = ")
+		sb.WriteString(prefixStr)
+		sb.WriteString("\t_ret1 = ")
 	} else {
-		sb.WriteString(prefixStr + "\t")
+		sb.WriteString(prefixStr)
+		sb.WriteByte('\t')
 	}
-	sb.WriteString(gdxMgrName + "." + pureFuncName + "(")
+	fmt.Fprintf(&sb, "%s.%s(", gdxMgrName, pureFuncName)
 	wroteArg = false
 	for _, arg := range args {
 		if g.ShouldSkipHighLevelArgument(function, arg) {
@@ -567,7 +556,8 @@ func (g *Generator) genSyncApiWrapFunction(function *clang.TypedefFunction) stri
 `)
 
 	if retType != "" {
-		sb.WriteString(prefixStr + "return _ret1 \n")
+		sb.WriteString(prefixStr)
+		sb.WriteString("return _ret1 \n")
 	}
 	sb.WriteString("}")
 	return sb.String()
@@ -585,7 +575,7 @@ func (g *Generator) getManagerImplPure(function *clang.TypedefFunction, clsName 
 	funcName := function.Name[len(prefix)+len(mgrName):]
 	args := EffectiveArguments(function)
 	retType := g.EffectiveGoReturnType(function)
-	sb.WriteString("func (pself *" + clsName + ") " + funcName + "(")
+	fmt.Fprintf(&sb, "func (pself *%s) %s(", clsName, funcName)
 	wroteArg := false
 	for i, arg := range args {
 		if i == 0 && arg.Name == "obj" {
@@ -605,11 +595,12 @@ func (g *Generator) getManagerImplPure(function *clang.TypedefFunction, clsName 
 	}
 	sb.WriteString(") ")
 	if retType != "" {
-		sb.WriteString(retType + " ")
+		sb.WriteString(retType)
+		sb.WriteByte(' ')
 	}
 	sb.WriteString("{\n")
 	if retType != "" {
-		sb.WriteString("\treturn " + goZeroValue(retType) + "\n")
+		fmt.Fprintf(&sb, "\treturn %s\n", goZeroValue(retType))
 	}
 	sb.WriteString("}\n")
 	return sb.String()
@@ -627,7 +618,7 @@ func (g *Generator) getManagerImpl(function *clang.TypedefFunction, clsName stri
 	// Check if the first argument is "obj" to determine if this is an instance method
 	hasObjArg := len(args) > 0 && args[0].Name == "obj"
 
-	sb.WriteString("func (pself *" + clsName + ") " + funcName + "(")
+	fmt.Fprintf(&sb, "func (pself *%s) %s(", clsName, funcName)
 	wroteArg := false
 	for i, arg := range args {
 		if i == 0 && arg.Name == "obj" {
@@ -647,14 +638,15 @@ func (g *Generator) getManagerImpl(function *clang.TypedefFunction, clsName stri
 	}
 	sb.WriteString(") ")
 	if retType != "" {
-		sb.WriteString(retType + " ")
+		sb.WriteString(retType)
+		sb.WriteByte(' ')
 	}
 	sb.WriteString("{\n")
 	sb.WriteString("\t")
 	if retType != "" {
 		sb.WriteString("return ")
 	}
-	sb.WriteString(mgrName + "Mgr." + funcName + "(")
+	fmt.Fprintf(&sb, "%sMgr.%s(", mgrName, funcName)
 	// Only add pself.Id if the first argument is "obj" (instance method)
 	wroteCallArg := false
 	if hasObjArg {

--- a/internal/cmd/codegen/generate/gdext/generate.go
+++ b/internal/cmd/codegen/generate/gdext/generate.go
@@ -14,13 +14,10 @@
  * limitations under the License.
  */
 
-// Package gdextensionwrapper generates C code to wrap all of the gdextension
-// methods to call functions on the gdextension_api_structs to work
-// around the Cgo C function pointer limitation.
+// Package gdext generates the SPX GDExtension headers and engine bindings.
 package gdext
 
 import (
-	"bytes"
 	_ "embed"
 	"fmt"
 	"io"
@@ -64,7 +61,7 @@ func (g *Generator) Generate(projectPath, spxModulePath string, headers Headers)
 
 	// use the new format header
 	outputFile = filepath.Join(projectPath, NativeRelDir, "gdextension_spx_ext.h")
-	if err := os.WriteFile(outputFile, []byte(headers.Standard), 0o644); err != nil {
+	if err := WriteGeneratedFile(outputFile, []byte(headers.Standard), 0o644); err != nil {
 		return err
 	}
 	if err := fileCopy(outputFile, filepath.Join(spxModulePath, "gdextension_spx_ext.h")); err != nil {
@@ -176,24 +173,11 @@ func (g *Generator) generateGdCppFile(projectPath string, templateStr string, ou
 		},
 	}
 
-	tmpl, err := template.New(outputFileName).
-		Funcs(funcs).
-		Parse(templateStr)
+	output, err := RenderTemplate(funcs, outputFileName, templateStr, g.ManagerData())
 	if err != nil {
 		return err
 	}
-
-	var b bytes.Buffer
-	err = tmpl.Execute(&b, g.ManagerData())
-	if err != nil {
-		return err
-	}
-
-	headerFileName := filepath.Join(projectPath, NativeRelDir, outputFileName)
-	if err := os.WriteFile(headerFileName, b.Bytes(), 0o644); err != nil {
-		return fmt.Errorf("write %s: %w", outputFileName, err)
-	}
-	return nil
+	return WriteGeneratedFile(filepath.Join(projectPath, NativeRelDir, outputFileName), output, 0o644)
 }
 
 // Web owns the value returned by this legacy method.

--- a/internal/cmd/codegen/generate/gdext/header_generator.go
+++ b/internal/cmd/codegen/generate/gdext/header_generator.go
@@ -156,12 +156,12 @@ func mergeManagerHeader(dir string) (string, error) {
 			}
 
 			if inPublicSection {
-				buffer.WriteString("\t" + line + "\n")
+				fmt.Fprintf(&buffer, "\t%s\n", line)
 			}
 		}
 
 		if className != "" {
-			builder.WriteString(fmt.Sprintf("class %s {\n", className))
+			fmt.Fprintf(&builder, "class %s {\n", className)
 			builder.WriteString(buffer.String())
 			builder.WriteString("\n};\n\n")
 		}
@@ -265,7 +265,7 @@ func (g *headerCollector) render(rawFormat bool) string {
 	baseMethods := make(map[string]classMethodDecl)
 	for _, method := range g.methods {
 		if method.MethodName == "" {
-			builder.WriteString("// " + method.ClassName + "\n")
+			fmt.Fprintf(&builder, "// %s\n", method.ClassName)
 			continue
 		}
 		baseMethods[method.ClassName+"::"+method.MethodName] = method
@@ -429,10 +429,10 @@ func (g *headerCollector) appendSyntheticArrayTransformTypedefs(builder *strings
 			continue
 		}
 		if rawFormat {
-			builder.WriteString(fmt.Sprintf("typedef GdArray (*%s)(GdArray %s);\n", spec.FunctionName, spec.ArrayArgName))
+			fmt.Fprintf(builder, "typedef GdArray (*%s)(GdArray %s);\n", spec.FunctionName, spec.ArrayArgName)
 			continue
 		}
-		builder.WriteString(fmt.Sprintf("typedef void (*%s)(GdArray %s, GdArray *ret_value);\n", spec.FunctionName, spec.ArrayArgName))
+		fmt.Fprintf(builder, "typedef void (*%s)(GdArray %s, GdArray *ret_value);\n", spec.FunctionName, spec.ArrayArgName)
 	}
 }
 

--- a/internal/cmd/codegen/generate/webffi/generate.go
+++ b/internal/cmd/codegen/generate/webffi/generate.go
@@ -14,9 +14,7 @@
  * limitations under the License.
  */
 
-// Package gdextensionwrapper generates C code to wrap all of the gdextension
-// methods to call functions on the gdextension_api_structs to work
-// around the Cgo C function pointer limitation.
+// Package webffi generates Go, JavaScript, and worker bindings for Web runtimes.
 package webffi
 
 import (
@@ -35,9 +33,7 @@ import (
 	"github.com/iancoleman/strcase"
 )
 
-var (
-	WebRelDir = "../../gdengine/binding/web"
-)
+const WebRelDir = "../../gdengine/binding/web"
 
 var (
 
@@ -238,33 +234,16 @@ func (g *Generator) GenerateJsEngineJsFile(projectPath, spxModulePath string) er
 		"loadProcAddressName": LoadProcAddressName,
 	}
 
-	tmpl, err := template.New("gdspx.js").
-		Funcs(funcs).
-		Parse(jsEngineJsFileText)
+	output, err := RenderTemplate(funcs, "gdspx.js", jsEngineJsFileText, g.AST())
 	if err != nil {
 		return err
 	}
-
-	var b bytes.Buffer
-	err = tmpl.Execute(&b, g.AST())
-	if err != nil {
+	output = trimTrailingWhitespace(output)
+	dstPath := filepath.Join(spxModulePath, "web", "js", "engine", "gdspx.js")
+	if err := os.MkdirAll(filepath.Dir(dstPath), os.ModePerm); err != nil {
 		return err
 	}
-	output := trimTrailingWhitespace(b.Bytes())
-
-	headerFileName := filepath.Join(spxModulePath, "web", "js", "engine", "gdspx.js")
-	err = os.MkdirAll(filepath.Dir(headerFileName), os.ModePerm)
-	if err != nil {
-		return err
-	}
-	f, err := os.Create(headerFileName)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-
-	_, err = f.Write(output)
-	return err
+	return WriteGeneratedFile(dstPath, output, 0o666)
 }
 
 func trimTrailingWhitespace(src []byte) []byte {
@@ -292,7 +271,8 @@ func (g *Generator) getManagerFuncBody(function *clang.TypedefFunction) string {
 		sb.WriteString(prefixTab)
 		if g.IsNativeArrayDataArg(function, arg) {
 			argName := "arg" + strconv.Itoa(i)
-			sb.WriteString(argName + " := JsFromGdArray(")
+			sb.WriteString(argName)
+			sb.WriteString(" := JsFromGdArray(")
 			sb.WriteString(g.EffectiveGoArgumentName(function, arg))
 			sb.WriteString(")\n")
 			params = append(params, argName)
@@ -303,7 +283,7 @@ func (g *Generator) getManagerFuncBody(function *clang.TypedefFunction) string {
 			argName := "arg" + strconv.Itoa(i)
 			lowName := argName + "Low"
 			highName := argName + "High"
-			sb.WriteString(lowName + ", " + highName + " := ")
+			fmt.Fprintf(&sb, "%s, %s := ", lowName, highName)
 			sb.WriteString(flatJsSplitHelper(typeName))
 			sb.WriteString("(")
 			sb.WriteString(g.EffectiveGoArgumentName(function, arg))
@@ -312,8 +292,10 @@ func (g *Generator) getManagerFuncBody(function *clang.TypedefFunction) string {
 			continue
 		}
 		argName := "arg" + strconv.Itoa(i)
-		sb.WriteString(argName + " := ")
-		sb.WriteString("JsFrom" + typeName)
+		sb.WriteString(argName)
+		sb.WriteString(" := ")
+		sb.WriteString("JsFrom")
+		sb.WriteString(typeName)
 		sb.WriteString("(")
 		sb.WriteString(g.EffectiveGoArgumentName(function, arg))
 		sb.WriteString(")")
@@ -340,14 +322,15 @@ func (g *Generator) getManagerFuncBody(function *clang.TypedefFunction) string {
 	sb.WriteString(")")
 
 	if HasEffectiveReturn(function) {
-		sb.WriteString("\n" + prefixTab)
+		sb.WriteByte('\n')
+		sb.WriteString(prefixTab)
 		sb.WriteString("return ")
 		typeName := EffectiveRawReturnType(function)
 		name := strcase.ToCamel(typeName)
 		if name == "GdObj" {
 			name = "GdObject"
 		}
-		sb.WriteString("JsTo" + name + "(_retValue)")
+		fmt.Fprintf(&sb, "JsTo%s(_retValue)", name)
 	}
 	return sb.String()
 }
@@ -516,7 +499,7 @@ func (g *Generator) getJsFuncBody(function *clang.TypedefFunction) string {
 
 	// call the function
 	if rawRetType != "" {
-		sb.WriteString("var _retValue = Alloc" + rawRetType + "();")
+		fmt.Fprintf(&sb, "var _retValue = Alloc%s();", rawRetType)
 	}
 	sb.WriteString("\n")
 
@@ -526,18 +509,19 @@ func (g *Generator) getJsFuncBody(function *clang.TypedefFunction) string {
 		typeName := MustPrimitiveTypeName(arg, function.Name)
 		argName := "_arg" + strconv.Itoa(i)
 		if g.usesFlatJsGdIntArg(function, arg) {
-			sb.WriteString("var " + argName + " = ")
+			fmt.Fprintf(&sb, "var %s = ", argName)
 			sb.WriteString(flatJsCtor(typeName))
 			sb.WriteString("(")
-			sb.WriteString(arg.Name + "_high, " + arg.Name + "_low")
+			fmt.Fprintf(&sb, "%s_high, %s_low", arg.Name, arg.Name)
 			sb.WriteString(");")
 
 			sb.WriteString("\n")
 			params = append(params, argName)
 			continue
 		}
-		sb.WriteString("var " + argName + " = ")
-		sb.WriteString("To" + typeName)
+		fmt.Fprintf(&sb, "var %s = ", argName)
+		sb.WriteString("To")
+		sb.WriteString(typeName)
 		sb.WriteString("(")
 		sb.WriteString(arg.Name)
 		sb.WriteString(");")
@@ -568,11 +552,12 @@ func (g *Generator) getJsFuncBody(function *clang.TypedefFunction) string {
 		sb.WriteString(prefixTab)
 		typeName := MustPrimitiveTypeName(arg, function.Name)
 		argName := "_arg" + strconv.Itoa(i)
-		sb.WriteString("Free" + typeName + "(" + argName + "); \n")
+		fmt.Fprintf(&sb, "Free%s(%s); \n", typeName, argName)
 	}
 
 	if rawRetType != "" {
-		sb.WriteString(prefixTab + "var _finalRetValue = ")
+		sb.WriteString(prefixTab)
+		sb.WriteString("var _finalRetValue = ")
 		if isFlatJsGdIntLikeType(rawRetType) {
 			sb.WriteString("this._readGdIntLike(_retValue, ")
 			sb.WriteString(flatJsScratchAccessor(rawRetType))
@@ -581,10 +566,12 @@ func (g *Generator) getJsFuncBody(function *clang.TypedefFunction) string {
 			typeName := rawRetType
 			funcName := strcase.ToCamel(typeName)
 			funcName = "ToJs" + strings.ReplaceAll(funcName, "Gd", "")
-			sb.WriteString(funcName + "(_retValue);\n")
+			sb.WriteString(funcName)
+			sb.WriteString("(_retValue);\n")
 		}
-		sb.WriteString(prefixTab + "Free" + rawRetType + "(_retValue); \n")
-		sb.WriteString(prefixTab + "return _finalRetValue")
+		fmt.Fprintf(&sb, "%sFree%s(_retValue); \n", prefixTab, rawRetType)
+		sb.WriteString(prefixTab)
+		sb.WriteString("return _finalRetValue")
 	}
 	return sb.String()
 }

--- a/internal/cmd/codegen/main.go
+++ b/internal/cmd/codegen/main.go
@@ -124,7 +124,7 @@ func generateCode() error {
 		if err != nil {
 			return fmt.Errorf("prepare GDExtension headers: %w", err)
 		}
-		if err := os.WriteFile(filepath.Join(packagePath, common.NativeRelDir, "gdextension_spx_ext.h"), []byte(headers.Raw), 0o644); err != nil {
+		if err := common.WriteGeneratedFile(filepath.Join(packagePath, common.NativeRelDir, "gdextension_spx_ext.h"), []byte(headers.Raw), 0o644); err != nil {
 			return fmt.Errorf("generate GDExtension header: %w", err)
 		}
 		ast, err := gdextensionparser.GenerateGDExtensionInterfaceAST(packagePath, parsedASTPath)


### PR DESCRIPTION
Use shared template rendering and generated-file writing helpers across native headers, Go bindings, GDExtension sources, and JavaScript glue. Retain output-specific Go formatting, license headers, JavaScript whitespace processing, and creation modes.

Correct generator package comments and make the Web output directory constant.

Validation: generator tests and `make generate` passed; generated binding contents remain unchanged.

Also replace return-type string concatenation in manager signatures with direct builder writes, preserving the existing whitespace and output exactly.

The same audit covers all handwritten Go files under `internal`, including multiline expressions. Simplify 58 in-memory `WriteString` concatenations with direct writes or `fmt.Fprintf`; preserve the three stderr/configuration-file writes as single I/O operations. No new string-writing abstraction is introduced.
