### PR TITLE
refactor(codegen): derive fast array access from C parameters

### DIFF
--- a/internal/cmd/codegen/generate/webffi/generate_test.go
+++ b/internal/cmd/codegen/generate/webffi/generate_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/goplus/spx/v3/internal/cmd/codegen/gdextensionparser/clang"
 	"github.com/goplus/spx/v3/internal/cmd/codegen/generate/common"
+	"github.com/goplus/spx/v3/internal/cmd/codegen/generate/gdext"
 	"github.com/stretchr/testify/require"
 )
 
@@ -83,6 +84,7 @@ func TestGetJsFuncArgsSkipsNativeArrayLenArg(t *testing.T) {
 
 	metadata.NativeArrayBridges = map[string]common.NativeArrayBridgeSpec{"GDExtensionSpxSpriteBatchUpdateTransforms": {
 		BaseFunctionName: "GDExtensionSpxSpriteBatchUpdateTransforms",
+		RawDataCType:     "const float *",
 		BaseArgName:      "buffer",
 		DataArgName:      "buffer_data",
 		DataArgGoType:    "[]float32",
@@ -192,17 +194,40 @@ func TestGetJsFuncBodyUsesArrayTransformBridgeSpec(t *testing.T) {
 	require.Contains(t, body, `throw new Error("gdspx_sprite_batch_retrieve_positions fast path unavailable")`)
 }
 
-func TestGetJsFuncBodyRequiresWasmArrayForInputSnapshot(t *testing.T) {
-	generation := &Generator{GenerationContext: common.NewGenerationContext(clang.CHeaderFileAST{}, common.GenerationMetadata{})}
+func TestGetJsFuncBodyUsesArrayAccessSemantics(t *testing.T) {
+	dir := t.TempDir()
+	header := `
+class SpxTestMgr : public SpxBaseMgr {
+public:
+	SPX_API void read_values(const float *values_data, int len);
+	SPX_API void write_values(float *values_data, int len);
+	SPX_API void write_bytes(uint8_t *out, int len);
+};
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "spx_test_mgr.h"), []byte(header), 0o600))
+	headers, err := gdext.PrepareHeaders(dir)
+	require.NoError(t, err)
+	generation := &Generator{GenerationContext: common.NewGenerationContext(clang.CHeaderFileAST{}, headers.Metadata)}
 
-	function := &clang.TypedefFunction{
-		Name: "GDExtensionSpxInputWriteSnapshot",
+	for _, test := range []struct {
+		name string
+		want string
+	}{
+		{"GDExtensionSpxTestReadValues", `RequireFastArray(values, "gdspx_test_read_values", 2)`},
+		{"GDExtensionSpxTestWriteValues", `RequireWasmFastArray(values, "gdspx_test_write_values", 2)`},
+		{"GDExtensionSpxTestWriteBytes", `RequireWasmFastArray(out, "gdspx_test_write_bytes", 5)`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			require.Contains(t, headers.Metadata.NativeArrayBridges, test.name)
+			body := generation.getJsFuncBody(&clang.TypedefFunction{
+				Name:       test.name,
+				ReturnType: clang.PrimativeType{Name: "void"},
+			})
+			require.Contains(t, body, test.want)
+			require.Contains(t, body, "_gdFuncPtr(_arg0, _arg1);")
+			require.NotContains(t, body, "GetFastArrayWasmPtr(")
+		})
 	}
-
-	body := generation.getJsFuncBody(function)
-	require.Contains(t, body, `RequireWasmFastArray(out, "gdspx_input_write_snapshot", 2)`)
-	require.Contains(t, body, "var _arg1 = FastArrayCount(out);")
-	require.NotContains(t, body, "GetFastArrayWasmPtr(out)")
 }
 
 func TestGetJsFuncBodyTreatsWebFreeStrAsValueOperation(t *testing.T) {
@@ -219,6 +244,7 @@ func TestGetJsFuncBodyValidatesNativeFastArray(t *testing.T) {
 
 	metadata.NativeArrayBridges = map[string]common.NativeArrayBridgeSpec{"GDExtensionSpxSpriteBatchUpdateTransforms": {
 		BaseFunctionName: "GDExtensionSpxSpriteBatchUpdateTransforms",
+		RawDataCType:     "const float *",
 		BaseArgName:      "buffer",
 		FastArrayType:    2,
 	}}

--- a/internal/cmd/codegen/generate/webffi/javascript.go
+++ b/internal/cmd/codegen/generate/webffi/javascript.go
@@ -110,19 +110,17 @@ func (g *Generator) getJsFuncBody(function *clang.TypedefFunction) string {
 			"\t}\n" +
 			"\treturn _fastRetValue"
 	}
-	if function.Name == "GDExtensionSpxInputWriteSnapshot" {
-		return "var _arg0 = RequireWasmFastArray(out, \"gdspx_input_write_snapshot\", 2);\n" +
-			"\tvar _arg1 = FastArrayCount(out);\n" +
-			"\t_gdFuncPtr(_arg0, _arg1);"
-	}
 	if spec, ok := g.GetNativeArrayBridgeSpec(function.Name); ok {
 		if common.HasEffectiveReturn(function) {
 			panic(fmt.Sprintf("native-array webffi path does not support return values: %s", function.Name))
 		}
-		argName := spec.BaseArgName
-		return "var _arg0 = RequireFastArray(" + argName + ", \"gd" + common.LoadProcAddressName(function.Name) + "\", " + strconv.Itoa(int(spec.FastArrayType)) + ");\n" +
-			"\tvar _arg1 = FastArrayCount(" + argName + ");\n" +
-			"\t_gdFuncPtr(_arg0, _arg1);"
+		requireArray := "RequireFastArray"
+		if !strings.HasPrefix(spec.RawDataCType, "const ") {
+			// Writable arrays must stay in Wasm memory so writes reach the caller.
+			requireArray = "RequireWasmFastArray"
+		}
+		return fmt.Sprintf("var _arg0 = %s(%s, %q, %d);\n\tvar _arg1 = FastArrayCount(%s);\n\t_gdFuncPtr(_arg0, _arg1);",
+			requireArray, spec.BaseArgName, "gd"+common.LoadProcAddressName(function.Name), spec.FastArrayType, spec.BaseArgName)
 	}
 	if function.Name == "GDExtensionSpxInputGetGlobalMousePos" {
 		return "var _retValue = AllocGdVec2();\n" +


### PR DESCRIPTION
Writable array bridges previously required a hardcoded check for InputWriteSnapshot, while other raw-array bridges used the input path. Select the fast-array access policy from the existing C parameter type: const pointers allow checked input copies; writable pointers require Wasm-backed storage so writes reach the caller. This removes the method-name exception and preserves the output for all existing bindings.

Validation: generated tests derive metadata from a C header containing unfamiliar read/write methods and both float and byte arrays. Codegen `go test ./...`, `staticcheck -checks=all ./...`, and gopls diagnostics passed. `make generate` completed without generated-file changes.
